### PR TITLE
fix(core): resolve descriptor ids through active catalog

### DIFF
--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -24,6 +24,45 @@ describe("createI18n", () => {
     )
   })
 
+  it("resolves descriptor ids through the active catalog", () => {
+    const i18n = createI18n()
+
+    i18n.load("de", {
+      "inbox.summary": "{count, plural, one {# Nachricht} other {# Nachrichten}} fuer {name}",
+    })
+    i18n.activate("de")
+
+    expect(
+      i18n._(
+        { id: "inbox.summary", message: "{count, plural, one {# message} other {# messages}} for {name}" },
+        { count: 2, name: "Ada" }
+      )
+    ).toBe("2 Nachrichten fuer Ada")
+  })
+
+  it("falls back to the descriptor message when its active catalog is missing", () => {
+    const i18n = createI18n()
+    i18n.activate("de")
+
+    expect(
+      i18n._(
+        { id: "inbox.summary", message: "{count, plural, one {# message} other {# messages}} for {name}" },
+        { count: 1, name: "Ada" }
+      )
+    ).toBe("1 message for Ada")
+  })
+
+  it("keeps descriptors without ids message-only", () => {
+    const i18n = createI18n()
+
+    i18n.load("de", {
+      "{name}": "Ada aus dem Katalog",
+    })
+    i18n.activate("de")
+
+    expect(i18n._({ message: "{name}" }, { name: "Inline" })).toBe("Inline")
+  })
+
   it("formats select and selectordinal messages", () => {
     const i18n = createI18n()
     i18n.activate("en")

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -52,6 +52,22 @@ describe("createI18n", () => {
     ).toBe("1 message for Ada")
   })
 
+  it("falls back to the descriptor message when its active catalog lacks the id", () => {
+    const i18n = createI18n()
+
+    i18n.load("de", {
+      "other.message": "Andere Nachricht",
+    })
+    i18n.activate("de")
+
+    expect(
+      i18n._(
+        { id: "inbox.summary", message: "{count, plural, one {# message} other {# messages}} for {name}" },
+        { count: 2, name: "Ada" }
+      )
+    ).toBe("2 messages for Ada")
+  })
+
   it("keeps descriptors without ids message-only", () => {
     const i18n = createI18n()
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -49,6 +49,10 @@ export function createI18n(): PalamedesI18n {
         return formatMessagePattern(this.getMessage(idOrDescriptor, descriptor), values, activeLocale)
       }
 
+      if (idOrDescriptor.id !== undefined) {
+        return formatMessagePattern(this.getMessage(idOrDescriptor.id, idOrDescriptor), values, activeLocale)
+      }
+
       return formatMessagePattern(idOrDescriptor.message ?? "", values, activeLocale)
     },
   }


### PR DESCRIPTION
## Summary

- resolve `i18n._({ id, message }, values)` through the active catalog when a descriptor id is present
- keep `message` as the fallback for missing catalog entries
- preserve message-only behavior for descriptors without an id

Fixes #136.

## Problem

The public `MessageDescriptor` overload accepted an `id`, but the descriptor branch formatted `descriptor.message` directly. Migrated Lingui-style descriptor maps such as `const labels = { foo: msg`Foo` }` therefore stayed in the source locale even when the active catalog contained a translation for the descriptor id.

## Fix

The descriptor overload now delegates id-bearing descriptors through `getMessage(id, descriptor)`, matching the existing string-id path and retaining the descriptor message as fallback. Descriptors without `id` still format their inline `message` directly.

## Validation

- `pnpm --filter @palamedes/core test`
- `git diff --check`

Note: pnpm emitted expected unsupported-platform warnings for optional native packages on darwin arm64; the core Vitest suite passed.