### PR TITLE
[codex] add native extract batch path

### DIFF
--- a/crates/palamedes-node/src/extract.rs
+++ b/crates/palamedes-node/src/extract.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use napi::bindgen_prelude::Result;
 use napi_derive::napi;
 
+use crate::catalog::CatalogUpdateMessage;
 use crate::shared::{checked_optional_u32, checked_u32, to_napi_error};
 
 #[napi(object)]
@@ -19,6 +20,25 @@ pub struct NativeExtractedMessage {
     pub context: Option<String>,
     pub placeholders: Option<HashMap<String, String>>,
     pub origin: ExtractedMessageOrigin,
+}
+
+#[napi(object)]
+pub struct ExtractCatalogMessagesRequest {
+    pub root_dir: String,
+    pub files: Vec<String>,
+}
+
+#[napi(object)]
+pub struct ExtractCatalogFileFailure {
+    pub path: String,
+    pub message: String,
+}
+
+#[napi(object)]
+pub struct ExtractCatalogMessagesResult {
+    pub messages: Vec<CatalogUpdateMessage>,
+    pub file_count: u32,
+    pub failed_files: Vec<ExtractCatalogFileFailure>,
 }
 
 impl TryFrom<palamedes::ExtractedMessageRecord> for NativeExtractedMessage {
@@ -41,6 +61,48 @@ impl TryFrom<palamedes::ExtractedMessageRecord> for NativeExtractedMessage {
     }
 }
 
+impl From<ExtractCatalogMessagesRequest> for palamedes::ExtractCatalogMessagesRequest {
+    fn from(value: ExtractCatalogMessagesRequest) -> Self {
+        Self {
+            root_dir: value.root_dir,
+            files: value.files,
+        }
+    }
+}
+
+impl From<palamedes::CatalogUpdateMessage> for CatalogUpdateMessage {
+    fn from(value: palamedes::CatalogUpdateMessage) -> Self {
+        Self {
+            message: value.message,
+            context: value.context,
+            placeholders: Some(value.placeholders.into_iter().collect()),
+            extracted_comments: value.extracted_comments,
+            origins: value.origins.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<palamedes::ExtractCatalogFileFailure> for ExtractCatalogFileFailure {
+    fn from(value: palamedes::ExtractCatalogFileFailure) -> Self {
+        Self {
+            path: value.path,
+            message: value.message,
+        }
+    }
+}
+
+impl TryFrom<palamedes::ExtractCatalogMessagesResult> for ExtractCatalogMessagesResult {
+    type Error = napi::Error;
+
+    fn try_from(value: palamedes::ExtractCatalogMessagesResult) -> Result<Self> {
+        Ok(Self {
+            messages: value.messages.into_iter().map(Into::into).collect(),
+            file_count: checked_u32(value.file_count, "fileCount")?,
+            failed_files: value.failed_files.into_iter().map(Into::into).collect(),
+        })
+    }
+}
+
 #[napi]
 #[allow(clippy::needless_pass_by_value)]
 /// Extracts source-first messages from a JavaScript or TypeScript module.
@@ -58,4 +120,20 @@ pub fn extract_messages(source: String, filename: String) -> Result<Vec<NativeEx
                 .map(NativeExtractedMessage::try_from)
                 .collect()
         })
+}
+
+#[napi]
+#[allow(clippy::needless_pass_by_value)]
+/// Extracts and aggregates source-first catalog update messages from files.
+///
+/// # Errors
+///
+/// Returns an error when extraction encounters a fatal authoring issue or when
+/// result counters exceed the Node binding range.
+pub fn extract_catalog_messages_from_files(
+    request: ExtractCatalogMessagesRequest,
+) -> Result<ExtractCatalogMessagesResult> {
+    palamedes::extract_catalog_messages_from_files(request.into())
+        .map_err(to_napi_error)
+        .and_then(ExtractCatalogMessagesResult::try_from)
 }

