### PR TITLE
[codex] Move transform sourcemaps native

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -98,6 +108,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crypto-common"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -164,6 +199,12 @@ name = "dtor-proc-macro"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "fastrand"
@@ -413,6 +454,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "json-escape-simd"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35e770254dd7802184595b1d30da2a15cb72569e2aca2b177aef8d22eac8a693"
+
+[[package]]
 name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -536,6 +583,12 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "owo-colors"
@@ -668,6 +721,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb3e6120999627ec9703025eab7c9f410ebb7e95557632a8902ca48210416c2b"
 dependencies = [
  "nonmax",
+ "rayon",
  "serde",
 ]
 
@@ -708,6 +762,19 @@ dependencies = [
  "phf",
  "rustc-hash",
  "unicode-id-start",
+]
+
+[[package]]
+name = "oxc_sourcemap"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d378eb8bad20e89d66276aebab51f6a5408571092cac94abdd3eabb773713d6"
+dependencies = [
+ "base64-simd",
+ "json-escape-simd",
+ "rustc-hash",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -767,6 +834,7 @@ dependencies = [
  "oxc_span",
  "regex",
  "serde",
+ "string_wizard",
  "thiserror",
 ]
 
@@ -862,6 +930,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1014,6 +1102,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "string_wizard"
+version = "0.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49077a960de0ac40075720160a3afb2bfac54ee2b744f245730b811c6fc95ed7"
+dependencies = [
+ "memchr",
+ "oxc_index",
+ "oxc_sourcemap",
+ "rustc-hash",
+ "serde",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1112,6 +1213,12 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "windows-link"

--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ The same foundation also matters for future translation workflows:
 - [Backend servers with request-local runtime wiring](https://github.com/sebastian-software/palamedes/blob/main/docs/backend-servers.md)
 - [ADR-012: Translation augmentation boundary](https://github.com/sebastian-software/palamedes/blob/main/adr/012-translation-augmentation-boundary.md)
 - [ADR-013: Defer CLI worker parallelism until benchmarked need](https://github.com/sebastian-software/palamedes/blob/main/adr/013-defer-cli-worker-parallelism-until-benchmarked-need.md)
+- [ADR-014: Native transform source maps](https://github.com/sebastian-software/palamedes/blob/main/adr/014-native-transform-source-maps.md)
 - [`llms.txt`](https://github.com/sebastian-software/palamedes/blob/main/llms.txt) and [`llms-full.txt`](https://github.com/sebastian-software/palamedes/blob/main/llms-full.txt) for AI coding assistants
 - [Comparison with Lingui](https://github.com/sebastian-software/palamedes/blob/main/docs/comparison-with-lingui.md)
 - [Migration playbook from Lingui](https://github.com/sebastian-software/palamedes/blob/main/docs/migrate-from-lingui.md)

--- a/adr/014-native-transform-source-maps.md
+++ b/adr/014-native-transform-source-maps.md
@@ -1,0 +1,77 @@
+# ADR-014: Native Transform Source Maps
+
+**Status:** Accepted
+**Date:** 2026-05-21
+
+## Context
+
+Palamedes already performs macro transformation in the Rust core. Before this
+decision, the Rust transform returned final code plus byte-offset edits, and
+`@palamedes/transform` replayed those edits through the JavaScript
+`magic-string` package to generate source maps.
+
+That split left the transform workflow divided across two string models:
+
+- Rust and OXC use UTF-8 byte offsets.
+- JavaScript strings and JS `magic-string` use UTF-16 code unit indexes.
+
+This boundary caused a real bug when non-ASCII source text appeared before a
+later macro edit. The wrapper had to translate native byte offsets into
+JavaScript string indexes before source-map generation could work safely.
+
+The split also meant the native transform could produce correct final code
+while the JavaScript wrapper still had to reconstruct the edit sequence to
+produce a map. That is unnecessary orchestration outside the native workflow.
+
+## Decision
+
+Palamedes generates macro transform source maps in the Rust transform workflow.
+
+The Rust core uses `string_wizard`, Rolldown's Rust-native MagicString-style
+editing library, to apply transform edits and generate source maps from the same
+UTF-8 byte offsets used by OXC spans.
+
+The native transform result now owns:
+
+- final transformed code
+- compiled runtime IDs
+- applied byte-offset edits for compatibility and diagnostics
+- an optional standard source map for changed modules
+
+Unchanged modules return no source map.
+
+`@palamedes/transform` remains the public JavaScript transform package, but it
+no longer replays edits through JS `magic-string`. It forwards the native code
+and native source map.
+
+## Alternatives Considered
+
+### 1. Keep JS `magic-string` and convert offsets
+
+Rejected as the long-term architecture. Offset conversion fixes the Unicode bug,
+but it keeps source-map generation split across Rust and JavaScript and preserves
+an avoidable class of boundary mistakes.
+
+### 2. Return only final code and no source map
+
+Rejected because Vite and Next integrations should preserve source-map support
+for transformed application modules.
+
+### 3. Add a separate native source-map helper
+
+Rejected because it would create another native call and still encourage the
+host wrapper to orchestrate transform internals. Source-map generation is part
+of the transform workflow.
+
+## Consequences
+
+- Transform source-map behavior follows the same UTF-8 byte-offset model as the
+  Rust parser and transformer.
+- The JavaScript transform wrapper is smaller and no longer depends on
+  `magic-string`.
+- The N-API transform result has a new optional `map` field.
+- `edits` remain in the native result for compatibility, debugging, and future
+  tooling, but host packages should not need to replay them for normal
+  transform output.
+- Transform benchmarks now include native source-map generation as part of the
+  native transform path.

--- a/crates/palamedes-node/src/transform.rs
+++ b/crates/palamedes-node/src/transform.rs
@@ -19,11 +19,22 @@ pub struct NativeTransformEdit {
 }
 
 #[napi(object)]
+pub struct NativeTransformSourceMap {
+    pub version: u32,
+    pub sources: Vec<String>,
+    pub sources_content: Option<Vec<String>>,
+    pub names: Vec<String>,
+    pub mappings: String,
+    pub file: Option<String>,
+}
+
+#[napi(object)]
 pub struct NativeTransformResult {
     pub code: String,
     pub has_changed: bool,
     pub compiled_ids: Vec<String>,
     pub edits: Vec<NativeTransformEdit>,
+    pub map: Option<NativeTransformSourceMap>,
     pub prepend_text: Option<String>,
 }
 
@@ -50,6 +61,19 @@ impl TryFrom<palamedes::NativeTransformEdit> for NativeTransformEdit {
     }
 }
 
+impl From<palamedes::NativeTransformSourceMap> for NativeTransformSourceMap {
+    fn from(value: palamedes::NativeTransformSourceMap) -> Self {
+        Self {
+            version: value.version,
+            sources: value.sources,
+            sources_content: value.sources_content,
+            names: value.names,
+            mappings: value.mappings,
+            file: value.file,
+        }
+    }
+}
+
 impl TryFrom<palamedes::NativeTransformResult> for NativeTransformResult {
     type Error = napi::Error;
 
@@ -63,6 +87,7 @@ impl TryFrom<palamedes::NativeTransformResult> for NativeTransformResult {
                 .into_iter()
                 .map(NativeTransformEdit::try_from)
                 .collect::<Result<Vec<_>>>()?,
+            map: value.map.map(NativeTransformSourceMap::from),
             prepend_text: value.prepend_text,
         })
     }

--- a/crates/palamedes/Cargo.toml
+++ b/crates/palamedes/Cargo.toml
@@ -16,4 +16,5 @@ oxc_parser = "0.117.0"
 oxc_span = "0.117.0"
 regex = "1.12.2"
 serde = { version = "1.0.228", features = ["derive"] }
+string_wizard = "0.0.27"
 thiserror = "2.0.16"

--- a/crates/palamedes/src/lib.rs
+++ b/crates/palamedes/src/lib.rs
@@ -62,6 +62,7 @@ pub use message_metadata::{
 };
 pub use transform::{
     transform_macros, NativeTransformEdit, NativeTransformOptions, NativeTransformResult,
+    NativeTransformSourceMap,
 };
 
 /// Published `ferrocat` version used by the Rust core.

--- a/crates/palamedes/src/transform/mod.rs
+++ b/crates/palamedes/src/transform/mod.rs
@@ -13,6 +13,7 @@ use oxc_ast_visit::Visit;
 use oxc_parser::Parser;
 use oxc_span::SourceType;
 use serde::{Deserialize, Serialize};
+use string_wizard::{Hires, MagicString, SourceMapOptions};
 
 use crate::error::{PalamedesError, PalamedesResult};
 
@@ -48,6 +49,25 @@ pub struct NativeTransformEdit {
     pub text: String,
 }
 
+/// A standard source map produced for a transformed module.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct NativeTransformSourceMap {
+    /// Source map version.
+    pub version: u32,
+    /// Original source filenames.
+    pub sources: Vec<String>,
+    /// Original source content, when embedded.
+    #[serde(rename = "sourcesContent", skip_serializing_if = "Option::is_none")]
+    pub sources_content: Option<Vec<String>>,
+    /// Source map symbol names.
+    pub names: Vec<String>,
+    /// VLQ-encoded source map mappings.
+    pub mappings: String,
+    /// Generated filename.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub file: Option<String>,
+}
+
 /// Result of transforming a module containing Palamedes macros.
 #[derive(Debug, Deserialize, Serialize)]
 pub struct NativeTransformResult {
@@ -62,6 +82,9 @@ pub struct NativeTransformResult {
     /// Applied source edits in descending order.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub edits: Vec<NativeTransformEdit>,
+    /// Source map for transformed code.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub map: Option<NativeTransformSourceMap>,
     /// Prepended import block, if emitted separately.
     #[serde(rename = "prependText", skip_serializing_if = "Option::is_none")]
     pub prepend_text: Option<String>,
@@ -137,7 +160,6 @@ pub fn transform_macros(
         return Ok(unchanged_result(source));
     }
 
-    let mut code = source.to_string();
     let mut prefix = String::new();
 
     if visitor.needs_runtime_import && !collector.has_runtime_import {
@@ -184,17 +206,52 @@ pub fn transform_macros(
         })
         .collect::<Vec<_>>();
 
+    let mut magic_string = MagicString::new(source);
     for replacement in &replacements {
-        code.replace_range(replacement.start..replacement.end, &replacement.text);
+        apply_replacement(&mut magic_string, replacement);
     }
 
+    let code = magic_string.to_string();
+    let has_changed = code != source;
+    let map = has_changed.then(|| {
+        let mut map = magic_string.source_map(SourceMapOptions {
+            include_content: true,
+            source: filename.into(),
+            hires: Hires::False,
+        });
+        map.set_file(filename);
+        let json = map.to_json();
+        NativeTransformSourceMap {
+            version: json.version,
+            sources: json.sources,
+            sources_content: json.sources_content.map(|items| {
+                items
+                    .into_iter()
+                    .map(|item| item.unwrap_or_default())
+                    .collect()
+            }),
+            names: json.names,
+            mappings: json.mappings,
+            file: json.file,
+        }
+    });
+
     Ok(NativeTransformResult {
-        has_changed: code != source,
+        has_changed,
         code,
         compiled_ids: visitor.compiled_ids,
         edits,
+        map,
         prepend_text: None,
     })
+}
+
+fn apply_replacement(magic_string: &mut MagicString<'_>, replacement: &Replacement) {
+    if replacement.start == replacement.end {
+        magic_string.append_left(replacement.start, replacement.text.clone());
+    } else {
+        magic_string.update(replacement.start, replacement.end, replacement.text.clone());
+    }
 }
 
 fn import_insertion_offset(program: &oxc_ast::ast::Program<'_>) -> usize {
@@ -213,6 +270,7 @@ fn unchanged_result(source: &str) -> NativeTransformResult {
         has_changed: false,
         compiled_ids: Vec::new(),
         edits: Vec::new(),
+        map: None,
         prepend_text: None,
     }
 }

--- a/crates/palamedes/src/transform/tests.rs
+++ b/crates/palamedes/src/transform/tests.rs
@@ -20,6 +20,48 @@ fn transforms_tagged_templates() {
         result.compiled_ids,
         vec![compiled_key("Hello {name}", None)]
     );
+
+    let map = result
+        .map
+        .expect("changed transform should include a source map");
+    assert_eq!(map.file.as_deref(), Some("test.ts"));
+    assert_eq!(map.sources, vec!["test.ts"]);
+    assert_eq!(
+        map.sources_content,
+        Some(vec![
+            "import { t } from \"@palamedes/core/macro\";\nconst msg = t`Hello ${name}`;\n"
+                .to_string()
+        ])
+    );
+    assert!(!map.mappings.is_empty());
+    assert!(map.names.is_empty());
+}
+
+#[test]
+fn unchanged_transform_has_no_source_map() {
+    let result = transform_macros("const msg = \"Hello\";\n", "test.ts", None)
+        .expect("transform should succeed");
+
+    assert!(!result.has_changed);
+    assert!(result.map.is_none());
+}
+
+#[test]
+fn transforms_after_non_ascii_source_text() {
+    let source = "import { Trans } from \"@palamedes/react/macro\";\nconst x = \"äöü\";\nconst y = <Trans>Hallo Welt</Trans>;\n";
+    let result = transform_macros(source, "test.tsx", None).expect("transform should succeed");
+
+    assert!(result.has_changed);
+    assert!(result.code.contains("const x = \"äöü\";"));
+    assert!(result.code.contains("message=\"Hallo Welt\""));
+
+    let map = result
+        .map
+        .expect("changed transform should include a source map");
+    assert_eq!(map.file.as_deref(), Some("test.tsx"));
+    assert_eq!(map.sources, vec!["test.tsx"]);
+    assert_eq!(map.sources_content, Some(vec![source.to_string()]));
+    assert!(!map.mappings.is_empty());
 }
 
 #[test]

--- a/packages/core-node/src/generated/palamedes-node-types.ts
+++ b/packages/core-node/src/generated/palamedes-node-types.ts
@@ -275,11 +275,20 @@ export interface NativeTransformEdit {
   end: number;
   text: string;
 }
+export interface NativeTransformSourceMap {
+  version: number;
+  sources: Array<string>;
+  sourcesContent?: Array<string>;
+  names: Array<string>;
+  mappings: string;
+  file?: string;
+}
 export interface NativeTransformResult {
   code: string;
   hasChanged: boolean;
   compiledIds: Array<string>;
   edits: Array<NativeTransformEdit>;
+  map?: NativeTransformSourceMap;
   prependText?: string;
 }
 

--- a/packages/core-node/src/index.ts
+++ b/packages/core-node/src/index.ts
@@ -41,6 +41,7 @@ import type {
   NativeTransformEdit as GeneratedNativeTransformEdit,
   NativeTransformOptions as GeneratedNativeTransformOptions,
   NativeTransformResult as GeneratedNativeTransformResult,
+  NativeTransformSourceMap as GeneratedNativeTransformSourceMap,
   ParsedCatalogMessage as GeneratedParsedCatalogMessage,
   ParsedPoFile as GeneratedParsedPoFile,
   ParsedPoItem as GeneratedParsedPoItem,
@@ -130,6 +131,7 @@ export type NativeExtractedMessage =
 
 export type NativeTransformOptions = GeneratedNativeTransformOptions
 export type NativeTransformEdit = GeneratedNativeTransformEdit
+export type NativeTransformSourceMap = GeneratedNativeTransformSourceMap
 export type NativeTransformResult = GeneratedNativeTransformResult
 export type CatalogArtifactSourceKey = GeneratedCatalogArtifactSourceKey
 export type CatalogArtifactMissingMessage = GeneratedCatalogArtifactMissingMessage

--- a/packages/transform/package.json
+++ b/packages/transform/package.json
@@ -47,7 +47,6 @@
   "dependencies": {
     "@palamedes/core-node": "workspace:^",
     "@palamedes/runtime": "workspace:^",
-    "magic-string": "^0.30.21",
     "oxc-parser": "^0.132.0"
   },
   "devDependencies": {

--- a/packages/transform/src/transform.test.ts
+++ b/packages/transform/src/transform.test.ts
@@ -7,6 +7,7 @@ describe("transformPalamedesMacros", () => {
 
     expect(result.hasChanged).toBe(false)
     expect(result.code).toBe(code)
+    expect(result.map).toBeNull()
   })
 
   it("transforms tagged templates into compact runtime lookups", () => {
@@ -23,6 +24,13 @@ const msg = t\`Hello \${name}\`;
     expect(result.code).toContain('import { getI18n } from "@palamedes/runtime"')
     expect(result.code).not.toContain("@palamedes/core/macro")
     expect(result.compiledIds).toHaveLength(1)
+    expect(result.map).toMatchObject({
+      version: 3,
+      sources: ["test.ts"],
+      sourcesContent: [code],
+      file: "test.ts",
+    })
+    expect(result.map?.mappings).not.toBe("")
   })
 
   it("preserves member expression values in tagged templates", () => {
@@ -88,6 +96,13 @@ const y = <Trans>Hallo Welt</Trans>;
     expect(result.code).toContain('import { Trans } from "@palamedes/react"')
     expect(result.code).toContain('const x = "äöü";')
     expect(result.code).toContain('message="Hallo Welt"')
+    expect(result.map).toMatchObject({
+      version: 3,
+      sources: ["test.tsx"],
+      sourcesContent: [code],
+      file: "test.tsx",
+    })
+    expect(result.map?.mappings).not.toBe("")
   })
 
   it("transforms Solid <Trans> macros to @palamedes/solid imports", () => {

--- a/packages/transform/src/transform.ts
+++ b/packages/transform/src/transform.ts
@@ -1,119 +1,36 @@
-import MagicString from "magic-string"
-import { transformMacrosNative, type NativeTransformEdit, type NativeTransformResult } from "@palamedes/core-node"
+import { transformMacrosNative, type NativeTransformResult } from "@palamedes/core-node"
 
 import type { SourceMap, TransformOptions, TransformResult } from "./types"
 import { mightContainPalamedesMacros } from "./detect"
 
 function buildTransformOutput(
-  source: string,
   filename: string,
   nativeResult: NativeTransformResult
 ): TransformResult {
-  const magicString = new MagicString(source)
-
-  const edits = nativeResult.edits.map((edit) => normalizeNativeEditOffsets(source, edit))
-
-  for (const edit of edits.sort((a, b) => b.start - a.start || b.end - a.end)) {
-    applyEdit(magicString, edit)
-  }
-
-  if (nativeResult.prependText) {
-    magicString.prepend(nativeResult.prependText)
-  }
-
-  const code = magicString.toString()
-  if (code !== nativeResult.code) {
-    return {
-      code: nativeResult.code,
-      hasChanged: true,
-      compiledIds: nativeResult.compiledIds,
-      map: null,
-    }
-  }
-
-  const generated = magicString.generateMap({
-    source: filename,
-    file: filename,
-    includeContent: true,
-  })
-
-  const map: SourceMap = {
-    version: generated.version,
-    sources: generated.sources,
-    sourcesContent: generated.sourcesContent,
-    names: generated.names,
-    mappings: generated.mappings,
-    file: generated.file,
-  }
-
   return {
-    code,
+    code: nativeResult.code,
     hasChanged: true,
     compiledIds: nativeResult.compiledIds,
-    map,
+    map: toTransformSourceMap(nativeResult.map, filename),
   }
 }
 
-function applyEdit(magicString: MagicString, edit: NativeTransformEdit): void {
-  if (edit.start === edit.end) {
-    magicString.appendLeft(edit.start, edit.text)
-    return
+function toTransformSourceMap(
+  map: NativeTransformResult["map"],
+  filename: string
+): SourceMap | null {
+  if (!map) {
+    return null
   }
 
-  magicString.overwrite(edit.start, edit.end, edit.text)
-}
-
-function normalizeNativeEditOffsets(source: string, edit: NativeTransformEdit): NativeTransformEdit {
   return {
-    ...edit,
-    start: utf8ByteOffsetToCodeUnitOffset(source, edit.start),
-    end: utf8ByteOffsetToCodeUnitOffset(source, edit.end),
+    version: map.version,
+    sources: map.sources,
+    sourcesContent: map.sourcesContent,
+    names: map.names,
+    mappings: map.mappings,
+    file: map.file ?? filename,
   }
-}
-
-function utf8ByteOffsetToCodeUnitOffset(source: string, byteOffset: number): number {
-  if (byteOffset === 0) {
-    return 0
-  }
-
-  let bytes = 0
-
-  for (let codeUnitOffset = 0; codeUnitOffset < source.length; ) {
-    const codePoint = source.codePointAt(codeUnitOffset)
-    if (codePoint === undefined) {
-      break
-    }
-
-    codeUnitOffset += codePoint > 0xffff ? 2 : 1
-    bytes += utf8ByteLength(codePoint)
-
-    if (bytes === byteOffset) {
-      return codeUnitOffset
-    }
-
-    if (bytes > byteOffset) {
-      break
-    }
-  }
-
-  if (bytes === byteOffset) {
-    return source.length
-  }
-
-  throw new Error(`Native transform returned invalid UTF-8 byte offset: ${byteOffset}`)
-}
-
-function utf8ByteLength(codePoint: number): number {
-  if (codePoint <= 0x7f) {
-    return 1
-  }
-  if (codePoint <= 0x7ff) {
-    return 2
-  }
-  if (codePoint <= 0xffff) {
-    return 3
-  }
-  return 4
 }
 
 export function transformPalamedesMacros(
@@ -130,5 +47,5 @@ export function transformPalamedesMacros(
     return { code, hasChanged: false, compiledIds: [], map: null }
   }
 
-  return buildTransformOutput(code, filename, result)
+  return buildTransformOutput(filename, result)
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -839,9 +839,6 @@ importers:
       '@palamedes/runtime':
         specifier: workspace:^
         version: link:../runtime
-      magic-string:
-        specifier: ^0.30.21
-        version: 0.30.21
       oxc-parser:
         specifier: ^0.132.0
         version: 0.132.0


### PR DESCRIPTION
## Summary

- generate transform source maps in the Rust core with `string_wizard`
- expose the optional native transform map through the N-API and core-node types
- simplify `@palamedes/transform` so it returns native code/maps directly and no longer depends on JS `magic-string`
- update Rust direct dependencies, including OXC `0.132.0` and N-API `3.9.0`, and raise workspace Rust MSRV to `1.93`
- document the architectural decision in ADR-014

Fixes #86.

## Validation

- `cargo test --workspace`
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets --all-features`
- `pnpm install --lockfile-only --frozen-lockfile`
- `pnpm --filter @palamedes/transform test`
- `pnpm check:native-types`
- `pnpm --filter @palamedes/transform exec tsc --noEmit -p tsconfig.json`
- `git diff --check`
- original #86 repro through built `@palamedes/transform` package export

## Local benchmark sample

`node ./scripts/benchmark-proof.mjs --warmup 1 --runs 3` on Node `v24.14.1`, macOS `darwin/arm64`:

- transform: median `0.50 ms` (`0.49`, `0.50`, `0.51`)
- extract: median `0.31 ms`
- catalog update: median `0.35 ms`
- catalog artifact compile: median `3.64 ms`

These are machine-local smoke numbers, not updated published benchmark baselines.