### PR TITLE
[codex] add catalog merge driver support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ diagnostics, and runtime artifact compilation.
 - Familiar macro-style authoring without carrying older compatibility paths forward
 - Fast transforms, extraction, catalog updates, audits, and compile steps
 - Source-string-first catalogs that translators can inspect and teams can trust
+- Semantic catalog merging for Git merge-driver workflows without gettext
 - A local foundation for future managed translation workflows without giving up repo ownership
 
 ## What Makes It Feel Better
@@ -162,6 +163,14 @@ setClientI18n(i18n)
 
 ```bash
 pnpm exec pmds extract
+```
+
+For semantic catalog conflict handling, Palamedes can also act as a Git merge
+driver:
+
+```bash
+git config merge.palamedes-catalog.driver \
+  'pmds catalog merge --format=po --strategy=use-first --output %A %A %B'
 ```
 
 For the full copy-paste path, including `.po` loading and the first translated

--- a/crates/palamedes-node/src/catalog.rs
+++ b/crates/palamedes-node/src/catalog.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::path::PathBuf;
 
 use napi::bindgen_prelude::{Either, Result};
 use napi_derive::napi;
@@ -129,6 +130,35 @@ pub struct CatalogCombineStats {
 #[napi(object)]
 pub struct CatalogCombineResult {
     pub content: String,
+    pub stats: CatalogCombineStats,
+    pub diagnostics: Vec<CatalogDiagnostic>,
+}
+
+#[napi(string_enum)]
+pub enum CatalogMergeFormat {
+    Po,
+    Json,
+}
+
+#[napi(string_enum)]
+pub enum CatalogMergeStrategy {
+    UseFirst,
+}
+
+#[napi(object)]
+pub struct CatalogMergeRequest {
+    pub input_paths: Vec<String>,
+    pub output_path: String,
+    pub format: Option<CatalogMergeFormat>,
+    pub source_locale: String,
+    pub locale: Option<String>,
+    pub strategy: Option<CatalogMergeStrategy>,
+}
+
+#[napi(object)]
+pub struct CatalogMergeResult {
+    pub output_path: String,
+    pub format: CatalogMergeFormat,
     pub stats: CatalogCombineStats,
     pub diagnostics: Vec<CatalogDiagnostic>,
 }
@@ -534,6 +564,65 @@ impl TryFrom<palamedes::CatalogCombineResult> for CatalogCombineResult {
     fn try_from(value: palamedes::CatalogCombineResult) -> Result<Self> {
         Ok(Self {
             content: value.content,
+            stats: value.stats.try_into()?,
+            diagnostics: value
+                .diagnostics
+                .into_iter()
+                .map(CatalogDiagnostic::from)
+                .collect(),
+        })
+    }
+}
+
+impl From<CatalogMergeFormat> for palamedes::CatalogMergeFormat {
+    fn from(value: CatalogMergeFormat) -> Self {
+        match value {
+            CatalogMergeFormat::Po => Self::Po,
+            CatalogMergeFormat::Json => Self::Json,
+        }
+    }
+}
+
+impl From<palamedes::CatalogMergeFormat> for CatalogMergeFormat {
+    fn from(value: palamedes::CatalogMergeFormat) -> Self {
+        match value {
+            palamedes::CatalogMergeFormat::Po => Self::Po,
+            palamedes::CatalogMergeFormat::Json => Self::Json,
+        }
+    }
+}
+
+impl From<CatalogMergeStrategy> for palamedes::CatalogMergeStrategy {
+    fn from(value: CatalogMergeStrategy) -> Self {
+        match value {
+            CatalogMergeStrategy::UseFirst => Self::UseFirst,
+        }
+    }
+}
+
+impl From<CatalogMergeRequest> for palamedes::CatalogMergeRequest {
+    fn from(value: CatalogMergeRequest) -> Self {
+        Self {
+            input_paths: value.input_paths.into_iter().map(PathBuf::from).collect(),
+            output_path: PathBuf::from(value.output_path),
+            format: value.format.map(palamedes::CatalogMergeFormat::from),
+            source_locale: value.source_locale,
+            locale: value.locale,
+            strategy: value.strategy.map_or(
+                palamedes::CatalogMergeStrategy::UseFirst,
+                palamedes::CatalogMergeStrategy::from,
+            ),
+        }
+    }
+}
+
+impl TryFrom<palamedes::CatalogMergeResult> for CatalogMergeResult {
+    type Error = napi::Error;
+
+    fn try_from(value: palamedes::CatalogMergeResult) -> Result<Self> {
+        Ok(Self {
+            output_path: value.output_path.display().to_string(),
+            format: value.format.into(),
             stats: value.stats.try_into()?,
             diagnostics: value
                 .diagnostics
@@ -1081,6 +1170,20 @@ pub fn combine_catalogs(request: CatalogCombineRequest) -> Result<CatalogCombine
     palamedes::combine_catalogs(request)
         .map_err(to_napi_error)
         .and_then(CatalogCombineResult::try_from)
+}
+
+#[napi]
+#[allow(clippy::needless_pass_by_value)]
+/// Merges exactly two catalog files and replaces the output after a successful merge.
+///
+/// # Errors
+///
+/// Returns an error when inputs are invalid, cannot be parsed, contain rejected
+/// conflicts, or the output cannot be replaced.
+pub fn merge_catalog_files(request: CatalogMergeRequest) -> Result<CatalogMergeResult> {
+    palamedes::merge_catalog_files(request.into())
+        .map_err(to_napi_error)
+        .and_then(CatalogMergeResult::try_from)
 }
 
 #[napi]

--- a/crates/palamedes/src/catalog_combine.rs
+++ b/crates/palamedes/src/catalog_combine.rs
@@ -1,6 +1,10 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
 use ferrocat::{
     combine_catalogs as ferrocat_combine_catalogs, CatalogCombineInput as FerrocatCombineInput,
-    CombineCatalogOptions, OrderBy, PluralEncoding,
+    CatalogStorageFormat, CombineCatalogOptions, OrderBy, PluralEncoding,
 };
 use serde::{Deserialize, Serialize};
 
@@ -91,6 +95,56 @@ pub struct CatalogCombineStats {
     pub total: usize,
 }
 
+/// File storage format used by catalog merge operations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum CatalogMergeFormat {
+    /// Classic gettext PO catalog files.
+    Po,
+    /// Ferrocat source-first NDJSON catalog files, exposed as JSON for Palamedes V1.
+    Json,
+}
+
+/// Strategy used by catalog merge operations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum CatalogMergeStrategy {
+    /// Keep the first input's translator-facing content for duplicate identities.
+    UseFirst,
+}
+
+/// Request for merging exactly two catalog files and writing the result.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CatalogMergeRequest {
+    /// Input catalog file paths in precedence order.
+    pub input_paths: Vec<PathBuf>,
+    /// Output catalog file path to replace after a successful merge.
+    pub output_path: PathBuf,
+    /// Optional explicit format. When absent, the format is inferred from file paths.
+    pub format: Option<CatalogMergeFormat>,
+    /// Source locale used for source-side semantics and validation.
+    pub source_locale: String,
+    /// Locale of the merged catalog. When `None`, Ferrocat uses the first input locale if present.
+    pub locale: Option<String>,
+    /// Merge strategy. V1 supports only `useFirst`.
+    pub strategy: CatalogMergeStrategy,
+}
+
+/// Result returned by catalog merge operations.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CatalogMergeResult {
+    /// Output path that was replaced.
+    pub output_path: PathBuf,
+    /// Format used for the merge.
+    pub format: CatalogMergeFormat,
+    /// Summary counters for the operation.
+    pub stats: CatalogCombineStats,
+    /// Non-fatal diagnostics collected during processing.
+    pub diagnostics: Vec<CatalogDiagnostic>,
+}
+
 /// Combines multiple catalogs into one deterministic catalog.
 ///
 /// # Errors
