### PR TITLE
[codex] update extract README guidance

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -53,6 +53,10 @@ pnpm exec pmds catalog merge --output src/locales/de.po src/locales/de.po other.
 obsolete messages, and ICU compatibility issues through the same `ferrocat`
 catalog engine that powers Palamedes builds.
 
+For local performance checks, set `PALAMEDES_TIMING_JSON=1` on `pmds extract`.
+The command prints a machine-readable timing line with total, glob, extract,
+and catalog-write timings.
+
 ### Catalog Merge
 
 `pmds catalog merge` merges exactly two catalog files with V1 `use-first`

--- a/packages/extractor/README.md
+++ b/packages/extractor/README.md
@@ -7,9 +7,9 @@
 
 Fast message extraction for teams that want a lower-level API alongside the CLI.
 
-`@palamedes/extractor` uses OXC-backed parsing plus Palamedes' native core to
-pull messages out of JavaScript, TypeScript, and React codebases without sending
-the workflow through a Babel-heavy path.
+`@palamedes/extractor` uses Palamedes' native core first to pull messages out of
+JavaScript, TypeScript, and React codebases without sending the workflow through
+a Babel-heavy path.
 
 ## When To Use This Package
 
@@ -30,12 +30,14 @@ pnpm add -D @palamedes/extractor
 ## Minimal Example
 
 ```ts
-import { parseSync } from "oxc-parser"
-import { extractMessages } from "@palamedes/extractor"
+import { extractor } from "@palamedes/extractor"
 
 const source = 'import { t } from "@palamedes/core/macro"; const message = t`Hello ${name}`'
-const result = parseSync("example.ts", source, { sourceType: "module" })
-const messages = extractMessages(result.program, "example.ts", source)
+const messages = []
+
+await extractor.extract("example.ts", source, (message) => {
+  messages.push(message)
+})
 
 console.log(messages)
 ```
@@ -50,8 +52,8 @@ console.log(messages)
 ## Key Exports
 
 - `extractor`
-- `extractMessages(program, filename, source)`
-- `extractMessagesJs(source, filename)`
+- `extractMessages(program, filename, source)` for compatibility with callers that already have an OXC AST
+- `extractMessagesJs(program, filename, source)` for the JavaScript fallback extractor
 
 ## Related Packages
 


### PR DESCRIPTION
## Summary

- update `@palamedes/extractor` README to show the Native-first `extractor.extract()` API as the minimal example
- clarify that AST-based `extractMessages(program, filename, source)` remains the compatibility API
- document `PALAMEDES_TIMING_JSON=1` timing output in the CLI README

## Validation

- `git diff --check`
- docs-only change; no runtime tests run
