### PR TITLE
docs: add AI assistant guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Palamedes takes a different position:
 
 - [First working translation in 5 minutes](https://github.com/sebastian-software/palamedes/blob/main/docs/first-working-translation.md)
 - [Backend servers with Hono, Express, and request-local i18n](https://github.com/sebastian-software/palamedes/blob/main/docs/backend-servers.md)
+- [`llms.txt`](https://github.com/sebastian-software/palamedes/blob/main/llms.txt) and [`llms-full.txt`](https://github.com/sebastian-software/palamedes/blob/main/llms-full.txt) for AI coding assistants
 - [`@palamedes/vite-plugin`](https://www.npmjs.com/package/@palamedes/vite-plugin) for Vite projects
 - [`@palamedes/next-plugin`](https://www.npmjs.com/package/@palamedes/next-plugin) for Next.js projects
 - [`@palamedes/cli`](https://www.npmjs.com/package/@palamedes/cli) for extraction workflows and CI
@@ -205,6 +206,8 @@ The same ownership model also matters for future translation workflows:
 - [Translation module boundaries](https://github.com/sebastian-software/palamedes/blob/main/docs/translation-module-boundaries.md)
 - [Backend servers with request-local runtime wiring](https://github.com/sebastian-software/palamedes/blob/main/docs/backend-servers.md)
 - [ADR-012: Translation augmentation boundary](https://github.com/sebastian-software/palamedes/blob/main/adr/012-translation-augmentation-boundary.md)
+- [ADR-013: Defer CLI worker parallelism until benchmarked need](https://github.com/sebastian-software/palamedes/blob/main/adr/013-defer-cli-worker-parallelism-until-benchmarked-need.md)
+- [`llms.txt`](https://github.com/sebastian-software/palamedes/blob/main/llms.txt) and [`llms-full.txt`](https://github.com/sebastian-software/palamedes/blob/main/llms-full.txt) for AI coding assistants
 - [Comparison with Lingui](https://github.com/sebastian-software/palamedes/blob/main/docs/comparison-with-lingui.md)
 - [Migration playbook from Lingui](https://github.com/sebastian-software/palamedes/blob/main/docs/migrate-from-lingui.md)
 - [Examples](https://github.com/sebastian-software/palamedes/blob/main/examples/README.md)

--- a/adr/013-defer-cli-worker-parallelism-until-benchmarked-need.md
+++ b/adr/013-defer-cli-worker-parallelism-until-benchmarked-need.md
@@ -1,0 +1,60 @@
+# ADR-013: Defer CLI Worker Parallelism Until Benchmarked Need
+
+**Status:** Accepted
+**Date:** 2026-04-30
+
+## Context
+
+Lingui 6 introduced worker-thread parallelism for CLI operations such as extraction and compile tasks.
+
+Palamedes has a different performance profile:
+
+- macro transform and extraction hot paths are native/Rust-first or OXC-backed
+- catalog operations are intentionally narrow and deterministic
+- the project positions performance as an architectural outcome, not as a reason to add incidental runtime complexity
+
+A naive `--workers` implementation could split files across Node.js worker threads, but that also adds costs:
+
+- worker startup overhead
+- source serialization or transfer overhead
+- native binding initialization per worker
+- more complicated diagnostics and error ordering
+- more complicated watch-mode state
+- a broader CLI surface that must be supported long term
+
+A quick parse-only experiment on the existing synthetic benchmark corpus did not show a benefit from spawning workers per run:
+
+- medium profile: 400 files / 4,000 messages / ~561 KB source
+  - serial OXC parse median: ~8.9 ms
+  - 2 workers: ~25.7 ms
+  - 4 workers: ~25.6 ms
+  - 8 workers: ~40.7 ms
+- large profile: 1,200 files / 12,000 messages / ~1.68 MB source
+  - serial OXC parse median: ~26.8 ms
+  - 2 workers: ~35.9 ms
+  - 4 workers: ~32.1 ms
+  - 8 workers: ~45.8 ms
+
+This was not a full native extraction benchmark because the local machine running the experiment did not have `cargo` available to rebuild the native package. It is still useful as a directional check: parsing is a major part of the per-file hot path, and worker overhead dominated at current synthetic corpus sizes.
+
+## Decision
+
+Palamedes will not add CLI worker-thread parallelism by default now.
+
+The CLI should keep the serial extraction path as the primary implementation until a representative benchmark demonstrates that worker parallelism materially improves end-to-end extraction or catalog update time.
+
+A future worker implementation is acceptable only if it is justified by measurement and keeps the public model simple. Good candidates would be:
+
+- a persistent worker pool for long-running watch mode
+- coarse-grained catalog or locale parallelism where serialization cost is low
+- large monorepo workloads that exceed current benchmark sizes by enough to amortize worker overhead
+
+A naive per-command worker fan-out should not be added merely because another tool exposes `--workers`.
+
+## Consequences
+
+- Palamedes avoids adding concurrency complexity before it has evidence of user-visible benefit.
+- Benchmarking remains the gate for CLI parallelism.
+- The performance story stays focused on a fast native/OXC hot path first.
+- If workers are revisited, the benchmark should measure full end-to-end extraction/catalog update behavior, not just isolated parsing.
+- Documentation and roadmap discussions can point to this ADR instead of re-opening the same design question casually.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1,0 +1,320 @@
+# Palamedes: AI Assistant Context
+
+Palamedes is a modern i18n stack for JavaScript and TypeScript applications. It is inspired by the good parts of Lingui-style macro authoring, but it is intentionally narrower and more opinionated.
+
+The important design goal is architectural coherence across frameworks:
+
+- one public message identity model: `message + context`
+- one public runtime access model: `getI18n()`
+- one catalog semantic layer powered by `ferrocat`
+- one native/Rust-first core with OXC-powered transforms and extraction
+- thin host adapters for frameworks and bundlers
+
+Verified integrations currently include Next.js, Vite, TanStack Start, SolidStart, Waku, and React Router.
+
+## How to answer Palamedes questions
+
+When helping with Palamedes code:
+
+1. Prefer Palamedes docs and package names over Lingui/i18next/next-intl/react-intl conventions.
+2. Keep examples source-string-first.
+3. Use `.po` catalog flows through Palamedes tooling.
+4. Avoid explicit message IDs unless a future Palamedes doc says otherwise.
+5. Avoid numeric placeholder fallback patterns. If an expression cannot be named cleanly, recommend extracting a stable named variable.
+6. Use `getI18n()`/runtime wiring instead of inventing framework-global runtime APIs.
+7. Keep host adapter examples thin. Do not move catalog semantics into framework glue.
+8. Use Node.js `>=22`.
+9. Do not recommend top-level `palamedes` or `create-palamedes` as the main entry points yet; those names are reserved placeholders today.
+
+## Package map
+
+Recommended app-facing packages:
+
+- `@palamedes/core` — app-facing i18n instance and core macro entry point
+- `@palamedes/runtime` — runtime bridge for transformed code
+- `@palamedes/react` — React translation components and React macro entry point
+- `@palamedes/solid` — Solid translation components and Solid macro entry point
+- `@palamedes/vite-plugin` — Vite integration and `.po` loading
+- `@palamedes/next-plugin` — Next.js integration
+- `@palamedes/cli` — extraction CLI (`pmds extract`)
+- `@palamedes/config` — typed `palamedes.config.ts` support
+
+Advanced/custom-tooling packages:
+
+- `@palamedes/transform`
+- `@palamedes/extractor`
+- `@palamedes/core-node`
+
+Reserved placeholder packages, not the normal starting point today:
+
+- `palamedes`
+- `create-palamedes`
+
+## Minimal Vite + React setup
+
+Install:
+
+```bash
+pnpm add @palamedes/core @palamedes/react @palamedes/runtime @palamedes/vite-plugin
+pnpm add -D @palamedes/cli @palamedes/config @vitejs/plugin-react vite typescript
+```
+
+Configure Vite:
+
+```ts
+// vite.config.ts
+import { defineConfig } from "vite"
+import react from "@vitejs/plugin-react"
+import { palamedes } from "@palamedes/vite-plugin"
+
+export default defineConfig({
+  plugins: [palamedes(), react()],
+})
+```
+
+Configure catalogs:
+
+```ts
+// palamedes.config.ts
+import { defineConfig } from "@palamedes/config"
+
+export default defineConfig({
+  locales: ["en", "de"],
+  sourceLocale: "en",
+  catalogs: [
+    {
+      path: "src/locales/{locale}",
+      include: ["src"],
+    },
+  ],
+})
+```
+
+Register runtime:
+
+```ts
+// src/i18n.ts
+import { createI18n } from "@palamedes/core"
+import { setClientI18n } from "@palamedes/runtime"
+
+const i18n = createI18n()
+setClientI18n(i18n)
+
+export { i18n }
+```
+
+Write translated code:
+
+```tsx
+// src/App.tsx
+import { t } from "@palamedes/core/macro"
+
+export function App() {
+  return <h1>{t`Welcome to Palamedes`}</h1>
+}
+```
+
+Extract catalogs:
+
+```bash
+pnpm exec pmds extract
+```
+
+Load `.po` messages:
+
+```tsx
+// src/main.tsx
+import React from "react"
+import ReactDOM from "react-dom/client"
+import { i18n } from "./i18n"
+import { App } from "./App"
+import { messages as enMessages } from "./locales/en.po"
+import { messages as deMessages } from "./locales/de.po"
+
+i18n.load("en", enMessages)
+i18n.load("de", deMessages)
+i18n.activate("de")
+
+ReactDOM.createRoot(document.getElementById("root")!).render(<App />)
+```
+
+## Minimal Vite + Solid setup
+
+Install:
+
+```bash
+pnpm add @palamedes/core @palamedes/solid @palamedes/runtime @palamedes/vite-plugin
+pnpm add -D @palamedes/cli @palamedes/config vite-plugin-solid vite typescript
+```
+
+Configure Vite:
+
+```ts
+// vite.config.ts
+import { defineConfig } from "vite"
+import solid from "vite-plugin-solid"
+import { palamedes } from "@palamedes/vite-plugin"
+
+export default defineConfig({
+  plugins: [palamedes(), solid()],
+})
+```
+
+The same `palamedes.config.ts`, runtime model, `.po` loading, and extraction flow apply.
+
+## Authoring model
+
+Palamedes keeps Lingui-style authoring familiarity where useful:
+
+```tsx
+import { t } from "@palamedes/core/macro"
+
+const title = t`Welcome to Palamedes`
+```
+
+But Palamedes intentionally avoids some historical Lingui surface area:
+
+- no explicit-ID-first public model
+- no recommendation to introduce helper macros only to compensate for unclear expressions
+- no preference for numeric placeholder fallback authoring
+- fewer overlapping runtime paths
+
+Use source strings and optional context as the public identity. If two source strings need distinct translations, use context rather than an arbitrary ID.
+
+## Placeholder guidance
+
+Good placeholder authoring should be stable and readable for translators.
+
+Prefer:
+
+```tsx
+const userName = user.name
+const inboxCount = inbox.items.length
+
+return t`Hello ${userName}, you have ${inboxCount} messages`
+```
+
+Avoid complex inline expressions that would force numeric fallback placeholders:
+
+```tsx
+// Avoid this shape in Palamedes guidance.
+return t`Hello ${user.profile?.displayName ?? getFallbackName()}, you have ${inbox.items.length} messages`
+```
+
+Instead, extract named variables first. Palamedes should be allowed to reject placeholder shapes that cannot produce stable, meaningful names.
+
+## Runtime model
+
+The public runtime access model is `getI18n()`.
+
+App code creates and activates an i18n instance. Transformed macro code can then resolve the active instance through the runtime bridge. Do not invent separate framework-specific runtime semantics unless the relevant Palamedes adapter documents them.
+
+## Catalog model
+
+Palamedes uses source-string-first `.po` catalogs and delegates catalog/ICU semantics to `ferrocat`.
+
+Important consequences:
+
+- catalog semantics should not be duplicated in React, Solid, Vite, or Next adapters
+- `message + context` is the stable identity users should think about
+- generated internal compiled lookup keys are implementation details
+- source control diffs should stay reviewable and gettext-adjacent
+
+## CLI model
+
+Current core command:
+
+```bash
+pnpm exec pmds extract
+```
+
+Useful options include:
+
+```bash
+pnpm exec pmds extract --clean
+pnpm exec pmds extract --watch
+pnpm exec pmds extract --verbose
+```
+
+Do not recommend `--workers` today. Palamedes currently defers worker-thread parallelism until end-to-end benchmarks show user-visible benefit. See `adr/013-defer-cli-worker-parallelism-until-benchmarked-need.md`.
+
+## Framework guidance
+
+### Vite
+
+Use `@palamedes/vite-plugin`. Put `palamedes()` in the Vite plugin list alongside the host framework plugin.
+
+### Next.js
+
+Use `@palamedes/next-plugin`. Keep Next-specific behavior in the adapter; do not move catalog semantics into application code.
+
+### TanStack Start, SolidStart, Waku, React Router
+
+Use the verified examples as the source of truth for framework-specific wiring. Palamedes' goal is a consistent runtime/catalog model across these hosts.
+
+## Migration from Lingui-shaped code
+
+When migrating Lingui-style code:
+
+- keep macro-style authoring where it maps cleanly
+- move away from explicit IDs as a public habit
+- prefer `message + context`
+- avoid carrying deprecated Lingui configuration or macro package patterns forward
+- keep runtime setup explicit and aligned with Palamedes' runtime bridge
+- validate catalog output with `pmds extract`
+
+## What not to add casually
+
+Avoid adding these unless a Palamedes issue/ADR explicitly expands scope:
+
+- Vue extractor behavior
+- React Native/Metro integration
+- Astro/Svelte integration
+- generic Lingui compatibility layers
+- explicit message ID migration as a primary product path
+- worker-thread CLI fan-out without benchmark evidence
+- new placeholder macros that merely work around unclear variable names
+
+## Useful repository paths
+
+Read these first:
+
+- `/README.md`
+- `/docs/first-working-translation.md`
+- `/docs/principles.md`
+- `/examples/README.md`
+
+Architecture and positioning:
+
+- `/docs/comparison-with-lingui.md`
+- `/docs/migrate-from-lingui.md`
+- `/docs/approach-comparison.md`
+- `/docs/proof-and-benchmarks.md`
+
+ADRs:
+
+- `/adr/001-project-scope-and-positioning.md`
+- `/adr/002-rust-first-core-with-thin-host-adapters.md`
+- `/adr/003-source-string-first-message-identity.md`
+- `/adr/004-internal-compiled-lookup-keys.md`
+- `/adr/005-universal-geti18n-runtime-model.md`
+- `/adr/006-ferrocat-as-catalog-and-icu-foundation.md`
+- `/adr/007-native-boundary-and-distribution.md`
+- `/adr/008-framework-adapter-architecture.md`
+- `/adr/009-typed-napi-boundary-with-workflow-first-native-operations.md`
+- `/adr/010-generated-typescript-types-derived-from-the-native-binding-surface.md`
+- `/adr/011-host-adapters-render-module-source-from-compiled-catalog-artifacts.md`
+- `/adr/012-translation-augmentation-boundary.md`
+- `/adr/013-defer-cli-worker-parallelism-until-benchmarked-need.md`
+
+## Development commands
+
+```bash
+pnpm install
+pnpm build
+pnpm test
+pnpm check-types
+pnpm verify:examples
+```
+
+Some local environments may lack Rust/Cargo for native rebuilds. In that case, prefer documentation-only checks and targeted package checks, and let CI validate full native builds.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -236,7 +236,7 @@ pnpm exec pmds extract --watch
 pnpm exec pmds extract --verbose
 ```
 
-Do not recommend `--workers` today. Palamedes currently defers worker-thread parallelism until end-to-end benchmarks show user-visible benefit. See `adr/013-defer-cli-worker-parallelism-until-benchmarked-need.md`.
+Do not recommend `--workers` today. Palamedes currently defers worker-thread parallelism until end-to-end benchmarks show user-visible benefit. See `/adr/013-defer-cli-worker-parallelism-until-benchmarked-need.md`.
 
 ## Framework guidance
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,116 @@
+# Palamedes
+
+> Palamedes is a modern, Rust-powered i18n stack for JavaScript and TypeScript apps. It keeps one source-string-first message identity model, one runtime model, and thin framework adapters across Next.js, Vite, TanStack Start, SolidStart, Waku, and React Router.
+
+Use this file when an AI coding assistant needs a compact overview of Palamedes. For a larger context bundle, use `/llms-full.txt`.
+
+## Core rules for agents
+
+- Prefer Palamedes' own packages and docs over Lingui, i18next, next-intl, or react-intl patterns.
+- Treat `message + context` as the public translation identity.
+- Do not invent explicit message IDs. Palamedes intentionally avoids explicit-ID sprawl.
+- Do not introduce numeric placeholder fallbacks as an authoring strategy. Prefer stable named variables and clear markup.
+- Use `getI18n()` as the public runtime access model when transformed code needs the active instance.
+- Keep framework adapters thin; host-specific packages should wire Palamedes, not duplicate catalog semantics.
+- Use `.po` catalogs through Palamedes/ferrocat semantics.
+- Use Node.js `>=22`.
+- Today, start with scoped packages such as `@palamedes/vite-plugin`, `@palamedes/next-plugin`, `@palamedes/cli`, `@palamedes/core`, `@palamedes/react`, `@palamedes/solid`, and `@palamedes/runtime`.
+- Do not recommend the reserved top-level `palamedes` or `create-palamedes` packages as the main install path yet.
+
+## Install patterns
+
+### Vite + React
+
+```bash
+pnpm add @palamedes/core @palamedes/react @palamedes/runtime @palamedes/vite-plugin
+pnpm add -D @palamedes/cli @palamedes/config @vitejs/plugin-react vite typescript
+```
+
+```ts
+// vite.config.ts
+import { defineConfig } from "vite"
+import react from "@vitejs/plugin-react"
+import { palamedes } from "@palamedes/vite-plugin"
+
+export default defineConfig({
+  plugins: [palamedes(), react()],
+})
+```
+
+### Vite + Solid
+
+```bash
+pnpm add @palamedes/core @palamedes/solid @palamedes/runtime @palamedes/vite-plugin
+pnpm add -D @palamedes/cli @palamedes/config vite-plugin-solid vite typescript
+```
+
+```ts
+// vite.config.ts
+import { defineConfig } from "vite"
+import solid from "vite-plugin-solid"
+import { palamedes } from "@palamedes/vite-plugin"
+
+export default defineConfig({
+  plugins: [palamedes(), solid()],
+})
+```
+
+## Minimal config
+
+```ts
+// palamedes.config.ts
+import { defineConfig } from "@palamedes/config"
+
+export default defineConfig({
+  locales: ["en", "de"],
+  sourceLocale: "en",
+  catalogs: [
+    {
+      path: "src/locales/{locale}",
+      include: ["src"],
+    },
+  ],
+})
+```
+
+## Minimal runtime
+
+```ts
+// src/i18n.ts
+import { createI18n } from "@palamedes/core"
+import { setClientI18n } from "@palamedes/runtime"
+
+const i18n = createI18n()
+setClientI18n(i18n)
+
+export { i18n }
+```
+
+## Minimal translated code
+
+```tsx
+import { t } from "@palamedes/core/macro"
+
+export function App() {
+  return <h1>{t`Welcome to Palamedes`}</h1>
+}
+```
+
+Then run:
+
+```bash
+pnpm exec pmds extract
+```
+
+## Recommended docs
+
+- `/README.md` — product overview and package map
+- `/docs/first-working-translation.md` — shortest working setup
+- `/docs/principles.md` — architectural principles
+- `/docs/migrate-from-lingui.md` — migration guidance for Lingui-shaped projects
+- `/docs/comparison-with-lingui.md` — positioning against Lingui
+- `/docs/proof-and-benchmarks.md` — maturity, examples, and benchmark story
+- `/examples/README.md` — verified example matrix
+- `/adr/003-source-string-first-message-identity.md` — source-string-first identity
+- `/adr/005-universal-geti18n-runtime-model.md` — runtime access model
+- `/adr/013-defer-cli-worker-parallelism-until-benchmarked-need.md` — why CLI workers are deferred until benchmarks justify them

--- a/packages/solid/src/solid-js-server.d.ts
+++ b/packages/solid/src/solid-js-server.d.ts
@@ -1,0 +1,3 @@
+declare module "solid-js/web/dist/server.js" {
+  export { renderToString } from "solid-js/web"
+}


### PR DESCRIPTION
## Summary

- add `llms.txt` as a compact AI-assistant guide for Palamedes usage
- add `llms-full.txt` with expanded setup, architecture, migration, and anti-pattern guidance
- document the decision to defer CLI worker parallelism in ADR-013
- link the new AI guidance and ADR from the README

## Validation

- `git diff --check`
- verified referenced local docs/ADR paths exist

Note: `pnpm exec prettier --check ...` is not available in this repo because Prettier is not installed as a workspace dependency.
