### PR TITLE
ci: expand PR validation matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,24 @@ on:
 
 jobs:
   validate:
-    runs-on: ubuntu-24.04
+    name: validate (${{ matrix.os }}, Node ${{ matrix.node }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            node: 24
+            full: true
+          - os: ubuntu-24.04
+            node: 22
+            full: true
+          - os: macos-14
+            node: 24
+            full: false
+          - os: windows-2025
+            node: 24
+            full: false
 
     steps:
       - name: Check out repository
@@ -20,7 +37,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: ${{ matrix.node }}
 
       - name: Enable Corepack
         run: corepack enable
@@ -32,13 +49,20 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Check release package set
+        if: matrix.full
         run: pnpm check:release-set
 
       - name: Build packages
         run: pnpm build
 
+      - name: Smoke-test native binding load
+        if: ${{ !matrix.full }}
+        run: node -e "const core = require('@palamedes/core-node'); if (typeof core.transform !== 'function') process.exit(1)"
+
       - name: Run tests
+        if: matrix.full
         run: pnpm test
 
       - name: Check types
+        if: matrix.full
         run: pnpm check-types

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Check release package set
-        if: matrix.full
+        if: ${{ matrix.full }}
         run: pnpm check:release-set
 
       - name: Build packages
@@ -57,12 +57,12 @@ jobs:
 
       - name: Smoke-test native binding load
         if: ${{ !matrix.full }}
-        run: node -e "const core = require('@palamedes/core-node'); if (typeof core.transform !== 'function') process.exit(1)"
+        run: pnpm --filter @palamedes/core-node exec node -e "const core = require('./dist/index.cjs'); if (typeof core.transformMacrosNative !== 'function') process.exit(1)"
 
       - name: Run tests
-        if: matrix.full
+        if: ${{ matrix.full }}
         run: pnpm test
 
       - name: Check types
-        if: matrix.full
+        if: ${{ matrix.full }}
         run: pnpm check-types


### PR DESCRIPTION
## Summary

Expands PR validation beyond Linux + Node 24 so the supported Node floor and native wrapper load path get signal before publish.

## Changes

- adds a matrix leg for Node 22 on Ubuntu
- adds reduced macOS and Windows native build smoke legs
- keeps tests, type checks, and release-set validation on the full Linux legs

## Validation

- `git diff --check`

Closes #149