### PR TITLE
fix(cli): report package version

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,12 +1,15 @@
 #!/usr/bin/env node
 
+import { createRequire } from "node:module"
+
 import { program } from "commander"
 import chalk from "chalk"
 import { audit } from "./commands/audit"
 import { mergeCatalog } from "./commands/catalog"
 import { extract } from "./commands/extract"
 
-const VERSION = "0.0.1"
+const require = createRequire(import.meta.url)
+const VERSION = require("../package.json").version as string
 
 program
   .name("pmds")


### PR DESCRIPTION
## Summary

- read the CLI version from `@palamedes/cli`'s package metadata instead of the stale hard-coded `0.0.1`
- fixes both `pmds --version` and `pmds version` output for published packages

Fixes #97.

## Validation

- `pnpm --filter @palamedes/config build`
- `pnpm --filter @palamedes/core-node-darwin-arm64 build`
- `pnpm --filter @palamedes/core-node build`
- `pnpm --filter @palamedes/cli build`
- `node packages/cli/dist/cli.mjs --version` → `0.6.0`
- `node packages/cli/dist/cli.mjs version` → `pmds (Palamedes) v0.6.0`
- `pnpm --filter @palamedes/cli test`
