### PR TITLE
fix(runtime): add request-local server i18n scope

### DIFF
--- a/docs/migrate-from-lingui.md
+++ b/docs/migrate-from-lingui.md
@@ -158,6 +158,53 @@ import { setServerI18nGetter } from "@palamedes/runtime"
 setServerI18nGetter(() => getRequestScopedI18n())
 ```
 
+For Next.js App Router Server Components on the Node runtime, prefer the
+server-only helper:
+
+```ts
+// src/lib/i18n.server.ts
+import "server-only"
+
+import { cache } from "react"
+import { createServerI18nScope } from "@palamedes/runtime/server"
+import type { PalamedesI18n } from "@palamedes/core"
+
+export const serverI18n = createServerI18nScope<PalamedesI18n>()
+
+const loadActiveServerI18n = cache(async () => {
+  const locale = await resolveLocaleFromCookiesOrHeaders()
+  const i18n = await loadI18n(locale)
+  return { i18n, locale }
+})
+
+export async function createActiveServerI18n() {
+  const active = await loadActiveServerI18n()
+  serverI18n.activate(active.i18n)
+  return active
+}
+```
+
+```tsx
+// app/page.tsx
+import { t } from "@palamedes/core/macro"
+import { createActiveServerI18n } from "@/lib/i18n.server"
+
+function CheckoutTitle() {
+  return <h1>{t`Checkout`}</h1>
+}
+
+export default async function Page() {
+  await createActiveServerI18n()
+  return <CheckoutTitle />
+}
+```
+
+This follows the official RSC model: server-only modules prevent accidental
+client imports, React `cache()` memoizes work within the current request, and
+the runtime scope is activated before downstream Server Components call direct
+macros. Do not register a new global server getter from every Server Component
+render.
+
 For backend servers outside React frameworks, use the same runtime getter with
 request-local storage. The Hono/Express pattern is documented here:
 

--- a/examples/nextjs-cookie/src/app/page.tsx
+++ b/examples/nextjs-cookie/src/app/page.tsx
@@ -1,4 +1,4 @@
-import { defineMessage } from "@palamedes/core/macro"
+import { defineMessage, t } from "@palamedes/core/macro"
 import type { MessageDescriptor, PalamedesI18n } from "@palamedes/core"
 import { ClientLocaleBoundary } from "@/components/ClientLocaleBoundary"
 import { LanguageSwitcher } from "@/components/LanguageSwitcher"
@@ -16,6 +16,7 @@ const serverComponentProofMessage = defineMessage({ message: "Server Component P
 const serverSectionMessage = defineMessage({ message: "This section was rendered on the server for locale {localeLabel}." }) as unknown as MessageDescriptor
 const serverLocaleMessage = defineMessage({ message: "Server locale" }) as unknown as MessageDescriptor
 const localeSourceMessage = defineMessage({ message: "Locale source" }) as unknown as MessageDescriptor
+const directServerMacroMessage = defineMessage({ message: "Direct server macro" }) as unknown as MessageDescriptor
 const cookieStrategyMessage = defineMessage({ message: "Cookie strategy" }) as unknown as MessageDescriptor
 const cookieStrategyDescriptionMessage = defineMessage({
   message: "Without a locale cookie, the server picks the best supported language from Accept-Language. After switching, the cookie becomes authoritative.",
@@ -32,8 +33,12 @@ function translate(
   return i18n._(id, values, descriptor)
 }
 
+function DirectServerMacroProbe() {
+  return t({ message: "Direct server macro ran inside the request scope." })
+}
+
 // This is a Server Component!
-// Direct macros compile to getI18n()._() and resolve the active server instance.
+// Direct macros compile to getI18n()._() and resolve through the request-local server scope.
 // When the user changes language, router.refresh() is called,
 // which causes the server to re-render with the new locale from the cookie.
 
@@ -74,6 +79,10 @@ export default async function Home() {
           <dd data-testid="server-locale-value" style={{ margin: 0 }}>{localeLabel}</dd>
           <dt>{translate(i18n, localeSourceMessage)}</dt>
           <dd style={{ margin: 0 }}>{source}</dd>
+          <dt>{translate(i18n, directServerMacroMessage)}</dt>
+          <dd data-testid="direct-server-macro-value" style={{ margin: 0 }}>
+            <DirectServerMacroProbe />
+          </dd>
           <dt>{translate(i18n, renderedOnServerMessage)}</dt>
           <dd style={{ margin: 0 }}>
             <code>{renderedAt}</code>

--- a/examples/nextjs-cookie/src/lib/i18n.server.ts
+++ b/examples/nextjs-cookie/src/lib/i18n.server.ts
@@ -1,11 +1,14 @@
 import "server-only"
 
+import { cache } from "react"
 import { cookies } from "next/headers"
 import { headers } from "next/headers"
-import { setServerI18nGetter } from "@palamedes/runtime"
+import { createServerI18nScope } from "@palamedes/runtime/server"
 import type { PalamedesI18n } from "@palamedes/core"
 import { resolveCookieLocale, type LocaleSource } from "@palamedes/example-locale-shared"
 import { createExampleI18n, type Locale, loadMessages } from "./i18n"
+
+export const serverI18nScope = createServerI18nScope<PalamedesI18n>()
 
 /**
  * Get the current locale from cookies (server-side only)
@@ -22,13 +25,13 @@ export async function getLocale(): Promise<{ locale: Locale; source: LocaleSourc
 }
 
 /**
- * Initialize a request-local i18n instance and register it for server-side rendering.
+ * Initialize a request-local i18n instance for server-side rendering.
  */
-export async function createActiveServerI18n(locale?: Locale): Promise<{
+const resolveActiveServerI18n = cache(async (locale?: Locale): Promise<{
   i18n: PalamedesI18n
   locale: Locale
   source: LocaleSource
-}> {
+}> => {
   const resolved = locale
     ? { locale, source: "cookie" as const }
     : await getLocale()
@@ -38,17 +41,33 @@ export async function createActiveServerI18n(locale?: Locale): Promise<{
 
   i18n.load(resolvedLocale, messages)
   i18n.activate(resolvedLocale)
-  setServerI18nGetter(() => i18n)
 
   return {
     i18n,
     locale: resolvedLocale,
     source: resolved.source,
   }
+})
+
+export async function createActiveServerI18n(locale?: Locale): Promise<{
+  i18n: PalamedesI18n
+  locale: Locale
+  source: LocaleSource
+}> {
+  const active = await resolveActiveServerI18n(locale)
+  serverI18nScope.activate(active.i18n)
+  return active
+}
+
+export function runWithServerI18n<Result>(
+  i18n: PalamedesI18n,
+  callback: () => Result
+): Result {
+  return serverI18nScope.run(i18n, callback)
 }
 
 /**
- * Initialize i18n for server-side rendering and register the request-local instance.
+ * Initialize i18n for server-side rendering.
  */
 export async function initI18nServer(): Promise<Locale> {
   const { locale } = await createActiveServerI18n()

--- a/examples/nextjs-cookie/src/locales/de.po
+++ b/examples/nextjs-cookie/src/locales/de.po
@@ -12,89 +12,136 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "X-Generator: palamedes\n"
 
-#: src/components/Counter.tsx:40
-msgid "Click me"
-msgstr "Klick mich"
-
-#: src/components/ServerActionProbe.tsx:45
+#: src/components/ServerActionProbe.tsx:58
 msgid "Ask server for localized status"
 msgstr "Server nach lokalisiertem Status fragen"
 
-#: src/components/Counter.tsx:20
+#: src/components/Counter.tsx:36
+msgid "Click me"
+msgstr "Klick mich"
+
+#: src/components/Counter.tsx:13
+msgid "Client interaction"
+msgstr "Client-Interaktion"
+
+#: src/app/page.tsx:20
+msgid "Cookie strategy"
+msgstr "Cookie-Strategie"
+
+#: src/components/Counter.tsx:16
 msgid "Counter Example"
 msgstr "Zaehlerbeispiel"
 
-#: src/components/ServerActionProbe.tsx:31
-msgid ""
-"This button calls a dedicated server action that reads the active locale"
-" from the request cookie and returns localized text from the server."
-msgstr ""
-"Dieser Button ruft eine eigene Server-Action auf, die die aktive"
-" Sprache aus dem Request-Cookie liest und lokalisierten Text vom Server"
-" zurueckgibt."
+#: src/app/page.tsx:19
+msgid "Direct server macro"
+msgstr "Direktes Server-Makro"
 
-#: src/components/ServerActionProbe.tsx:75
-msgid "Run the action to fetch a server-localized result."
-msgstr "Fuehre die Action aus, um ein server-lokalisiertes Ergebnis zu laden."
+#: src/app/page.tsx:37
+msgid "Direct server macro ran inside the request scope."
+msgstr "Direktes Server-Makro lief im Request-Scope."
 
-#: src/app/page.tsx:25
-msgid "Language"
-msgstr "Sprache"
-
-#: src/components/ServerActionProbe.tsx:32
-msgid "Server Action Proof"
-msgstr "Server-Action-Beweis"
-
-#: src/app/page.tsx:31
-msgid "Server Component Proof"
-msgstr "Server-Component-Beweis"
-
-#: src/components/ServerActionProbe.tsx:65
-#: src/app/page.tsx:42
-msgid "Server locale"
-msgstr "Server-Sprache"
-
-#: src/components/ServerActionProbe.tsx:69
-#: src/app/page.tsx:44
+#: src/components/ServerActionProbe.tsx:74
 msgid "Handled at"
 msgstr "Bearbeitet um"
 
-#: src/components/ServerActionProbe.tsx:73
+#: src/app/page.tsx:14
+msgid "Language"
+msgstr "Sprache"
+
+#: src/app/page.tsx:18
+msgid "Locale source"
+msgstr "Sprachquelle"
+
+#: src/components/ServerActionProbe.tsx:80
 msgid "Localized message"
 msgstr "Lokalisierte Nachricht"
 
-#: src/app/page.tsx:47
-msgid "Rendered on server"
-msgstr "Auf dem Server gerendert"
+#: src/components/ServerActionProbe.tsx:36
+msgid "Localized server action result"
+msgstr "Lokalisierte Server-Action-Antwort"
 
-#: src/app/page.tsx:36
-msgid "This section was rendered on the server for locale {localeLabel}."
-msgstr "Dieser Abschnitt wurde auf dem Server fuer die Sprache {localeLabel} gerendert."
+#~ #: src/app/page.tsx:33
+#~ msgid "Powered by <0>@palamedes/next-plugin</0>"
+#~ msgstr "Bereitgestellt von <0>@palamedes/next-plugin</0>"
 
-#: src/app/page.tsx:33
-msgid "Powered by <0>@palamedes/next-plugin</0>"
-msgstr "Bereitgestellt von <0>@palamedes/next-plugin</0>"
-
-#: src/app/page.tsx:33
+#: src/app/page.tsx:25
 msgid "Powered by @palamedes/next-plugin"
 msgstr "Bereitgestellt von @palamedes/next-plugin"
 
-#: src/app/page.tsx:21
-msgid ""
-"This example demonstrates the Palamedes-owned runtime with the OXC-based macro"
-" transformer in a Next.js App Router project. No Babel required!"
-msgstr ""
-"Dieses Beispiel zeigt die Palamedes-eigene Runtime mit dem OXC-basierten"
-" Makro-Transformer in einem Next.js-App-Router-Projekt. Kein Babel noetig!"
+#: src/app/page.tsx:24
+msgid "Rendered on server"
+msgstr "Auf dem Server gerendert"
 
-#: src/app/page.tsx:18
-msgid "Welcome to Palamedes"
-msgstr "Willkommen bei Palamedes"
+#: src/components/ServerActionProbe.tsx:86
+msgid "Run the action to fetch a server-localized result."
+msgstr "Fuehre die Action aus, um ein server-lokalisiertes Ergebnis zu laden."
 
-#: src/lib/actions.ts:29
+#~ #: src/components/ServerActionProbe.tsx:32
+#~ msgid "Server Action Proof"
+#~ msgstr "Server-Action-Beweis"
+
+#: src/app/page.tsx:15
+msgid "Server Component Proof"
+msgstr "Server-Component-Beweis"
+
+#: src/lib/actions.ts:10
 msgid "Server action confirmed locale {locale}."
 msgstr "Die Server-Action hat die Sprache {locale} bestaetigt."
 
-#: src/components/Counter.tsx:23
+#: src/components/ServerActionProbe.tsx:33
+msgid "Server action proof"
+msgstr "Server-Action-Beweis"
+
+#: src/components/ServerActionProbe.tsx:70
+#: src/app/page.tsx:17
+msgid "Server locale"
+msgstr "Server-Sprache"
+
+#: src/components/ServerActionProbe.tsx:39
+msgid ""
+"This button calls a dedicated server action that reads the active locale from "
+"the request cookie and returns localized text from the server."
+msgstr ""
+"Dieser Button ruft eine eigene Server-Action auf, die die aktive Sprache aus "
+"dem Request-Cookie liest und lokalisierten Text vom Server zurueckgibt."
+
+#: src/app/page.tsx:11
+msgid ""
+"This cookie-based Next.js example derives the first locale from "
+"Accept-Language, persists it in a cookie, and keeps server components plus "
+"server actions localized from the request state."
+msgstr ""
+"Dieses Cookie-basierte Next.js-Beispiel leitet die erste Sprache aus "
+"Accept-Language ab, speichert sie in einem Cookie und haelt Server "
+"Components plus Server Actions anhand des Request-Zustands lokalisiert."
+
+#~ #: src/app/page.tsx:21
+#~ msgid ""
+#~ "This example demonstrates the Palamedes-owned runtime with the OXC-based macro"
+#~ " transformer in a Next.js App Router project. No Babel required!"
+#~ msgstr ""
+#~ "Dieses Beispiel zeigt die Palamedes-eigene Runtime mit dem OXC-basierten "
+#~ "Makro-Transformer in einem Next.js-App-Router-Projekt. Kein Babel noetig!"
+
+#: src/app/page.tsx:16
+msgid "This section was rendered on the server for locale {localeLabel}."
+msgstr ""
+"Dieser Abschnitt wurde auf dem Server fuer die Sprache {localeLabel} "
+"gerendert."
+
+#: src/app/page.tsx:10
+msgid "Welcome to Palamedes"
+msgstr "Willkommen bei Palamedes"
+
+#: src/app/page.tsx:21
+msgid ""
+"Without a locale cookie, the server picks the best supported language from "
+"Accept-Language. After switching, the cookie becomes authoritative."
+msgstr ""
+"Ohne Sprach-Cookie waehlt der Server die am besten passende unterstuetzte "
+"Sprache aus Accept-Language. Nach dem Wechsel ist das Cookie massgeblich."
+
+#: src/components/Counter.tsx:19
 msgid "{count, plural, one {You clicked # time} other {You clicked # times}}"
-msgstr "{count, plural, one {Du hast # Mal geklickt} other {Du hast # Mal geklickt}}"
+msgstr ""
+"{count, plural, one {Du hast # Mal geklickt} other {Du hast # Mal geklickt}}"

--- a/examples/nextjs-cookie/src/locales/en.po
+++ b/examples/nextjs-cookie/src/locales/en.po
@@ -12,88 +12,133 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "X-Generator: palamedes\n"
 
-#: src/components/Counter.tsx:40
-msgid "Click me"
-msgstr "Click me"
-
-#: src/components/ServerActionProbe.tsx:45
+#: src/components/ServerActionProbe.tsx:58
 msgid "Ask server for localized status"
 msgstr "Ask server for localized status"
 
-#: src/components/Counter.tsx:20
+#: src/components/Counter.tsx:36
+msgid "Click me"
+msgstr "Click me"
+
+#: src/components/Counter.tsx:13
+msgid "Client interaction"
+msgstr "Client interaction"
+
+#: src/app/page.tsx:20
+msgid "Cookie strategy"
+msgstr "Cookie strategy"
+
+#: src/components/Counter.tsx:16
 msgid "Counter Example"
 msgstr "Counter Example"
 
-#: src/components/ServerActionProbe.tsx:31
-msgid ""
-"This button calls a dedicated server action that reads the active locale"
-" from the request cookie and returns localized text from the server."
-msgstr ""
-"This button calls a dedicated server action that reads the active locale"
-" from the request cookie and returns localized text from the server."
+#: src/app/page.tsx:19
+msgid "Direct server macro"
+msgstr "Direct server macro"
 
-#: src/components/ServerActionProbe.tsx:75
-msgid "Run the action to fetch a server-localized result."
-msgstr "Run the action to fetch a server-localized result."
+#: src/app/page.tsx:37
+msgid "Direct server macro ran inside the request scope."
+msgstr "Direct server macro ran inside the request scope."
 
-#: src/app/page.tsx:25
-msgid "Language"
-msgstr "Language"
-
-#: src/components/ServerActionProbe.tsx:32
-msgid "Server Action Proof"
-msgstr "Server Action Proof"
-
-#: src/app/page.tsx:31
-msgid "Server Component Proof"
-msgstr "Server Component Proof"
-
-#: src/components/ServerActionProbe.tsx:65
-#: src/app/page.tsx:42
-msgid "Server locale"
-msgstr "Server locale"
-
-#: src/components/ServerActionProbe.tsx:69
-#: src/app/page.tsx:44
+#: src/components/ServerActionProbe.tsx:74
 msgid "Handled at"
 msgstr "Handled at"
 
-#: src/components/ServerActionProbe.tsx:73
+#: src/app/page.tsx:14
+msgid "Language"
+msgstr "Language"
+
+#: src/app/page.tsx:18
+msgid "Locale source"
+msgstr "Locale source"
+
+#: src/components/ServerActionProbe.tsx:80
 msgid "Localized message"
 msgstr "Localized message"
 
-#: src/app/page.tsx:47
-msgid "Rendered on server"
-msgstr "Rendered on server"
+#: src/components/ServerActionProbe.tsx:36
+msgid "Localized server action result"
+msgstr "Localized server action result"
 
-#: src/app/page.tsx:36
-msgid "This section was rendered on the server for locale {localeLabel}."
-msgstr "This section was rendered on the server for locale {localeLabel}."
+#~ #: src/app/page.tsx:33
+#~ msgid "Powered by <0>@palamedes/next-plugin</0>"
+#~ msgstr "Powered by <0>@palamedes/next-plugin</0>"
 
-#: src/app/page.tsx:33
-msgid "Powered by <0>@palamedes/next-plugin</0>"
-msgstr "Powered by <0>@palamedes/next-plugin</0>"
-
-#: src/app/page.tsx:33
+#: src/app/page.tsx:25
 msgid "Powered by @palamedes/next-plugin"
 msgstr "Powered by @palamedes/next-plugin"
 
-#: src/app/page.tsx:21
-msgid ""
-"This example demonstrates the Palamedes-owned runtime with the OXC-based macro"
-" transformer in a Next.js App Router project. No Babel required!"
-msgstr ""
-"This example demonstrates the Palamedes-owned runtime with the OXC-based macro"
-" transformer in a Next.js App Router project. No Babel required!"
+#: src/app/page.tsx:24
+msgid "Rendered on server"
+msgstr "Rendered on server"
 
-#: src/app/page.tsx:18
-msgid "Welcome to Palamedes"
-msgstr "Welcome to Palamedes"
+#: src/components/ServerActionProbe.tsx:86
+msgid "Run the action to fetch a server-localized result."
+msgstr "Run the action to fetch a server-localized result."
 
-#: src/lib/actions.ts:29
+#~ #: src/components/ServerActionProbe.tsx:32
+#~ msgid "Server Action Proof"
+#~ msgstr "Server Action Proof"
+
+#: src/app/page.tsx:15
+msgid "Server Component Proof"
+msgstr "Server Component Proof"
+
+#: src/lib/actions.ts:10
 msgid "Server action confirmed locale {locale}."
 msgstr "Server action confirmed locale {locale}."
 
-#: src/components/Counter.tsx:23
+#: src/components/ServerActionProbe.tsx:33
+msgid "Server action proof"
+msgstr "Server action proof"
+
+#: src/components/ServerActionProbe.tsx:70
+#: src/app/page.tsx:17
+msgid "Server locale"
+msgstr "Server locale"
+
+#: src/components/ServerActionProbe.tsx:39
+msgid ""
+"This button calls a dedicated server action that reads the active locale from "
+"the request cookie and returns localized text from the server."
+msgstr ""
+"This button calls a dedicated server action that reads the active locale from "
+"the request cookie and returns localized text from the server."
+
+#: src/app/page.tsx:11
+msgid ""
+"This cookie-based Next.js example derives the first locale from "
+"Accept-Language, persists it in a cookie, and keeps server components plus "
+"server actions localized from the request state."
+msgstr ""
+"This cookie-based Next.js example derives the first locale from "
+"Accept-Language, persists it in a cookie, and keeps server components plus "
+"server actions localized from the request state."
+
+#~ #: src/app/page.tsx:21
+#~ msgid ""
+#~ "This example demonstrates the Palamedes-owned runtime with the OXC-based macro"
+#~ " transformer in a Next.js App Router project. No Babel required!"
+#~ msgstr ""
+#~ "This example demonstrates the Palamedes-owned runtime with the OXC-based macro"
+#~ " transformer in a Next.js App Router project. No Babel required!"
+
+#: src/app/page.tsx:16
+msgid "This section was rendered on the server for locale {localeLabel}."
+msgstr "This section was rendered on the server for locale {localeLabel}."
+
+#: src/app/page.tsx:10
+msgid "Welcome to Palamedes"
+msgstr "Welcome to Palamedes"
+
+#: src/app/page.tsx:21
+msgid ""
+"Without a locale cookie, the server picks the best supported language from "
+"Accept-Language. After switching, the cookie becomes authoritative."
+msgstr ""
+"Without a locale cookie, the server picks the best supported language from "
+"Accept-Language. After switching, the cookie becomes authoritative."
+
+#: src/components/Counter.tsx:19
 msgid "{count, plural, one {You clicked # time} other {You clicked # times}}"
 msgstr "{count, plural, one {You clicked # time} other {You clicked # times}}"

--- a/examples/nextjs-cookie/src/locales/es.po
+++ b/examples/nextjs-cookie/src/locales/es.po
@@ -12,89 +12,135 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "X-Generator: palamedes\n"
 
-#: src/components/Counter.tsx:40
-msgid "Click me"
-msgstr "Haz clic"
-
-#: src/components/ServerActionProbe.tsx:45
+#: src/components/ServerActionProbe.tsx:58
 msgid "Ask server for localized status"
 msgstr "Pedir al servidor un estado localizado"
 
-#: src/components/Counter.tsx:20
+#: src/components/Counter.tsx:36
+msgid "Click me"
+msgstr "Haz clic"
+
+#: src/components/Counter.tsx:13
+msgid "Client interaction"
+msgstr "Interaccion del cliente"
+
+#: src/app/page.tsx:20
+msgid "Cookie strategy"
+msgstr "Estrategia de cookies"
+
+#: src/components/Counter.tsx:16
 msgid "Counter Example"
 msgstr "Ejemplo del contador"
 
-#: src/components/ServerActionProbe.tsx:31
-msgid ""
-"This button calls a dedicated server action that reads the active locale"
-" from the request cookie and returns localized text from the server."
-msgstr ""
-"Este boton llama a una accion dedicada del servidor que lee el idioma"
-" activo desde la cookie de la solicitud y devuelve texto localizado desde el"
-" servidor."
+#: src/app/page.tsx:19
+msgid "Direct server macro"
+msgstr "Macro directo del servidor"
 
-#: src/components/ServerActionProbe.tsx:75
-msgid "Run the action to fetch a server-localized result."
-msgstr "Ejecuta la accion para obtener un resultado localizado del servidor."
+#: src/app/page.tsx:37
+msgid "Direct server macro ran inside the request scope."
+msgstr "El macro directo del servidor se ejecuto en el alcance de la solicitud."
 
-#: src/app/page.tsx:25
-msgid "Language"
-msgstr "Idioma"
-
-#: src/components/ServerActionProbe.tsx:32
-msgid "Server Action Proof"
-msgstr "Prueba de la accion del servidor"
-
-#: src/app/page.tsx:31
-msgid "Server Component Proof"
-msgstr "Prueba del componente del servidor"
-
-#: src/components/ServerActionProbe.tsx:65
-#: src/app/page.tsx:42
-msgid "Server locale"
-msgstr "Idioma del servidor"
-
-#: src/components/ServerActionProbe.tsx:69
-#: src/app/page.tsx:44
+#: src/components/ServerActionProbe.tsx:74
 msgid "Handled at"
 msgstr "Atendido en"
 
-#: src/components/ServerActionProbe.tsx:73
+#: src/app/page.tsx:14
+msgid "Language"
+msgstr "Idioma"
+
+#: src/app/page.tsx:18
+msgid "Locale source"
+msgstr "Origen del idioma"
+
+#: src/components/ServerActionProbe.tsx:80
 msgid "Localized message"
 msgstr "Mensaje localizado"
 
-#: src/app/page.tsx:47
-msgid "Rendered on server"
-msgstr "Renderizado en el servidor"
+#: src/components/ServerActionProbe.tsx:36
+msgid "Localized server action result"
+msgstr "Resultado localizado de la accion del servidor"
 
-#: src/app/page.tsx:36
-msgid "This section was rendered on the server for locale {localeLabel}."
-msgstr "Esta seccion se renderizo en el servidor para el idioma {localeLabel}."
+#~ #: src/app/page.tsx:33
+#~ msgid "Powered by <0>@palamedes/next-plugin</0>"
+#~ msgstr "Impulsado por <0>@palamedes/next-plugin</0>"
 
-#: src/app/page.tsx:33
-msgid "Powered by <0>@palamedes/next-plugin</0>"
-msgstr "Impulsado por <0>@palamedes/next-plugin</0>"
-
-#: src/app/page.tsx:33
+#: src/app/page.tsx:25
 msgid "Powered by @palamedes/next-plugin"
 msgstr "Impulsado por @palamedes/next-plugin"
 
-#: src/app/page.tsx:21
-msgid ""
-"This example demonstrates the Palamedes-owned runtime with the OXC-based macro"
-" transformer in a Next.js App Router project. No Babel required!"
-msgstr ""
-"Este ejemplo muestra la runtime propia de Palamedes con el transformador de"
-" macros basado en OXC en un proyecto Next.js App Router. No se necesita Babel."
+#: src/app/page.tsx:24
+msgid "Rendered on server"
+msgstr "Renderizado en el servidor"
 
-#: src/app/page.tsx:18
-msgid "Welcome to Palamedes"
-msgstr "Bienvenido a Palamedes"
+#: src/components/ServerActionProbe.tsx:86
+msgid "Run the action to fetch a server-localized result."
+msgstr "Ejecuta la accion para obtener un resultado localizado del servidor."
 
-#: src/lib/actions.ts:29
+#~ #: src/components/ServerActionProbe.tsx:32
+#~ msgid "Server Action Proof"
+#~ msgstr "Prueba de la accion del servidor"
+
+#: src/app/page.tsx:15
+msgid "Server Component Proof"
+msgstr "Prueba del componente del servidor"
+
+#: src/lib/actions.ts:10
 msgid "Server action confirmed locale {locale}."
 msgstr "La accion del servidor confirmo el idioma {locale}."
 
-#: src/components/Counter.tsx:23
+#: src/components/ServerActionProbe.tsx:33
+msgid "Server action proof"
+msgstr "Prueba de la accion del servidor"
+
+#: src/components/ServerActionProbe.tsx:70
+#: src/app/page.tsx:17
+msgid "Server locale"
+msgstr "Idioma del servidor"
+
+#: src/components/ServerActionProbe.tsx:39
+msgid ""
+"This button calls a dedicated server action that reads the active locale from "
+"the request cookie and returns localized text from the server."
+msgstr ""
+"Este boton llama a una accion dedicada del servidor que lee el idioma activo "
+"desde la cookie de la solicitud y devuelve texto localizado desde el servidor."
+
+#: src/app/page.tsx:11
+msgid ""
+"This cookie-based Next.js example derives the first locale from "
+"Accept-Language, persists it in a cookie, and keeps server components plus "
+"server actions localized from the request state."
+msgstr ""
+"Este ejemplo de Next.js basado en cookies deriva el primer idioma de "
+"Accept-Language, lo guarda en una cookie y mantiene Server Components y "
+"Server Actions localizados desde el estado de la solicitud."
+
+#~ #: src/app/page.tsx:21
+#~ msgid ""
+#~ "This example demonstrates the Palamedes-owned runtime with the OXC-based macro"
+#~ " transformer in a Next.js App Router project. No Babel required!"
+#~ msgstr ""
+#~ "Este ejemplo muestra la runtime propia de Palamedes con el transformador de "
+#~ "macros basado en OXC en un proyecto Next.js App Router. No se necesita Babel."
+
+#: src/app/page.tsx:16
+msgid "This section was rendered on the server for locale {localeLabel}."
+msgstr "Esta seccion se renderizo en el servidor para el idioma {localeLabel}."
+
+#: src/app/page.tsx:10
+msgid "Welcome to Palamedes"
+msgstr "Bienvenido a Palamedes"
+
+#: src/app/page.tsx:21
+msgid ""
+"Without a locale cookie, the server picks the best supported language from "
+"Accept-Language. After switching, the cookie becomes authoritative."
+msgstr ""
+"Sin una cookie de idioma, el servidor elige el idioma compatible mas "
+"adecuado desde Accept-Language. Despues del cambio, la cookie tiene "
+"prioridad."
+
+#: src/components/Counter.tsx:19
 msgid "{count, plural, one {You clicked # time} other {You clicked # times}}"
-msgstr "{count, plural, one {Has hecho clic # vez} other {Has hecho clic # veces}}"
+msgstr ""
+"{count, plural, one {Has hecho clic # vez} other {Has hecho clic # veces}}"

--- a/packages/next-plugin/README.md
+++ b/packages/next-plugin/README.md
@@ -59,6 +59,58 @@ export default defineConfig({
 
 Transformed code expects `getI18n()` from `@palamedes/runtime`, so make sure the active i18n instance is available on both the client and the server before translated code executes.
 
+For App Router Server Components on the Node runtime, use a server-only module
+with `@palamedes/runtime/server`. This follows the official RSC shape: keep
+server code behind `server-only`, memoize request work with React `cache()`, and
+bind direct macro calls to the active request scope while rendering.
+
+```ts
+// src/lib/i18n.server.ts
+import "server-only"
+
+import { cache } from "react"
+import { createServerI18nScope } from "@palamedes/runtime/server"
+import type { PalamedesI18n } from "@palamedes/core"
+
+export const serverI18n = createServerI18nScope<PalamedesI18n>()
+
+const loadActiveServerI18n = cache(async () => {
+  const locale = await resolveLocaleFromCookiesOrHeaders()
+  const i18n = await loadI18n(locale)
+  return { i18n, locale }
+})
+
+export async function createActiveServerI18n() {
+  const active = await loadActiveServerI18n()
+  serverI18n.activate(active.i18n)
+  return active
+}
+```
+
+```tsx
+// app/page.tsx
+import { t } from "@palamedes/core/macro"
+import { createActiveServerI18n } from "@/lib/i18n.server"
+
+function DownstreamServerTitle() {
+  return <h1>{t`Welcome to Palamedes`}</h1>
+}
+
+export default async function Page() {
+  await createActiveServerI18n()
+  return <DownstreamServerTitle />
+}
+```
+
+Do not call `setServerI18nGetter()` inside every Server Component render. Create
+one server scope at module level, activate it during request-local server
+initialization, and let downstream Server Components call macros normally. Use
+`serverI18n.run(i18n, callback)` for tightly scoped helper callbacks or classic
+Node request handlers. The `@palamedes/runtime/server` subpath imports Node
+`async_hooks`, so keep it out of Client Components and Edge runtime code.
+
+References: [Next.js Server and Client Components](https://nextjs.org/docs/app/getting-started/server-and-client-components), [Next.js data fetching and request-scoped React cache](https://nextjs.org/docs/app/getting-started/fetching-data), and [React `cache`](https://react.dev/reference/react/cache).
+
 ## Options
 
 ```js

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -48,26 +48,43 @@ setServerI18nGetter(() => {
 })
 ```
 
+For Node server code, prefer the server-only helper subpath. It uses
+`AsyncLocalStorage` internally and registers the runtime getter once when the
+scope is created:
+
+```ts
+import { createI18n } from "@palamedes/core"
+import { createServerI18nScope } from "@palamedes/runtime/server"
+
+const serverI18n = createServerI18nScope<ReturnType<typeof createI18n>>()
+
+serverI18n.activate(i18n)
+renderTranslatedServerComponents()
+
+await serverI18n.run(i18n, async () => {
+  renderTranslatedRequestHandler()
+})
+```
+
 ## Backend Servers
 
 The same runtime model also works in classic backend applications such as Hono,
 Express, or custom Node servers.
 
 The important requirement is request-local access to the active i18n instance.
-The recommended pattern is `AsyncLocalStorage`:
+The recommended pattern is `@palamedes/runtime/server`:
 
 ```ts
