### PR TITLE
docs: document pseudo-locale config

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ The same foundation also matters for future translation workflows:
 - [MDX-ready messaging source for homepage/docs](https://github.com/sebastian-software/palamedes/blob/main/docs/site/index.mdx)
 - [Proof, benchmarks, and current maturity](https://github.com/sebastian-software/palamedes/blob/main/docs/proof-and-benchmarks.md)
 - [Example matrix and local/CI verification story](https://github.com/sebastian-software/palamedes/blob/main/examples/README.md)
+- [Pseudo-localization and fallback locale config](https://github.com/sebastian-software/palamedes/blob/main/docs/pseudo-localization.md)
 - [Versioned example screenshots](https://github.com/sebastian-software/palamedes/blob/main/docs/example-screenshots/README.md)
 - [Optional demo deployment note](https://github.com/sebastian-software/palamedes/blob/main/docs/demo-deployments.md)
 - [Benchmarking against Lingui v6 Preview](https://github.com/sebastian-software/palamedes/blob/main/docs/benchmark-lingui-v6-preview.md)

--- a/docs/pseudo-localization.md
+++ b/docs/pseudo-localization.md
@@ -1,0 +1,107 @@
+# Pseudo-Localization And Fallback Locales
+
+Palamedes supports two config options that are useful during adoption and UI
+quality checks:
+
+- `pseudoLocale` marks one locale as a generated pseudo-locale.
+- `fallbackLocales` defines which locale chain is used when a message is
+  missing in the active locale.
+
+Both options live in `palamedes.config.ts`.
+
+```ts
+import { defineConfig } from "@palamedes/config"
+
+export default defineConfig({
+  locales: ["en", "de", "pseudo"],
+  sourceLocale: "en",
+  pseudoLocale: "pseudo",
+  fallbackLocales: {
+    de: ["en"],
+    pseudo: ["en"],
+  },
+  catalogs: [
+    {
+      path: "src/locales/{locale}",
+      include: ["src"],
+    },
+  ],
+})
+```
+
+## `pseudoLocale`
+
+Set `pseudoLocale` to the locale code you use for pseudo-localized UI testing.
+The value must also appear in `locales`.
+
+Palamedes treats the pseudo-locale as a development aid, not as a real
+translation target. The Vite and Next.js plugin integrations pass the value
+through to catalog compilation and skip `failOnMissing` failures for that
+locale. That lets you keep strict missing-translation checks for real locales
+while still running a generated pseudo-locale during layout testing.
+
+Use it for checks such as:
+
+- text expansion and truncation
+- hardcoded strings that extraction missed
+- layout assumptions around word length
+- UI paths that are difficult to inspect in every real locale
+
+Pseudo-localization does not replace real translation QA. It is an early signal
+that the UI can tolerate translated text.
+
+## `fallbackLocales`
+
+Set `fallbackLocales` when a locale should fall back through one or more other
+locales before Palamedes falls back to the source message.
+
+The option accepts either one shared chain:
+
+```ts
+export default defineConfig({
+  locales: ["en", "de", "fr"],
+  sourceLocale: "en",
+  fallbackLocales: ["en"],
+  catalogs: [
+    {
+      path: "src/locales/{locale}",
+      include: ["src"],
+    },
+  ],
+})
+```
+
+or a per-locale map:
+
+```ts
+export default defineConfig({
+  locales: ["en", "de-CH", "de", "fr"],
+  sourceLocale: "en",
+  fallbackLocales: {
+    "de-CH": ["de", "en"],
+    de: ["en"],
+    fr: ["en"],
+  },
+  catalogs: [
+    {
+      path: "src/locales/{locale}",
+      include: ["src"],
+    },
+  ],
+})
+```
+
+The config loader removes a locale from its own fallback chain, so
+`fallbackLocales: ["en"]` does not make `en` fall back to itself.
+
+## Recommended Workflow
+
+Keep production locales strict and use the pseudo-locale for local layout
+testing:
+
+1. Add a pseudo locale code to `locales`.
+2. Set `pseudoLocale` to that code.
+3. Keep `failOnMissing` enabled for real locales in the plugin.
+4. Run `pmds audit --fail-on error` in CI.
+5. Use the pseudo-locale in development routes, screenshots, or story fixtures
+   to find layout problems before translators finish the real catalog.

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -35,6 +35,17 @@ export default defineConfig({
 - `CONFIG_FILENAMES`
 - `expandFallbackLocales(locales, fallbackLocales?)`
 
+## Configuration Notes
+
+- `fallbackLocales` defines the fallback chain for missing translations. It can
+  be one shared array or a per-locale map.
+- `pseudoLocale` marks a generated pseudo-locale used for layout and hardcoded
+  string checks. Plugin integrations skip `failOnMissing` failures for that
+  locale while keeping strict checks for real locales.
+
+See [Pseudo-localization and fallback locales](../../docs/pseudo-localization.md)
+for examples and the recommended development workflow.
+
 ## License
 
 [![Sebastian Software](https://sebastian-brand.vercel.app/sebastian-software/logo-software.svg)](https://oss.sebastian-software.com/)

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -43,7 +43,7 @@ export default defineConfig({
   string checks. Plugin integrations skip `failOnMissing` failures for that
   locale while keeping strict checks for real locales.
 
-See [Pseudo-localization and fallback locales](../../docs/pseudo-localization.md)
+See [Pseudo-localization and fallback locales](https://github.com/sebastian-software/palamedes/blob/main/docs/pseudo-localization.md)
 for examples and the recommended development workflow.
 
 ## License


### PR DESCRIPTION
## Summary

Documents the existing `pseudoLocale` and `fallbackLocales` config options so users can discover and apply them without reading source.

## Changes

- adds `docs/pseudo-localization.md` with examples and workflow guidance
- links the page from the README proof/adoption docs list
- adds config README notes for both options

## Validation

- `git diff --check`

Closes #158