@@ -98,6 +152,13 @@ pub struct CatalogCombineStats {
 /// Returns an error when inputs are invalid, cannot be parsed, or contain
 /// rejected translation conflicts.
 pub fn combine_catalogs(request: CatalogCombineRequest) -> PalamedesResult<CatalogCombineResult> {
+    combine_catalog_contents(request, CatalogStorageFormat::Po)
+}
+
+fn combine_catalog_contents(
+    request: CatalogCombineRequest,
+    storage_format: CatalogStorageFormat,
+) -> PalamedesResult<CatalogCombineResult> {
     let inputs = request
         .inputs
         .iter()
@@ -111,6 +172,7 @@ pub fn combine_catalogs(request: CatalogCombineRequest) -> PalamedesResult<Catal
         inputs: &inputs,
         locale: request.locale.as_deref(),
         source_locale: &request.source_locale,
+        storage_format,
         plural_encoding: PluralEncoding::Icu,
         conflict_strategy: request.conflict_strategy.into(),
         selection: request.selection.into(),
@@ -130,6 +192,72 @@ pub fn combine_catalogs(request: CatalogCombineRequest) -> PalamedesResult<Catal
             .into_iter()
             .map(CatalogDiagnostic::from)
             .collect(),
+    })
+}
+
+/// Merges exactly two catalog files and atomically replaces the requested output path.
+///
+/// # Errors
+///
+/// Returns an error when paths are invalid, inputs cannot be parsed, formats
+/// cannot be inferred, or the output file cannot be replaced.
+pub fn merge_catalog_files(request: CatalogMergeRequest) -> PalamedesResult<CatalogMergeResult> {
+    if request.input_paths.len() != 2 {
+        return Err(PalamedesError::InvalidCatalogMergeInputCount {
+            count: request.input_paths.len(),
+        });
+    }
+
+    let format = match request.format {
+        Some(format) => format,
+        None => infer_merge_format(&request.input_paths, &request.output_path)?,
+    };
+    let inputs = request
+        .input_paths
+        .iter()
+        .map(|path| {
+            fs::read_to_string(path).map_err(|source| PalamedesError::ReadFile {
+                path: path.clone(),
+                source,
+            })
+        })
+        .collect::<PalamedesResult<Vec<_>>>()?;
+
+    let combine = combine_catalog_contents(
+        CatalogCombineRequest {
+            inputs: inputs
+                .into_iter()
+                .zip(request.input_paths.iter())
+                .map(|(content, path)| CatalogCombineInput {
+                    content,
+                    label: Some(path.display().to_string()),
+                })
+                .collect(),
+            source_locale: request.source_locale,
+            locale: request.locale,
+            conflict_strategy: match request.strategy {
+                CatalogMergeStrategy::UseFirst => CatalogCombineConflictStrategy::UseFirst,
+            },
+            selection: CatalogCombineSelection::All,
+            include_obsolete: false,
+        },
+        format.into(),
+    )?;
+
+    let temp_path = temp_output_path(&request.output_path);
+    if let Err(source) = fs::write(&temp_path, &combine.content) {
+        return Err(PalamedesError::WriteFile {
+            path: temp_path,
+            source,
+        });
+    }
+    replace_output(&temp_path, &request.output_path)?;
+
+    Ok(CatalogMergeResult {
+        output_path: request.output_path,
+        format,
+        stats: combine.stats,
+        diagnostics: combine.diagnostics,
     })
 }
 
@@ -154,6 +282,15 @@ impl From<CatalogCombineSelection> for ferrocat::CatalogCombineSelection {
     }
 }
 