-import { AsyncLocalStorage } from "node:async_hooks"
 import { createI18n } from "@palamedes/core"
-import { setServerI18nGetter } from "@palamedes/runtime"
+import { createServerI18nScope } from "@palamedes/runtime/server"
 
-const i18nStorage = new AsyncLocalStorage<ReturnType<typeof createI18n>>()
-
-setServerI18nGetter(() => i18nStorage.getStore())
+const serverI18n = createServerI18nScope<ReturnType<typeof createI18n>>()
 ```
 
 Per request, resolve the locale from `Accept-Language`, cookies, session data,
-or the user profile, then run the request inside `i18nStorage.run(i18n, ...)`.
+or the user profile. Use `serverI18n.activate(i18n)` when framework rendering
+continues after the initializer returns, as in React Server Components. Use
+`serverI18n.run(i18n, ...)` for tightly scoped request-handler callbacks.
 
 For a fuller walkthrough, including Hono and Express examples, see:
 
@@ -79,6 +96,10 @@ For a fuller walkthrough, including Hono and Express examples, see:
 - `setClientI18n(i18n)`
 - `setServerI18nGetter(getter)`
 - `resetI18nRuntime()`
+- `createServerI18nScope()` from `@palamedes/runtime/server` for Node runtimes
+  - `scope.activate(i18n)` binds an i18n instance to the current async context
+  - `scope.run(i18n, callback)` runs a callback inside a scoped async context
+  - `scope.get()` returns the current scoped i18n instance, if one is active
 
 ## Related Packages
 

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -66,6 +66,10 @@ await serverI18n.run(i18n, async () => {
 })
 ```
 
