### PR TITLE
fix(transform): emit valid JSX for macro replacements

### DIFF
--- a/crates/palamedes/src/transform/runtime.rs
+++ b/crates/palamedes/src/transform/runtime.rs
@@ -177,7 +177,7 @@ pub(super) fn transform_trans_element(
 
     let mut attrs = vec![
         format!("id=\"{}\"", escape_string(&lookup_key)),
-        format!("message=\"{}\"", escape_string(&message)),
+        format!("message={{\"{}\"}}", escape_string(&message)),
     ];
 
     if !components.is_empty() {

--- a/crates/palamedes/src/transform/tests.rs
+++ b/crates/palamedes/src/transform/tests.rs
@@ -294,6 +294,32 @@ fn keeps_choice_jsx_macro_as_expression_outside_jsx_children() {
 }
 
 #[test]
+fn keeps_choice_jsx_macro_as_expression_in_jsx_attribute_container() {
+    let result = transform_macros(
+        "import { Plural } from \"@palamedes/react/macro\";\nconst el = <Summary label={<Plural value={count} one=\"# item\" other=\"# items\" />} />;\n",
+        "test.tsx",
+        None,
+    )
+    .expect("transform should succeed");
+
+    assert!(result.code.contains("label={getI18n()._(\""));
+    assert!(!result.code.contains("label={{getI18n()._(\""));
+}
+
+#[test]
+fn keeps_choice_jsx_macro_as_expression_in_jsx_child_expression_container() {
+    let result = transform_macros(
+        "import { Plural } from \"@palamedes/react/macro\";\nconst el = <Summary>{show && <Plural value={count} one=\"# item\" other=\"# items\" />}</Summary>;\n",
+        "test.tsx",
+        None,
+    )
+    .expect("transform should succeed");
+
+    assert!(result.code.contains("{show && getI18n()._(\""));
+    assert!(!result.code.contains("{show && {getI18n()._(\""));
+}
+
+#[test]
 fn rejects_explicit_ids() {
     let error = transform_macros(
         "import { t } from \"@palamedes/core/macro\";\nconst msg = t({ id: \"greeting\", message: \"Hello\" });\n",

--- a/crates/palamedes/src/transform/tests.rs
+++ b/crates/palamedes/src/transform/tests.rs
@@ -53,7 +53,7 @@ fn transforms_after_non_ascii_source_text() {
 
     assert!(result.has_changed);
     assert!(result.code.contains("const x = \"äöü\";"));
-    assert!(result.code.contains("message=\"Hallo Welt\""));
+    assert!(result.code.contains("message={\"Hallo Welt\"}"));
 
     let map = result
         .map
@@ -137,7 +137,7 @@ fn transforms_trans_jsx_macro() {
         .code
         .contains("import { Trans } from \"@palamedes/react\";"));
     assert!(result.code.contains("<Trans id=\""));
-    assert!(result.code.contains("message=\"Hello {name}\""));
+    assert!(result.code.contains("message={\"Hello {name}\"}"));
     assert!(result.code.contains("values={{ name }}"));
     assert!(!result.code.contains("@palamedes/runtime"));
 }
@@ -155,7 +155,7 @@ fn transforms_solid_trans_jsx_macro() {
         .code
         .contains("import { Trans } from \"@palamedes/solid\";"));
     assert!(result.code.contains("<Trans id=\""));
-    assert!(result.code.contains("message=\"Hello <0>{name}</0>\""));
+    assert!(result.code.contains("message={\"Hello <0>{name}</0>\"}"));
     assert!(result
         .code
         .contains("components={{ 0: (children) => <strong>{children}</strong> }}"));
@@ -172,7 +172,7 @@ fn deduplicates_same_tag_component_placeholders() {
 
     assert!(result
         .code
-        .contains("message=\"Accept <0>terms</0> and <1>privacy</1>\""));
+        .contains("message={\"Accept <0>terms</0> and <1>privacy</1>\"}"));
     assert!(result
         .code
         .contains("components={{ 0: <a href=\"/terms\" />, 1: <a href=\"/privacy\" /> }}"));
@@ -187,7 +187,7 @@ fn deduplicates_same_tag_component_placeholders_with_identical_markup() {
     )
     .expect("transform should succeed");
 
-    assert!(result.code.contains("message=\"<0>A</0> and <1>B</1>\""));
+    assert!(result.code.contains("message={\"<0>A</0> and <1>B</1>\"}"));
     assert!(result
         .code
         .contains("components={{ 0: <strong />, 1: <strong /> }}"));
@@ -245,6 +245,52 @@ fn strips_message_field_when_requested() {
 
     assert!(!result.code.contains("message:"));
     assert!(result.code.contains("comment: \"Greeting\""));
+}
+
+#[test]
+fn trans_jsx_macro_escapes_double_quotes_in_message_attribute() {
+    let result = transform_macros(
+        "import { Trans } from \"@palamedes/react/macro\";\nconst el = <Trans>Upload settlement data file with \"3Degrees Audit Summary\" tab</Trans>;\n",
+        "test.tsx",
+        None,
+    )
+    .expect("transform should succeed");
+
+    assert!(result.code.contains(
+        "message={\"Upload settlement data file with \\\"3Degrees Audit Summary\\\" tab\"}"
+    ));
+    assert!(!result
+        .code
+        .contains("message=\"Upload settlement data file with \\\""));
+}
+
+#[test]
+fn wraps_choice_jsx_macro_when_used_as_jsx_child() {
+    let result = transform_macros(
+        "import { Plural } from \"@palamedes/react/macro\";\nfunction Demo({ totalRows }) { return <p><Plural value={totalRows} one=\"# row\" other=\"# rows\" /></p>; }\n",
+        "test.tsx",
+        None,
+    )
+    .expect("transform should succeed");
+
+    assert!(result.code.contains("<p>{getI18n()._(\""));
+    assert!(result
+        .code
+        .contains("message: \"{totalRows, plural, one {# row} other {# rows}}\""));
+    assert!(result.code.contains(")}</p>"));
+}
+
+#[test]
+fn keeps_choice_jsx_macro_as_expression_outside_jsx_children() {
+    let result = transform_macros(
+        "import { Plural } from \"@palamedes/react/macro\";\nconst el = <Plural value={count} one=\"# item\" other=\"# items\" />;\n",
+        "test.tsx",
+        None,
+    )
+    .expect("transform should succeed");
+
+    assert!(result.code.contains("const el = getI18n()._(\""));
+    assert!(!result.code.contains("const el = {getI18n()._(\""));
 }
 
 #[test]

--- a/crates/palamedes/src/transform/visitor.rs
+++ b/crates/palamedes/src/transform/visitor.rs
@@ -29,6 +29,7 @@ pub(super) struct TransformVisitor<'a> {
     pub needs_runtime_import: bool,
     pub trans_import_modules: HashSet<String>,
     pub error: Option<PalamedesError>,
+    jsx_element_depth: usize,
 }
 
 impl<'a> TransformVisitor<'a> {
@@ -46,6 +47,7 @@ impl<'a> TransformVisitor<'a> {
             needs_runtime_import: false,
             trans_import_modules: HashSet::new(),
             error: None,
+            jsx_element_depth: 0,
         }
     }
 
@@ -73,12 +75,16 @@ impl<'a> Visit<'a> for TransformVisitor<'a> {
         }
 
         let Some(tag_name) = it.opening_element.name.get_identifier_name() else {
+            self.jsx_element_depth += 1;
             walk::walk_jsx_element(self, it);
+            self.jsx_element_depth -= 1;
             return;
         };
 
         let Some(macro_info) = self.macro_imports.get(tag_name.as_str()) else {
+            self.jsx_element_depth += 1;
             walk::walk_jsx_element(self, it);
+            self.jsx_element_depth -= 1;
             return;
         };
 
@@ -102,6 +108,11 @@ impl<'a> Visit<'a> for TransformVisitor<'a> {
 
         match replacement {
             Ok(Some((text, compiled_id))) => {
+                let text = if macro_info.imported_name != "Trans" && self.jsx_element_depth > 0 {
+                    format!("{{{text}}}")
+                } else {
+                    text
+                };
                 self.replacements.push(Replacement {
                     start: it.span.start as usize,
                     end: it.span.end as usize,
@@ -125,7 +136,9 @@ impl<'a> Visit<'a> for TransformVisitor<'a> {
             }
         }
 
+        self.jsx_element_depth += 1;
         walk::walk_jsx_element(self, it);
+        self.jsx_element_depth -= 1;
     }
 
     fn visit_tagged_template_expression(&mut self, it: &TaggedTemplateExpression<'a>) {

--- a/crates/palamedes/src/transform/visitor.rs
+++ b/crates/palamedes/src/transform/visitor.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
-use oxc_ast::ast::{CallExpression, JSXElement, TaggedTemplateExpression};
+use oxc_ast::ast::{CallExpression, JSXChild, JSXElement, TaggedTemplateExpression};
 use oxc_ast_visit::{walk, Visit};
 
 use crate::error::PalamedesError;
@@ -29,7 +29,7 @@ pub(super) struct TransformVisitor<'a> {
     pub needs_runtime_import: bool,
     pub trans_import_modules: HashSet<String>,
     pub error: Option<PalamedesError>,
-    jsx_element_depth: usize,
+    jsx_child_element_depth: usize,
 }
 
 impl<'a> TransformVisitor<'a> {
@@ -47,7 +47,7 @@ impl<'a> TransformVisitor<'a> {
             needs_runtime_import: false,
             trans_import_modules: HashSet::new(),
             error: None,
-            jsx_element_depth: 0,
+            jsx_child_element_depth: 0,
         }
     }
 
@@ -75,16 +75,12 @@ impl<'a> Visit<'a> for TransformVisitor<'a> {
         }
 
         let Some(tag_name) = it.opening_element.name.get_identifier_name() else {
-            self.jsx_element_depth += 1;
             walk::walk_jsx_element(self, it);
-            self.jsx_element_depth -= 1;
             return;
         };
 
         let Some(macro_info) = self.macro_imports.get(tag_name.as_str()) else {
-            self.jsx_element_depth += 1;
             walk::walk_jsx_element(self, it);
-            self.jsx_element_depth -= 1;
             return;
         };
 
@@ -108,11 +104,12 @@ impl<'a> Visit<'a> for TransformVisitor<'a> {
 
         match replacement {
             Ok(Some((text, compiled_id))) => {
-                let text = if macro_info.imported_name != "Trans" && self.jsx_element_depth > 0 {
-                    format!("{{{text}}}")
-                } else {
-                    text
-                };
+                let text =
+                    if macro_info.imported_name != "Trans" && self.jsx_child_element_depth > 0 {
+                        format!("{{{text}}}")
+                    } else {
+                        text
+                    };
                 self.replacements.push(Replacement {
                     start: it.span.start as usize,
                     end: it.span.end as usize,
@@ -136,9 +133,17 @@ impl<'a> Visit<'a> for TransformVisitor<'a> {
             }
         }
 
-        self.jsx_element_depth += 1;
         walk::walk_jsx_element(self, it);
-        self.jsx_element_depth -= 1;
+    }
+
+    fn visit_jsx_child(&mut self, it: &JSXChild<'a>) {
+        if matches!(it, JSXChild::Element(_)) {
+            self.jsx_child_element_depth += 1;
+            walk::walk_jsx_child(self, it);
+            self.jsx_child_element_depth -= 1;
+        } else {
+            walk::walk_jsx_child(self, it);
+        }
     }
 
     fn visit_tagged_template_expression(&mut self, it: &TaggedTemplateExpression<'a>) {

--- a/packages/transform/src/transform.test.ts
+++ b/packages/transform/src/transform.test.ts
@@ -81,7 +81,7 @@ const el = <Trans>Hello {name}</Trans>;
 
     expect(result.code).toContain('import { Trans } from "@palamedes/react"')
     expect(result.code).toContain('<Trans id="')
-    expect(result.code).toContain('message="Hello {name}"')
+    expect(result.code).toContain('message={"Hello {name}"}')
     expect(result.code).toContain('values={{ name }}')
   })
 
@@ -95,7 +95,7 @@ const y = <Trans>Hallo Welt</Trans>;
     expect(result.hasChanged).toBe(true)
     expect(result.code).toContain('import { Trans } from "@palamedes/react"')
     expect(result.code).toContain('const x = "äöü";')
-    expect(result.code).toContain('message="Hallo Welt"')
+    expect(result.code).toContain('message={"Hallo Welt"}')
     expect(result.map).toMatchObject({
       version: 3,
       sources: ["test.tsx"],
@@ -114,7 +114,7 @@ const el = <Trans>Hello <strong>{name}</strong></Trans>;
 
     expect(result.code).toContain('import { Trans } from "@palamedes/solid"')
     expect(result.code).toContain('<Trans id="')
-    expect(result.code).toContain('message="Hello <0>{name}</0>"')
+    expect(result.code).toContain('message={"Hello <0>{name}</0>"}')
     expect(result.code).toContain(
       'components={{ 0: (children) => <strong>{children}</strong> }}'
     )
@@ -127,7 +127,7 @@ const el = <Trans>Accept <a href="/terms">terms</a> and <a href="/privacy">priva
 `
     const result = transformPalamedesMacros(code, "test.tsx")
 
-    expect(result.code).toContain('message="Accept <0>terms</0> and <1>privacy</1>"')
+    expect(result.code).toContain('message={"Accept <0>terms</0> and <1>privacy</1>"}')
     expect(result.code).toContain(
       'components={{ 0: <a href="/terms" />, 1: <a href="/privacy" /> }}'
     )
@@ -141,7 +141,7 @@ const el = <Trans><strong>A</strong> and <strong>B</strong></Trans>;
     const result = transformPalamedesMacros(code, "test.tsx")
 
     expect(result.code).toContain(
-      'message="<0>A</0> and <1>B</1>"'
+      'message={"<0>A</0> and <1>B</1>"}'
     )
     expect(result.code).toContain(
       "components={{ 0: <strong />, 1: <strong /> }}"
@@ -159,6 +159,47 @@ const msg = t({ message: "Hello" });
 
     expect(result.code).toContain('getI18n()._("')
     expect(result.code).not.toContain('message: "Hello"')
+  })
+
+
+  it("emits parseable JSX for <Trans> messages containing double quotes", () => {
+    const code = `
+import { Trans } from "@palamedes/react/macro";
+export function Demo() {
+  return <Trans>Upload settlement data file with "3Degrees Audit Summary" tab</Trans>;
+}
+`
+    const result = transformPalamedesMacros(code, "test.tsx")
+
+    expect(result.code).toContain(
+      'message={"Upload settlement data file with \\\"3Degrees Audit Summary\\\" tab"}'
+    )
+    expect(result.code).not.toContain('message="Upload settlement data file with \\\"')
+  })
+
+  it("wraps JSX choice macro replacements when used as children", () => {
+    const code = `
+import { Plural } from "@palamedes/react/macro";
+export function Demo({ totalRows }: { totalRows: number }) {
+  return <p><Plural one="# row" other="# rows" value={totalRows} /></p>;
+}
+`
+    const result = transformPalamedesMacros(code, "test.tsx")
+
+    expect(result.code).toContain('<p>{getI18n()._("')
+    expect(result.code).toContain('message: "{totalRows, plural, one {# row} other {# rows}}"')
+    expect(result.code).toContain(')}</p>')
+  })
+
+  it("keeps JSX choice macro replacements as expressions outside JSX children", () => {
+    const code = `
+import { Plural } from "@palamedes/react/macro";
+const text = <Plural one="# row" other="# rows" value={totalRows} />;
+`
+    const result = transformPalamedesMacros(code, "test.tsx")
+
+    expect(result.code).toContain('const text = getI18n()._("')
+    expect(result.code).not.toContain('const text = {getI18n()._')
   })
 
   it("rejects explicit ids in macro authoring", () => {


### PR DESCRIPTION
## Summary

- emit `<Trans message={"..."} />` so literal double quotes in message text remain valid JSX
- wrap JSX choice macro replacements in `{...}` when they are emitted as JSX children
- add native and JS regression coverage for the reported `<Trans>` and `<Plural>` cases

Fixes #132.
Fixes #133.

## Validation

- `cargo fmt --check`
- `cargo test -p palamedes`
- `corepack pnpm --filter @palamedes/core-node-darwin-arm64 build`
- `corepack pnpm --filter @palamedes/core-node build`
- `corepack pnpm --filter @palamedes/transform build`
- `corepack pnpm --filter @palamedes/transform test`
