### PR TITLE
fix(cli): keep extract source references deterministic

### DIFF
--- a/crates/palamedes/src/extract.rs
+++ b/crates/palamedes/src/extract.rs
@@ -1095,12 +1095,21 @@ fn catalog_key(message: &str, context: Option<&str>) -> String {
 
 impl From<AggregatedCatalogEntry> for CatalogUpdateMessage {
     fn from(value: AggregatedCatalogEntry) -> Self {
+        let AggregatedCatalogEntry {
+            message,
+            context,
+            placeholders,
+            extracted_comments,
+            mut origins,
+        } = value;
+        origins.sort_by(|a, b| a.file.cmp(&b.file).then(a.line.cmp(&b.line)));
+
         Self {
-            message: value.message,
-            context: value.context,
-            placeholders: value.placeholders,
-            extracted_comments: value.extracted_comments,
-            origins: value.origins,
+            message,
+            context,
+            placeholders,
+            extracted_comments,
+            origins,
         }
     }
 }
@@ -1284,6 +1293,59 @@ mod tests {
                 .get("name")
                 .expect("placeholder expression"),
             &vec!["user.name".to_string()]
+        );
+
+        fs::remove_dir_all(root).expect("cleanup");
+    }
+
+    #[test]
+    fn batch_sorts_aggregated_origins_by_file_then_line() {
+        let root = temp_root("batch-origin-order");
+        let src = root.join("src");
+        fs::create_dir_all(&src).expect("src dir");
+        let first = src.join("A.tsx");
+        let second = src.join("Z.tsx");
+        fs::write(
+            &first,
+            concat!(
+                "import { t } from \"@palamedes/core/macro\"\n",
+                "export const early = t`Shared origin`\n",
+                "\n",
+                "export const later = t`Shared origin`\n",
+            ),
+        )
+        .expect("first source");
+        fs::write(
+            &second,
+            concat!(
+                "import { t } from \"@palamedes/core/macro\"\n",
+                "export const duplicate = t`Shared origin`\n",
+            ),
+        )
+        .expect("second source");
+
+        let result = extract_catalog_messages_from_files(ExtractCatalogMessagesRequest {
+            root_dir: root.to_string_lossy().into_owned(),
+            files: vec![
+                second.to_string_lossy().into_owned(),
+                first.to_string_lossy().into_owned(),
+            ],
+        })
+        .expect("batch extraction");
+
+        let shared = result
+            .messages
+            .iter()
+            .find(|message| message.message == "Shared origin")
+            .expect("shared message");
+        let origins = shared
+            .origins
+            .iter()
+            .map(|origin| (origin.file.as_str(), origin.line))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            origins,
+            vec![("src/A.tsx", 2), ("src/A.tsx", 4), ("src/Z.tsx", 2)]
         );
 
         fs::remove_dir_all(root).expect("cleanup");

--- a/packages/cli/src/commands/extract.test.ts
+++ b/packages/cli/src/commands/extract.test.ts
@@ -77,6 +77,22 @@ describe("extract", () => {
     expect(findItem(deCatalog.items, "Old only")).toBeUndefined()
   })
 
+  it("keeps repeated extract --clean output byte stable", async () => {
+    const fixtureDir = await copyFixture()
+    const options = {
+      config: path.join(fixtureDir, "palamedes.config.ts"),
+      clean: true,
+    }
+
+    await extract(options)
+    const firstEnCatalog = await readCatalog(fixtureDir, "en")
+    const firstDeCatalog = await readCatalog(fixtureDir, "de")
+
+    await extract(options)
+    expect(await readCatalog(fixtureDir, "en")).toBe(firstEnCatalog)
+    expect(await readCatalog(fixtureDir, "de")).toBe(firstDeCatalog)
+  })
+
   it("emits timing JSON with glob and extract buckets", async () => {
     const fixtureDir = await copyFixture()
     process.env.PALAMEDES_TIMING_JSON = "1"

--- a/packages/cli/src/commands/extract.ts
+++ b/packages/cli/src/commands/extract.ts
@@ -116,11 +116,11 @@ async function extractFromCatalog(
   ) || ["**/node_modules/**"]
 
   const globStartedAt = Date.now()
-  const files = await glob(includePatterns, {
+  const files = (await glob(includePatterns, {
     ignore: excludePatterns,
     absolute: true,
     nodir: true,
-  })
+  })).sort(compareFilePaths)
   const globMs = Date.now() - globStartedAt
 
   if (options.verbose) {
@@ -225,4 +225,14 @@ async function runWatchMode(
 
 function shouldEmitTimingJson(): boolean {
   return process.env.PALAMEDES_TIMING_JSON === "1"
+}
+
+function compareFilePaths(a: string, b: string): number {
+  if (a < b) {
+    return -1
+  }
+  if (a > b) {
+    return 1
+  }
+  return 0
 }


### PR DESCRIPTION
## Summary

- sort `pmds extract` glob results before native batch extraction
- sort aggregated source origins by file and line before catalog update messages are serialized
- add native and CLI regressions for stable source-reference ordering and repeated `extract --clean` output

Fixes #138.

## Problem

`pmds extract --clean` could rewrite PO files even when no source files changed because source-reference ordering followed the non-guaranteed order of globbed files and aggregation input. The catalog contents were semantically identical, but `#:` reference lines could move between runs and dirty the working tree.

## Fix

The CLI now feeds files to the native extractor in deterministic path order. The native extractor also sorts each aggregated message's origins by relative file path and line number before returning `CatalogUpdateMessage` values, so catalog writers see stable references even if callers pass files in a different order.

## Validation

- `cargo fmt --check`
- `cargo test -p palamedes extract`
- `pnpm --filter @palamedes/cli test`
- `git diff --check`

Note: the CLI test initially needed local package builds for config/core-node/native artifacts in this fresh worktree; after building those local packages, the CLI suite passed.