+All scopes created by this helper share the same runtime getter, so independently
+created scopes do not disconnect transformed `getI18n()` calls from the scope
+that was activated for the current async context.
+
 ## Backend Servers
 
 The same runtime model also works in classic backend applications such as Hono,
@@ -100,6 +104,10 @@ For a fuller walkthrough, including Hono and Express examples, see:
   - `scope.activate(i18n)` binds an i18n instance to the current async context
   - `scope.run(i18n, callback)` runs a callback inside a scoped async context
   - `scope.get()` returns the current scoped i18n instance, if one is active
+
+The `@palamedes/runtime/server` implementation imports Node `async_hooks`. In
+non-Node bundles, the subpath resolves to a small fallback module that throws an
+actionable Node-only error when called.
 
 ## Related Packages
 

--- a/packages/runtime/build.config.ts
+++ b/packages/runtime/build.config.ts
@@ -1,0 +1,10 @@
+import { defineBuildConfig } from "unbuild"
+
+export default defineBuildConfig({
+  entries: ["./src/index", "./src/server"],
+  declaration: true,
+  failOnWarn: false,
+  rollup: {
+    emitCJS: true,
+  },
+})

--- a/packages/runtime/build.config.ts
+++ b/packages/runtime/build.config.ts
@@ -1,7 +1,7 @@
 import { defineBuildConfig } from "unbuild"
 
 export default defineBuildConfig({
-  entries: ["./src/index", "./src/server"],
+  entries: ["./src/index", "./src/server", "./src/server-unavailable"],
   declaration: true,
   failOnWarn: false,
   rollup: {

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -22,7 +22,9 @@
       "node": {
         "import": "./dist/server.mjs",
         "require": "./dist/server.cjs"
-      }
+      },
+      "browser": "./dist/server-unavailable.mjs",
+      "default": "./dist/server-unavailable.mjs"
     }
   },
   "main": "./dist/index.cjs",
