### PR TITLE
Update Ferrocat to 0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,11 +31,11 @@ checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "block-buffer"
-version = "0.10.4"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -68,6 +68,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "convert_case"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -84,21 +90,20 @@ checksum = "417bef24afe1460300965a25ff4a24b8b45ad011948302ec221e8a0a81eb2c79"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.17"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
 dependencies = [
- "generic-array",
- "typenum",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -119,11 +124,12 @@ checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
 name = "digest"
-version = "0.10.7"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
 ]
 
@@ -167,9 +173,9 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ferrocat"
-version = "0.8.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12602137d419b7fbf932f0d0aa89635463cc1c8bb94e93817cfd000630b43948"
+checksum = "c2819ef849070b2438f930e61e68e3273a5a721ea832ef3249b7a98c0c96439d"
 dependencies = [
  "ferrocat-icu",
  "ferrocat-po",
@@ -177,20 +183,25 @@ dependencies = [
 
 [[package]]
 name = "ferrocat-icu"
-version = "0.8.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ff0e05621ee03911ef5215ac15403690d49bb03e63a0383422edad29e9c1914"
+checksum = "df81ce074d4f016f999b3bf4efde8f5d002d2efed45b561580e84143e0ec5fd5"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "ferrocat-po"
-version = "0.8.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44b01a8829d57bbcc9922fc9baa510495e760b559f9b9a6b40e0a48379aad0ee"
+checksum = "a2922dfef94ab1da6773842e49e7a57e80f6ee13871ffb3b0a415d0c64ca320d"
 dependencies = [
  "ferrocat-icu",
  "icu_locale",
  "icu_plurals",
  "memchr",
+ "serde",
+ "serde_json",
  "sha2",
 ]
 
@@ -294,22 +305,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
+]
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
 ]
 
 [[package]]
@@ -944,10 +954,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha2"
-version = "0.10.9"
+name = "serde_json"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1056,9 +1079,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unicode-id-start"
@@ -1089,12 +1112,6 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "windows-link"
@@ -1183,3 +1200,9 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Palamedes takes a different position:
 
 - Recommended for new projects and teams already doing architecture cleanup
 - Verified today across Next.js, TanStack Start, SolidStart, Waku, and React Router on Node.js `>=22`
-- Source-string-first catalogs are stable and powered by `ferrocat`
+- Source-string-first catalogs are stable and powered by `ferrocat`, including ICU authoring diagnostics for compiled catalogs
 - Placeholder top-level packages exist, but there is no `palamedes` or `create-palamedes` first-run entry yet
 
 ## What Exists Today As Proof
@@ -181,7 +181,7 @@ Palamedes is opinionated in a few places on purpose:
 
 - `message + context` is the semantic identity
 - `getI18n()` is the public runtime model
-- catalog semantics live in `ferrocat`, not in duplicate PO glue
+- catalog semantics, placeholder comments, and ICU source/translation QA live in `ferrocat`, not in duplicate PO glue
 - host adapters render modules, while the core stays host-neutral
 
 That gives teams something stronger than a benchmark number:

