### PR TITLE
fix: dedupe repeated Trans component bindings

### DIFF
--- a/crates/palamedes/src/transform/messages.rs
+++ b/crates/palamedes/src/transform/messages.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use oxc_ast::ast::{
     Argument, Expression, JSXAttributeValue, JSXChild, JSXExpression, JSXOpeningElement,
@@ -319,6 +319,11 @@ pub(super) fn extract_jsx_children_parts(
             }
         }
     }
+
+    let mut seen_components = HashSet::<(String, String)>::new();
+    components.retain(|binding| {
+        seen_components.insert((binding.name.clone(), binding.expression.clone()))
+    });
 
     Ok((parts.join("").trim().to_string(), values, components))
 }

--- a/crates/palamedes/src/transform/tests.rs
+++ b/crates/palamedes/src/transform/tests.rs
@@ -181,6 +181,22 @@ fn deduplicates_same_tag_component_placeholders() {
 }
 
 #[test]
+fn reuses_identical_component_binding_once() {
+    let result = transform_macros(
+        "import { Trans } from \"@palamedes/react/macro\";\nconst el = <Trans><strong>A</strong> and <strong>B</strong></Trans>;\n",
+        "test.tsx",
+        None,
+    )
+    .expect("transform should succeed");
+
+    assert!(result
+        .code
+        .contains("message=\"<strong>A</strong> and <strong>B</strong>\""));
+    assert!(result.code.contains("components={{ strong: <strong /> }}"));
+    assert!(!result.code.contains("strong: <strong />, strong:"));
+}
+
+#[test]
 fn preserves_use_client_directive_before_injected_imports() {
     let result = transform_macros(
         "\"use client\";\nimport { Trans } from \"@palamedes/react/macro\";\nconst el = <Trans>Hello</Trans>;\n",

--- a/packages/transform/src/transform.test.ts
+++ b/packages/transform/src/transform.test.ts
@@ -133,6 +133,18 @@ const el = <Trans>Accept <a href="/terms">terms</a> and <a href="/privacy">priva
     )
   })
 
+  it("reuses identical component bindings once", () => {
+    const code = `
+import { Trans } from "@palamedes/react/macro";
+const el = <Trans><strong>A</strong> and <strong>B</strong></Trans>;
+`
+    const result = transformPalamedesMacros(code, "test.tsx")
+
+    expect(result.code).toContain('message="<strong>A</strong> and <strong>B</strong>"')
+    expect(result.code).toContain('components={{ strong: <strong /> }}')
+    expect(result.code).not.toContain('strong: <strong />, strong:')
+  })
+
   it("strips the message field when requested", () => {
     const code = `
 import { t } from "@palamedes/core/macro";


### PR DESCRIPTION
## Summary

- dedupe identical JSX component bindings emitted for `<Trans>` messages
- keep repeated same-tag markup in the message while emitting a single `components` object key when the wrapper expression is identical
- add Rust/native and TS package regression tests for repeated `<strong>` tags

Fixes #93.

## Validation

- `cargo fmt --check`
- `cargo test -p palamedes`
- `pnpm --filter @palamedes/transform build`
- `pnpm --filter @palamedes/transform test`
