### PR TITLE
ci: validate release commits before publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,8 +45,44 @@ jobs:
             echo "should_publish=false" >> "$GITHUB_OUTPUT"
           fi
 
-  publish-native:
+  validate-release:
     needs: determine-release
+    if: needs.determine-release.outputs.should_publish == 'true'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Check release package set
+        run: pnpm check:release-set
+
+      - name: Build packages
+        run: pnpm build
+
+      - name: Run tests
+        run: pnpm test
+
+      - name: Check types
+        run: pnpm check-types
+
+  publish-native:
+    needs:
+      - determine-release
+      - validate-release
     if: needs.determine-release.outputs.should_publish == 'true'
     strategy:
       fail-fast: false
@@ -89,6 +125,11 @@ jobs:
 
       - name: Build native package
         run: pnpm --filter "${{ matrix.package_name }}" build
+
+      - name: Smoke-test native package
+        env:
+          PACKAGE_NAME: ${{ matrix.package_name }}
+        run: node -e "const binding = require(process.env.PACKAGE_NAME); if (typeof binding.transform !== 'function') process.exit(1)"
 
       - name: Publish native package
         run: pnpm --filter "${{ matrix.package_name }}" publish --access public --no-git-checks

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,6 +49,9 @@ jobs:
     needs: determine-release
     if: needs.determine-release.outputs.should_publish == 'true'
     runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    env:
+      PALAMEDES_RUST_PROFILE: release
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
@@ -127,9 +130,7 @@ jobs:
         run: pnpm --filter "${{ matrix.package_name }}" build
 
       - name: Smoke-test native package
-        env:
-          PACKAGE_NAME: ${{ matrix.package_name }}
-        run: node -e "const binding = require(process.env.PACKAGE_NAME); if (typeof binding.transform !== 'function') process.exit(1)"
+        run: pnpm --filter "${{ matrix.package_name }}" exec node --input-type=module -e "import { createRequire } from 'node:module'; const require = createRequire(import.meta.url); const native = require('./palamedes-node.node'); if (typeof native.transformMacros !== 'function') process.exit(1)"
 
       - name: Publish native package
         run: pnpm --filter "${{ matrix.package_name }}" publish --access public --no-git-checks


### PR DESCRIPTION
## Summary

Adds a validation gate to the publish workflow so release commits are checked before npm publishing starts, and smoke-tests each native package before upload.

## Changes

- adds a `validate-release` job gated by release commit detection
- makes native publishing depend on that validation job
- loads each freshly built native package and verifies the binding exposes `transform` before publish

## Validation

- `git diff --check`

Closes #150