--- a/crates/palamedes/src/catalog_update.rs
+++ b/crates/palamedes/src/catalog_update.rs
@@ -13,7 +13,7 @@ use ferrocat::{
 use serde::{Deserialize, Serialize};
 
 /// Source origin used for catalog updates and parsed catalog messages.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CatalogUpdateOrigin {
     /// Source filename.
@@ -23,7 +23,7 @@ pub struct CatalogUpdateOrigin {
 }
 
 /// Source-first extracted message used for catalog updates.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CatalogUpdateMessage {
     /// Source message string.

--- a/crates/palamedes/src/extract.rs
+++ b/crates/palamedes/src/extract.rs
@@ -1,5 +1,7 @@
 use std::collections::{BTreeMap, HashMap};
+use std::path::{Path, PathBuf};
 
+use crate::catalog_update::{CatalogUpdateMessage, CatalogUpdateOrigin};
 use crate::error::{PalamedesError, PalamedesResult};
 use oxc_allocator::Allocator;
 use oxc_ast::ast::{
@@ -40,6 +42,46 @@ pub struct ExtractedMessageRecord {
     pub placeholders: Option<BTreeMap<String, String>>,
     /// Source origin as `(filename, line, column)`.
     pub origin: (String, usize, Option<usize>),
+}
+
+/// Request for extracting and aggregating catalog messages from source files.
+#[derive(Debug, Clone)]
+pub struct ExtractCatalogMessagesRequest {
+    /// Root directory used to make extracted origins relative.
+    pub root_dir: String,
+    /// Source files to read and extract in caller-provided order.
+    pub files: Vec<String>,
+}
+
+/// Non-fatal source file extraction failure.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExtractCatalogFileFailure {
+    /// File path that failed to read, parse, or extract.
+    pub path: String,
+    /// Human-readable failure message.
+    pub message: String,
+}
+
+/// Aggregated catalog extraction result.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExtractCatalogMessagesResult {
+    /// Deduplicated source-first catalog update messages.
+    pub messages: Vec<CatalogUpdateMessage>,
+    /// Number of input files processed.
+    pub file_count: usize,
+    /// Non-fatal file failures skipped during extraction.
+    pub failed_files: Vec<ExtractCatalogFileFailure>,
+}
+
+#[derive(Debug)]
+struct AggregatedCatalogEntry {
+    message: String,
+    context: Option<String>,
+    placeholders: BTreeMap<String, Vec<String>>,
+    extracted_comments: Vec<String>,
+    origins: Vec<CatalogUpdateOrigin>,
 }
 
 struct LineLocator {
@@ -993,9 +1035,146 @@ pub fn extract_messages(
     Ok(extractor.messages)
 }
 
+/// Extracts and aggregates source-first catalog update messages from files.
+///
+/// # Errors
+///
+/// Returns an error only for fatal authoring failures such as explicit message
+/// IDs. Read, parse, and non-fatal extraction failures are returned in
+/// `failed_files` so callers can preserve the CLI's warning-oriented behavior.
+pub fn extract_catalog_messages_from_files(
+    request: ExtractCatalogMessagesRequest,
+) -> PalamedesResult<ExtractCatalogMessagesResult> {
+    let root_dir = PathBuf::from(&request.root_dir);
+    let mut catalog = BTreeMap::<String, AggregatedCatalogEntry>::new();
+    let mut failed_files = Vec::new();
+    let file_count = request.files.len();
+
+    for file in &request.files {
+        let source = match std::fs::read_to_string(file) {
+            Ok(source) => source,
+            Err(source) => {
+                failed_files.push(ExtractCatalogFileFailure {
+                    path: file.clone(),
+                    message: PalamedesError::ReadFile {
+                        path: PathBuf::from(file),
+                        source,
+                    }
+                    .to_string(),
+                });
+                continue;
+            }
+        };
+
+        let extracted = match extract_messages(&source, file) {
+            Ok(messages) => messages,
+            Err(PalamedesError::ExplicitMessageIdsUnsupported) => {
+                return Err(PalamedesError::ExplicitMessageIdsUnsupported);
+            }
+            Err(error) => {
+                failed_files.push(ExtractCatalogFileFailure {
+                    path: file.clone(),
+                    message: error.to_string(),
+                });
+                continue;
+            }
+        };
+
+        let relative_file = relative_origin_file(&root_dir, file);
+        for message in extracted {
+            add_extracted_message(&mut catalog, message, &relative_file);
+        }
+    }
+
+    Ok(ExtractCatalogMessagesResult {
+        messages: catalog
+            .into_values()
+            .map(CatalogUpdateMessage::from)
+            .collect(),
+        file_count,
+        failed_files,
+    })
+}
+
+fn relative_origin_file(root_dir: &Path, file: &str) -> String {
+    let path = Path::new(file);
+    path.strip_prefix(root_dir)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+fn add_extracted_message(
+    catalog: &mut BTreeMap<String, AggregatedCatalogEntry>,
+    message: ExtractedMessageRecord,
+    relative_file: &str,
+) {
+    if message.message.is_empty() {
+        return;
+    }
+
+    let key = catalog_key(&message.message, message.context.as_deref());
+    let entry = catalog
+        .entry(key)
+        .or_insert_with(|| AggregatedCatalogEntry {
+            message: message.message.clone(),
+            context: message.context.clone(),
+            placeholders: BTreeMap::new(),
+            extracted_comments: Vec::new(),
+            origins: Vec::new(),
+        });
+
+    if let Some(comment) = message.comment {
+        if !entry.extracted_comments.contains(&comment) {
+            entry.extracted_comments.push(comment);
+        }
+    }
+
+    if let Some(placeholders) = message.placeholders {
+        for (name, expression) in placeholders {
+            let values = entry.placeholders.entry(name).or_default();
+            if !values.contains(&expression) {
+                values.push(expression);
+            }
+        }
+    }
+
+    let origin = CatalogUpdateOrigin {
+        file: relative_file.to_string(),
+        line: u32::try_from(message.origin.1).unwrap_or(u32::MAX),
+    };
+    if !entry.origins.contains(&origin) {
+        entry.origins.push(origin);
+    }
+}
+
+fn catalog_key(message: &str, context: Option<&str>) -> String {
+    format!("{}\u{4}{message}", context.unwrap_or_default())
+}
+
+impl From<AggregatedCatalogEntry> for CatalogUpdateMessage {
+    fn from(value: AggregatedCatalogEntry) -> Self {
+        Self {
+            message: value.message,
+            context: value.context,
+            placeholders: value.placeholders,
+            extracted_comments: value.extracted_comments,
+            origins: value.origins,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::extract_messages;
+    use std::fs;
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use super::{
+        extract_catalog_messages_from_files, extract_messages, ExtractCatalogMessagesRequest,
+    };
+
+    static TEMP_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
     #[test]
     fn extracts_tagged_templates() {
@@ -1090,5 +1269,120 @@ mod tests {
         .expect_err("unnamed JSX placeholders should fail");
 
         assert!(error.to_string().contains("stable placeholder name"));
+    }
+
+    #[test]
+    fn batch_extracts_deduped_catalog_messages_with_relative_origins() {
+        let root = temp_root("batch-relative");
+        let src = root.join("src");
+        fs::create_dir_all(&src).expect("src dir");
+        let first = src.join("App.tsx");
+        let second = src.join("More.tsx");
+        fs::write(
+            &first,
+            r#"
+              import { t } from "@palamedes/core/macro"
+              const a = t({ message: "Hello {name}", comment: "Greeting" })
+              const b = t`Computed ${user.name}`
+            "#,
+        )
+        .expect("first source");
+        fs::write(
+            &second,
+            r#"
+              import { t } from "@palamedes/core/macro"
+              const a = t({ message: "Hello {name}", comment: "Greeting" })
+            "#,
+        )
+        .expect("second source");
+
+        let result = extract_catalog_messages_from_files(ExtractCatalogMessagesRequest {
+            root_dir: root.to_string_lossy().into_owned(),
+            files: vec![
+                first.to_string_lossy().into_owned(),
+                second.to_string_lossy().into_owned(),
+            ],
+        })
+        .expect("batch extraction");
+
+        assert_eq!(result.file_count, 2);
+        assert!(result.failed_files.is_empty());
+
+        let hello = result
+            .messages
+            .iter()
+            .find(|message| message.message == "Hello {name}")
+            .expect("hello message");
+        assert_eq!(hello.extracted_comments, vec!["Greeting"]);
+        assert_eq!(hello.origins.len(), 2);
+        assert_eq!(hello.origins[0].file, "src/App.tsx");
+        assert_eq!(hello.origins[1].file, "src/More.tsx");
+
+        let computed = result
+            .messages
+            .iter()
+            .find(|message| message.message == "Computed {name}")
+            .expect("computed message");
+        assert_eq!(
+            computed
+                .placeholders
+                .get("name")
+                .expect("placeholder expression"),
+            &vec!["user.name".to_string()]
+        );
+
+        fs::remove_dir_all(root).expect("cleanup");
+    }
+
+    #[test]
+    fn batch_reports_non_fatal_file_failures() {
+        let root = temp_root("batch-failure");
+        fs::create_dir_all(&root).expect("root dir");
+        let invalid = root.join("invalid.ts");
+        fs::write(&invalid, "const broken =").expect("invalid source");
+
+        let result = extract_catalog_messages_from_files(ExtractCatalogMessagesRequest {
+            root_dir: root.to_string_lossy().into_owned(),
+            files: vec![invalid.to_string_lossy().into_owned()],
+        })
+        .expect("batch extraction should continue");
+
+        assert_eq!(result.file_count, 1);
+        assert_eq!(result.failed_files.len(), 1);
+        assert!(result.failed_files[0].message.contains("Parse error"));
+
+        fs::remove_dir_all(root).expect("cleanup");
+    }
+
+    #[test]
+    fn batch_keeps_explicit_ids_fatal() {
+        let root = temp_root("batch-explicit-id");
+        fs::create_dir_all(&root).expect("root dir");
+        let source = root.join("bad.ts");
+        fs::write(
+            &source,
+            r#"
+              import { t } from "@palamedes/core/macro"
+              const message = t({ id: "greeting", message: "Hello" })
+            "#,
+        )
+        .expect("source");
+
+        let error = extract_catalog_messages_from_files(ExtractCatalogMessagesRequest {
+            root_dir: root.to_string_lossy().into_owned(),
+            files: vec![source.to_string_lossy().into_owned()],
+        })
+        .expect_err("explicit IDs should fail");
+
+        assert!(error.to_string().contains("Explicit message ids"));
+        fs::remove_dir_all(root).expect("cleanup");
+    }
+
+    fn temp_root(label: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "palamedes-{label}-{}-{}",
+            std::process::id(),
+            TEMP_COUNTER.fetch_add(1, Ordering::Relaxed)
+        ))
     }
 }

--- a/crates/palamedes/src/lib.rs
+++ b/crates/palamedes/src/lib.rs
@@ -53,7 +53,10 @@ pub use catalog_update::{
 };
 pub use diagnostic::{CatalogDiagnostic, CatalogDiagnosticSeverity, CatalogDiagnosticSourceKey};
 pub use error::{PalamedesError, PalamedesResult};
-pub use extract::{extract_messages, ExtractedMessageRecord};
+pub use extract::{
+    extract_catalog_messages_from_files, extract_messages, ExtractCatalogFileFailure,
+    ExtractCatalogMessagesRequest, ExtractCatalogMessagesResult, ExtractedMessageRecord,
+};
 pub use message_metadata::{
     derive_message_metadata, normalize_message_metadata, validate_message_metadata,
     MessageArgumentFormatMetadata, MessageArgumentKind, MessageArgumentMetadata,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -50,7 +50,6 @@
   "dependencies": {
     "@palamedes/config": "workspace:^",
     "@palamedes/core-node": "workspace:^",
-    "@palamedes/extractor": "workspace:^",
     "chalk": "^5.6.2",
     "chokidar": "^5.0.0",
     "commander": "^14.0.3",

--- a/packages/cli/src/commands/extract.ts
+++ b/packages/cli/src/commands/extract.ts
@@ -1,4 +1,4 @@
-import { readFile, mkdir } from "fs/promises"
+import { mkdir } from "fs/promises"
 import path from "path"
 import chalk from "chalk"
 import { glob } from "glob"
@@ -10,8 +10,11 @@ import {
   type LoadedPalamedesConfig,
   type PalamedesCatalogConfig,
 } from "@palamedes/config"
-import { updateCatalogFile, type CatalogUpdateMessage } from "@palamedes/core-node"
-import { extractor } from "@palamedes/extractor"
+import {
+  extractCatalogMessagesFromFiles,
+  updateCatalogFile,
+  type CatalogUpdateMessage,
+} from "@palamedes/core-node"
 
 interface ExtractOptions {
   config?: string
@@ -22,18 +25,8 @@ interface ExtractOptions {
 
 const TIMING_MARKER = "__PALAMEDES_TIMINGS__"
 
-interface AggregatedCatalogEntry {
-  message: string
-  context?: string
-  placeholders: Record<string, string[]>
-  extractedComments: string[]
-  origins: Array<{ file: string; line: number }>
-}
-
-type AggregatedCatalog = Record<string, AggregatedCatalogEntry>
-
 interface CatalogExtractionResult {
-  messages: AggregatedCatalog
+  messages: CatalogUpdateMessage[]
   fileCount: number
   globMs: number
   extractMs: number
@@ -66,10 +59,14 @@ async function runExtraction(
   const catalogs = config.catalogs ?? []
 
   for (const catalog of catalogs) {
-    const { messages, fileCount, globMs, extractMs } = await extractFromCatalog(catalog, config, options)
+    const { messages, fileCount, globMs, extractMs } = await extractFromCatalog(
+      catalog,
+      config,
+      options
+    )
     totalGlobMs += globMs
     totalExtractMs += extractMs
-    totalMessages += Object.keys(messages).length
+    totalMessages += messages.length
     totalFiles += fileCount
 
     // Write catalogs for each locale
@@ -105,7 +102,6 @@ async function extractFromCatalog(
   config: LoadedPalamedesConfig,
   options: ExtractOptions
 ): Promise<CatalogExtractionResult> {
-  const messages: AggregatedCatalog = {}
   const rootDir = config.rootDir
 
   const includePatterns = catalog.include.map((pattern) => {
@@ -132,61 +128,34 @@ async function extractFromCatalog(
   }
 
   const extractStartedAt = Date.now()
-  for (const file of files) {
-    try {
-      const code = await readFile(file, "utf-8")
-      const relativePath = path.relative(rootDir, file)
-
-      await extractor.extract(file, code, (msg) => {
-        if (!msg.message) {
-          return
-        }
-        const key = createCatalogKey(msg.message, msg.context)
-
-        if (!messages[key]) {
-          messages[key] = {
-            message: msg.message,
-            context: msg.context,
-            placeholders: {},
-            extractedComments: msg.comment ? [msg.comment] : [],
-            origins: [],
-          }
-        }
-
-        mergePlaceholders(messages[key].placeholders, msg.placeholders)
-
-        if (msg.origin) {
-          const origin = {
-            file: relativePath,
-            line: msg.origin[1],
-          }
-          if (!messages[key].origins.some((entry) => entry.file === origin.file && entry.line === origin.line)) {
-            messages[key].origins.push(origin)
-          }
-        }
-      })
-    } catch (error) {
-      if (
-        error instanceof Error &&
-        error.message.includes("Explicit message ids are no longer supported")
-      ) {
-        throw error
-      }
-
-      if (options.verbose) {
-        console.warn(chalk.yellow("Warning:"), `Failed to extract from ${file}:`, error)
-      }
-    }
-  }
+  const result = extractCatalogMessagesFromFiles({
+    rootDir,
+    files,
+  })
   const extractMs = Date.now() - extractStartedAt
 
-  return { messages, fileCount: files.length, globMs, extractMs }
+  if (options.verbose) {
+    for (const failure of result.failedFiles) {
+      console.warn(
+        chalk.yellow("Warning:"),
+        `Failed to extract from ${failure.path}:`,
+        failure.message
+      )
+    }
+  }
+
+  return {
+    messages: result.messages,
+    fileCount: result.fileCount,
+    globMs,
+    extractMs,
+  }
 }
 
 async function writeCatalog(
   catalog: PalamedesCatalogConfig,
   locale: string,
-  extractedMessages: AggregatedCatalog,
+  extractedMessages: CatalogUpdateMessage[],
   config: LoadedPalamedesConfig,
   options: ExtractOptions
 ): Promise<number> {
@@ -202,7 +171,7 @@ async function writeCatalog(
     locale,
     sourceLocale: config.sourceLocale,
     clean: Boolean(options.clean),
-    messages: catalogToMessages(extractedMessages),
+    messages: extractedMessages,
   })
 
   if (options.verbose) {
@@ -256,38 +225,4 @@ async function runWatchMode(
 
 function shouldEmitTimingJson(): boolean {
   return process.env.PALAMEDES_TIMING_JSON === "1"
-}
-
-function catalogToMessages(catalog: AggregatedCatalog): CatalogUpdateMessage[] {
-  return Object.values(catalog).map((entry) => ({
-    message: entry.message,
-    context: entry.context,
-    placeholders: entry.placeholders,
-    extractedComments: entry.extractedComments ?? [],
-    origins: (entry.origins ?? []).map((origin) => ({
-      file: origin.file,
-      line: origin.line ?? 0,
-    })),
-  }))
-}
-
-function createCatalogKey(message: string, context?: string): string {
-  return `${context ?? ""}\u0004${message}`
-}
-
-function mergePlaceholders(
-  target: Record<string, string[]>,
-  source?: Record<string, string>
-): void {
-  if (!source) {
-    return
-  }
-
-  for (const [name, expression] of Object.entries(source)) {
-    const values = target[name] ?? []
-    if (!values.includes(expression)) {
-      values.push(expression)
-    }
-    target[name] = values
-  }
 }

--- a/packages/core-node/README.md
+++ b/packages/core-node/README.md
@@ -91,6 +91,7 @@ console.log(po.headers.Language)
 - `compileCatalogArtifact(config, resourcePath)`
 - `compileCatalogArtifactSelected(config, resourcePath, compiledIds)`
 - `extractMessagesNative(source, filename)`
+- `extractCatalogMessagesFromFiles(request)`
 - `transformMacrosNative(source, filename, options?)`
 
 Catalog operations use Ferrocat for parsing, updates, audits, ICU authoring

--- a/packages/core-node/src/generated/palamedes-node-types.ts
+++ b/packages/core-node/src/generated/palamedes-node-types.ts
@@ -263,6 +263,19 @@ export interface NativeExtractedMessage {
   placeholders?: Record<string, string>;
   origin: ExtractedMessageOrigin;
 }
+export interface ExtractCatalogMessagesRequest {
+  rootDir: string;
+  files: Array<string>;
+}
+export interface ExtractCatalogFileFailure {
+  path: string;
+  message: string;
+}
+export interface ExtractCatalogMessagesResult {
+  messages: Array<CatalogUpdateMessage>;
+  fileCount: number;
+  failedFiles: Array<ExtractCatalogFileFailure>;
+}
 export interface NativeInfo {
   palamedesVersion: string;
   ferrocatVersion: string;
@@ -327,6 +340,7 @@ export interface NativeBindings {
   compileCatalogArtifact(request: CatalogArtifactRequest): CatalogArtifactResult;
   compileCatalogArtifactSelected(request: CatalogArtifactSelectedRequest): CatalogArtifactResult;
   extractMessages(source: string, filename: string): Array<NativeExtractedMessage>;
+  extractCatalogMessagesFromFiles(request: ExtractCatalogMessagesRequest): ExtractCatalogMessagesResult;
   getNativeInfo(): NativeInfo;
   parsePo(source: string): ParsedPoFile;
   transformMacros(source: string, filename: string, options?: NativeTransformOptions | undefined | null): NativeTransformResult;

--- a/packages/core-node/src/index.ts
+++ b/packages/core-node/src/index.ts
@@ -26,6 +26,9 @@ import type {
   CatalogUpdateRequest as GeneratedCatalogUpdateRequest,
   CatalogUpdateResult as GeneratedCatalogUpdateResult,
   CatalogUpdateStats as GeneratedCatalogUpdateStats,
+  ExtractCatalogFileFailure as GeneratedExtractCatalogFileFailure,
+  ExtractCatalogMessagesRequest as GeneratedExtractCatalogMessagesRequest,
+  ExtractCatalogMessagesResult as GeneratedExtractCatalogMessagesResult,
   MessageArgumentFormatMetadata as GeneratedMessageArgumentFormatMetadata,
   MessageArgumentKind as GeneratedMessageArgumentKind,
   MessageArgumentMetadata as GeneratedMessageArgumentMetadata,
@@ -57,6 +60,9 @@ export type CatalogOrigin = GeneratedCatalogOrigin
 export type CatalogUpdateMessage = GeneratedCatalogUpdateMessage
 export type CatalogUpdateRequest = GeneratedCatalogUpdateRequest
 export type CatalogUpdateStats = GeneratedCatalogUpdateStats
+export type ExtractCatalogFileFailure = GeneratedExtractCatalogFileFailure
+export type ExtractCatalogMessagesRequest = GeneratedExtractCatalogMessagesRequest
+export type ExtractCatalogMessagesResult = GeneratedExtractCatalogMessagesResult
 export type CatalogParseRequest = GeneratedCatalogParseRequest
 export type ParsedCatalogMessage = GeneratedParsedCatalogMessage
 export type MachineTranslationMetadata = GeneratedMachineTranslationMetadata
@@ -469,6 +475,12 @@ export function extractMessagesNative(
     ...message,
     origin: [message.origin.filename, message.origin.line, message.origin.column],
   }))
+}
+
+export function extractCatalogMessagesFromFiles(
+  request: ExtractCatalogMessagesRequest
+): ExtractCatalogMessagesResult {
+  return native.extractCatalogMessagesFromFiles(request)
 }
 
 export function transformMacrosNative(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -595,9 +595,6 @@ importers:
       '@palamedes/core-node':
         specifier: workspace:^
         version: link:../core-node
-      '@palamedes/extractor':
-        specifier: workspace:^
-        version: link:../extractor
       chalk:
         specifier: ^5.6.2
         version: 5.6.2


### PR DESCRIPTION
## Summary

- adds a Rust core `extract_catalog_messages_from_files` batch API that reads files, extracts messages, normalizes origins relative to `rootDir`, and deduplicates into catalog update messages
- exposes the batch API through NAPI and `@palamedes/core-node` as `extractCatalogMessagesFromFiles(request)`
- switches `pmds extract` from JS per-file read/extract/aggregate to the native batch path while keeping JS globbing and catalog update semantics unchanged
- removes the CLI dependency on `@palamedes/extractor`

## Behavior

- non-fatal read/parse/extract failures are returned as `failedFiles` and printed as verbose warnings, matching the previous CLI warning-oriented behavior
- explicit author-facing message IDs remain fatal
- existing `PALAMEDES_TIMING_JSON` fields stay intact; `extractMs` now measures the native batch read/extract/aggregate call

## Performance

CLI fixture timing, 5 runs on `packages/cli/src/commands/fixtures/ferrocat-first-test`:

- total samples: `9, 8, 8, 7, 7` ms
- extract bucket: `2, 1, 1, 1, 1` ms

Direct old-vs-new batch comparison on the same fixture files, 2,000 iterations, 7 measured runs:

- old per-file JS aggregate path: median 557.72 ms (`532.08, 542.54, 542.86, 557.72, 566.15, 582.14, 582.49`)
- new native batch path: median 358.03 ms (`350.22, 353.91, 356.19, 358.03, 365.63, 365.98, 368.89`)

`pnpm benchmark:proof`:

- transform: median 0.51 ms
- extract: median 0.28 ms
- catalog-update: median 0.28 ms
- catalog-artifact-compile: median 3.69 ms

## Validation

- `cargo test -p palamedes extract::tests`
- `cargo test -p palamedes-node`
- `cargo test -p palamedes`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets`
- `cargo fmt --check`
- `pnpm --filter @palamedes/core-node check-native-types`
- `pnpm --filter @palamedes/core-node build`
- `pnpm --filter @palamedes/cli test`
- `pnpm --filter @palamedes/cli build`
- `pnpm benchmark:proof`
