### PR TITLE
[codex] speed up extract native hot path

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -54,8 +54,7 @@
     "chalk": "^5.6.2",
     "chokidar": "^5.0.0",
     "commander": "^14.0.3",
-    "glob": "^13.0.6",
-    "oxc-parser": "^0.132.0"
+    "glob": "^13.0.6"
   },
   "devDependencies": {
     "@types/node": "^25.9.0",

--- a/packages/cli/src/commands/extract.test.ts
+++ b/packages/cli/src/commands/extract.test.ts
@@ -76,6 +76,33 @@ describe("extract", () => {
     expect(findItem(enCatalog.items, "Old only")).toBeUndefined()
     expect(findItem(deCatalog.items, "Old only")).toBeUndefined()
   })
+
+  it("emits timing JSON with glob and extract buckets", async () => {
+    const fixtureDir = await copyFixture()
+    process.env.PALAMEDES_TIMING_JSON = "1"
+
+    await extract({
+      config: path.join(fixtureDir, "palamedes.config.ts"),
+    })
+
+    const timingCall = vi.mocked(console.log).mock.calls.find(
+      ([first]) => typeof first === "string" && first.startsWith("__PALAMEDES_TIMINGS__")
+    )
+    expect(timingCall).toBeDefined()
+
+    const timing = JSON.parse(
+      String(timingCall?.[0]).slice("__PALAMEDES_TIMINGS__".length)
+    )
+    expect(timing).toMatchObject({
+      engine: "ferrocat",
+      totalMessages: 7,
+      totalFiles: 2,
+    })
+    expect(timing.globMs).toEqual(expect.any(Number))
+    expect(timing.extractMs).toEqual(expect.any(Number))
+    expect(timing.writeMs).toEqual(expect.any(Number))
+    expect(timing.totalMs).toEqual(expect.any(Number))
+  })
 })
 
 async function copyFixture(): Promise<string> {

--- a/packages/cli/src/commands/extract.ts
+++ b/packages/cli/src/commands/extract.ts
@@ -11,8 +11,7 @@ import {
   type PalamedesCatalogConfig,
 } from "@palamedes/config"
 import { updateCatalogFile, type CatalogUpdateMessage } from "@palamedes/core-node"
-import { parseSync } from "oxc-parser"
-import { extractMessages } from "@palamedes/extractor"
+import { extractor } from "@palamedes/extractor"
 
 interface ExtractOptions {
   config?: string
@@ -32,6 +31,13 @@ interface AggregatedCatalogEntry {
 }
 
 type AggregatedCatalog = Record<string, AggregatedCatalogEntry>
+
+interface CatalogExtractionResult {
+  messages: AggregatedCatalog
+  fileCount: number
+  globMs: number
+  extractMs: number
+}
 
 export async function extract(options: ExtractOptions): Promise<void> {
   const config = await loadPalamedesConfig({ configPath: options.config })
@@ -53,12 +59,16 @@ async function runExtraction(
 ): Promise<void> {
   const startTime = Date.now()
   let totalWriteMs = 0
+  let totalGlobMs = 0
+  let totalExtractMs = 0
   let totalMessages = 0
   let totalFiles = 0
   const catalogs = config.catalogs ?? []
 
   for (const catalog of catalogs) {
-    const { messages, fileCount } = await extractFromCatalog(catalog, config, options)
+    const { messages, fileCount, globMs, extractMs } = await extractFromCatalog(catalog, config, options)
+    totalGlobMs += globMs
+    totalExtractMs += extractMs
     totalMessages += Object.keys(messages).length
     totalFiles += fileCount
 
@@ -80,6 +90,8 @@ async function runExtraction(
       `${TIMING_MARKER}${JSON.stringify({
         engine: "ferrocat",
         totalMs: duration,
+        globMs: totalGlobMs,
+        extractMs: totalExtractMs,
         writeMs: totalWriteMs,
         totalMessages,
         totalFiles,
@@ -92,7 +104,7 @@ async function extractFromCatalog(
   catalog: PalamedesCatalogConfig,
   config: LoadedPalamedesConfig,
   options: ExtractOptions
-): Promise<{ messages: AggregatedCatalog; fileCount: number }> {
+): Promise<CatalogExtractionResult> {
   const messages: AggregatedCatalog = {}
   const rootDir = config.rootDir
 
@@ -107,32 +119,27 @@ async function extractFromCatalog(
     resolveConfigPattern(config, pattern)
   ) || ["**/node_modules/**"]
 
+  const globStartedAt = Date.now()
   const files = await glob(includePatterns, {
     ignore: excludePatterns,
     absolute: true,
     nodir: true,
   })
+  const globMs = Date.now() - globStartedAt
 
   if (options.verbose) {
     console.log(chalk.gray(`Found ${files.length} files to extract from`))
   }
 
+  const extractStartedAt = Date.now()
   for (const file of files) {
     try {
       const code = await readFile(file, "utf-8")
       const relativePath = path.relative(rootDir, file)
-      const result = parseSync(file, code, { sourceType: "module" })
 
-      if (result.errors.length > 0) {
-        const errorMessages = result.errors.map((error) => error.message).join(", ")
-        throw new Error(`Parse error: ${errorMessages}`)
-      }
-
-      const extractedMessages = extractMessages(result.program, file, code)
-
-      for (const msg of extractedMessages) {
+      await extractor.extract(file, code, (msg) => {
         if (!msg.message) {
-          continue
+          return
         }
         const key = createCatalogKey(msg.message, msg.context)
 
@@ -157,7 +164,7 @@ async function extractFromCatalog(
             messages[key].origins.push(origin)
           }
         }
-      }
+      })
     } catch (error) {
       if (
         error instanceof Error &&
@@ -171,8 +178,9 @@ async function extractFromCatalog(
       }
     }
   }
+  const extractMs = Date.now() - extractStartedAt
 
-  return { messages, fileCount: files.length }
+  return { messages, fileCount: files.length, globMs, extractMs }
 }
 
 async function writeCatalog(

--- a/packages/extractor/src/extractMessages.test.ts
+++ b/packages/extractor/src/extractMessages.test.ts
@@ -1,6 +1,7 @@
 import { parseSync } from "oxc-parser"
 
-import { extractMessages } from "./extractMessages"
+import { extractMessages, type ExtractedMessageInfo } from "./extractMessages"
+import { extractor } from "./index"
 
 function extract(code: string) {
   const result = parseSync("test.tsx", code, { sourceType: "module" })
@@ -131,6 +132,38 @@ describe("extractMessages", () => {
         name: "name",
         locale: "resolved.locale",
       })
+    })
+  })
+
+  describe("source extractor", () => {
+    it("extracts directly from source without a caller-provided AST", async () => {
+      const code = `
+        import { t } from "@palamedes/core/macro"
+        const message = t\`Hello \${name}\`
+      `
+      const messages: ExtractedMessageInfo[] = []
+
+      await extractor.extract("test.ts", code, (message) => {
+        messages.push(message)
+      })
+
+      expect(messages).toHaveLength(1)
+      expect(messages[0].message).toBe("Hello {name}")
+      expect(messages[0].placeholders).toEqual({
+        name: "name",
+      })
+      expect(messages[0].origin[0]).toBe("test.ts")
+    })
+
+    it("does not hide fatal native extraction errors", async () => {
+      const code = `
+        import { t } from "@palamedes/core/macro"
+        const message = t({ id: "greeting", message: "Hello" })
+      `
+
+      await expect(
+        extractor.extract("test.ts", code, () => undefined)
+      ).rejects.toThrow(/Explicit message ids/)
     })
   })
 

--- a/packages/extractor/src/index.ts
+++ b/packages/extractor/src/index.ts
@@ -1,7 +1,7 @@
 /**
  * @palamedes/extractor
  *
- * High-performance message extractor using oxc-parser.
+ * High-performance message extractor using the native Palamedes core.
  * This extractor is ~20-100x faster than the Babel-based extractor.
  *
  * It directly extracts messages from Palamedes macro syntax without
@@ -9,14 +9,16 @@
  */
 
 import { parseSync } from "oxc-parser"
+import { extractMessagesNative } from "@palamedes/core-node"
 
-import { extractMessages } from "./extractMessages"
+import type { ExtractedMessageInfo } from "./extractMessages"
+import { extractMessagesJs } from "./extractMessagesJs"
 
 const SUPPORTED_EXTENSIONS =
   /\.(js|mjs|cjs|jsx|ts|mts|cts|tsx)$/i
 
 /**
- * OXC-based extractor for Palamedes-compatible message syntax.
+ * Native-first extractor for Palamedes-compatible message syntax.
  *
  * Supports:
  * - JSX: <Trans>, <Plural>, <Select>, <SelectOrdinal>
@@ -52,22 +54,46 @@ export const extractor: PalamedesExtractor = {
     code: string,
     onMessageExtracted: (msg: import("./extractMessages").ExtractedMessageInfo) => void
   ): Promise<void> {
-    const result = parseSync(filename, code, {
-      sourceType: "module",
-    })
+    let messages: ExtractedMessageInfo[]
 
-    if (result.errors.length > 0) {
-      // Throw on parse errors so the CLI can handle them appropriately
-      const errorMessages = result.errors.map((e) => e.message).join(", ")
-      throw new Error(`Parse error: ${errorMessages}`)
+    try {
+      messages = extractMessagesNative(code, filename)
+    } catch (error) {
+      if (isFatalNativeExtractionError(error)) {
+        throw error
+      }
+
+      messages = extractMessagesWithJsFallback(filename, code)
     }
-
-    const messages = extractMessages(result.program, filename, code)
 
     for (const msg of messages) {
       onMessageExtracted(msg)
     }
   },
+}
+
+function extractMessagesWithJsFallback(
+  filename: string,
+  code: string
+): ExtractedMessageInfo[] {
+  const result = parseSync(filename, code, {
+    sourceType: "module",
+  })
+
+  if (result.errors.length > 0) {
+    // Throw on parse errors so the CLI can handle them appropriately
+    const errorMessages = result.errors.map((e) => e.message).join(", ")
+    throw new Error(`Parse error: ${errorMessages}`)
+  }
+
+  return extractMessagesJs(result.program, filename, code)
+}
+
+function isFatalNativeExtractionError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    error.message.includes("Explicit message ids are no longer supported")
+  )
 }
 
 export default extractor

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -610,9 +610,6 @@ importers:
       glob:
         specifier: ^13.0.6
         version: 13.0.6
-      oxc-parser:
-        specifier: ^0.132.0
-        version: 0.132.0
     devDependencies:
       '@types/node':
         specifier: ^25.9.0


### PR DESCRIPTION
## Summary

- routes `@palamedes/extractor`'s source-based `extractor.extract()` through `extractMessagesNative()` first, avoiding the old CLI double-parse hot path
- keeps the existing AST-based `extractMessages(program, filename, code)` API intact and preserves JS fallback for non-fatal native extraction failures
- changes `pmds extract` to use the source-based extractor path directly and removes the CLI's direct `oxc-parser` dependency
- extends `PALAMEDES_TIMING_JSON=1` with `globMs` and `extractMs` while keeping the existing timing fields

## Performance

Fixture CLI timing, 5 runs on `packages/cli/src/commands/fixtures/ferrocat-first-test`:

- before: total median 9 ms (`8, 8, 9, 9, 9`)
- after: total median 8 ms (`7, 8, 8, 8, 9`), with extract bucket around 1-2 ms

Isolated extract hot path on the same fixture files, 2,000 iterations, 7 measured runs:

- old double-parse path: median 408.43 ms (`393.15, 403.64, 407.45, 408.43, 410.27, 414.91, 417.08`)
- new native-first path: median 254.45 ms (`252.33, 253.52, 253.72, 254.45, 254.49, 254.53, 255.46`)

## Validation

- `pnpm --filter @palamedes/extractor test`
- `pnpm --filter @palamedes/cli test`
- `pnpm --filter @palamedes/cli build`
- `pnpm benchmark:proof`