--- a/crates/palamedes-node/src/catalog.rs
+++ b/crates/palamedes-node/src/catalog.rs
@@ -16,6 +16,7 @@ pub struct CatalogOrigin {
 pub struct CatalogUpdateMessage {
     pub message: String,
     pub context: Option<String>,
+    pub placeholders: Option<HashMap<String, Vec<String>>>,
     pub extracted_comments: Vec<String>,
     pub origins: Vec<CatalogOrigin>,
 }
@@ -125,6 +126,7 @@ impl From<CatalogUpdateMessage> for palamedes::CatalogUpdateMessage {
         Self {
             message: value.message,
             context: value.context,
+            placeholders: value.placeholders.unwrap_or_default().into_iter().collect(),
             extracted_comments: value.extracted_comments,
             origins: value
                 .origins

--- a/crates/palamedes/Cargo.toml
+++ b/crates/palamedes/Cargo.toml
@@ -8,7 +8,7 @@ rust-version.workspace = true
 description = "Rust core for Palamedes."
 
 [dependencies]
-ferrocat = "0.8.0"
+ferrocat = "0.11.0"
 oxc_allocator = "0.117.0"
 oxc_ast = "0.117.0"
 oxc_ast_visit = "0.117.0"

--- a/crates/palamedes/src/catalog_artifact/load.rs
+++ b/crates/palamedes/src/catalog_artifact/load.rs
@@ -37,6 +37,7 @@ pub(super) fn load_catalogs(
             source_locale: &config.source_locale,
             plural_encoding: PluralEncoding::Icu,
             strict: false,
+            ..ParseCatalogOptions::default()
         })
         .map_err(|source| PalamedesError::ParseCatalog {
             path: file.clone(),

--- a/crates/palamedes/src/catalog_artifact/mod.rs
+++ b/crates/palamedes/src/catalog_artifact/mod.rs
@@ -59,6 +59,8 @@ pub fn compile_catalog_artifact(
             key_strategy: CompiledKeyStrategy::FerrocatV1,
             source_fallback: true,
             strict_icu: false,
+            icu_compatibility: true,
+            ..CompileCatalogArtifactOptions::default()
         },
     )
     .map_err(PalamedesError::CompileCatalogArtifact)?;
@@ -101,7 +103,9 @@ pub fn compile_catalog_artifact_selected(
             key_strategy: CompiledKeyStrategy::FerrocatV1,
             source_fallback: true,
             strict_icu: false,
+            icu_compatibility: true,
             compiled_ids: &request.compiled_ids,
+            ..CompileSelectedCatalogArtifactOptions::default()
         },
     )
     .map_err(PalamedesError::CompileSelectedCatalogArtifact)?;

--- a/crates/palamedes/src/catalog_artifact/tests.rs
+++ b/crates/palamedes/src/catalog_artifact/tests.rs
@@ -134,6 +134,63 @@ msgstr "{name"
 }
 
 #[test]
+fn compile_catalog_artifact_reports_icu_compatibility_diagnostics() {
+    let fixture = create_fixture_dir("catalog-artifact-icu-compatibility");
+    let locale_dir = fixture.join("src/locales");
+    fs::create_dir_all(&locale_dir).expect("locale dir");
+
+    fs::write(
+        locale_dir.join("en.po"),
+        r#"msgid ""
+msgstr ""
+"Language: en\n"
+
+msgid "Hello {name}"
+msgstr ""
+"#,
+    )
+    .expect("write en");
+
+    fs::write(
+        locale_dir.join("de.po"),
+        r#"msgid ""
+msgstr ""
+"Language: de\n"
+
+msgid "Hello {name}"
+msgstr "Hallo {firstName}"
+"#,
+    )
+    .expect("write de");
+
+    let request = CatalogArtifactRequest {
+        config: CatalogArtifactConfig {
+            root_dir: fixture.to_string_lossy().into_owned(),
+            locales: vec!["en".to_owned(), "de".to_owned()],
+            source_locale: "en".to_owned(),
+            fallback_locales: None,
+            pseudo_locale: None,
+            catalogs: vec![CatalogConfig {
+                path: "src/locales/{locale}".to_owned(),
+            }],
+        },
+        resource_path: locale_dir.join("de.po").to_string_lossy().into_owned(),
+    };
+    let result = compile_catalog_artifact(&request).expect("catalog artifact");
+
+    assert!(result
+        .diagnostics
+        .iter()
+        .any(|diagnostic| diagnostic.code == "icu.missing_argument"
+            && diagnostic.source_key.message == "Hello {name}"
+            && diagnostic.locale == "de"));
+    assert!(result
+        .diagnostics
+        .iter()
+        .any(|diagnostic| diagnostic.code == "icu.extra_argument"));
+}
+
+#[test]
 fn compile_catalog_artifact_selected_returns_requested_ids_only() {
     let fixture = create_fixture_dir("catalog-artifact-selected");
     let locale_dir = fixture.join("src/locales");
@@ -193,6 +250,59 @@ msgstr "Hallo"
     assert!(!result
         .messages
         .contains_key(&compiled_key("Only source", None)));
+}
+
+#[test]
+fn compile_catalog_artifact_selected_reports_icu_compatibility_diagnostics() {
+    let fixture = create_fixture_dir("catalog-artifact-selected-icu-compatibility");
+    let locale_dir = fixture.join("src/locales");
+    fs::create_dir_all(&locale_dir).expect("locale dir");
+
+    fs::write(
+        locale_dir.join("en.po"),
+        r#"msgid ""
+msgstr ""
+"Language: en\n"
+
+msgid "Hello {name}"
+msgstr ""
+"#,
+    )
+    .expect("write en");
+
+    fs::write(
+        locale_dir.join("de.po"),
+        r#"msgid ""
+msgstr ""
+"Language: de\n"
+
+msgid "Hello {name}"
+msgstr "Hallo {firstName}"
+"#,
+    )
+    .expect("write de");
+
+    let request = CatalogArtifactSelectedRequest {
+        config: CatalogArtifactConfig {
+            root_dir: fixture.to_string_lossy().into_owned(),
+            locales: vec!["en".to_owned(), "de".to_owned()],
+            source_locale: "en".to_owned(),
+            fallback_locales: None,
+            pseudo_locale: None,
+            catalogs: vec![CatalogConfig {
+                path: "src/locales/{locale}".to_owned(),
+            }],
+        },
+        resource_path: locale_dir.join("de.po").to_string_lossy().into_owned(),
+        compiled_ids: vec![compiled_key("Hello {name}", None)],
+    };
+    let result = compile_catalog_artifact_selected(&request).expect("selected catalog artifact");
+
+    assert_eq!(result.messages.len(), 1);
+    assert!(result
+        .diagnostics
+        .iter()
+        .any(|diagnostic| diagnostic.code == "icu.missing_argument"));
 }
 
 fn create_fixture_dir(prefix: &str) -> PathBuf {

--- a/crates/palamedes/src/catalog_update.rs
+++ b/crates/palamedes/src/catalog_update.rs
@@ -29,6 +29,9 @@ pub struct CatalogUpdateMessage {
     /// Optional gettext context.
     #[serde(default)]
     pub context: Option<String>,
+    /// Placeholder hints keyed by placeholder name.
+    #[serde(default)]
+    pub placeholders: BTreeMap<String, Vec<String>>,
     /// Extracted comments refreshed into the catalog.
     #[serde(default)]
     pub extracted_comments: Vec<String>,
@@ -223,7 +226,7 @@ fn project_message(message: CatalogUpdateMessage) -> PalamedesResult<SourceExtra
         msgctxt: message.context,
         comments: message.extracted_comments,
         origin: origins,
-        placeholders: BTreeMap::new(),
+        placeholders: message.placeholders,
     })
 }
 