+impl From<CatalogMergeFormat> for CatalogStorageFormat {
+    fn from(value: CatalogMergeFormat) -> Self {
+        match value {
+            CatalogMergeFormat::Po => Self::Po,
+            CatalogMergeFormat::Json => Self::Ndjson,
+        }
+    }
+}
+
 impl From<ferrocat::CatalogCombineStats> for CatalogCombineStats {
     fn from(value: ferrocat::CatalogCombineStats) -> Self {
         Self {
@@ -167,11 +304,97 @@ impl From<ferrocat::CatalogCombineStats> for CatalogCombineStats {
     }
 }
 
+fn infer_merge_format(
+    input_paths: &[PathBuf],
+    output_path: &Path,
+) -> PalamedesResult<CatalogMergeFormat> {
+    let mut paths = input_paths.to_vec();
+    paths.push(output_path.to_owned());
+    let mut formats = paths
+        .iter()
+        .map(|path| infer_format_from_path(path))
+        .collect::<PalamedesResult<Vec<_>>>()?;
+    let first = formats
+        .pop()
+        .expect("format list contains output path plus at least one input");
+    if formats.into_iter().all(|format| format == first) {
+        Ok(first)
+    } else {
+        Err(PalamedesError::MixedCatalogMergeFormats)
+    }
+}
+
+fn infer_format_from_path(path: &Path) -> PalamedesResult<CatalogMergeFormat> {
+    let name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    if name.ends_with(".po") {
+        return Ok(CatalogMergeFormat::Po);
+    }
+    if name.ends_with(".json") || name.ends_with(".ndjson") || name.ends_with(".fcat.ndjson") {
+        return Ok(CatalogMergeFormat::Json);
+    }
+    Err(PalamedesError::CouldNotInferCatalogMergeFormat {
+        path: path.to_owned(),
+    })
+}
+
+fn temp_output_path(output_path: &Path) -> PathBuf {
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |duration| duration.as_nanos());
+    let filename = output_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("catalog");
+    output_path.with_file_name(format!(".{filename}.{}.{}.tmp", std::process::id(), stamp))
+}
+
+fn replace_output(temp_path: &Path, output_path: &Path) -> PalamedesResult<()> {
+    match fs::rename(temp_path, output_path) {
+        Ok(()) => Ok(()),
+        Err(source) => {
+            if output_path.exists() {
+                fs::remove_file(output_path).map_err(|source| PalamedesError::ReplaceFile {
+                    path: output_path.to_owned(),
+                    temp_path: {
+                        let _ = fs::remove_file(temp_path);
+                        temp_path.to_owned()
+                    },
+                    source,
+                })?;
+                fs::rename(temp_path, output_path).map_err(|source| {
+                    let _ = fs::remove_file(temp_path);
+                    PalamedesError::ReplaceFile {
+                        path: output_path.to_owned(),
+                        temp_path: temp_path.to_owned(),
+                        source,
+                    }
+                })
+            } else {
+                let _ = fs::remove_file(temp_path);
+                Err(PalamedesError::ReplaceFile {
+                    path: output_path.to_owned(),
+                    temp_path: temp_path.to_owned(),
+                    source,
+                })
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use std::fs;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
     use super::{
-        combine_catalogs, CatalogCombineConflictStrategy, CatalogCombineInput,
-        CatalogCombineRequest, CatalogCombineSelection,
+        combine_catalogs, merge_catalog_files, CatalogCombineConflictStrategy, CatalogCombineInput,
+        CatalogCombineRequest, CatalogCombineSelection, CatalogMergeFormat, CatalogMergeRequest,
+        CatalogMergeStrategy,
     };
 
     #[test]
@@ -227,5 +450,210 @@ mod tests {
 
         assert!(result.content.contains("Only first"));
         assert!(!result.content.contains("Shared"));
+    }
+
+    #[test]
+    fn merges_po_files_with_use_first_and_preserves_first_header() {
+        let dir = temp_dir("po-use-first");
+        let ours = dir.join("ours.po");
+        let theirs = dir.join("theirs.po");
+        fs::write(
+            &ours,
+            concat!(
+                "msgid \"\"\n",
+                "msgstr \"\"\n",
+                "\"Language: de\\n\"\n\n",
+                "msgid \"Hello\"\n",
+                "msgstr \"Hallo\"\n",
+            ),
+        )
+        .expect("write ours");
+        fs::write(
+            &theirs,
+            concat!(
+                "msgid \"\"\n",
+                "msgstr \"\"\n",
+                "\"Language: fr\\n\"\n\n",
+                "msgid \"Hello\"\n",
+                "msgstr \"Bonjour\"\n\n",
+                "msgid \"New\"\n",
+                "msgstr \"Neu\"\n",
+            ),
+        )
+        .expect("write theirs");
+
+        let result = merge_catalog_files(CatalogMergeRequest {
+            input_paths: vec![ours.clone(), theirs],
+            output_path: ours.clone(),
+            format: None,
+            source_locale: "en".to_owned(),
+            locale: Some("de".to_owned()),
+            strategy: CatalogMergeStrategy::UseFirst,
+        })
+        .expect("merge");
+
+        assert_eq!(result.format, CatalogMergeFormat::Po);
+        let parsed = ferrocat::parse_po(&fs::read_to_string(&ours).expect("read output"))
+            .expect("parse output");
+        assert_eq!(
+            parsed
+                .headers
+                .iter()
+                .find(|header| header.key == "Language")
+                .map(|header| header.value.as_str()),
+            Some("de")
+        );
+        let hello = parsed
+            .items
+            .iter()
+            .find(|item| item.msgid == "Hello")
+            .expect("hello");
+        assert_eq!(hello.msgstr[0], "Hallo");
+        assert!(parsed.items.iter().any(|item| item.msgid == "New"));
+    }
+
+    #[test]
+    fn merges_po_context_identities_and_skips_second_obsolete_entries() {
+        let dir = temp_dir("po-contexts");
+        let ours = dir.join("ours.po");
+        let theirs = dir.join("theirs.po");
+        let output = dir.join("merged.po");
+        fs::write(
+            &ours,
+            concat!(
+                "msgid \"Open\"\n",
+                "msgstr \"Oeffnen\"\n\n",
+                "msgctxt \"\"\n",
+                "msgid \"Open\"\n",
+                "msgstr \"Leer\"\n",
+            ),
+        )
+        .expect("write ours");
+        fs::write(
+            &theirs,
+            concat!(
+                "msgctxt \"menu\"\n",
+                "msgid \"Open\"\n",
+                "msgstr \"Menue\"\n\n",
+                "#~ msgid \"Old\"\n",
+                "#~ msgstr \"Alt\"\n",
+            ),
+        )
+        .expect("write theirs");
+
+        merge_catalog_files(CatalogMergeRequest {
+            input_paths: vec![ours, theirs],
+            output_path: output.clone(),
+            format: None,
+            source_locale: "en".to_owned(),
+            locale: Some("de".to_owned()),
+            strategy: CatalogMergeStrategy::UseFirst,
+        })
+        .expect("merge");
+
+        let parsed = ferrocat::parse_po(&fs::read_to_string(output).expect("read output"))
+            .expect("parse output");
+        assert!(parsed
+            .items
+            .iter()
+            .any(|item| item.msgid == "Open" && item.msgctxt.is_none()));
+        assert!(parsed
+            .items
+            .iter()
+            .any(|item| item.msgid == "Open" && item.msgctxt.as_deref() == Some("")));
+        assert!(parsed
+            .items
+            .iter()
+            .any(|item| item.msgid == "Open" && item.msgctxt.as_deref() == Some("menu")));
+        assert!(!parsed.items.iter().any(|item| item.msgid == "Old"));
+    }
+
+    #[test]
+    fn merges_ndjson_files_when_public_format_is_json() {
+        let dir = temp_dir("ndjson");
+        let ours = dir.join("ours.json");
+        let theirs = dir.join("theirs.json");
+        let output = dir.join("merged.json");
+        fs::write(
+            &ours,
+            concat!(
+                "---\n",
+                "format: ferrocat.ndjson.v1\n",
+                "source_locale: en\n",
+                "locale: de\n",
+                "---\n",
+                "{\"id\":\"Hello\",\"str\":\"Hallo\"}\n",
+            ),
+        )
+        .expect("write ours");
+        fs::write(
+            &theirs,
+            concat!(
+                "---\n",
+                "format: ferrocat.ndjson.v1\n",
+                "source_locale: en\n",
+                "locale: de\n",
+                "---\n",
+                "{\"id\":\"Hello\",\"str\":\"Servus\"}\n",
+                "{\"id\":\"New\",\"str\":\"Neu\",\"ctx\":\"nav\"}\n",
+            ),
+        )
+        .expect("write theirs");
+
+        let result = merge_catalog_files(CatalogMergeRequest {
+            input_paths: vec![ours, theirs],
+            output_path: output.clone(),
+            format: Some(CatalogMergeFormat::Json),
+            source_locale: "en".to_owned(),
+            locale: Some("de".to_owned()),
+            strategy: CatalogMergeStrategy::UseFirst,
+        })
+        .expect("merge");
+
+        assert_eq!(result.format, CatalogMergeFormat::Json);
+        let merged = fs::read_to_string(output).expect("read output");
+        assert!(merged.contains("format: ferrocat.ndjson.v1"));
+        assert!(merged.contains("\"id\":\"Hello\",\"str\":\"Hallo\""));
+        assert!(merged.contains("\"id\":\"New\",\"str\":\"Neu\",\"ctx\":\"nav\""));
+        assert!(!merged.contains("Servus"));
+    }
+
+    #[test]
+    fn invalid_inferred_format_leaves_output_unchanged() {
+        let dir = temp_dir("invalid-format");
+        let ours = dir.join("ours.txt");
+        let theirs = dir.join("theirs.txt");
+        let output = dir.join("merged.txt");
+        fs::write(&ours, "msgid \"Hello\"\nmsgstr \"Hallo\"\n").expect("write ours");
+        fs::write(&theirs, "msgid \"New\"\nmsgstr \"Neu\"\n").expect("write theirs");
+        fs::write(&output, "unchanged").expect("write output");
+
+        let error = merge_catalog_files(CatalogMergeRequest {
+            input_paths: vec![ours, theirs],
+            output_path: output.clone(),
+            format: None,
+            source_locale: "en".to_owned(),
+            locale: Some("de".to_owned()),
+            strategy: CatalogMergeStrategy::UseFirst,
+        })
+        .expect_err("unsupported format");
+
+        assert!(error
+            .to_string()
+            .contains("Could not infer catalog merge format"));
+        assert_eq!(
+            fs::read_to_string(output).expect("read output"),
+            "unchanged"
+        );
+    }
+
+    fn temp_dir(name: &str) -> PathBuf {
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_or(0, |duration| duration.as_nanos());
+        let dir =
+            std::env::temp_dir().join(format!("palamedes-{name}-{}-{stamp}", std::process::id()));
+        fs::create_dir_all(&dir).expect("create temp dir");
+        dir
     }
 }

--- a/crates/palamedes/src/error.rs
+++ b/crates/palamedes/src/error.rs
@@ -26,6 +26,43 @@ pub enum PalamedesError {
         /// Underlying filesystem error.
         source: std::io::Error,
     },
+    /// Writing a file to disk failed.
+    #[error("Failed to write {path}: {source}")]
+    WriteFile {
+        /// Path that was written.
+        path: PathBuf,
+        #[source]
+        /// Underlying filesystem error.
+        source: std::io::Error,
+    },
+    /// Replacing a file on disk failed.
+    #[error("Failed to replace {path} with {temp_path}: {source}")]
+    ReplaceFile {
+        /// Final path that should have been replaced.
+        path: PathBuf,
+        /// Temporary path that should have been moved into place.
+        temp_path: PathBuf,
+        #[source]
+        /// Underlying filesystem error.
+        source: std::io::Error,
+    },
+    /// A catalog merge request must include exactly two inputs.
+    #[error("Catalog merge requires exactly two input files, received {count}.")]
+    InvalidCatalogMergeInputCount {
+        /// Number of input files provided.
+        count: usize,
+    },
+    /// A catalog merge format could not be inferred from a path.
+    #[error("Could not infer catalog merge format from {path}. Expected .po, .json, .ndjson, or .fcat.ndjson.")]
+    CouldNotInferCatalogMergeFormat {
+        /// Path whose extension was inspected.
+        path: PathBuf,
+    },
+    /// A catalog merge request inferred multiple formats.
+    #[error(
+        "Catalog merge inputs and output must use the same format unless --format is provided."
+    )]
+    MixedCatalogMergeFormats,
     /// A configured catalog glob/path could not be compiled to a matcher.
     #[error("Invalid catalog path pattern {pattern}: {source}")]
     InvalidCatalogPathPattern {

--- a/crates/palamedes/src/lib.rs
+++ b/crates/palamedes/src/lib.rs
@@ -42,8 +42,9 @@ pub use catalog_audit::{
     CatalogAuditResult, CatalogAuditSummary,
 };
 pub use catalog_combine::{
-    combine_catalogs, CatalogCombineConflictStrategy, CatalogCombineInput, CatalogCombineRequest,
-    CatalogCombineResult, CatalogCombineSelection, CatalogCombineStats,
+    combine_catalogs, merge_catalog_files, CatalogCombineConflictStrategy, CatalogCombineInput,
+    CatalogCombineRequest, CatalogCombineResult, CatalogCombineSelection, CatalogCombineStats,
+    CatalogMergeFormat, CatalogMergeRequest, CatalogMergeResult, CatalogMergeStrategy,
 };
 pub use catalog_update::{
     parse_catalog, update_catalog_file, CatalogParseRequest, CatalogParseResult,

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -19,6 +19,7 @@ Use `@palamedes/cli` when you want:
 - structured catalog audits in CI
 - watch mode during development
 - a clean way to update `.po` catalogs in CI
+- a semantic catalog merge command for Git merge drivers
 
 If you are building your own extraction workflow inside your i18n config or custom tooling, look at [`@palamedes/extractor`](https://www.npmjs.com/package/@palamedes/extractor) instead.
 
@@ -45,11 +46,45 @@ pnpm exec pmds extract --verbose
 pnpm exec pmds audit
 pnpm exec pmds audit --json
 pnpm exec pmds audit --fail-on warning
+pnpm exec pmds catalog merge --output src/locales/de.po src/locales/de.po other.po
 ```
 
 `pmds audit` reports missing translations, extra catalog entries, fuzzy or
 obsolete messages, and ICU compatibility issues through the same `ferrocat`
 catalog engine that powers Palamedes builds.
+
+### Catalog Merge
+
+`pmds catalog merge` merges exactly two catalog files with V1 `use-first`
+semantics. When both inputs contain the same semantic identity, the first input
+wins for translator-facing content; messages that only exist in the second
+input are added.
+
+```bash
+pnpm exec pmds catalog merge --format=po --strategy=use-first --output %A %A %B
+```
+
+`--format` can be omitted when all input and output extensions are supported
+and match. `.po` maps to `po`; `.json`, `.ndjson`, and `.fcat.ndjson` map to
+`json`. The public `json` format is Ferrocat's source-first
+`ferrocat.ndjson.v1` storage format.
+
+For Git merge-driver usage:
+
+```gitattributes
+*.po merge=palamedes-catalog
+*.fcat.ndjson merge=palamedes-catalog-json
+```
+
+```bash
+git config merge.palamedes-catalog.driver \
+  'pmds catalog merge --format=po --strategy=use-first --output %A %A %B'
+git config merge.palamedes-catalog-json.driver \
+  'pmds catalog merge --format=json --strategy=use-first --output %A %A %B'
+```
+
+`--source-locale` is optional. The command uses an explicit value first, then
+`palamedes.config.*` when available, then `en`.
 
 ## Configuration
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -3,6 +3,7 @@
 import { program } from "commander"
 import chalk from "chalk"
 import { audit } from "./commands/audit"
+import { mergeCatalog } from "./commands/catalog"
 import { extract } from "./commands/extract"
 
 const VERSION = "0.0.1"
@@ -38,6 +39,29 @@ program
   .action(async (options) => {
     try {
       await audit(options)
+    } catch (error) {
+      console.error(chalk.red("Error:"), error instanceof Error ? error.message : error)
+      process.exit(1)
+    }
+  })
+
+const catalog = program
+  .command("catalog")
+  .description("Work with Palamedes catalog files")
+
+catalog
+  .command("merge")
+  .description("Merge two catalog files with semantic use-first behavior")
+  .argument("<inputs...>", "Input catalog files in precedence order")
+  .requiredOption("--output <path>", "Output catalog path")
+  .option("-c, --config <path>", "Path to palamedes.config.ts")
+  .option("--format <format>", "Catalog format: po or json")
+  .option("--strategy <strategy>", "Merge strategy", "use-first")
+  .option("--source-locale <locale>", "Source locale for catalog semantics")
+  .option("--locale <locale>", "Locale of the merged catalog")
+  .action(async (inputs: string[], options) => {
+    try {
+      await mergeCatalog(inputs, options)
     } catch (error) {
       console.error(chalk.red("Error:"), error instanceof Error ? error.message : error)
       process.exit(1)

--- a/packages/cli/src/commands/catalog.test.ts
+++ b/packages/cli/src/commands/catalog.test.ts
@@ -1,0 +1,230 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { mergeCatalog } from "./catalog"
+
+vi.mock("@palamedes/core-node", async () => {
+  const { readFileSync, writeFileSync } = await import("node:fs")
+
+  function inferFormat(inputPaths: string[], outputPath: string): "po" | "json" {
+    const formats = [...inputPaths, outputPath].map((filePath) => {
+      if (filePath.endsWith(".po")) {
+        return "po"
+      }
+      if (
+        filePath.endsWith(".json") ||
+        filePath.endsWith(".ndjson") ||
+        filePath.endsWith(".fcat.ndjson")
+      ) {
+        return "json"
+      }
+      throw new Error("Could not infer catalog merge format")
+    })
+    if (!formats.every((format) => format === formats[0])) {
+      throw new Error(
+        "Catalog merge inputs and output must use the same format unless --format is provided."
+      )
+    }
+    return formats[0]
+  }
+
+  function mergePo(first: string, second: string): string {
+    const known = new Set(
+      [...first.matchAll(/msgid "([^"]*)"/g)].map((match) => match[1])
+    )
+    const additions = splitEntries(second).filter((entry) => {
+      const id = entry.match(/msgid "([^"]*)"/)?.[1]
+      return id && id !== "" && !known.has(id)
+    })
+    return `${first.trimEnd()}\n\n${additions.join("\n\n")}\n`
+  }
+
+  function mergeNdjson(first: string, second: string): string {
+    const known = new Set(
+      [...first.matchAll(/"id":"([^"]*)"/g)].map((match) => match[1])
+    )
+    const additions = second
+      .split("\n")
+      .filter((line) => line.startsWith("{"))
+      .filter((line) => {
+        const id = line.match(/"id":"([^"]*)"/)?.[1]
+        return id && !known.has(id)
+      })
+    return `${first.trimEnd()}\n${additions.join("\n")}\n`
+  }
+
+  function splitEntries(content: string): string[] {
+    return content
+      .split(/\n\s*\n/)
+      .map((entry) => entry.trim())
+      .filter((entry) => entry.length > 0)
+  }
+
+  function countMessages(content: string, format: "po" | "json"): number {
+    return format === "po"
+      ? [...content.matchAll(/\n?msgid "([^"]+)"/g)].length
+      : [...content.matchAll(/"id":"([^"]*)"/g)].length
+  }
+
+  return {
+    mergeCatalogFiles: (request: {
+      inputPaths: string[]
+      outputPath: string
+      format?: "po" | "json"
+    }) => {
+      const format = request.format ?? inferFormat(request.inputPaths, request.outputPath)
+      const [firstPath, secondPath] = request.inputPaths
+      const first = readFileSync(firstPath, "utf8")
+      const second = readFileSync(secondPath, "utf8")
+      const content = format === "po" ? mergePo(first, second) : mergeNdjson(first, second)
+      writeFileSync(request.outputPath, content)
+      return {
+        outputPath: request.outputPath,
+        format,
+        stats: {
+          inputs: 2,
+          definitions: 0,
+          selected: 0,
+          skipped: 0,
+          conflictsResolved: 0,
+          total: countMessages(content, format),
+        },
+        diagnostics: [],
+      }
+    },
+  }
+})
+
+const tempDirs: string[] = []
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs.splice(0).map(async (dir) => {
+      await rm(dir, { recursive: true, force: true })
+    })
+  )
+})
+
+describe("catalog merge", () => {
+  it("merges PO catalogs with inferred format and git-driver-style output", async () => {
+    const dir = await tempDir("po-inferred")
+    const ours = path.join(dir, "messages.po")
+    const theirs = path.join(dir, "theirs.po")
+    await writeFile(
+      ours,
+      `msgid ""
+msgstr ""
+"Language: de\\n"
+
+msgid "Hello"
+msgstr "Hallo"
+`
+    )
+    await writeFile(
+      theirs,
+      `msgid "Hello"
+msgstr "Servus"
+
+msgid "New"
+msgstr "Neu"
+`
+    )
+
+    const result = await mergeCatalog([ours, theirs], { output: ours })
+
+    expect(result.format).toBe("po")
+    expect(result.stats.total).toBe(2)
+    const merged = await readFile(ours, "utf8")
+    expect(merged).toContain('"Language: de\\n"')
+    expect(merged).toContain('msgid "Hello"\nmsgstr "Hallo"')
+    expect(merged).toContain('msgid "New"\nmsgstr "Neu"')
+    expect(merged).not.toContain("Servus")
+  })
+
+  it("merges PO catalogs with explicit format", async () => {
+    const dir = await tempDir("po-explicit")
+    const ours = path.join(dir, "ours.catalog")
+    const theirs = path.join(dir, "theirs.catalog")
+    const output = path.join(dir, "merged.catalog")
+    await writeFile(ours, 'msgid "Hello"\nmsgstr "Hallo"\n')
+    await writeFile(theirs, 'msgid "New"\nmsgstr "Neu"\n')
+
+    const result = await mergeCatalog([ours, theirs], {
+      output,
+      format: "po",
+      sourceLocale: "en",
+    })
+
+    expect(result.format).toBe("po")
+    const merged = await readFile(output, "utf8")
+    expect(merged).toContain('msgid "Hello"')
+    expect(merged).toContain('msgid "New"')
+  })
+
+  it("merges ferrocat ndjson catalogs through public json format", async () => {
+    const dir = await tempDir("json")
+    const ours = path.join(dir, "ours.json")
+    const theirs = path.join(dir, "theirs.json")
+    const output = path.join(dir, "merged.json")
+    await writeFile(
+      ours,
+      `---
+format: ferrocat.ndjson.v1
+source_locale: en
+locale: de
+---
+{"id":"Hello","str":"Hallo"}
+`
+    )
+    await writeFile(
+      theirs,
+      `---
+format: ferrocat.ndjson.v1
+source_locale: en
+locale: de
+---
+{"id":"Hello","str":"Servus"}
+{"id":"New","str":"Neu","ctx":"nav"}
+`
+    )
+
+    const result = await mergeCatalog([ours, theirs], {
+      output,
+      format: "json",
+      sourceLocale: "en",
+    })
+
+    expect(result.format).toBe("json")
+    const merged = await readFile(output, "utf8")
+    expect(merged).toContain("format: ferrocat.ndjson.v1")
+    expect(merged).toContain('"id":"Hello","str":"Hallo"')
+    expect(merged).toContain('"id":"New","str":"Neu","ctx":"nav"')
+    expect(merged).not.toContain("Servus")
+  })
+
+  it("fails mixed inferred formats without changing output", async () => {
+    const dir = await tempDir("mixed")
+    const ours = path.join(dir, "ours.po")
+    const theirs = path.join(dir, "theirs.json")
+    const output = path.join(dir, "merged.po")
+    await writeFile(ours, 'msgid "Hello"\nmsgstr "Hallo"\n')
+    await writeFile(theirs, '{"id":"Hello","str":"Hallo"}\n')
+    await writeFile(output, "unchanged")
+
+    await expect(mergeCatalog([ours, theirs], { output })).rejects.toThrow(
+      "same format"
+    )
+    await expect(readFile(output, "utf8")).resolves.toBe("unchanged")
+  })
+})
+
+async function tempDir(name: string): Promise<string> {
+  const dir = await mkdtemp(
+    path.join(os.tmpdir(), `palamedes-cli-merge-${name}-`)
+  )
+  tempDirs.push(dir)
+  return dir
+}

--- a/packages/cli/src/commands/catalog.ts
+++ b/packages/cli/src/commands/catalog.ts
@@ -1,0 +1,78 @@
+import { loadPalamedesConfig } from "@palamedes/config"
+import {
+  mergeCatalogFiles,
+  type CatalogMergeFormat,
+  type CatalogMergeResult,
+} from "@palamedes/core-node"
+
+export interface CatalogMergeOptions {
+  config?: string
+  output: string
+  format?: string
+  strategy?: string
+  sourceLocale?: string
+  locale?: string
+}
+
+export async function mergeCatalog(
+  inputPaths: string[],
+  options: CatalogMergeOptions
+): Promise<CatalogMergeResult> {
+  if (!options.output) {
+    throw new Error("Missing required --output path.")
+  }
+  if (inputPaths.length !== 2) {
+    throw new Error(
+      `Catalog merge requires exactly two input files, received ${inputPaths.length}.`
+    )
+  }
+
+  return mergeCatalogFiles({
+    inputPaths,
+    outputPath: options.output,
+    format: normalizeFormat(options.format),
+    sourceLocale: await resolveSourceLocale(options),
+    locale: options.locale,
+    strategy: normalizeStrategy(options.strategy),
+  })
+}
+
+function normalizeFormat(value: string | undefined): CatalogMergeFormat | undefined {
+  if (value === undefined) {
+    return undefined
+  }
+  if (value === "po" || value === "json") {
+    return value
+  }
+  throw new Error("Invalid --format value. Expected `po` or `json`.")
+}
+
+function normalizeStrategy(value: string | undefined): "useFirst" {
+  if (value === undefined || value === "use-first") {
+    return "useFirst"
+  }
+  throw new Error("Invalid --strategy value. Expected `use-first`.")
+}
+
+async function resolveSourceLocale(options: CatalogMergeOptions): Promise<string> {
+  if (options.sourceLocale) {
+    return options.sourceLocale
+  }
+
+  try {
+    const config = await loadPalamedesConfig({ configPath: options.config })
+    return config.sourceLocale
+  } catch (error) {
+    if (options.config || !isMissingConfigError(error)) {
+      throw error
+    }
+    return "en"
+  }
+}
+
+function isMissingConfigError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    error.message.startsWith("Could not find a Palamedes config.")
+  )
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -5,4 +5,5 @@
  */
 
 export { audit } from "./commands/audit"
+export { mergeCatalog } from "./commands/catalog"
 export { extract } from "./commands/extract"

--- a/packages/core-node/README.md
+++ b/packages/core-node/README.md
@@ -45,7 +45,12 @@ The package loads one of these platform packages behind the scenes:
 ## Example
 
 ```ts
-import { getNativeInfo, parsePo, updateCatalogFile } from "@palamedes/core-node"
+import {
+  getNativeInfo,
+  mergeCatalogFiles,
+  parsePo,
+  updateCatalogFile,
+} from "@palamedes/core-node"
 
 const info = getNativeInfo()
 const po = parsePo(`
@@ -59,6 +64,12 @@ updateCatalogFile({
   sourceLocale: "en",
   clean: false,
   messages: [{ message: "Hello {name}", extractedComments: [], origins: [] }],
+})
+mergeCatalogFiles({
+  inputPaths: ["src/locales/de.po", "incoming/de.po"],
+  outputPath: "src/locales/de.po",
+  format: "po",
+  sourceLocale: "en",
 })
 
 console.log(info.palamedesVersion)
@@ -76,6 +87,7 @@ console.log(po.headers.Language)
 - `normalizeMessageMetadata(input)`
 - `validateMessageMetadata(input)`
 - `combineCatalogs(request)`
+- `mergeCatalogFiles(request)`
 - `compileCatalogArtifact(config, resourcePath)`
 - `compileCatalogArtifactSelected(config, resourcePath, compiledIds)`
 - `extractMessagesNative(source, filename)`

--- a/packages/core-node/src/generated/palamedes-node-types.ts
+++ b/packages/core-node/src/generated/palamedes-node-types.ts
@@ -89,6 +89,22 @@ export interface CatalogCombineResult {
   stats: CatalogCombineStats;
   diagnostics: Array<CatalogDiagnostic>;
 }
+export type CatalogMergeFormat = "Po" | "Json"
+export type CatalogMergeStrategy = "UseFirst"
+export interface CatalogMergeRequest {
+  inputPaths: Array<string>;
+  outputPath: string;
+  format?: CatalogMergeFormat;
+  sourceLocale: string;
+  locale?: string;
+  strategy?: CatalogMergeStrategy;
+}
+export interface CatalogMergeResult {
+  outputPath: string;
+  format: CatalogMergeFormat;
+  stats: CatalogCombineStats;
+  diagnostics: Array<CatalogDiagnostic>;
+}
 export type CatalogDiagnosticSeverity = "Info" | "Warning" | "Error"
 export interface CatalogDiagnosticSourceKey {
   message: string;
@@ -307,6 +323,7 @@ export interface NativeBindings {
   normalizeMessageMetadata(input: MessageMetadataInput): MessageMetadata;
   validateMessageMetadata(input: MessageMetadataInput): MessageMetadataValidationReport;
   combineCatalogs(request: CatalogCombineRequest): CatalogCombineResult;
+  mergeCatalogFiles(request: CatalogMergeRequest): CatalogMergeResult;
   compileCatalogArtifact(request: CatalogArtifactRequest): CatalogArtifactResult;
   compileCatalogArtifactSelected(request: CatalogArtifactSelectedRequest): CatalogArtifactResult;
   extractMessages(source: string, filename: string): Array<NativeExtractedMessage>;

--- a/packages/core-node/src/index.ts
+++ b/packages/core-node/src/index.ts
@@ -9,6 +9,8 @@ import type {
   CatalogAuditSummary as GeneratedCatalogAuditSummary,
   CatalogCombineRequest as GeneratedCatalogCombineRequest,
   CatalogCombineResult as GeneratedCatalogCombineResult,
+  CatalogMergeRequest as GeneratedCatalogMergeRequest,
+  CatalogMergeResult as GeneratedCatalogMergeResult,
   CatalogArtifactConfig as GeneratedCatalogArtifactConfig,
   CatalogArtifactDiagnostic as GeneratedCatalogArtifactDiagnostic,
   CatalogArtifactMissingMessage as GeneratedCatalogArtifactMissingMessage,
@@ -103,6 +105,21 @@ export type CatalogCombineResult =
   Omit<GeneratedCatalogCombineResult, "diagnostics"> & {
   diagnostics: CatalogDiagnostic[]
   }
+export type CatalogMergeFormat = "po" | "json"
+export type CatalogMergeStrategy = "useFirst"
+export interface CatalogMergeRequest {
+  inputPaths: string[]
+  outputPath: string
+  format?: CatalogMergeFormat
+  sourceLocale: string
+  locale?: string
+  strategy?: CatalogMergeStrategy
+}
+export type CatalogMergeResult =
+  Omit<GeneratedCatalogMergeResult, "format" | "diagnostics"> & {
+  format: CatalogMergeFormat
+  diagnostics: CatalogDiagnostic[]
+  }
 export interface CatalogAuditOptions {
   locales?: string[]
   checks?: CatalogAuditCheckOptions
@@ -153,6 +170,7 @@ export type CatalogArtifactResult =
 type NativeBindings = GeneratedNativeBindings
 type NativeCatalogAuditRequest = GeneratedCatalogAuditRequest
 type NativeCatalogCombineRequest = GeneratedCatalogCombineRequest
+type NativeCatalogMergeRequest = GeneratedCatalogMergeRequest
 type NativeCatalogArtifactRequest = GeneratedCatalogArtifactRequest
 type NativeCatalogArtifactSelectedRequest = GeneratedCatalogArtifactSelectedRequest
 
@@ -307,6 +325,15 @@ export function combineCatalogs(request: CatalogCombineRequest): CatalogCombineR
   }
 }
 
+export function mergeCatalogFiles(request: CatalogMergeRequest): CatalogMergeResult {
+  const result = native.mergeCatalogFiles(toNativeMergeRequest(request))
+  return {
+    ...result,
+    format: fromNativeMergeFormat(result.format),
+    diagnostics: mapCatalogDiagnostics(result.diagnostics),
+  }
+}
+
 function toNativeCombineRequest(request: CatalogCombineRequest): NativeCatalogCombineRequest {
   return {
     inputs: request.inputs,
@@ -330,6 +357,48 @@ function toNativeConflictStrategy(
       return "UseLast"
     case "error":
       return "Error"
+  }
+}
+
+function toNativeMergeRequest(request: CatalogMergeRequest): NativeCatalogMergeRequest {
+  return {
+    inputPaths: request.inputPaths,
+    outputPath: request.outputPath,
+    format: request.format ? toNativeMergeFormat(request.format) : undefined,
+    sourceLocale: request.sourceLocale,
+    locale: request.locale,
+    strategy: request.strategy ? toNativeMergeStrategy(request.strategy) : undefined,
+  }
+}
+
+function toNativeMergeFormat(
+  format: CatalogMergeFormat
+): NonNullable<NativeCatalogMergeRequest["format"]> {
+  switch (format) {
+    case "po":
+      return "Po"
+    case "json":
+      return "Json"
+  }
+}
+
+function fromNativeMergeFormat(
+  format: GeneratedCatalogMergeResult["format"]
+): CatalogMergeFormat {
+  switch (format) {
+    case "Po":
+      return "po"
+    case "Json":
+      return "json"
+  }
+}
+
+function toNativeMergeStrategy(
+  strategy: CatalogMergeStrategy
+): NonNullable<NativeCatalogMergeRequest["strategy"]> {
+  switch (strategy) {
+    case "useFirst":
+      return "UseFirst"
   }
 }
 


### PR DESCRIPTION
## Summary

- add a Palamedes-native file merge API backed by Ferrocat combine semantics
- expose `mergeCatalogFiles()` through napi and `@palamedes/core-node`
- add `pmds catalog merge` for PO and JSON-as-Ferrocat-NDJSON merge-driver workflows
- document Git merge-driver setup for `.po` and `ferrocat.ndjson.v1` catalogs

Closes #12

## Notes

`--format=json` intentionally maps to Ferrocat's source-first `ferrocat.ndjson.v1` storage format for V1. The merge strategy is limited to `use-first`; true three-way `%O` merge semantics remain out of scope.

## Validation

- `cargo test --workspace`
- `pnpm --filter @palamedes/core-node check-native-types`
- `pnpm --filter @palamedes/cli test`
- `pnpm --filter @palamedes/cli build`
