### PR TITLE
feat: reject unnamed placeholders

### DIFF
--- a/crates/palamedes/src/error.rs
+++ b/crates/palamedes/src/error.rs
@@ -118,4 +118,12 @@ pub enum PalamedesError {
         "Explicit message ids are no longer supported. Remove `id` and rely on message/context instead."
     )]
     ExplicitMessageIdsUnsupported,
+    /// A placeholder expression could not be represented with a stable, meaningful name.
+    #[error(
+        "Could not infer a stable placeholder name for {syntax}. Extract the expression into a named variable before translating it."
+    )]
+    UnnamedPlaceholder {
+        /// Human-readable source shape that failed placeholder naming.
+        syntax: &'static str,
+    },
 }

--- a/crates/palamedes/src/extract.rs
+++ b/crates/palamedes/src/extract.rs
@@ -167,7 +167,12 @@ impl<'a> Visit<'a> for ExtractionVisitor<'a> {
             tag_name.as_str(),
             &["Trans", "Plural", "Select", "SelectOrdinal"],
         ) {
-            match extract_from_jsx_element(it, macro_name, self.origin(it.span.start as usize)) {
+            match extract_from_jsx_element(
+                it,
+                macro_name,
+                self.origin(it.span.start as usize),
+                self.source,
+            ) {
                 Ok(Some(message)) => self.push(message),
                 Ok(None) => {}
                 Err(error) => {
@@ -190,25 +195,35 @@ impl<'a> Visit<'a> for ExtractionVisitor<'a> {
                 self.imported_macro_name(tag_name, &["t", "msg"]),
                 Some("t" | "msg")
             ) {
-                if let Some(message) = extract_from_tagged_template(
+                match extract_from_tagged_template(
                     &it.quasi,
                     self.origin(it.span.start as usize),
                     self.source,
                     false,
                 ) {
-                    self.push(message);
+                    Ok(Some(message)) => self.push(message),
+                    Ok(None) => {}
+                    Err(error) => {
+                        self.fail(error);
+                        return;
+                    }
                 }
             }
         }
 
         if is_i18n_runtime_call(&it.tag, true) {
-            if let Some(message) = extract_from_tagged_template(
+            match extract_from_tagged_template(
                 &it.quasi,
                 self.origin(it.span.start as usize),
                 self.source,
                 true,
             ) {
-                self.push(message);
+                Ok(Some(message)) => self.push(message),
+                Ok(None) => {}
+                Err(error) => {
+                    self.fail(error);
+                    return;
+                }
             }
         }
 
@@ -233,11 +248,11 @@ impl<'a> Visit<'a> for ExtractionVisitor<'a> {
                 ],
             ) {
                 let message = match macro_name {
-                    "plural" | "select" | "selectOrdinal" => Ok(extract_from_choice_call(
+                    "plural" | "select" | "selectOrdinal" => extract_from_choice_call(
                         it,
                         macro_name,
                         self.origin(it.span.start as usize),
-                    )),
+                    ),
                     _ => extract_from_descriptor_call(
                         it,
                         macro_name,
@@ -346,6 +361,7 @@ fn extract_from_jsx_element(
     element: &JSXElement<'_>,
     macro_name: &str,
     origin: (String, usize, Option<usize>),
+    source: &str,
 ) -> PalamedesResult<Option<ExtractedMessageRecord>> {
     let attrs = jsx_attributes(&element.opening_element);
 
@@ -353,11 +369,13 @@ fn extract_from_jsx_element(
         if attrs.contains_key("id") {
             return Err(PalamedesError::ExplicitMessageIdsUnsupported);
         }
-        let message = attrs
-            .get("message")
-            .cloned()
-            .or_else(|| Some(extract_jsx_children_as_message(&element.children)))
-            .filter(|message| !message.is_empty());
+        let message = match attrs.get("message") {
+            Some(message) => Some(message.clone()),
+            None => {
+                let children_message = extract_jsx_children_as_message(&element.children, source)?;
+                (!children_message.is_empty()).then_some(children_message)
+            }
+        };
         let comment = attrs.get("comment").cloned();
         let context = attrs.get("context").cloned();
 
@@ -378,7 +396,7 @@ fn extract_from_jsx_element(
         if attrs.contains_key("id") {
             return Err(PalamedesError::ExplicitMessageIdsUnsupported);
         }
-        let Some(value_name) = extract_jsx_value_name(&element.opening_element) else {
+        let Some(value_name) = extract_jsx_value_name(&element.opening_element)? else {
             return Ok(None);
         };
         let options = extract_choice_options_from_jsx(&element.opening_element);
@@ -418,19 +436,19 @@ fn extract_from_tagged_template(
     origin: (String, usize, Option<usize>),
     source: &str,
     _runtime: bool,
-) -> Option<ExtractedMessageRecord> {
-    let (message, placeholders) = template_to_message(template, source);
+) -> PalamedesResult<Option<ExtractedMessageRecord>> {
+    let (message, placeholders) = template_to_message(template, source)?;
     if message.is_empty() {
-        return None;
+        return Ok(None);
     }
 
-    Some(ExtractedMessageRecord {
+    Ok(Some(ExtractedMessageRecord {
         message,
         comment: None,
         context: None,
         placeholders: (!placeholders.is_empty()).then_some(placeholders),
         origin,
-    })
+    }))
 }
 
 fn extract_from_descriptor_call(
@@ -476,35 +494,43 @@ fn extract_from_choice_call(
     call: &CallExpression<'_>,
     macro_name: &str,
     origin: (String, usize, Option<usize>),
-) -> Option<ExtractedMessageRecord> {
-    let value_arg = call.arguments.first()?;
-    let options_arg = call.arguments.get(1)?;
+) -> PalamedesResult<Option<ExtractedMessageRecord>> {
+    let Some(value_arg) = call.arguments.first() else {
+        return Ok(None);
+    };
+    let Some(options_arg) = call.arguments.get(1) else {
+        return Ok(None);
+    };
     let Argument::ObjectExpression(object) = options_arg else {
-        return None;
+        return Ok(None);
     };
 
-    let value_name = argument_expression_name(value_arg)?;
     let options = extract_choice_options_from_object(object);
     if options.is_empty() {
-        return None;
+        return Ok(None);
     }
+    let Some(value_name) = argument_expression_name(value_arg) else {
+        return Err(PalamedesError::UnnamedPlaceholder {
+            syntax: "choice value expression",
+        });
+    };
 
     let format = match macro_name {
         "plural" => "plural",
         "select" => "select",
         "selectOrdinal" => "selectordinal",
-        _ => return None,
+        _ => return Ok(None),
     };
 
     let message = build_icu_message(format, &value_name, &options, None);
 
-    Some(ExtractedMessageRecord {
+    Ok(Some(ExtractedMessageRecord {
         message,
         comment: None,
         context: None,
         placeholders: None,
         origin,
-    })
+    }))
 }
 
 fn is_i18n_runtime_call(expr: &Expression<'_>, allow_t: bool) -> bool {
@@ -583,7 +609,7 @@ fn extract_from_runtime_call(
 fn template_to_message(
     template: &TemplateLiteral<'_>,
     source: &str,
-) -> (String, BTreeMap<String, String>) {
+) -> PalamedesResult<(String, BTreeMap<String, String>)> {
     let mut message = String::new();
     let mut placeholders = BTreeMap::new();
 
@@ -595,7 +621,11 @@ fn template_to_message(
         }
 
         if let Some(expr) = template.expressions.get(index) {
-            let placeholder = expression_name(expr).unwrap_or_else(|| index.to_string());
+            let Some(placeholder) = expression_name(expr) else {
+                return Err(PalamedesError::UnnamedPlaceholder {
+                    syntax: "template expression",
+                });
+            };
             let expression = expression_source(expr, source).unwrap_or_else(|| placeholder.clone());
             message.push('{');
             message.push_str(&placeholder);
@@ -604,7 +634,7 @@ fn template_to_message(
         }
     }
 
-    (message, placeholders)
+    Ok((message, placeholders))
 }
 
 fn expression_source(expr: &Expression<'_>, source: &str) -> Option<String> {
@@ -653,7 +683,9 @@ fn jsx_expression_string_value(expr: &JSXExpression<'_>) -> Option<String> {
     }
 }
 
-fn extract_jsx_value_name(opening_element: &JSXOpeningElement<'_>) -> Option<String> {
+fn extract_jsx_value_name(
+    opening_element: &JSXOpeningElement<'_>,
+) -> PalamedesResult<Option<String>> {
     for attr in &opening_element.attributes {
         let Some(attr) = attr.as_attribute() else {
             continue;
@@ -665,10 +697,14 @@ fn extract_jsx_value_name(opening_element: &JSXOpeningElement<'_>) -> Option<Str
             continue;
         };
 
-        return jsx_expression_name(&container.expression);
+        return jsx_expression_name(&container.expression).map(Some).ok_or(
+            PalamedesError::UnnamedPlaceholder {
+                syntax: "JSX choice value expression",
+            },
+        );
     }
 
-    None
+    Ok(None)
 }
 
 fn jsx_expression_name(expr: &JSXExpression<'_>) -> Option<String> {
@@ -684,9 +720,12 @@ fn jsx_expression_name(expr: &JSXExpression<'_>) -> Option<String> {
     }
 }
 
-fn extract_jsx_children_as_message(children: &[JSXChild<'_>]) -> String {
-    let mut placeholder_index = 0usize;
+fn extract_jsx_children_as_message(
+    children: &[JSXChild<'_>],
+    source: &str,
+) -> PalamedesResult<String> {
     let mut parts = Vec::new();
+    let mut used_component_names = HashMap::<String, String>::new();
 
     for child in children {
         match child {
@@ -699,34 +738,111 @@ fn extract_jsx_children_as_message(children: &[JSXChild<'_>]) -> String {
             JSXChild::ExpressionContainer(container) => match &container.expression {
                 JSXExpression::StringLiteral(literal) => parts.push(literal.value.to_string()),
                 expr => {
-                    if let Some(name) = jsx_expression_name(expr) {
-                        parts.push(format!("{{{name}}}"));
-                    } else {
-                        parts.push(format!("{{{placeholder_index}}}"));
-                        placeholder_index += 1;
-                    }
+                    let Some(name) = jsx_expression_name(expr) else {
+                        return Err(PalamedesError::UnnamedPlaceholder {
+                            syntax: "JSX expression",
+                        });
+                    };
+                    parts.push(format!("{{{name}}}"));
                 }
             },
             JSXChild::Element(element) => {
-                let current_index = placeholder_index;
-                let inner = extract_jsx_children_as_message(&element.children);
-                parts.push(format!("<{current_index}>{inner}</{current_index}>"));
-                placeholder_index += 1;
+                let component_expression =
+                    opening_element_to_component(&element.opening_element, source);
+                let name = jsx_component_placeholder_name(&element.opening_element, source)?;
+                let name = make_unique_binding_name(
+                    name,
+                    &component_expression,
+                    &mut used_component_names,
+                );
+                let inner = extract_jsx_children_as_message(&element.children, source)?;
+                parts.push(format!("<{name}>{inner}</{name}>"));
             }
             JSXChild::Fragment(fragment) => {
-                let inner = extract_jsx_children_as_message(&fragment.children);
+                let inner = extract_jsx_children_as_message(&fragment.children, source)?;
                 if !inner.is_empty() {
                     parts.push(inner);
                 }
             }
             JSXChild::Spread(_) => {
-                parts.push(format!("{{{placeholder_index}}}"));
-                placeholder_index += 1;
+                return Err(PalamedesError::UnnamedPlaceholder {
+                    syntax: "JSX spread child",
+                });
             }
         }
     }
 
-    parts.join("").trim().to_string()
+    Ok(parts.join("").trim().to_string())
+}
+
+fn opening_element_to_component(opening_element: &JSXOpeningElement<'_>, source: &str) -> String {
+    let start = opening_element.span.start as usize;
+    let end = opening_element.span.end as usize;
+    let markup = &source[start..end];
+
+    if markup.trim_end().ends_with("/>") {
+        return markup.to_string();
+    }
+
+    if let Some(prefix) = markup.strip_suffix('>') {
+        format!("{prefix} />")
+    } else {
+        format!("{markup} />")
+    }
+}
+
+fn make_unique_binding_name(
+    preferred_name: String,
+    expression: &str,
+    used_names: &mut HashMap<String, String>,
+) -> String {
+    if let Some(existing_expression) = used_names.get(&preferred_name) {
+        if existing_expression == expression {
+            return preferred_name;
+        }
+    } else {
+        used_names.insert(preferred_name.clone(), expression.to_string());
+        return preferred_name;
+    }
+
+    let mut suffix = 1usize;
+    loop {
+        let candidate = format!("{preferred_name}_{suffix}");
+        match used_names.get(&candidate) {
+            Some(existing_expression) if existing_expression != expression => {
+                suffix += 1;
+            }
+            _ => {
+                used_names.insert(candidate.clone(), expression.to_string());
+                return candidate;
+            }
+        }
+    }
+}
+
+fn jsx_component_placeholder_name(
+    opening_element: &JSXOpeningElement<'_>,
+    source: &str,
+) -> PalamedesResult<String> {
+    let name_span = opening_element.name.span();
+    let raw_name = source[name_span.start as usize..name_span.end as usize].trim();
+    let name = raw_name
+        .rsplit(['.', ':'])
+        .next()
+        .unwrap_or(raw_name)
+        .trim();
+
+    if !name.is_empty()
+        && name
+            .chars()
+            .all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
+    {
+        return Ok(name.to_string());
+    }
+
+    Err(PalamedesError::UnnamedPlaceholder {
+        syntax: "JSX element",
+    })
 }
 
 fn clean_jsx_text(text: &str) -> String {
@@ -886,21 +1002,21 @@ mod tests {
         let messages = extract_messages(
             r#"
               import { t } from "@palamedes/core/macro"
-              const message = t`Hello ${name} and ${first + last}`
+              const message = t`Hello ${name} and ${resolved.locale}`
             "#,
             "test.tsx",
         )
         .expect("messages should extract");
 
-        assert_eq!(messages[0].message, "Hello {name} and {1}");
+        assert_eq!(messages[0].message, "Hello {name} and {locale}");
         let placeholders = messages[0]
             .placeholders
             .as_ref()
             .expect("placeholder metadata");
         assert_eq!(placeholders.get("name").map(String::as_str), Some("name"));
         assert_eq!(
-            placeholders.get("1").map(String::as_str),
-            Some("first + last")
+            placeholders.get("locale").map(String::as_str),
+            Some("resolved.locale")
         );
     }
 
@@ -929,5 +1045,50 @@ mod tests {
         .expect_err("explicit ids should fail");
 
         assert!(error.to_string().contains("Explicit message ids"));
+    }
+
+    #[test]
+    fn rejects_unnamed_template_placeholders() {
+        let error = extract_messages(
+            r#"
+              import { t } from "@palamedes/core/macro"
+              const message = t`Hello ${firstName + lastName}`
+            "#,
+            "test.tsx",
+        )
+        .expect_err("unnamed placeholders should fail");
+
+        assert!(error.to_string().contains("stable placeholder name"));
+    }
+
+    #[test]
+    fn uses_stable_jsx_component_placeholder_names() {
+        let messages = extract_messages(
+            r#"
+              import { Trans } from "@palamedes/react/macro"
+              const message = <Trans>Accept <a href="/terms">terms</a> and <a href="/privacy">privacy</a></Trans>
+            "#,
+            "test.tsx",
+        )
+        .expect("messages should extract");
+
+        assert_eq!(
+            messages[0].message,
+            "Accept <a>terms</a> and <a_1>privacy</a_1>"
+        );
+    }
+
+    #[test]
+    fn rejects_unnamed_jsx_placeholders() {
+        let error = extract_messages(
+            r#"
+              import { Trans } from "@palamedes/react/macro"
+              const message = <Trans>Hello {firstName + lastName}</Trans>
+            "#,
+            "test.tsx",
+        )
+        .expect_err("unnamed JSX placeholders should fail");
+
+        assert!(error.to_string().contains("stable placeholder name"));
     }
 }

--- a/crates/palamedes/src/transform/messages.rs
+++ b/crates/palamedes/src/transform/messages.rs
@@ -6,6 +6,8 @@ use oxc_ast::ast::{
 };
 use oxc_span::GetSpan;
 
+use crate::error::{PalamedesError, PalamedesResult};
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct ValueBinding {
     pub expression: String,
@@ -113,7 +115,7 @@ pub(super) fn jsx_attributes(opening_element: &JSXOpeningElement<'_>) -> HashMap
 pub(super) fn extract_jsx_value_binding(
     opening_element: &JSXOpeningElement<'_>,
     source: &str,
-) -> Option<ValueBinding> {
+) -> PalamedesResult<Option<ValueBinding>> {
     for attr in &opening_element.attributes {
         let Some(attr) = attr.as_attribute() else {
             continue;
@@ -126,15 +128,16 @@ pub(super) fn extract_jsx_value_binding(
         };
 
         let mut used_value_names = HashMap::<String, String>::new();
-        return Some(jsx_value_binding(
+        return jsx_value_binding(
             &container.expression,
             source,
-            0,
+            "JSX choice value expression",
             &mut used_value_names,
-        ));
+        )
+        .map(Some);
     }
 
-    None
+    Ok(None)
 }
 
 pub(super) fn jsx_expression_name(expr: &JSXExpression<'_>) -> Option<String> {
@@ -241,13 +244,14 @@ pub(super) fn opening_element_to_component_wrapper(
 pub(super) fn extract_jsx_children_parts(
     children: &[JSXChild<'_>],
     source: &str,
-    next_component_index: &mut usize,
+    _next_component_index: &mut usize,
     solid_wrappers: bool,
-) -> (String, Vec<ValueBinding>, Vec<String>) {
+) -> PalamedesResult<(String, Vec<ValueBinding>, Vec<ValueBinding>)> {
     let mut parts = Vec::new();
     let mut values = Vec::new();
     let mut components = Vec::new();
     let mut used_value_names = HashMap::<String, String>::new();
+    let mut used_component_names = HashMap::<String, String>::new();
 
     for child in children {
         match child {
@@ -261,29 +265,37 @@ pub(super) fn extract_jsx_children_parts(
                 JSXExpression::StringLiteral(literal) => parts.push(literal.value.to_string()),
                 expr => {
                     let binding =
-                        jsx_value_binding(expr, source, values.len(), &mut used_value_names);
+                        jsx_value_binding(expr, source, "JSX expression", &mut used_value_names)?;
                     parts.push(format!("{{{}}}", binding.name));
                     values.push(binding);
                 }
             },
             JSXChild::Element(element) => {
-                let current_index = *next_component_index;
-                *next_component_index += 1;
+                let component_expression = if solid_wrappers {
+                    opening_element_to_component_wrapper(&element.opening_element, source)
+                } else {
+                    opening_element_to_component(&element.opening_element, source)
+                };
+                let component_name = component_placeholder_name(&element.opening_element, source)?;
+                let component_name = make_unique_binding_name(
+                    component_name,
+                    &component_expression,
+                    &mut used_component_names,
+                );
 
                 let (inner_message, inner_values, inner_components) = extract_jsx_children_parts(
                     &element.children,
                     source,
-                    next_component_index,
+                    _next_component_index,
                     solid_wrappers,
-                );
+                )?;
                 parts.push(format!(
-                    "<{current_index}>{inner_message}</{current_index}>"
+                    "<{component_name}>{inner_message}</{component_name}>"
                 ));
                 values.extend(inner_values);
-                components.push(if solid_wrappers {
-                    opening_element_to_component_wrapper(&element.opening_element, source)
-                } else {
-                    opening_element_to_component(&element.opening_element, source)
+                components.push(ValueBinding {
+                    expression: component_expression,
+                    name: component_name,
                 });
                 components.extend(inner_components);
             }
@@ -291,20 +303,49 @@ pub(super) fn extract_jsx_children_parts(
                 let (inner_message, inner_values, inner_components) = extract_jsx_children_parts(
                     &fragment.children,
                     source,
-                    next_component_index,
+                    _next_component_index,
                     solid_wrappers,
-                );
+                )?;
                 if !inner_message.is_empty() {
                     parts.push(inner_message);
                 }
                 values.extend(inner_values);
                 components.extend(inner_components);
             }
-            JSXChild::Spread(_) => {}
+            JSXChild::Spread(_) => {
+                return Err(PalamedesError::UnnamedPlaceholder {
+                    syntax: "JSX spread child",
+                });
+            }
         }
     }
 
-    (parts.join("").trim().to_string(), values, components)
+    Ok((parts.join("").trim().to_string(), values, components))
+}
+
+fn component_placeholder_name(
+    opening_element: &JSXOpeningElement<'_>,
+    source: &str,
+) -> PalamedesResult<String> {
+    let name_span = opening_element.name.span();
+    let raw_name = source[name_span.start as usize..name_span.end as usize].trim();
+    let name = raw_name
+        .rsplit(['.', ':'])
+        .next()
+        .unwrap_or(raw_name)
+        .trim();
+
+    if !name.is_empty()
+        && name
+            .chars()
+            .all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
+    {
+        return Ok(name.to_string());
+    }
+
+    Err(PalamedesError::UnnamedPlaceholder {
+        syntax: "JSX element",
+    })
 }
 
 pub(super) fn expression_name(expr: &Expression<'_>) -> Option<String> {
@@ -358,14 +399,16 @@ fn make_unique_binding_name(
 pub(super) fn expression_binding(
     expr: &Expression<'_>,
     source: &str,
-    fallback_index: usize,
+    syntax: &'static str,
     used_value_names: &mut HashMap<String, String>,
-) -> ValueBinding {
+) -> PalamedesResult<ValueBinding> {
     let expression = expression_source(expr, source);
-    let preferred_name = expression_name(expr).unwrap_or_else(|| fallback_index.to_string());
+    let Some(preferred_name) = expression_name(expr) else {
+        return Err(PalamedesError::UnnamedPlaceholder { syntax });
+    };
     let name = make_unique_binding_name(preferred_name, &expression, used_value_names);
 
-    ValueBinding { expression, name }
+    Ok(ValueBinding { expression, name })
 }
 
 fn jsx_expression_source(expr: &JSXExpression<'_>, source: &str) -> Option<String> {
@@ -381,21 +424,22 @@ fn jsx_expression_source(expr: &JSXExpression<'_>, source: &str) -> Option<Strin
 pub(super) fn jsx_value_binding(
     expr: &JSXExpression<'_>,
     source: &str,
-    fallback_index: usize,
+    syntax: &'static str,
     used_value_names: &mut HashMap<String, String>,
-) -> ValueBinding {
-    let expression =
-        jsx_expression_source(expr, source).unwrap_or_else(|| fallback_index.to_string());
-    let preferred_name = jsx_expression_name(expr).unwrap_or_else(|| fallback_index.to_string());
+) -> PalamedesResult<ValueBinding> {
+    let expression = jsx_expression_source(expr, source).unwrap_or_default();
+    let Some(preferred_name) = jsx_expression_name(expr) else {
+        return Err(PalamedesError::UnnamedPlaceholder { syntax });
+    };
     let name = make_unique_binding_name(preferred_name, &expression, used_value_names);
 
-    ValueBinding { expression, name }
+    Ok(ValueBinding { expression, name })
 }
 
 pub(super) fn template_to_message(
     template: &TemplateLiteral<'_>,
     source: &str,
-) -> (String, Option<Vec<ValueBinding>>) {
+) -> PalamedesResult<(String, Option<Vec<ValueBinding>>)> {
     let mut message = String::new();
     let mut values = Vec::new();
     let mut used_value_names = HashMap::<String, String>::new();
@@ -408,7 +452,8 @@ pub(super) fn template_to_message(
         }
 
         if let Some(expr) = template.expressions.get(index) {
-            let binding = expression_binding(expr, source, index, &mut used_value_names);
+            let binding =
+                expression_binding(expr, source, "template expression", &mut used_value_names)?;
             message.push('{');
             message.push_str(&binding.name);
             message.push('}');
@@ -416,14 +461,14 @@ pub(super) fn template_to_message(
         }
     }
 
-    (
+    Ok((
         message,
         if values.is_empty() {
             None
         } else {
             Some(values)
         },
-    )
+    ))
 }
 
 pub(super) fn build_icu_message(

--- a/crates/palamedes/src/transform/runtime.rs
+++ b/crates/palamedes/src/transform/runtime.rs
@@ -15,14 +15,14 @@ pub(super) fn transform_tagged_template(
     template: &TemplateLiteral<'_>,
     source: &str,
     options: &NativeTransformOptions,
-) -> Option<(String, String)> {
-    let (message, values) = template_to_message(template, source);
+) -> PalamedesResult<Option<(String, String)>> {
+    let (message, values) = template_to_message(template, source)?;
     if message.is_empty() {
-        return None;
+        return Ok(None);
     }
 
     let lookup_key = compiled_key(&message, None);
-    Some((
+    Ok(Some((
         build_runtime_call(
             &lookup_key,
             Some(&message),
@@ -32,7 +32,7 @@ pub(super) fn transform_tagged_template(
             options,
         ),
         lookup_key,
-    ))
+    )))
 }
 
 pub(super) fn transform_descriptor_call(
@@ -102,22 +102,33 @@ pub(super) fn transform_choice_call(
     source: &str,
     macro_name: &str,
     options: &NativeTransformOptions,
-) -> Option<(String, String)> {
-    let value_arg = call.arguments.first()?;
-    let options_arg = call.arguments.get(1)?;
+) -> PalamedesResult<Option<(String, String)>> {
+    let Some(value_arg) = call.arguments.first() else {
+        return Ok(None);
+    };
+    let Some(options_arg) = call.arguments.get(1) else {
+        return Ok(None);
+    };
 
-    let value_expr = value_arg.as_expression()?;
+    let Some(value_expr) = value_arg.as_expression() else {
+        return Ok(None);
+    };
     let oxc_ast::ast::Argument::ObjectExpression(choice_object) = options_arg else {
-        return None;
+        return Ok(None);
     };
 
     let mut used_value_names = std::collections::HashMap::new();
-    let value_binding = expression_binding(value_expr, source, 0, &mut used_value_names);
+    let value_binding = expression_binding(
+        value_expr,
+        source,
+        "choice value expression",
+        &mut used_value_names,
+    )?;
     let value_name = value_binding.name.clone();
     let choice_options = extract_choice_options(choice_object);
 
     if choice_options.is_empty() {
-        return None;
+        return Ok(None);
     }
 
     let format = if macro_name == "selectOrdinal" {
@@ -128,7 +139,7 @@ pub(super) fn transform_choice_call(
     let message = build_icu_message(format, &value_name, &choice_options, None);
     let lookup_key = compiled_key(&message, None);
     let values = [value_binding];
-    Some((
+    Ok(Some((
         build_runtime_call(
             &lookup_key,
             Some(&message),
@@ -138,7 +149,7 @@ pub(super) fn transform_choice_call(
             options,
         ),
         lookup_key,
-    ))
+    )))
 }
 
 pub(super) fn transform_trans_element(
@@ -159,7 +170,7 @@ pub(super) fn transform_trans_element(
         source,
         &mut next_component_index,
         solid_wrappers,
-    );
+    )?;
     let message = attrs
         .get("message")
         .cloned()
@@ -175,12 +186,7 @@ pub(super) fn transform_trans_element(
     ];
 
     if !components.is_empty() {
-        let components_prop = components
-            .iter()
-            .enumerate()
-            .map(|(index, component)| format!("{index}: {component}"))
-            .collect::<Vec<_>>()
-            .join(", ");
+        let components_prop = render_value_bindings(&components);
         attrs.push(format!("components={{{{ {components_prop} }}}}"));
     }
 
@@ -206,7 +212,7 @@ pub(super) fn transform_choice_jsx_element(
     }
     let context = attrs.get("context").cloned();
     let comment = attrs.get("comment").cloned();
-    let Some(value_binding) = extract_jsx_value_binding(&element.opening_element, source) else {
+    let Some(value_binding) = extract_jsx_value_binding(&element.opening_element, source)? else {
         return Ok(None);
     };
     let value_name = value_binding.name.clone();

--- a/crates/palamedes/src/transform/tests.rs
+++ b/crates/palamedes/src/transform/tests.rs
@@ -155,10 +155,29 @@ fn transforms_solid_trans_jsx_macro() {
         .code
         .contains("import { Trans } from \"@palamedes/solid\";"));
     assert!(result.code.contains("<Trans id=\""));
-    assert!(result.code.contains("message=\"Hello <0>{name}</0>\""));
     assert!(result
         .code
-        .contains("components={{ 0: (children) => <strong>{children}</strong> }}"));
+        .contains("message=\"Hello <strong>{name}</strong>\""));
+    assert!(result
+        .code
+        .contains("components={{ strong: (children) => <strong>{children}</strong> }}"));
+}
+
+#[test]
+fn deduplicates_same_tag_component_placeholders() {
+    let result = transform_macros(
+        "import { Trans } from \"@palamedes/react/macro\";\nconst el = <Trans>Accept <a href=\"/terms\">terms</a> and <a href=\"/privacy\">privacy</a></Trans>;\n",
+        "test.tsx",
+        None,
+    )
+    .expect("transform should succeed");
+
+    assert!(result
+        .code
+        .contains("message=\"Accept <a>terms</a> and <a_1>privacy</a_1>\""));
+    assert!(result
+        .code
+        .contains("components={{ a: <a href=\"/terms\" />, a_1: <a href=\"/privacy\" /> }}"));
 }
 
 #[test]
@@ -225,4 +244,40 @@ fn rejects_explicit_ids() {
     .expect_err("explicit ids should fail");
 
     assert!(error.to_string().contains("Explicit message ids"));
+}
+
+#[test]
+fn rejects_unnamed_template_placeholders() {
+    let error = transform_macros(
+        "import { t } from \"@palamedes/core/macro\";\nconst msg = t`Hello ${firstName + lastName}`;\n",
+        "test.ts",
+        None,
+    )
+    .expect_err("unnamed placeholders should fail");
+
+    assert!(error.to_string().contains("stable placeholder name"));
+}
+
+#[test]
+fn rejects_unnamed_jsx_placeholders() {
+    let error = transform_macros(
+        "import { Trans } from \"@palamedes/react/macro\";\nconst el = <Trans>Hello {firstName + lastName}</Trans>;\n",
+        "test.tsx",
+        None,
+    )
+    .expect_err("unnamed placeholders should fail");
+
+    assert!(error.to_string().contains("stable placeholder name"));
+}
+
+#[test]
+fn rejects_unnamed_choice_value_placeholders() {
+    let error = transform_macros(
+        "import { plural } from \"@palamedes/core/macro\";\nconst msg = plural(count + 1, { one: \"# item\", other: \"# items\" });\n",
+        "test.ts",
+        None,
+    )
+    .expect_err("unnamed choice value should fail");
+
+    assert!(error.to_string().contains("stable placeholder name"));
 }

--- a/crates/palamedes/src/transform/visitor.rs
+++ b/crates/palamedes/src/transform/visitor.rs
@@ -148,16 +148,21 @@ impl<'a> Visit<'a> for TransformVisitor<'a> {
             return;
         }
 
-        if let Some((text, compiled_id)) =
-            transform_tagged_template(&it.quasi, self.source, self.options)
-        {
-            self.replacements.push(Replacement {
-                start: it.span.start as usize,
-                end: it.span.end as usize,
-                text,
-            });
-            self.push_compiled_id(&compiled_id);
-            self.needs_runtime_import = true;
+        match transform_tagged_template(&it.quasi, self.source, self.options) {
+            Ok(Some((text, compiled_id))) => {
+                self.replacements.push(Replacement {
+                    start: it.span.start as usize,
+                    end: it.span.end as usize,
+                    text,
+                });
+                self.push_compiled_id(&compiled_id);
+                self.needs_runtime_import = true;
+            }
+            Ok(None) => {}
+            Err(error) => {
+                self.fail(error);
+                return;
+            }
         }
 
         walk::walk_tagged_template_expression(self, it);
@@ -200,16 +205,26 @@ impl<'a> Visit<'a> for TransformVisitor<'a> {
                 }
             }
             "plural" | "select" | "selectOrdinal" => {
-                if let Some((text, compiled_id)) =
-                    transform_choice_call(it, self.source, &macro_info.imported_name, self.options)
-                {
-                    self.replacements.push(Replacement {
-                        start: it.span.start as usize,
-                        end: it.span.end as usize,
-                        text,
-                    });
-                    self.push_compiled_id(&compiled_id);
-                    self.needs_runtime_import = true;
+                match transform_choice_call(
+                    it,
+                    self.source,
+                    &macro_info.imported_name,
+                    self.options,
+                ) {
+                    Ok(Some((text, compiled_id))) => {
+                        self.replacements.push(Replacement {
+                            start: it.span.start as usize,
+                            end: it.span.end as usize,
+                            text,
+                        });
+                        self.push_compiled_id(&compiled_id);
+                        self.needs_runtime_import = true;
+                    }
+                    Ok(None) => {}
+                    Err(error) => {
+                        self.fail(error);
+                        return;
+                    }
                 }
             }
             _ => {

--- a/packages/cli/src/commands/extract.test.ts
+++ b/packages/cli/src/commands/extract.test.ts
@@ -43,7 +43,7 @@ describe("extract", () => {
     const deCatalog = normalizePo(await readCatalog(fixtureDir, "de"))
     expect(findItem(deCatalog.items, "Simple hello")?.msgstr).toEqual(["Einfach hallo"])
     expect(findItem(deCatalog.items, "Hello descriptor")).toBeDefined()
-    expect(findItem(deCatalog.items, "Computed {0}")).toBeDefined()
+    expect(findItem(deCatalog.items, "Computed {last}")).toBeDefined()
     expect(findItem(deCatalog.items, "Context hello", "email.subject")).toBeDefined()
     expect(
       findItem(deCatalog.items, "{count, plural, one {# item} other {# items}}")
@@ -55,9 +55,6 @@ describe("extract", () => {
 
     const enCatalog = normalizePo(await readCatalog(fixtureDir, "en"))
     expect(findItem(enCatalog.items, "Hello descriptor")?.msgstr).toEqual(["Hello descriptor"])
-    expect(await readCatalog(fixtureDir, "en")).toContain(
-      "#. placeholder {0}: first + last"
-    )
   })
 
   it("marks obsolete entries by default and removes them when clean is enabled", async () => {

--- a/packages/cli/src/commands/fixtures/ferrocat-first-test/src/App.tsx
+++ b/packages/cli/src/commands/fixtures/ferrocat-first-test/src/App.tsx
@@ -2,7 +2,7 @@ import { defineMessage, plural, t } from "@palamedes/core/macro"
 
 export const simple = t`Simple hello`
 export const generated = t`Hello ${name}`
-export const computed = t`Computed ${first + last}`
+export const computed = t`Computed ${user.last}`
 export const plainDescriptor = t({ message: "Hello descriptor" })
 export const contextual = defineMessage({
   message: "Context hello",

--- a/packages/extractor/package.json
+++ b/packages/extractor/package.json
@@ -17,6 +17,7 @@
   },
   "bugs": "https://github.com/sebastian-software/palamedes/issues",
   "license": "MIT",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/packages/extractor/src/extractMessages.test.ts
+++ b/packages/extractor/src/extractMessages.test.ts
@@ -36,7 +36,17 @@ describe("extractMessages", () => {
       `
       const messages = extract(code)
       expect(messages).toHaveLength(1)
-      expect(messages[0].message).toBe("Hello <0>World</0>")
+      expect(messages[0].message).toBe("Hello <b>World</b>")
+    })
+
+    it("deduplicates same-tag component placeholders with different props", () => {
+      const code = `
+        import { Trans } from "@palamedes/react/macro"
+        const x = <Trans>Accept <a href="/terms">terms</a> and <a href="/privacy">privacy</a></Trans>
+      `
+      const messages = extract(code)
+      expect(messages).toHaveLength(1)
+      expect(messages[0].message).toBe("Accept <a>terms</a> and <a_1>privacy</a_1>")
     })
 
     it("extracts Solid Trans macros with the same semantics", () => {
@@ -111,15 +121,15 @@ describe("extractMessages", () => {
     it("keeps source expressions for template literal placeholder hints", () => {
       const code = `
         import { t } from "@palamedes/core/macro"
-        const message = t\`Hello \${name}, \${first + last}\`
+        const message = t\`Hello \${name}, \${resolved.locale}\`
       `
       const messages = extract(code)
 
       expect(messages).toHaveLength(1)
-      expect(messages[0].message).toBe("Hello {name}, {1}")
+      expect(messages[0].message).toBe("Hello {name}, {locale}")
       expect(messages[0].placeholders).toEqual({
         name: "name",
-        "1": "first + last",
+        locale: "resolved.locale",
       })
     })
   })
@@ -140,6 +150,33 @@ describe("extractMessages", () => {
       `
 
       expect(() => extract(code)).toThrow(/Explicit message ids/)
+    })
+
+    it("rejects unnamed template placeholders", () => {
+      const code = [
+        `import { t } from "@palamedes/core/macro"`,
+        "const x = t`Hello ${firstName + lastName}`",
+      ].join("\n")
+
+      expect(() => extract(code)).toThrow(/stable placeholder name/)
+    })
+
+    it("rejects unnamed JSX placeholders", () => {
+      const code = `
+        import { Trans } from "@palamedes/react/macro"
+        const x = <Trans>Hello {firstName + lastName}</Trans>
+      `
+
+      expect(() => extract(code)).toThrow(/stable placeholder name/)
+    })
+
+    it("rejects unnamed choice value placeholders", () => {
+      const code = `
+        import { plural } from "@palamedes/core/macro"
+        const x = plural(count + 1, { one: "# item", other: "# items" })
+      `
+
+      expect(() => extract(code)).toThrow(/stable placeholder name/)
     })
   })
 })

--- a/packages/extractor/src/extractMessagesJs.ts
+++ b/packages/extractor/src/extractMessagesJs.ts
@@ -142,10 +142,10 @@ export function extractMessages(
         const macro = isPalamedesMacro(tagName, JSX_MACROS)
         if (!macro) return
 
-          const extracted = extractFromJSXElement(node, macro.importedName, filename, getLine)
-          if (extracted) {
-            messages.push(extracted)
-          }
+        const extracted = extractFromJSXElement(node, macro.importedName, filename, getLine, code)
+        if (extracted) {
+          messages.push(extracted)
+        }
       }
 
       // Tagged Template: t`...`, msg`...`
@@ -215,7 +215,8 @@ function extractFromJSXElement(
   node: any,
   macroName: string,
   filename: string,
-  getLine: (offset: number) => number
+  getLine: (offset: number) => number,
+  code?: string
 ): ExtractedMessageInfo | null {
   const attrs = getJSXAttributes(node.openingElement)
   const line = getLine(node.start || 0)
@@ -226,7 +227,7 @@ function extractFromJSXElement(
       throw new Error(unsupportedExplicitIdMessage())
     }
 
-    const message = attrs.message || extractJSXChildrenAsMessage(node.children)
+    const message = attrs.message || extractJSXChildrenAsMessage(node.children, code)
     const comment = attrs.comment
     const context = attrs.context
 
@@ -249,7 +250,10 @@ function extractFromJSXElement(
     const valueName = extractValueName(node.openingElement)
     const options = extractChoiceOptions(attrs)
 
-    if (!valueName || Object.keys(options).length === 0) return null
+    if (Object.keys(options).length === 0) return null
+    if (!valueName) {
+      throw new Error(unnamedPlaceholderMessage("JSX choice value expression"))
+    }
 
     const message = buildICUMessage(format, valueName, options, attrs.offset)
     const context = attrs.context
@@ -367,7 +371,10 @@ function extractFromCallExpression(
     const options = extractChoiceOptionsFromObject(optionsArg)
     const format = macroName === "selectOrdinal" ? "selectordinal" : macroName
 
-    if (!valueName || Object.keys(options).length === 0) return null
+    if (Object.keys(options).length === 0) return null
+    if (!valueName) {
+      throw new Error(unnamedPlaceholderMessage("choice value expression"))
+    }
 
     const message = buildICUMessage(format, valueName, options)
 
@@ -424,11 +431,11 @@ function getJSXAttributeValue(valueNode: any): string | undefined {
 /**
  * Extract text content from JSX children, converting expressions to placeholders
  */
-function extractJSXChildrenAsMessage(children: any[]): string {
+function extractJSXChildrenAsMessage(children: any[], code?: string): string {
   if (!children) return ""
 
-  let placeholderIndex = 0
   const parts: string[] = []
+  const usedComponentNames = new Map<string, string>()
 
   for (const child of children) {
     if (child.type === "JSXText") {
@@ -438,20 +445,87 @@ function extractJSXChildrenAsMessage(children: any[]): string {
       const expr = child.expression
       if (expr?.type === "StringLiteral") {
         parts.push(expr.value)
-      } else if (expr?.type === "Identifier") {
-        parts.push(`{${expr.name}}`)
       } else {
-        parts.push(`{${placeholderIndex++}}`)
+        const name = extractExpressionName(expr)
+        if (!name) {
+          throw new Error(unnamedPlaceholderMessage("JSX expression"))
+        }
+        parts.push(`{${name}}`)
       }
     } else if (child.type === "JSXElement") {
-      // Nested element: <Trans>Hello <b>world</b></Trans> → "Hello <0>world</0>"
-      const innerText = extractJSXChildrenAsMessage(child.children)
-      parts.push(`<${placeholderIndex}>${innerText}</${placeholderIndex}>`)
-      placeholderIndex++
+      const preferredName = extractJSXElementName(child.openingElement)
+      if (!preferredName) {
+        throw new Error(unnamedPlaceholderMessage("JSX element"))
+      }
+      const componentExpression = openingElementToComponent(child.openingElement, code)
+      const name = makeUniqueBindingName(preferredName, componentExpression, usedComponentNames)
+      const innerText = extractJSXChildrenAsMessage(child.children, code)
+      parts.push(`<${name}>${innerText}</${name}>`)
+    } else if (child.type === "JSXSpreadChild") {
+      throw new Error(unnamedPlaceholderMessage("JSX spread child"))
     }
   }
 
   return parts.join("").trim()
+}
+
+function openingElementToComponent(openingElement: any, code?: string): string {
+  if (
+    !code ||
+    typeof openingElement?.start !== "number" ||
+    typeof openingElement?.end !== "number"
+  ) {
+    return extractJSXElementName(openingElement) || ""
+  }
+
+  const markup = code.slice(openingElement.start, openingElement.end)
+  if (markup.trimEnd().endsWith("/>")) {
+    return markup
+  }
+
+  return markup.endsWith(">") ? `${markup.slice(0, -1)} />` : `${markup} />`
+}
+
+function makeUniqueBindingName(
+  preferredName: string,
+  expression: string,
+  usedNames: Map<string, string>
+): string {
+  const existingExpression = usedNames.get(preferredName)
+  if (existingExpression === expression) {
+    return preferredName
+  }
+  if (existingExpression === undefined) {
+    usedNames.set(preferredName, expression)
+    return preferredName
+  }
+
+  let suffix = 1
+  while (true) {
+    const candidate = `${preferredName}_${suffix}`
+    const existingCandidateExpression = usedNames.get(candidate)
+    if (existingCandidateExpression === expression || existingCandidateExpression === undefined) {
+      usedNames.set(candidate, expression)
+      return candidate
+    }
+    suffix += 1
+  }
+}
+
+function extractJSXElementName(openingElement: any): string | undefined {
+  const name = openingElement?.name
+  if (name?.type === "JSXIdentifier") {
+    return isValidTagPlaceholderName(name.name) ? name.name : undefined
+  }
+  if (name?.type === "JSXMemberExpression") {
+    const propertyName = name.property?.name
+    return isValidTagPlaceholderName(propertyName) ? propertyName : undefined
+  }
+  return undefined
+}
+
+function isValidTagPlaceholderName(name: unknown): name is string {
+  return typeof name === "string" && /^[A-Za-z0-9_]+$/.test(name)
 }
 
 /**
@@ -479,13 +553,13 @@ function extractValueName(openingElement: any): string | undefined {
 
 /**
  * Extract a meaningful name from an expression for use as placeholder.
- * Tries to extract something readable before falling back to numeric index.
+ * Tries to extract something readable and returns undefined otherwise.
  *
  * - Identifier: `userName` → "userName"
  * - MemberExpression: `user.name` → "name"
  * - Computed property with string: `user["role"]` → "role"
  * - Getter call: `getUser()` → "user", `getUserName()` → "userName"
- * - Everything else: undefined → caller uses numeric index
+ * - Everything else: undefined → caller rejects with a diagnostic
  */
 function extractExpressionName(expr: any): string | undefined {
   if (!expr) return undefined
@@ -510,7 +584,7 @@ function extractExpressionName(expr: any): string | undefined {
       // user["role"] → "role" (oxc sometimes uses Literal instead of StringLiteral)
       return property.value
     }
-    // user[0] or user[someVar] → undefined (will become numeric index)
+    // user[0] or user[someVar] → undefined (not stable enough for a placeholder name)
   }
 
   // Call expression: getUser() → "user", getUserName() → "userName"
@@ -532,8 +606,12 @@ function extractExpressionName(expr: any): string | undefined {
   }
 
   // BinaryExpression, ConditionalExpression, etc.
-  // → undefined (will become numeric index)
+  // → undefined (not stable enough for a placeholder name)
   return undefined
+}
+
+function unnamedPlaceholderMessage(syntax: string): string {
+  return `Could not infer a stable placeholder name for ${syntax}. Extract the expression into a named variable before translating it.`
 }
 
 /**
@@ -657,7 +735,10 @@ function extractFromTemplateLiteral(quasi: any, code?: string): {
 
     if (i < expressions.length) {
       const expr = expressions[i]
-      const name = extractExpressionName(expr) || String(i)
+      const name = extractExpressionName(expr)
+      if (!name) {
+        throw new Error(unnamedPlaceholderMessage("template expression"))
+      }
       parts.push(`{${name}}`)
       placeholders[name] = extractExpressionSource(expr, code) || name
     }

--- a/packages/next-plugin/package.json
+++ b/packages/next-plugin/package.json
@@ -21,6 +21,7 @@
     "stub": "unbuild --stub"
   },
   "homepage": "https://github.com/sebastian-software/palamedes",
+  "type": "module",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/sebastian-software/palamedes.git",

--- a/packages/transform/package.json
+++ b/packages/transform/package.json
@@ -17,6 +17,7 @@
   },
   "bugs": "https://github.com/sebastian-software/palamedes/issues",
   "license": "MIT",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/packages/transform/src/transform.test.ts
+++ b/packages/transform/src/transform.test.ts
@@ -114,8 +114,23 @@ const el = <Trans>Hello <strong>{name}</strong></Trans>;
 
     expect(result.code).toContain('import { Trans } from "@palamedes/solid"')
     expect(result.code).toContain('<Trans id="')
-    expect(result.code).toContain('message="Hello <0>{name}</0>"')
-    expect(result.code).toContain('components={{ 0: (children) => <strong>{children}</strong> }}')
+    expect(result.code).toContain('message="Hello <strong>{name}</strong>"')
+    expect(result.code).toContain(
+      'components={{ strong: (children) => <strong>{children}</strong> }}'
+    )
+  })
+
+  it("deduplicates same-tag component placeholders", () => {
+    const code = `
+import { Trans } from "@palamedes/react/macro";
+const el = <Trans>Accept <a href="/terms">terms</a> and <a href="/privacy">privacy</a></Trans>;
+`
+    const result = transformPalamedesMacros(code, "test.tsx")
+
+    expect(result.code).toContain('message="Accept <a>terms</a> and <a_1>privacy</a_1>"')
+    expect(result.code).toContain(
+      'components={{ a: <a href="/terms" />, a_1: <a href="/privacy" /> }}'
+    )
   })
 
   it("strips the message field when requested", () => {
@@ -147,6 +162,33 @@ const el = <Trans id="greeting">Hello</Trans>;
 `
 
     expect(() => transformPalamedesMacros(code, "test.tsx")).toThrow(/Explicit message ids/)
+  })
+
+  it("rejects unnamed template placeholders", () => {
+    const code = `
+import { t } from "@palamedes/core/macro";
+const msg = t\`Hello \${firstName + lastName}\`;
+`
+
+    expect(() => transformPalamedesMacros(code, "test.ts")).toThrow(/stable placeholder name/)
+  })
+
+  it("rejects unnamed JSX placeholders", () => {
+    const code = `
+import { Trans } from "@palamedes/react/macro";
+const el = <Trans>Hello {firstName + lastName}</Trans>;
+`
+
+    expect(() => transformPalamedesMacros(code, "test.tsx")).toThrow(/stable placeholder name/)
+  })
+
+  it("rejects unnamed choice value placeholders", () => {
+    const code = `
+import { plural } from "@palamedes/core/macro";
+const msg = plural(count + 1, { one: "# item", other: "# items" });
+`
+
+    expect(() => transformPalamedesMacros(code, "test.ts")).toThrow(/stable placeholder name/)
   })
 
   it("leaves legacy Lingui macro imports untouched", () => {

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -21,6 +21,7 @@
     "stub": "unbuild --stub"
   },
   "homepage": "https://github.com/sebastian-software/palamedes",
+  "type": "module",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/sebastian-software/palamedes.git",


### PR DESCRIPTION
## Summary
- reject template/JSX/choice placeholders when Palamedes cannot infer a stable name
- replace numeric JSX component placeholders with stable element-name placeholders and deduplicate same-tag components by expression
- mirror the strict diagnostics in the JS extractor fallback
- add `type: "module"` to the dual-published extractor/transform/Vite/Next packages after checking CJS/ESM entry compatibility
- update the CLI extraction fixture to use a stable placeholder expression under the stricter rule

## Validation
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets --all-features`
- `cargo test --workspace`
- `pnpm check:native-types`
- `pnpm --filter @palamedes/extractor test`
- `pnpm --filter @palamedes/transform test`
- `pnpm --filter @palamedes/cli test`
- `pnpm --filter @palamedes/extractor exec tsc --noEmit -p tsconfig.json`
- `pnpm --filter @palamedes/transform exec tsc --noEmit -p tsconfig.json`
- `pnpm --filter @palamedes/vite-plugin exec tsc --noEmit -p tsconfig.json`
- `pnpm --filter @palamedes/next-plugin exec tsc --noEmit -p tsconfig.json`
- `pnpm --filter @palamedes/cli exec tsc --noEmit -p tsconfig.json`
- `pnpm --filter @palamedes/extractor build`
- `pnpm --filter @palamedes/transform build`
- `pnpm --filter @palamedes/vite-plugin build`
- `pnpm --filter @palamedes/next-plugin build`
- CJS smoke: `require('./packages/next-plugin/dist/index.cjs')` and `require('./packages/vite-plugin/dist/index.cjs')`
- ESM smoke: dynamic imports for `packages/next-plugin/dist/index.mjs` and `packages/vite-plugin/dist/index.mjs`
- `git diff --check`