@@ -287,6 +290,8 @@ fn format_diagnostic(diagnostic: &Diagnostic) -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
     use super::{
         update_catalog_file, CatalogUpdateMessage, CatalogUpdateOrigin, CatalogUpdateRequest,
     };
@@ -313,6 +318,7 @@ mod tests {
             messages: vec![CatalogUpdateMessage {
                 message: "Hello".to_owned(),
                 context: None,
+                placeholders: BTreeMap::new(),
                 extracted_comments: vec![],
                 origins: vec![CatalogUpdateOrigin {
                     file: "src/App.tsx".to_owned(),
@@ -351,6 +357,7 @@ mod tests {
             messages: vec![CatalogUpdateMessage {
                 message: "Hello".to_owned(),
                 context: None,
+                placeholders: BTreeMap::new(),
                 extracted_comments: vec![],
                 origins: vec![],
             }],
@@ -384,6 +391,7 @@ mod tests {
             messages: vec![CatalogUpdateMessage {
                 message: "Keep".to_owned(),
                 context: None,
+                placeholders: BTreeMap::new(),
                 extracted_comments: vec![],
                 origins: vec![],
             }],
@@ -406,6 +414,7 @@ mod tests {
             messages: vec![CatalogUpdateMessage {
                 message: "{count, plural, one {# item} other {# items}}".to_owned(),
                 context: None,
+                placeholders: BTreeMap::new(),
                 extracted_comments: vec![],
                 origins: vec![],
             }],
@@ -414,5 +423,28 @@ mod tests {
 
         let output = std::fs::read_to_string(&path).expect("read");
         assert!(output.contains("{count, plural, one {# item} other {# items}}"));
+    }
+
+    #[test]
+    fn forwards_extracted_placeholders_to_ferrocat_update() {
+        let path = temp_file("placeholders");
+
+        update_catalog_file(CatalogUpdateRequest {
+            target_path: path.clone(),
+            locale: "en".to_owned(),
+            source_locale: "en".to_owned(),
+            clean: false,
+            messages: vec![CatalogUpdateMessage {
+                message: "Hello {0}".to_owned(),
+                context: None,
+                placeholders: BTreeMap::from([("0".to_owned(), vec!["user.name".to_owned()])]),
+                extracted_comments: vec![],
+                origins: vec![],
+            }],
+        })
+        .expect("update");
+
+        let output = std::fs::read_to_string(&path).expect("read");
+        assert!(output.contains("#. placeholder {0}: user.name"));
     }
 }

--- a/crates/palamedes/src/catalog_update.rs
+++ b/crates/palamedes/src/catalog_update.rs
@@ -164,6 +164,7 @@ pub fn parse_catalog(request: &CatalogParseRequest) -> PalamedesResult<CatalogPa
         source_locale: &request.source_locale,
         plural_encoding: PluralEncoding::Icu,
         strict: false,
+        ..ParseCatalogOptions::default()
     })
     .map_err(PalamedesError::from)?;
 

--- a/crates/palamedes/src/extract.rs
+++ b/crates/palamedes/src/extract.rs
@@ -9,7 +9,7 @@ use oxc_ast::ast::{
 };
 use oxc_ast_visit::{walk, Visit};
 use oxc_parser::Parser;
-use oxc_span::SourceType;
+use oxc_span::{GetSpan, SourceType};
 use serde::Serialize;
 
 const PALAMEDES_MACRO_PACKAGES: [&str; 3] = [
@@ -101,6 +101,7 @@ impl<'a> Visit<'a> for MacroCollector {
 
 struct ExtractionVisitor<'a> {
     filename: String,
+    source: &'a str,
     line_locator: &'a LineLocator,
     imported_macros: &'a HashMap<String, ImportedMacro>,
     messages: Vec<ExtractedMessageRecord>,
@@ -110,11 +111,13 @@ struct ExtractionVisitor<'a> {
 impl<'a> ExtractionVisitor<'a> {
     fn new(
         filename: &str,
+        source: &'a str,
         line_locator: &'a LineLocator,
         imported_macros: &'a HashMap<String, ImportedMacro>,
     ) -> Self {
         Self {
             filename: filename.to_string(),
+            source,
             line_locator,
             imported_macros,
             messages: Vec::new(),
@@ -190,6 +193,7 @@ impl<'a> Visit<'a> for ExtractionVisitor<'a> {
                 if let Some(message) = extract_from_tagged_template(
                     &it.quasi,
                     self.origin(it.span.start as usize),
+                    self.source,
                     false,
                 ) {
                     self.push(message);
@@ -198,9 +202,12 @@ impl<'a> Visit<'a> for ExtractionVisitor<'a> {
         }
 
         if is_i18n_runtime_call(&it.tag, true) {
-            if let Some(message) =
-                extract_from_tagged_template(&it.quasi, self.origin(it.span.start as usize), true)
-            {
+            if let Some(message) = extract_from_tagged_template(
+                &it.quasi,
+                self.origin(it.span.start as usize),
+                self.source,
+                true,
+            ) {
                 self.push(message);
             }
         }
@@ -409,9 +416,10 @@ fn extract_from_jsx_element(
 fn extract_from_tagged_template(
     template: &TemplateLiteral<'_>,
     origin: (String, usize, Option<usize>),
+    source: &str,
     _runtime: bool,
 ) -> Option<ExtractedMessageRecord> {
-    let (message, placeholders) = template_to_message(template);
+    let (message, placeholders) = template_to_message(template, source);
     if message.is_empty() {
         return None;
     }
@@ -572,7 +580,10 @@ fn extract_from_runtime_call(
     }))
 }
 
-fn template_to_message(template: &TemplateLiteral<'_>) -> (String, BTreeMap<String, String>) {
+fn template_to_message(
+    template: &TemplateLiteral<'_>,
+    source: &str,
+) -> (String, BTreeMap<String, String>) {
     let mut message = String::new();
     let mut placeholders = BTreeMap::new();
 
@@ -585,14 +596,24 @@ fn template_to_message(template: &TemplateLiteral<'_>) -> (String, BTreeMap<Stri
 
         if let Some(expr) = template.expressions.get(index) {
             let placeholder = expression_name(expr).unwrap_or_else(|| index.to_string());
+            let expression = expression_source(expr, source).unwrap_or_else(|| placeholder.clone());
             message.push('{');
             message.push_str(&placeholder);
             message.push('}');
-            placeholders.insert(placeholder.clone(), placeholder);
+            placeholders.insert(placeholder, expression);
         }
     }
 
     (message, placeholders)
+}
+
+fn expression_source(expr: &Expression<'_>, source: &str) -> Option<String> {
+    let span = expr.span();
+    source
+        .get(span.start as usize..span.end as usize)
+        .map(str::trim)
+        .filter(|expression| !expression.is_empty())
+        .map(ToOwned::to_owned)
 }
 
 fn jsx_attributes(opening_element: &JSXOpeningElement<'_>) -> BTreeMap<String, String> {
@@ -845,7 +866,8 @@ pub fn extract_messages(
     let mut collector = MacroCollector::new();
     collector.visit_program(&parsed.program);
 
-    let mut extractor = ExtractionVisitor::new(filename, &line_locator, &collector.imported_macros);
+    let mut extractor =
+        ExtractionVisitor::new(filename, source, &line_locator, &collector.imported_macros);
     extractor.visit_program(&parsed.program);
 
     if let Some(error) = extractor.error {
@@ -864,13 +886,22 @@ mod tests {
         let messages = extract_messages(
             r#"
               import { t } from "@palamedes/core/macro"
-              const message = t`Hello ${name}`
+              const message = t`Hello ${name} and ${first + last}`
             "#,
             "test.tsx",
         )
         .expect("messages should extract");
 
-        assert_eq!(messages[0].message, "Hello {name}");
+        assert_eq!(messages[0].message, "Hello {name} and {1}");
+        let placeholders = messages[0]
+            .placeholders
+            .as_ref()
+            .expect("placeholder metadata");
+        assert_eq!(placeholders.get("name").map(String::as_str), Some("name"));
+        assert_eq!(
+            placeholders.get("1").map(String::as_str),
+            Some("first + last")
+        );
     }
 
     #[test]

--- a/crates/palamedes/src/transform/messages.rs
+++ b/crates/palamedes/src/transform/messages.rs
@@ -260,7 +260,8 @@ pub(super) fn extract_jsx_children_parts(
             JSXChild::ExpressionContainer(container) => match &container.expression {
                 JSXExpression::StringLiteral(literal) => parts.push(literal.value.to_string()),
                 expr => {
-                    let binding = jsx_value_binding(expr, source, values.len(), &mut used_value_names);
+                    let binding =
+                        jsx_value_binding(expr, source, values.len(), &mut used_value_names);
                     parts.push(format!("{{{}}}", binding.name));
                     values.push(binding);
                 }
@@ -269,13 +270,12 @@ pub(super) fn extract_jsx_children_parts(
                 let current_index = *next_component_index;
                 *next_component_index += 1;
 
-                let (inner_message, inner_values, inner_components) =
-                    extract_jsx_children_parts(
-                        &element.children,
-                        source,
-                        next_component_index,
-                        solid_wrappers,
-                    );
+                let (inner_message, inner_values, inner_components) = extract_jsx_children_parts(
+                    &element.children,
+                    source,
+                    next_component_index,
+                    solid_wrappers,
+                );
                 parts.push(format!(
                     "<{current_index}>{inner_message}</{current_index}>"
                 ));
@@ -288,13 +288,12 @@ pub(super) fn extract_jsx_children_parts(
                 components.extend(inner_components);
             }
             JSXChild::Fragment(fragment) => {
-                let (inner_message, inner_values, inner_components) =
-                    extract_jsx_children_parts(
-                        &fragment.children,
-                        source,
-                        next_component_index,
-                        solid_wrappers,
-                    );
+                let (inner_message, inner_values, inner_components) = extract_jsx_children_parts(
+                    &fragment.children,
+                    source,
+                    next_component_index,
+                    solid_wrappers,
+                );
                 if !inner_message.is_empty() {
                     parts.push(inner_message);
                 }
@@ -385,8 +384,8 @@ pub(super) fn jsx_value_binding(
     fallback_index: usize,
     used_value_names: &mut HashMap<String, String>,
 ) -> ValueBinding {
-    let expression = jsx_expression_source(expr, source)
-        .unwrap_or_else(|| fallback_index.to_string());
+    let expression =
+        jsx_expression_source(expr, source).unwrap_or_else(|| fallback_index.to_string());
     let preferred_name = jsx_expression_name(expr).unwrap_or_else(|| fallback_index.to_string());
     let name = make_unique_binding_name(preferred_name, &expression, used_value_names);
 

--- a/crates/palamedes/src/transform/runtime.rs
+++ b/crates/palamedes/src/transform/runtime.rs
@@ -154,13 +154,12 @@ pub(super) fn transform_trans_element(
     let solid_wrappers = jsx_runtime_module == "@palamedes/solid";
 
     let mut next_component_index = 0usize;
-    let (children_message, values, components) =
-        extract_jsx_children_parts(
-            &element.children,
-            source,
-            &mut next_component_index,
-            solid_wrappers,
-        );
+    let (children_message, values, components) = extract_jsx_children_parts(
+        &element.children,
+        source,
+        &mut next_component_index,
+        solid_wrappers,
+    );
     let message = attrs
         .get("message")
         .cloned()
@@ -186,7 +185,10 @@ pub(super) fn transform_trans_element(
     }
 
     if !values.is_empty() {
-        attrs.push(format!("values={{{{ {} }}}}", render_value_bindings(&values)));
+        attrs.push(format!(
+            "values={{{{ {} }}}}",
+            render_value_bindings(&values)
+        ));
     }
 
     Ok(Some((format!("<Trans {} />", attrs.join(" ")), lookup_key)))

--- a/crates/palamedes/src/transform/visitor.rs
+++ b/crates/palamedes/src/transform/visitor.rs
@@ -91,14 +91,12 @@ impl<'a> Visit<'a> for TransformVisitor<'a> {
                     .strip_suffix("/macro")
                     .unwrap_or("@palamedes/react"),
             ),
-            "Plural" | "Select" | "SelectOrdinal" => {
-                transform_choice_jsx_element(
-                    it,
-                    self.source,
-                    &macro_info.imported_name,
-                    self.options,
-                )
-            }
+            "Plural" | "Select" | "SelectOrdinal" => transform_choice_jsx_element(
+                it,
+                self.source,
+                &macro_info.imported_name,
+                self.options,
+            ),
             _ => Ok(None),
         };
 

--- a/packages/cli/src/commands/extract.test.ts
+++ b/packages/cli/src/commands/extract.test.ts
@@ -43,17 +43,21 @@ describe("extract", () => {
     const deCatalog = normalizePo(await readCatalog(fixtureDir, "de"))
     expect(findItem(deCatalog.items, "Simple hello")?.msgstr).toEqual(["Einfach hallo"])
     expect(findItem(deCatalog.items, "Hello descriptor")).toBeDefined()
+    expect(findItem(deCatalog.items, "Computed {0}")).toBeDefined()
     expect(findItem(deCatalog.items, "Context hello", "email.subject")).toBeDefined()
     expect(
       findItem(deCatalog.items, "{count, plural, one {# item} other {# items}}")
     ).toBeDefined()
     expect(findItem(deCatalog.items, "Repeated origin")?.references).toEqual([
-      "src/App.tsx:14",
+      "src/App.tsx:15",
       "src/More.tsx:3",
     ])
 
     const enCatalog = normalizePo(await readCatalog(fixtureDir, "en"))
     expect(findItem(enCatalog.items, "Hello descriptor")?.msgstr).toEqual(["Hello descriptor"])
+    expect(await readCatalog(fixtureDir, "en")).toContain(
+      "#. placeholder {0}: 0"
+    )
   })
 
   it("marks obsolete entries by default and removes them when clean is enabled", async () => {

--- a/packages/cli/src/commands/extract.test.ts
+++ b/packages/cli/src/commands/extract.test.ts
@@ -56,7 +56,7 @@ describe("extract", () => {
     const enCatalog = normalizePo(await readCatalog(fixtureDir, "en"))
     expect(findItem(enCatalog.items, "Hello descriptor")?.msgstr).toEqual(["Hello descriptor"])
     expect(await readCatalog(fixtureDir, "en")).toContain(
-      "#. placeholder {0}: 0"
+      "#. placeholder {0}: first + last"
     )
   })
 

--- a/packages/cli/src/commands/extract.ts
+++ b/packages/cli/src/commands/extract.ts
@@ -26,6 +26,7 @@ const TIMING_MARKER = "__PALAMEDES_TIMINGS__"
 interface AggregatedCatalogEntry {
   message: string
   context?: string
+  placeholders: Record<string, string[]>
   extractedComments: string[]
   origins: Array<{ file: string; line: number }>
 }
@@ -139,10 +140,13 @@ async function extractFromCatalog(
           messages[key] = {
             message: msg.message,
             context: msg.context,
+            placeholders: {},
             extractedComments: msg.comment ? [msg.comment] : [],
             origins: [],
           }
         }
+
+        mergePlaceholders(messages[key].placeholders, msg.placeholders)
 
         if (msg.origin) {
           const origin = {
@@ -244,6 +248,7 @@ function catalogToMessages(catalog: AggregatedCatalog): CatalogUpdateMessage[] {
   return Object.values(catalog).map((entry) => ({
     message: entry.message,
     context: entry.context,
+    placeholders: entry.placeholders,
     extractedComments: entry.extractedComments ?? [],
     origins: (entry.origins ?? []).map((origin) => ({
       file: origin.file,
@@ -254,4 +259,21 @@ function catalogToMessages(catalog: AggregatedCatalog): CatalogUpdateMessage[] {
 
 function createCatalogKey(message: string, context?: string): string {
   return `${context ?? ""}\u0004${message}`
+}
+
+function mergePlaceholders(
+  target: Record<string, string[]>,
+  source?: Record<string, string>
+): void {
+  if (!source) {
+    return
+  }
+
+  for (const [name, expression] of Object.entries(source)) {
+    const values = target[name] ?? []
+    if (!values.includes(expression)) {
+      values.push(expression)
+    }
+    target[name] = values
+  }
 }

--- a/packages/cli/src/commands/fixtures/ferrocat-first-test/src/App.tsx
+++ b/packages/cli/src/commands/fixtures/ferrocat-first-test/src/App.tsx
@@ -2,6 +2,7 @@ import { defineMessage, plural, t } from "@palamedes/core/macro"
 
 export const simple = t`Simple hello`
 export const generated = t`Hello ${name}`
+export const computed = t`Computed ${first + last}`
 export const plainDescriptor = t({ message: "Hello descriptor" })
 export const contextual = defineMessage({
   message: "Context hello",

--- a/packages/core-node/README.md
+++ b/packages/core-node/README.md
@@ -72,6 +72,10 @@ console.log(po.headers.Language)
 - `extractMessagesNative(source, filename)`
 - `transformMacrosNative(source, filename, options?)`
 
+Catalog artifact compilation uses Ferrocat's ICU authoring diagnostics to report
+source/translation argument and tag mismatches without taking over runtime
+number, date, or locale formatting.
+
 ## Related Packages
 
 - [`@palamedes/transform`](https://www.npmjs.com/package/@palamedes/transform)

--- a/packages/core-node/src/generated/palamedes-node-types.ts
+++ b/packages/core-node/src/generated/palamedes-node-types.ts
@@ -8,6 +8,7 @@ export interface CatalogOrigin {
 export interface CatalogUpdateMessage {
   message: string;
   context?: string;
+  placeholders?: Record<string, Array<string>>;
   extractedComments: Array<string>;
   origins: Array<CatalogOrigin>;
 }

--- a/packages/extractor/src/extractMessages.test.ts
+++ b/packages/extractor/src/extractMessages.test.ts
@@ -107,6 +107,23 @@ describe("extractMessages", () => {
     })
   })
 
+  describe("placeholder metadata", () => {
+    it("keeps source expressions for template literal placeholder hints", () => {
+      const code = `
+        import { t } from "@palamedes/core/macro"
+        const message = t\`Hello \${name}, \${first + last}\`
+      `
+      const messages = extract(code)
+
+      expect(messages).toHaveLength(1)
+      expect(messages[0].message).toBe("Hello {name}, {1}")
+      expect(messages[0].placeholders).toEqual({
+        name: "name",
+        "1": "first + last",
+      })
+    })
+  })
+
   describe("breaking changes", () => {
     it("rejects explicit ids in macros", () => {
       const code = `

--- a/packages/extractor/src/extractMessagesJs.ts
+++ b/packages/extractor/src/extractMessagesJs.ts
@@ -154,7 +154,7 @@ export function extractMessages(
         const macro = isPalamedesMacro(tagName, JS_MACROS)
 
         if (macro && (macro.importedName === "t" || macro.importedName === "msg")) {
-          const extracted = extractFromTaggedTemplate(node, filename, getLine)
+          const extracted = extractFromTaggedTemplate(node, filename, getLine, code)
           if (extracted) {
             messages.push(extracted)
           }
@@ -194,7 +194,7 @@ export function extractMessages(
       if (node.type === "TaggedTemplateExpression") {
         // Check for i18n.t`...`
         if (isI18nRuntimeCall(node.tag, true)) {
-          const extracted = extractFromRuntimeTaggedTemplate(node, filename, getLine)
+          const extracted = extractFromRuntimeTaggedTemplate(node, filename, getLine, code)
           if (extracted) {
             messages.push(extracted)
           }
@@ -272,7 +272,8 @@ function extractFromJSXElement(
 function extractFromTaggedTemplate(
   node: any,
   filename: string,
-  getLine: (offset: number) => number
+  getLine: (offset: number) => number,
+  code?: string
 ): ExtractedMessageInfo | null {
   const quasi = node.quasi
   if (!quasi) return null
@@ -280,7 +281,7 @@ function extractFromTaggedTemplate(
   const line = getLine(node.start || 0)
   const column = undefined
 
-  const { message, placeholders } = extractFromTemplateLiteral(quasi)
+  const { message, placeholders } = extractFromTemplateLiteral(quasi, code)
 
   if (!message) return null
 
@@ -298,7 +299,8 @@ function extractFromTaggedTemplate(
 function extractFromRuntimeTaggedTemplate(
   node: any,
   filename: string,
-  getLine: (offset: number) => number
+  getLine: (offset: number) => number,
+  code?: string
 ): ExtractedMessageInfo | null {
   const quasi = node.quasi
   if (!quasi) return null
@@ -306,7 +308,7 @@ function extractFromRuntimeTaggedTemplate(
   const line = getLine(node.start || 0)
   const column = undefined
 
-  const { message, placeholders } = extractFromTemplateLiteral(quasi)
+  const { message, placeholders } = extractFromTemplateLiteral(quasi, code)
 
   if (!message) return null
 
@@ -640,7 +642,7 @@ function getStringValue(node: any): string | undefined {
 /**
  * Extract message and placeholders from template literal
  */
-function extractFromTemplateLiteral(quasi: any): {
+function extractFromTemplateLiteral(quasi: any, code?: string): {
   message: string
   placeholders: Record<string, string>
 } {
@@ -657,8 +659,7 @@ function extractFromTemplateLiteral(quasi: any): {
       const expr = expressions[i]
       const name = extractExpressionName(expr) || String(i)
       parts.push(`{${name}}`)
-      // Store the original expression as placeholder
-      placeholders[name] = name
+      placeholders[name] = extractExpressionSource(expr, code) || name
     }
   }
 
@@ -666,6 +667,15 @@ function extractFromTemplateLiteral(quasi: any): {
     message: parts.join(""),
     placeholders,
   }
+}
+
+function extractExpressionSource(expr: any, code?: string): string | undefined {
+  if (!code || typeof expr?.start !== "number" || typeof expr?.end !== "number") {
+    return undefined
+  }
+
+  const expression = code.slice(expr.start, expr.end).trim()
+  return expression || undefined
 }
 
 /**

--- a/packages/next-plugin/README.md
+++ b/packages/next-plugin/README.md
@@ -77,6 +77,7 @@ module.exports = withPalamedes({}, {
 - transforms supported message macros in JavaScript and TypeScript sources
 - compiles imported `.po` files into JavaScript modules
 - keeps source-string-first catalog semantics aligned with the native core
+- reports placeholder and ICU compatibility diagnostics from the native catalog compiler
 - integrates with both webpack and Turbopack
 
 ## Related Docs

--- a/packages/vite-plugin/README.md
+++ b/packages/vite-plugin/README.md
@@ -103,7 +103,7 @@ palamedes({
 - transforms supported message macros before the rest of the Vite pipeline runs
 - compiles imported `.po` files into JavaScript modules
 - keeps source-string-first catalog semantics aligned with the native core
-- reports common macro and catalog issues during dev and build
+- reports common macro, catalog, placeholder, and ICU compatibility issues during dev and build
 
 ## Related Docs
 


### PR DESCRIPTION
## Summary
- preserve extracted placeholders when projecting catalog updates into Ferrocat
- update the Palamedes Rust core to Ferrocat 0.11.0
- enable Ferrocat ICU source/translation compatibility diagnostics for full and selected artifact compilation
- document the new catalog diagnostic behavior and keep rustfmt clean on the current toolchain

## Verification
- cargo fmt --all --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --workspace
- pnpm build
- pnpm test
- pnpm check-types