### PR TITLE
chore: update OXC crates in lockstep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,9 +305,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 dependencies = [
  "allocator-api2",
 ]
@@ -535,9 +535,9 @@ checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "oxc-miette"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a7ba54c704edefead1f44e9ef09c43e5cfae666bdc33516b066011f0e6ebf7"
+checksum = "4356a61f2ed4c9b3610245215fbf48970eb277126919f87db9d0efa93a74245c"
 dependencies = [
  "cfg-if",
  "owo-colors",
@@ -550,9 +550,9 @@ dependencies = [
 
 [[package]]
 name = "oxc-miette-derive"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4faecb54d0971f948fbc1918df69b26007e6f279a204793669542e1e8b75eb3"
+checksum = "b237422b014f8f8fff75bb9379e697d13f8d57551a22c88bebb39f073c1bf696"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -561,9 +561,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_allocator"
-version = "0.117.0"
+version = "0.128.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b44277218c002c09167474648a478d3d29a29095ef8950ec9f1fac016c62d7"
+checksum = "8b554cc48bdde5684b8a2bf3355524694ee47d9de4246eaf6199b8aecfd952cb"
 dependencies = [
  "allocator-api2",
  "hashbrown",
@@ -573,9 +573,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast"
-version = "0.117.0"
+version = "0.128.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4222e4e7a1ab01b2a20420a5a65798377a748ea37ee7ece4d7a6b733f86eb61"
+checksum = "d027d8f8b23257e1711e0db8b80c9dacb3ab567a3357b4560eaa1d0a04da2d30"
 dependencies = [
  "bitflags",
  "oxc_allocator",
@@ -585,14 +585,15 @@ dependencies = [
  "oxc_estree",
  "oxc_regular_expression",
  "oxc_span",
+ "oxc_str",
  "oxc_syntax",
 ]
 
 [[package]]
 name = "oxc_ast_macros"
-version = "0.117.0"
+version = "0.128.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e65a38ae589e284dd45a85008024f04aa680e9ddf1321c163cf7f187c805e91"
+checksum = "340ac9cb05bc9963811e3dc1585b85618471cc339d0ab0072d097dd85d78d09e"
 dependencies = [
  "phf",
  "proc-macro2",
@@ -602,9 +603,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast_visit"
-version = "0.117.0"
+version = "0.128.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fddbcd453c55d11995a55f5b1b0dec2768f7e578eb0a7fdcf17d7724c2b45e2"
+checksum = "cf96f11ef5a8152aadd004616f4a91405cedab5e081f9fc816bcc02019d5f8db"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -614,15 +615,15 @@ dependencies = [
 
 [[package]]
 name = "oxc_data_structures"
-version = "0.117.0"
+version = "0.128.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f53bed71cad192596aee8f87f6d6bc2a38a4f898255a69b1d41da1968b9b2c6f"
+checksum = "c425cdc1a05603d9b6d13786892d69364a0c18de06ffa511109a9e0a760b423c"
 
 [[package]]
 name = "oxc_diagnostics"
-version = "0.117.0"
+version = "0.128.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a2d2491c0a1ea29a83abe645424f85c64b5c825f60e5304a453e4314a8b6d88"
+checksum = "fa06c0bec3b31c76e6b30b935f80dd3b29c01bf0d0fbc13b5b8f3eca508ad9ee"
 dependencies = [
  "cow-utils",
  "oxc-miette",
@@ -631,9 +632,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_ecmascript"
-version = "0.117.0"
+version = "0.128.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71b23b64fa8c4a84b1406de383c4666366c9f54ffb9cb11a63b8d7433950460a"
+checksum = "c675d7ad122e907016b6b7eb3e01228f313e6ff59f2a49d35d230ce214a8be9d"
 dependencies = [
  "cow-utils",
  "num-bigint",
@@ -647,9 +648,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_estree"
-version = "0.117.0"
+version = "0.128.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47515ead44bc8beec1ae1514f10ecca63cde043da167c0395dc914f098ea5d2"
+checksum = "0aef225084b2735b871215ceba04582ecfe15be563c4c3a9e22f33e34fab74f4"
 
 [[package]]
 name = "oxc_index"
@@ -663,9 +664,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_parser"
-version = "0.117.0"
+version = "0.128.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3278d4f34d01cdaf85a2391d7b12daba1d95c20c1ff2ac9316d3c28f36353e4e"
+checksum = "6ad27270e0ef6b957eeda354a9a4c3ba2b42a055d4d3f2311bc72735cefaac5f"
 dependencies = [
  "bitflags",
  "cow-utils",
@@ -679,6 +680,7 @@ dependencies = [
  "oxc_ecmascript",
  "oxc_regular_expression",
  "oxc_span",
+ "oxc_str",
  "oxc_syntax",
  "rustc-hash",
  "seq-macro",
@@ -686,15 +688,16 @@ dependencies = [
 
 [[package]]
 name = "oxc_regular_expression"
-version = "0.117.0"
+version = "0.128.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3d680252672b22c24abbaf6e401eace0be9f53072a03411936204625ff349d0"
+checksum = "9e92ddddf8645910675528f66b3159c018c553fa47e4644514513705f5d3c22b"
 dependencies = [
  "bitflags",
  "oxc_allocator",
  "oxc_ast_macros",
  "oxc_diagnostics",
  "oxc_span",
+ "oxc_str",
  "phf",
  "rustc-hash",
  "unicode-id-start",
@@ -702,9 +705,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_span"
-version = "0.117.0"
+version = "0.128.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6eb1bd62de89fb0c646bfb053b72370750fab43a84ebe09ad97cfa020712314"
+checksum = "f03b54ae4c2254ffdbba43f82e4ea097182b300d2f3ccd1f81f8ca145556e659"
 dependencies = [
  "compact_str",
  "oxc-miette",
@@ -716,9 +719,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_str"
-version = "0.117.0"
+version = "0.128.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e65cbfb06ecbae07e0da931815b6b03ade886d016302c400bda7dc0a2f600d3"
+checksum = "686c0fe58e5a4a3698921871fbe23043ac271cf324540591dfcc5e7d0f127a5a"
 dependencies = [
  "compact_str",
  "hashbrown",
@@ -728,9 +731,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_syntax"
-version = "0.117.0"
+version = "0.128.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0f1617f0aa890517fb61ffa1d2d73a8497aca52e84ef6f027fad1e93250eccc"
+checksum = "35c0e13e50d92d4c518ed2484d4c5beea46c2f3311688aaff866420abf6a73eb"
 dependencies = [
  "bitflags",
  "cow-utils",
@@ -741,6 +744,7 @@ dependencies = [
  "oxc_estree",
  "oxc_index",
  "oxc_span",
+ "oxc_str",
  "phf",
  "unicode-id-start",
 ]

--- a/crates/palamedes/Cargo.toml
+++ b/crates/palamedes/Cargo.toml
@@ -9,11 +9,11 @@ description = "Rust core for Palamedes."
 
 [dependencies]
 ferrocat = "0.8.0"
-oxc_allocator = "0.117.0"
-oxc_ast = "0.117.0"
-oxc_ast_visit = "0.117.0"
-oxc_parser = "0.117.0"
-oxc_span = "0.117.0"
+oxc_allocator = "0.128.0"
+oxc_ast = "0.128.0"
+oxc_ast_visit = "0.128.0"
+oxc_parser = "0.128.0"
+oxc_span = "0.128.0"
 regex = "1.12.2"
 serde = { version = "1.0.228", features = ["derive"] }
 thiserror = "2.0.16"

--- a/crates/palamedes/src/transform/messages.rs
+++ b/crates/palamedes/src/transform/messages.rs
@@ -260,7 +260,8 @@ pub(super) fn extract_jsx_children_parts(
             JSXChild::ExpressionContainer(container) => match &container.expression {
                 JSXExpression::StringLiteral(literal) => parts.push(literal.value.to_string()),
                 expr => {
-                    let binding = jsx_value_binding(expr, source, values.len(), &mut used_value_names);
+                    let binding =
+                        jsx_value_binding(expr, source, values.len(), &mut used_value_names);
                     parts.push(format!("{{{}}}", binding.name));
                     values.push(binding);
                 }
@@ -269,13 +270,12 @@ pub(super) fn extract_jsx_children_parts(
                 let current_index = *next_component_index;
                 *next_component_index += 1;
 
-                let (inner_message, inner_values, inner_components) =
-                    extract_jsx_children_parts(
-                        &element.children,
-                        source,
-                        next_component_index,
-                        solid_wrappers,
-                    );
+                let (inner_message, inner_values, inner_components) = extract_jsx_children_parts(
+                    &element.children,
+                    source,
+                    next_component_index,
+                    solid_wrappers,
+                );
                 parts.push(format!(
                     "<{current_index}>{inner_message}</{current_index}>"
                 ));
@@ -288,13 +288,12 @@ pub(super) fn extract_jsx_children_parts(
                 components.extend(inner_components);
             }
             JSXChild::Fragment(fragment) => {
-                let (inner_message, inner_values, inner_components) =
-                    extract_jsx_children_parts(
-                        &fragment.children,
-                        source,
-                        next_component_index,
-                        solid_wrappers,
-                    );
+                let (inner_message, inner_values, inner_components) = extract_jsx_children_parts(
+                    &fragment.children,
+                    source,
+                    next_component_index,
+                    solid_wrappers,
+                );
                 if !inner_message.is_empty() {
                     parts.push(inner_message);
                 }
@@ -385,8 +384,8 @@ pub(super) fn jsx_value_binding(
     fallback_index: usize,
     used_value_names: &mut HashMap<String, String>,
 ) -> ValueBinding {
-    let expression = jsx_expression_source(expr, source)
-        .unwrap_or_else(|| fallback_index.to_string());
+    let expression =
+        jsx_expression_source(expr, source).unwrap_or_else(|| fallback_index.to_string());
     let preferred_name = jsx_expression_name(expr).unwrap_or_else(|| fallback_index.to_string());
     let name = make_unique_binding_name(preferred_name, &expression, used_value_names);
 

--- a/crates/palamedes/src/transform/runtime.rs
+++ b/crates/palamedes/src/transform/runtime.rs
@@ -154,13 +154,12 @@ pub(super) fn transform_trans_element(
     let solid_wrappers = jsx_runtime_module == "@palamedes/solid";
 
     let mut next_component_index = 0usize;
-    let (children_message, values, components) =
-        extract_jsx_children_parts(
-            &element.children,
-            source,
-            &mut next_component_index,
-            solid_wrappers,
-        );
+    let (children_message, values, components) = extract_jsx_children_parts(
+        &element.children,
+        source,
+        &mut next_component_index,
+        solid_wrappers,
+    );
     let message = attrs
         .get("message")
         .cloned()
@@ -186,7 +185,10 @@ pub(super) fn transform_trans_element(
     }
 
     if !values.is_empty() {
-        attrs.push(format!("values={{{{ {} }}}}", render_value_bindings(&values)));
+        attrs.push(format!(
+            "values={{{{ {} }}}}",
+            render_value_bindings(&values)
+        ));
     }
 
     Ok(Some((format!("<Trans {} />", attrs.join(" ")), lookup_key)))

--- a/crates/palamedes/src/transform/visitor.rs
+++ b/crates/palamedes/src/transform/visitor.rs
@@ -91,14 +91,12 @@ impl<'a> Visit<'a> for TransformVisitor<'a> {
                     .strip_suffix("/macro")
                     .unwrap_or("@palamedes/react"),
             ),
-            "Plural" | "Select" | "SelectOrdinal" => {
-                transform_choice_jsx_element(
-                    it,
-                    self.source,
-                    &macro_info.imported_name,
-                    self.options,
-                )
-            }
+            "Plural" | "Select" | "SelectOrdinal" => transform_choice_jsx_element(
+                it,
+                self.source,
+                &macro_info.imported_name,
+                self.options,
+            ),
             _ => Ok(None),
         };
 

--- a/packages/core-node/tsconfig.json
+++ b/packages/core-node/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "types": ["node"]
   },
   "include": ["src"]
 }

--- a/packages/runtime/tsconfig.json
+++ b/packages/runtime/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "types": ["node"]
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary
- update the direct OXC Rust dependencies from `0.117.0` to `0.128.0` together
- refresh `Cargo.lock` so transitive OXC crates stay on the same version family
- run `cargo fmt`, which also formats a few existing Rust call sites

This supersedes the individual Dependabot OXC PRs, which currently fail because updating only one OXC crate mixes incompatible OXC AST/parser/span/allocator versions.

## Validation
- `cargo fmt`
- `cargo check`
- `cargo test`

## Notes
- I intentionally did not include `napi-derive` here. The `napi-derive 3.5.5` PR currently pulls `napi-derive-backend 5.0.4`, which fails to compile the existing `#[napi]` attributes with `expected \`(\`, found \`]\`` errors.