@@ -35,7 +37,7 @@
   ],
   "scripts": {
     "build": "unbuild",
-    "test": "vitest run --globals src/index.test.ts src/server.test.ts",
+    "test": "vitest run --globals src/index.test.ts src/server.test.ts src/server-unavailable.test.ts",
     "stub": "unbuild --stub"
   },
   "engines": {

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -16,6 +16,13 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
+    },
+    "./server": {
+      "types": "./dist/server.d.ts",
+      "node": {
+        "import": "./dist/server.mjs",
+        "require": "./dist/server.cjs"
+      }
     }
   },
   "main": "./dist/index.cjs",
@@ -28,7 +35,7 @@
   ],
   "scripts": {
     "build": "unbuild",
-    "test": "vitest run --globals src/index.test.ts",
+    "test": "vitest run --globals src/index.test.ts src/server.test.ts",
     "stub": "unbuild --stub"
   },
   "engines": {

--- a/packages/runtime/src/index.test.ts
+++ b/packages/runtime/src/index.test.ts
@@ -2,9 +2,20 @@ import { AsyncLocalStorage } from "node:async_hooks"
 
 import { afterEach, describe, expect, it } from "vitest"
 
-import { createI18n } from "@palamedes/core"
+import {
+  type I18nInstance,
+  getI18n,
+  resetI18nRuntime,
+  setClientI18n,
+  setServerI18nGetter,
+} from "./index"
 
-import { getI18n, resetI18nRuntime, setClientI18n, setServerI18nGetter } from "./index"
+function createTestI18n(locale = "en"): I18nInstance {
+  return {
+    locale,
+    _: (message: string) => message,
+  }
+}
 
 describe("@palamedes/runtime", () => {
   afterEach(() => {
@@ -23,23 +34,23 @@ describe("@palamedes/runtime", () => {
 
   it("resolves the active client instance", () => {
     ;(globalThis as Record<string, unknown>).window = {}
-    const i18n = createI18n()
+    const i18n = createTestI18n()
     setClientI18n(i18n)
 
     expect(getI18n()).toBe(i18n)
   })
 
   it("resolves the request-local server instance", () => {
-    const i18n = createI18n()
+    const i18n = createTestI18n()
     setServerI18nGetter(() => i18n)
 
     expect(getI18n()).toBe(i18n)
   })
 
   it("supports async request-local server instances", async () => {
-    const storage = new AsyncLocalStorage<ReturnType<typeof createI18n>>()
-    const deI18n = createI18n()
-    const enI18n = createI18n()
+    const storage = new AsyncLocalStorage<I18nInstance>()
+    const deI18n = createTestI18n("de")
+    const enI18n = createTestI18n("en")
 
     setServerI18nGetter(() => storage.getStore())
 

--- a/packages/runtime/src/server-unavailable.test.ts
+++ b/packages/runtime/src/server-unavailable.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest"
+
+import { createServerI18nScope } from "./server-unavailable"
+
+describe("@palamedes/runtime/server fallback", () => {
+  it("throws an actionable error outside Node server runtimes", () => {
+    expect(() => createServerI18nScope()).toThrow(
+      /only available in Node\.js server runtimes/
+    )
+  })
+})

--- a/packages/runtime/src/server-unavailable.ts
+++ b/packages/runtime/src/server-unavailable.ts
@@ -1,0 +1,12 @@
+const SERVER_RUNTIME_UNAVAILABLE_MESSAGE =
+  "@palamedes/runtime/server is only available in Node.js server runtimes. Import it from server-only Node code, not Client Components or Edge runtime code."
+
+export interface ServerI18nScope<T = unknown> {
+  run<Result>(i18n: T, callback: () => Result): Result
+  activate(i18n: T): T
+  get(): T | undefined
+}
+
+export function createServerI18nScope(): never {
+  throw new Error(SERVER_RUNTIME_UNAVAILABLE_MESSAGE)
+}

--- a/packages/runtime/src/server.test.ts
+++ b/packages/runtime/src/server.test.ts
@@ -1,3 +1,5 @@
+import { AsyncLocalStorage } from "node:async_hooks"
+
 import { describe, expect, it, afterEach } from "vitest"
 
 import { type I18nInstance, getI18n, resetI18nRuntime } from "./index"
@@ -43,6 +45,17 @@ describe("@palamedes/runtime/server", () => {
     expect(getI18n()).toBe(i18n)
   })
 
+  it("keeps getI18n connected when multiple server scopes exist", () => {
+    const firstScope = createServerI18nScope<I18nInstance>()
+    createServerI18nScope<I18nInstance>()
+    const i18n = createTestI18n("de")
+
+    firstScope.run(i18n, () => {
+      expect(firstScope.get()).toBe(i18n)
+      expect(getI18n()).toBe(i18n)
+    })
+  })
+
   it("keeps concurrent async server scopes isolated", async () => {
     const scope = createServerI18nScope<I18nInstance>()
     const deI18n = createTestI18n("de")
@@ -56,6 +69,28 @@ describe("@palamedes/runtime/server", () => {
       }),
       scope.run(enI18n, async () => {
         await Promise.resolve()
+        expect(scope.get()).toBe(enI18n)
+        expect(getI18n()).toBe(enI18n)
+      }),
+    ])
+  })
+
+  it("keeps concurrent activated server contexts isolated", async () => {
+    const requestStorage = new AsyncLocalStorage<string>()
+    const scope = createServerI18nScope<I18nInstance>()
+    const deI18n = createTestI18n("de")
+    const enI18n = createTestI18n("en")
+
+    await Promise.all([
+      requestStorage.run("de", async () => {
+        scope.activate(deI18n)
+        await new Promise((resolve) => setTimeout(resolve, 0))
+        expect(scope.get()).toBe(deI18n)
+        expect(getI18n()).toBe(deI18n)
+      }),
+      requestStorage.run("en", async () => {
+        scope.activate(enI18n)
+        await new Promise((resolve) => setTimeout(resolve, 0))
         expect(scope.get()).toBe(enI18n)
         expect(getI18n()).toBe(enI18n)
       }),

--- a/packages/runtime/src/server.test.ts
+++ b/packages/runtime/src/server.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, afterEach } from "vitest"
+
+import { type I18nInstance, getI18n, resetI18nRuntime } from "./index"
+import { createServerI18nScope } from "./server"
+
+function createTestI18n(locale = "en"): I18nInstance {
+  return {
+    locale,
+    _: (message: string) => message,
+  }
+}
+
+describe("@palamedes/runtime/server", () => {
+  afterEach(() => {
+    resetI18nRuntime()
+  })
+
+  it("registers the scope as the active server i18n getter", () => {
+    const scope = createServerI18nScope<I18nInstance>()
+    const i18n = createTestI18n()
+
+    expect(scope.get()).toBeUndefined()
+
+    scope.run(i18n, () => {
+      expect(scope.get()).toBe(i18n)
+      expect(getI18n()).toBe(i18n)
+    })
+
+    expect(scope.get()).toBeUndefined()
+  })
+
+  it("activates an i18n instance for the current async server context", async () => {
+    const scope = createServerI18nScope<I18nInstance>()
+    const i18n = createTestI18n()
+
+    expect(scope.activate(i18n)).toBe(i18n)
+    expect(scope.get()).toBe(i18n)
+    expect(getI18n()).toBe(i18n)
+
+    await Promise.resolve()
+
+    expect(scope.get()).toBe(i18n)
+    expect(getI18n()).toBe(i18n)
+  })
+
+  it("keeps concurrent async server scopes isolated", async () => {
+    const scope = createServerI18nScope<I18nInstance>()
+    const deI18n = createTestI18n("de")
+    const enI18n = createTestI18n("en")
+
+    await Promise.all([
+      scope.run(deI18n, async () => {
+        await Promise.resolve()
+        expect(scope.get()).toBe(deI18n)
+        expect(getI18n()).toBe(deI18n)
+      }),
+      scope.run(enI18n, async () => {
+        await Promise.resolve()
+        expect(scope.get()).toBe(enI18n)
+        expect(getI18n()).toBe(enI18n)
+      }),
+    ])
+  })
+})

--- a/packages/runtime/src/server.ts
+++ b/packages/runtime/src/server.ts
@@ -2,22 +2,45 @@ import { AsyncLocalStorage } from "node:async_hooks"
 
 import { type I18nInstance, setServerI18nGetter } from "./index"
 
+const SERVER_SCOPE_STATE_KEY = Symbol.for("palamedes.runtime.serverI18nScopeState")
+
+interface ServerScopeState {
+  active: AsyncLocalStorage<I18nInstance>
+}
+
 export interface ServerI18nScope<T extends I18nInstance = I18nInstance> {
   run<Result>(i18n: T, callback: () => Result): Result
   activate(i18n: T): T
   get(): T | undefined
 }
 
+function getServerScopeState(): ServerScopeState {
+  const globalState = globalThis as typeof globalThis &
+    Record<symbol, ServerScopeState | undefined>
+  const existing = globalState[SERVER_SCOPE_STATE_KEY]
+  if (existing) {
+    return existing
+  }
+
+  const state: ServerScopeState = {
+    active: new AsyncLocalStorage<I18nInstance>(),
+  }
+  globalState[SERVER_SCOPE_STATE_KEY] = state
+  return state
+}
+
 export function createServerI18nScope<
   T extends I18nInstance = I18nInstance,
 >(): ServerI18nScope<T> {
+  const sharedState = getServerScopeState()
   const storage = new AsyncLocalStorage<T>()
 
   const scope: ServerI18nScope<T> = {
     run(i18n, callback) {
-      return storage.run(i18n, callback)
+      return sharedState.active.run(i18n, () => storage.run(i18n, callback))
     },
     activate(i18n) {
+      sharedState.active.enterWith(i18n)
       storage.enterWith(i18n)
       return i18n
     },
@@ -26,7 +49,7 @@ export function createServerI18nScope<
     },
   }
 
-  setServerI18nGetter(() => scope.get())
+  setServerI18nGetter(() => sharedState.active.getStore())
 
   return scope
 }

--- a/packages/runtime/src/server.ts
+++ b/packages/runtime/src/server.ts
@@ -1,0 +1,32 @@
+import { AsyncLocalStorage } from "node:async_hooks"
+
+import { type I18nInstance, setServerI18nGetter } from "./index"
+
+export interface ServerI18nScope<T extends I18nInstance = I18nInstance> {
+  run<Result>(i18n: T, callback: () => Result): Result
+  activate(i18n: T): T
+  get(): T | undefined
+}
+
+export function createServerI18nScope<
+  T extends I18nInstance = I18nInstance,
+>(): ServerI18nScope<T> {
+  const storage = new AsyncLocalStorage<T>()
+
+  const scope: ServerI18nScope<T> = {
+    run(i18n, callback) {
+      return storage.run(i18n, callback)
+    },
+    activate(i18n) {
+      storage.enterWith(i18n)
+      return i18n
+    },
+    get() {
+      return storage.getStore()
+    },
+  }
+
+  setServerI18nGetter(() => scope.get())
+
+  return scope
+}


### PR DESCRIPTION
## Problem

Direct Palamedes macros in downstream Next.js App Router Server Components compile to `getI18n()._()`. The existing example registered a server getter from the current initializer, which is fragile for React Server Components: child Server Components can render after the initializer has returned, so they need a request-local runtime scope instead of per-render global getter registration.

This caused the pattern reported in #134 to fail with `No active server i18n instance` when direct macros were used below the component that initialized i18n.

## Fix

- Add the Node-only `@palamedes/runtime/server` subpath.
- Implement `createServerI18nScope<T>()` with `AsyncLocalStorage` and one-time runtime getter registration.
- Expose both `scope.activate(i18n)` for framework render flows such as Next RSC and `scope.run(i18n, callback)` for tightly scoped request-handler work.
- Update the Next cookie example to initialize i18n through a server-only `cache()` helper and activate the request-local scope.
- Add a downstream Server Component probe that uses `t({ message })` directly, exercising the transformed `getI18n()` path.
- Document the official Next RSC pattern in `@palamedes/next-plugin`, `@palamedes/runtime`, and the Lingui migration guide.
- Refresh the Next example catalogs after extraction.

## Validation

- `pnpm --filter @palamedes/runtime test`
- `pnpm --filter @palamedes/runtime build`
- `pnpm check-types`
- `pnpm --filter @palamedes/example-nextjs-cookie exec tsc --noEmit -p tsconfig.json`
- `pnpm --filter @palamedes/next-plugin build`
- `pnpm --filter @palamedes/example-nextjs-cookie build`
- `node -e "import('@palamedes/runtime/server').then(...)"` from the Next example workspace
- `git diff --check`

Fixes #134