### PR TITLE
fix(next-plugin): suppress false apostrophe ICU diagnostics

### DIFF
--- a/crates/palamedes/src/catalog_artifact/compile.rs
+++ b/crates/palamedes/src/catalog_artifact/compile.rs
@@ -18,12 +18,13 @@ pub(super) fn align_diagnostics_with_runtime_icu_semantics(artifact: &mut Compil
         if diagnostic.code == "compile.invalid_icu_message" {
             if let Some(runtime_message) = artifact.messages.get(&diagnostic.key) {
                 if parse_runtime_icu(runtime_message).is_some() {
-                    push_runtime_icu_compatibility_diagnostics(
+                    if push_runtime_icu_compatibility_diagnostics(
                         &diagnostic,
                         runtime_message,
                         &mut additional,
-                    );
-                    continue;
+                    ) {
+                        continue;
+                    }
                 }
             }
         }
@@ -72,12 +73,12 @@ fn push_runtime_icu_compatibility_diagnostics(
     diagnostic: &CompiledCatalogDiagnostic,
     runtime_message: &str,
     diagnostics: &mut Vec<CompiledCatalogDiagnostic>,
-) {
+) -> bool {
     let Some(source_icu) = parse_runtime_icu(&diagnostic.msgid) else {
-        return;
+        return false;
     };
     let Some(runtime_icu) = parse_runtime_icu(runtime_message) else {
-        return;
+        return false;
     };
 
     let report = compare_icu_messages(
@@ -96,6 +97,8 @@ fn push_runtime_icu_compatibility_diagnostics(
             locale: diagnostic.locale.clone(),
         });
     }
+
+    true
 }
 
 fn parse_runtime_icu(message: &str) -> Option<ferrocat::IcuMessage> {

--- a/crates/palamedes/src/catalog_artifact/compile.rs
+++ b/crates/palamedes/src/catalog_artifact/compile.rs
@@ -1,8 +1,39 @@
 use std::path::PathBuf;
 
+use ferrocat::{
+    compare_icu_messages, parse_icu, CompiledCatalogArtifact, CompiledCatalogDiagnostic,
+    DiagnosticSeverity, IcuCompatibilityOptions, IcuDiagnosticSeverity,
+};
+
 use super::types::{
     CatalogArtifactDiagnostic, CatalogArtifactMissingMessage, CatalogArtifactResult,
 };
+
+pub(super) fn align_diagnostics_with_runtime_icu_semantics(artifact: &mut CompiledCatalogArtifact) {
+    let diagnostics = std::mem::take(&mut artifact.diagnostics);
+    let mut aligned = Vec::with_capacity(diagnostics.len());
+    let mut additional = Vec::new();
+
+    for diagnostic in diagnostics {
+        if diagnostic.code == "compile.invalid_icu_message" {
+            if let Some(runtime_message) = artifact.messages.get(&diagnostic.key) {
+                if parse_runtime_icu(runtime_message).is_some() {
+                    push_runtime_icu_compatibility_diagnostics(
+                        &diagnostic,
+                        runtime_message,
+                        &mut additional,
+                    );
+                    continue;
+                }
+            }
+        }
+
+        aligned.push(diagnostic);
+    }
+
+    aligned.extend(additional);
+    artifact.diagnostics = aligned;
+}
 
 pub(super) fn build_artifact_result(
     mut artifact: ferrocat::CompiledCatalogArtifact,
@@ -34,6 +65,52 @@ pub(super) fn build_artifact_result(
             .map(CatalogArtifactDiagnostic::from)
             .collect(),
         resolved_locale_chain: Some(fallback_chain),
+    }
+}
+
+fn push_runtime_icu_compatibility_diagnostics(
+    diagnostic: &CompiledCatalogDiagnostic,
+    runtime_message: &str,
+    diagnostics: &mut Vec<CompiledCatalogDiagnostic>,
+) {
+    let Some(source_icu) = parse_runtime_icu(&diagnostic.msgid) else {
+        return;
+    };
+    let Some(runtime_icu) = parse_runtime_icu(runtime_message) else {
+        return;
+    };
+
+    let report = compare_icu_messages(
+        &source_icu,
+        &runtime_icu,
+        &IcuCompatibilityOptions::default(),
+    );
+    for icu_diagnostic in report.diagnostics {
+        diagnostics.push(CompiledCatalogDiagnostic {
+            severity: runtime_icu_diagnostic_severity(icu_diagnostic.severity),
+            code: icu_diagnostic.code,
+            message: icu_diagnostic.message,
+            key: diagnostic.key.clone(),
+            msgid: diagnostic.msgid.clone(),
+            msgctxt: diagnostic.msgctxt.clone(),
+            locale: diagnostic.locale.clone(),
+        });
+    }
+}
+
+fn parse_runtime_icu(message: &str) -> Option<ferrocat::IcuMessage> {
+    parse_icu(&runtime_icu_validation_view(message)).ok()
+}
+
+fn runtime_icu_validation_view(message: &str) -> String {
+    message.replace('\'', "''")
+}
+
+const fn runtime_icu_diagnostic_severity(severity: IcuDiagnosticSeverity) -> DiagnosticSeverity {
+    match severity {
+        IcuDiagnosticSeverity::Info => DiagnosticSeverity::Info,
+        IcuDiagnosticSeverity::Warning => DiagnosticSeverity::Warning,
+        IcuDiagnosticSeverity::Error => DiagnosticSeverity::Error,
     }
 }
 

--- a/crates/palamedes/src/catalog_artifact/mod.rs
+++ b/crates/palamedes/src/catalog_artifact/mod.rs
@@ -17,7 +17,7 @@ use ferrocat::{
 
 use crate::error::{PalamedesError, PalamedesResult};
 
-use self::compile::build_artifact_result;
+use self::compile::{align_diagnostics_with_runtime_icu_semantics, build_artifact_result};
 use self::load::LocaleCatalogs;
 use self::resolve::{ferrocat_fallback_chain, prepare_compilation};
 pub use self::types::{
@@ -57,8 +57,9 @@ pub fn compile_catalog_artifact(
     options.source_fallback = true;
     options.icu_compatibility = true;
 
-    let artifact = ferrocat_compile_catalog_artifact(&catalogs, &options)
+    let mut artifact = ferrocat_compile_catalog_artifact(&catalogs, &options)
         .map_err(PalamedesError::CompileCatalogArtifact)?;
+    align_diagnostics_with_runtime_icu_semantics(&mut artifact);
 
     Ok(build_artifact_result(
         artifact,
@@ -98,9 +99,10 @@ pub fn compile_catalog_artifact_selected(
     options.source_fallback = true;
     options.icu_compatibility = true;
 
-    let artifact =
+    let mut artifact =
         ferrocat_compile_catalog_artifact_selected(&catalogs, &compiled_id_index, &options)
             .map_err(PalamedesError::CompileSelectedCatalogArtifact)?;
+    align_diagnostics_with_runtime_icu_semantics(&mut artifact);
 
     Ok(build_artifact_result(
         artifact,

--- a/crates/palamedes/src/catalog_artifact/tests.rs
+++ b/crates/palamedes/src/catalog_artifact/tests.rs
@@ -134,6 +134,127 @@ msgstr "{name"
 }
 
 #[test]
+fn compile_catalog_artifact_accepts_runtime_literal_apostrophes() {
+    let fixture = create_fixture_dir("catalog-artifact-apostrophes");
+    let locale_dir = fixture.join("src/locales");
+    fs::create_dir_all(&locale_dir).expect("locale dir");
+
+    fs::write(
+        locale_dir.join("en.po"),
+        r#"msgid ""
+msgstr ""
+"Language: en\n"
+
+msgid "Couldn't load applied rules"
+msgstr ""
+
+msgid "ACH Benefit Threshold"
+msgstr ""
+
+msgid "Approved - but the email didn't send"
+msgstr ""
+"#,
+    )
+    .expect("write en");
+
+    fs::write(
+        locale_dir.join("fr.po"),
+        r#"msgid ""
+msgstr ""
+"Language: fr\n"
+
+msgid "Couldn't load applied rules"
+msgstr ""
+
+msgid "ACH Benefit Threshold"
+msgstr ""
+
+msgid "Approved - but the email didn't send"
+msgstr ""
+"#,
+    )
+    .expect("write fr");
+
+    let request = CatalogArtifactRequest {
+        config: CatalogArtifactConfig {
+            root_dir: fixture.to_string_lossy().into_owned(),
+            locales: vec!["en".to_owned(), "fr".to_owned()],
+            source_locale: "en".to_owned(),
+            fallback_locales: None,
+            pseudo_locale: None,
+            catalogs: vec![CatalogConfig {
+                path: "src/locales/{locale}".to_owned(),
+            }],
+        },
+        resource_path: locale_dir.join("fr.po").to_string_lossy().into_owned(),
+    };
+    let result = compile_catalog_artifact(&request).expect("catalog artifact");
+
+    assert!(result.diagnostics.is_empty());
+}
+
+#[test]
+fn compile_catalog_artifact_keeps_icu_compatibility_diagnostics_with_apostrophes() {
+    let fixture = create_fixture_dir("catalog-artifact-apostrophe-compatibility");
+    let locale_dir = fixture.join("src/locales");
+    fs::create_dir_all(&locale_dir).expect("locale dir");
+
+    fs::write(
+        locale_dir.join("en.po"),
+        r#"msgid ""
+msgstr ""
+"Language: en\n"
+
+msgid "Couldn't load {name}"
+msgstr ""
+"#,
+    )
+    .expect("write en");
+
+    fs::write(
+        locale_dir.join("de.po"),
+        r#"msgid ""
+msgstr ""
+"Language: de\n"
+
+msgid "Couldn't load {name}"
+msgstr "Konnte {firstName}'s Daten nicht laden"
+"#,
+    )
+    .expect("write de");
+
+    let request = CatalogArtifactRequest {
+        config: CatalogArtifactConfig {
+            root_dir: fixture.to_string_lossy().into_owned(),
+            locales: vec!["en".to_owned(), "de".to_owned()],
+            source_locale: "en".to_owned(),
+            fallback_locales: None,
+            pseudo_locale: None,
+            catalogs: vec![CatalogConfig {
+                path: "src/locales/{locale}".to_owned(),
+            }],
+        },
+        resource_path: locale_dir.join("de.po").to_string_lossy().into_owned(),
+    };
+    let result = compile_catalog_artifact(&request).expect("catalog artifact");
+
+    assert!(!result
+        .diagnostics
+        .iter()
+        .any(|diagnostic| diagnostic.code == "compile.invalid_icu_message"));
+    assert!(result
+        .diagnostics
+        .iter()
+        .any(|diagnostic| diagnostic.code == "icu.missing_argument"
+            && diagnostic.source_key.message == "Couldn't load {name}"
+            && diagnostic.locale == "de"));
+    assert!(result
+        .diagnostics
+        .iter()
+        .any(|diagnostic| diagnostic.code == "icu.extra_argument"));
+}
+
+#[test]
 fn compile_catalog_artifact_reports_icu_compatibility_diagnostics() {
     let fixture = create_fixture_dir("catalog-artifact-icu-compatibility");
     let locale_dir = fixture.join("src/locales");

--- a/crates/palamedes/src/catalog_artifact/tests.rs
+++ b/crates/palamedes/src/catalog_artifact/tests.rs
@@ -255,6 +255,58 @@ msgstr "Konnte {firstName}'s Daten nicht laden"
 }
 
 #[test]
+fn compile_catalog_artifact_keeps_invalid_icu_when_source_msgid_cannot_parse() {
+    let fixture = create_fixture_dir("catalog-artifact-apostrophe-source-invalid");
+    let locale_dir = fixture.join("src/locales");
+    fs::create_dir_all(&locale_dir).expect("locale dir");
+
+    fs::write(
+        locale_dir.join("en.po"),
+        r#"msgid ""
+msgstr ""
+"Language: en\n"
+
+msgid "{unclosed"
+msgstr ""
+"#,
+    )
+    .expect("write en");
+
+    fs::write(
+        locale_dir.join("de.po"),
+        r#"msgid ""
+msgstr ""
+"Language: de\n"
+
+msgid "{unclosed"
+msgstr "John's Daten konnten nicht geladen werden"
+"#,
+    )
+    .expect("write de");
+
+    let request = CatalogArtifactRequest {
+        config: CatalogArtifactConfig {
+            root_dir: fixture.to_string_lossy().into_owned(),
+            locales: vec!["en".to_owned(), "de".to_owned()],
+            source_locale: "en".to_owned(),
+            fallback_locales: None,
+            pseudo_locale: None,
+            catalogs: vec![CatalogConfig {
+                path: "src/locales/{locale}".to_owned(),
+            }],
+        },
+        resource_path: locale_dir.join("de.po").to_string_lossy().into_owned(),
+    };
+    let result = compile_catalog_artifact(&request).expect("catalog artifact");
+
+    assert!(result.diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "compile.invalid_icu_message"
+            && diagnostic.source_key.message == "{unclosed"
+            && diagnostic.locale == "de"
+    }));
+}
+
+#[test]
 fn compile_catalog_artifact_reports_icu_compatibility_diagnostics() {
     let fixture = create_fixture_dir("catalog-artifact-icu-compatibility");
     let locale_dir = fixture.join("src/locales");
@@ -424,6 +476,63 @@ msgstr "Hallo {firstName}"
         .diagnostics
         .iter()
         .any(|diagnostic| diagnostic.code == "icu.missing_argument"));
+}
+
+#[test]
+fn compile_catalog_artifact_selected_accepts_runtime_literal_apostrophes() {
+    let fixture = create_fixture_dir("catalog-artifact-selected-apostrophes");
+    let locale_dir = fixture.join("src/locales");
+    fs::create_dir_all(&locale_dir).expect("locale dir");
+
+    fs::write(
+        locale_dir.join("en.po"),
+        r#"msgid ""
+msgstr ""
+"Language: en\n"
+
+msgid "Couldn't load applied rules"
+msgstr ""
+"#,
+    )
+    .expect("write en");
+
+    fs::write(
+        locale_dir.join("fr.po"),
+        r#"msgid ""
+msgstr ""
+"Language: fr\n"
+
+msgid "Couldn't load applied rules"
+msgstr "Impossible d'ouvrir les regles"
+"#,
+    )
+    .expect("write fr");
+
+    let request = CatalogArtifactSelectedRequest {
+        config: CatalogArtifactConfig {
+            root_dir: fixture.to_string_lossy().into_owned(),
+            locales: vec!["en".to_owned(), "fr".to_owned()],
+            source_locale: "en".to_owned(),
+            fallback_locales: None,
+            pseudo_locale: None,
+            catalogs: vec![CatalogConfig {
+                path: "src/locales/{locale}".to_owned(),
+            }],
+        },
+        resource_path: locale_dir.join("fr.po").to_string_lossy().into_owned(),
+        compiled_ids: vec![compiled_key("Couldn't load applied rules", None)],
+    };
+    let result = compile_catalog_artifact_selected(&request).expect("selected catalog artifact");
+
+    assert_eq!(result.messages.len(), 1);
+    assert_eq!(
+        result
+            .messages
+            .get(&compiled_key("Couldn't load applied rules", None))
+            .map(String::as_str),
+        Some("Impossible d'ouvrir les regles")
+    );
+    assert!(result.diagnostics.is_empty());
 }
 
 fn create_fixture_dir(prefix: &str) -> PathBuf {


### PR DESCRIPTION
## Summary

- align catalog artifact diagnostics with the runtime parser's literal-apostrophe behavior
- suppress `compile.invalid_icu_message` diagnostics when the final runtime message is valid after treating ordinary apostrophes as text
- keep ICU compatibility diagnostics for real source/translation structure mismatches, including messages that contain apostrophes

Fixes #137.

## Problem

`@palamedes/next-plugin` surfaces diagnostics from the native catalog artifact compiler. Ferrocat's strict ICU parser treats a single ASCII apostrophe as the start of an ICU escape, so ordinary source strings like `Couldn't load applied rules` and `Approved - but the email didn't send` were reported as invalid ICU even though Palamedes' runtime parser treats those apostrophes as literal text and renders the messages successfully. The noisy diagnostics obscured real build failures.

## Fix

The Palamedes catalog artifact boundary now post-processes Ferrocat diagnostics against a runtime-compatible ICU validation view. Runtime messages themselves are not rewritten. If a `compile.invalid_icu_message` is only caused by literal apostrophes, Palamedes drops that diagnostic and re-runs ICU compatibility comparison with the same validation view so genuine placeholder/tag mismatches are still reported.

## Validation

- `cargo fmt --check`
- `cargo test -p palamedes catalog_artifact`
- `pnpm --filter @palamedes/core-node build`

Note: pnpm emitted existing workspace bin-link warnings for example `pmds` binaries before the CLI package is built; the `@palamedes/core-node` build completed successfully.