### PR TITLE
ci: add Rust validation job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,14 +45,21 @@ jobs:
 
   validate-rust:
     runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        toolchain:
+          - stable
+          - "1.93"
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: ${{ matrix.toolchain }}
           components: clippy, rustfmt
 
       - name: Cache Rust build artifacts
@@ -62,7 +69,7 @@ jobs:
         run: cargo fmt --all --check
 
       - name: Run Rust lints
-        run: cargo clippy --workspace --all-targets -- -D warnings
+        run: cargo clippy --workspace --all-targets --locked -- -D warnings
 
       - name: Run Rust tests
-        run: cargo test --workspace
+        run: cargo test --workspace --locked

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,3 +42,27 @@ jobs:
 
       - name: Check types
         run: pnpm check-types
+
+  validate-rust:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+
+      - name: Check Rust formatting
+        run: cargo fmt --all --check
+
+      - name: Run Rust lints
+        run: cargo clippy --workspace --all-targets -- -D warnings
+
+      - name: Run Rust tests
+        run: cargo test --workspace

--- a/crates/palamedes/src/catalog_artifact/compile.rs
+++ b/crates/palamedes/src/catalog_artifact/compile.rs
@@ -17,14 +17,14 @@ pub(super) fn align_diagnostics_with_runtime_icu_semantics(artifact: &mut Compil
     for diagnostic in diagnostics {
         if diagnostic.code == "compile.invalid_icu_message" {
             if let Some(runtime_message) = artifact.messages.get(&diagnostic.key) {
-                if parse_runtime_icu(runtime_message).is_some() {
-                    if push_runtime_icu_compatibility_diagnostics(
+                if parse_runtime_icu(runtime_message).is_some()
+                    && push_runtime_icu_compatibility_diagnostics(
                         &diagnostic,
                         runtime_message,
                         &mut additional,
-                    ) {
-                        continue;
-                    }
+                    )
+                {
+                    continue;
                 }
             }
         }

--- a/crates/palamedes/src/extract.rs
+++ b/crates/palamedes/src/extract.rs
@@ -764,16 +764,15 @@ fn jsx_expression_name(expr: &JSXExpression<'_>) -> Option<String> {
 
 fn extract_jsx_children_as_message(
     children: &[JSXChild<'_>],
-    source: &str,
+    _source: &str,
 ) -> PalamedesResult<String> {
     let mut next_component_index = 0usize;
 
-    extract_jsx_children_as_message_with_state(children, source, &mut next_component_index)
+    extract_jsx_children_as_message_with_state(children, &mut next_component_index)
 }
 
 fn extract_jsx_children_as_message_with_state(
     children: &[JSXChild<'_>],
-    source: &str,
     next_component_index: &mut usize,
 ) -> PalamedesResult<String> {
     let mut parts = Vec::new();
@@ -802,7 +801,6 @@ fn extract_jsx_children_as_message_with_state(
                 *next_component_index += 1;
                 let inner = extract_jsx_children_as_message_with_state(
                     &element.children,
-                    source,
                     next_component_index,
                 )?;
                 parts.push(format!("<{name}>{inner}</{name}>"));
@@ -810,7 +808,6 @@ fn extract_jsx_children_as_message_with_state(
             JSXChild::Fragment(fragment) => {
                 let inner = extract_jsx_children_as_message_with_state(
                     &fragment.children,
-                    source,
                     next_component_index,
                 )?;
                 if !inner.is_empty() {


### PR DESCRIPTION
## Summary

Adds a dedicated Rust validation job to CI so PRs run the Rust checks that already exist locally.

## Changes

- installs the stable Rust toolchain with `clippy` and `rustfmt` components
- adds `Swatinem/rust-cache` for Cargo artifacts
- runs `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace`

## Validation

- `git diff --check`
- `cargo fmt --all --check`

Closes #143