### PR TITLE
docs: define stability and versioning policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ easier to review, and easier to carry from one framework to the next.
 - Verified today across Next.js, TanStack Start, SolidStart, Waku, and React Router on Node.js `>=22`
 - Source-string-first catalogs are stable and powered by `ferrocat`, including structured audits and ICU authoring diagnostics
 - Placeholder top-level packages exist, but there is no `palamedes` or `create-palamedes` first-run entry yet
+- Pre-1.0 stability tiers and public API expectations are documented in [Stability and versioning](https://github.com/sebastian-software/palamedes/blob/main/docs/stability.md)
 
 ## What Exists Today
 
@@ -207,6 +208,7 @@ The same foundation also matters for future translation workflows:
 
 - [MDX-ready messaging source for homepage/docs](https://github.com/sebastian-software/palamedes/blob/main/docs/site/index.mdx)
 - [Proof, benchmarks, and current maturity](https://github.com/sebastian-software/palamedes/blob/main/docs/proof-and-benchmarks.md)
+- [Stability and versioning](https://github.com/sebastian-software/palamedes/blob/main/docs/stability.md)
 - [Example matrix and local/CI verification story](https://github.com/sebastian-software/palamedes/blob/main/examples/README.md)
 - [Versioned example screenshots](https://github.com/sebastian-software/palamedes/blob/main/docs/example-screenshots/README.md)
 - [Optional demo deployment note](https://github.com/sebastian-software/palamedes/blob/main/docs/demo-deployments.md)

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -1,0 +1,87 @@
+# Stability And Versioning
+
+Palamedes is pre-1.0 software, but not every surface has the same stability
+level. This page defines what app teams can depend on today and where changes
+may still happen between minor releases.
+
+## Versioning During 0.x
+
+All publishable Palamedes packages ship in lockstep. A 0.x minor release may
+include breaking changes, but Palamedes treats the app-facing surfaces below as
+stable enough to require migration notes and release notes before they change.
+
+Patch releases should be compatible bug fixes.
+
+The 1.0 target is to make the stable surfaces below SemVer-stable in the usual
+major/minor/patch sense.
+
+## Stability Tiers
+
+| Surface | Tier | Notes |
+| --- | --- | --- |
+| `@palamedes/core` runtime API | Stable | `createI18n`, message descriptors, locale activation, and source-message fallback behavior are app-facing. |
+| `@palamedes/runtime` | Stable | `getI18n`, `setClientI18n`, and the server runtime contract are the public transform target. |
+| `@palamedes/react` and `@palamedes/solid` | Stable | Runtime components and macro entry points are public app APIs. |
+| `@palamedes/vite-plugin` and `@palamedes/next-plugin` | Stable | Plugin options and `.po` loading behavior are public integration APIs. |
+| `@palamedes/config` | Stable | Config file names, `defineConfig`, and the config schema are public. |
+| `@palamedes/cli` | Stable | Documented commands and flags are public. New commands may appear in minors. |
+| Source-string-first `.po` catalogs | Stable | Message identity is `message + context`. Catalog files remain user-owned. |
+| Macro syntax | Stable | Supported macros remain the authoring model. Unsupported explicit IDs are not a compatibility target. |
+| `@palamedes/core-node` | Preview | It is usable directly, but primarily exists as the JS boundary to the Rust core. Generated type details may change before 1.0. |
+| Platform native packages | Internal | `@palamedes/core-node-*` packages are optional dependency carriers for native binaries. Apps should not import them directly. |
+| `palamedes` and `create-palamedes` | Reserved | Placeholder top-level packages exist, but there is no supported first-run entry yet. |
+| Compiled catalog artifact internals | Preview | Public loaders can consume them; the internal representation may evolve before 1.0. |
+| `crates/*` Rust APIs | Preview | The Rust crates support the Node toolchain today. They are not yet a separately promised public Rust SDK. |
+
+## Stable Surfaces
+
+Palamedes treats these as stable adoption surfaces:
+
+- `palamedes.config.*` schema and config discovery
+- source-string-first PO catalogs using `message + context` identity
+- documented `pmds` commands and flags
+- Vite and Next plugin options documented in package READMEs
+- runtime access through `getI18n()`
+- `createI18n()` and descriptor-based lookup behavior
+- React and Solid runtime components and macro package names
+
+If one of these must change before 1.0, the release should include:
+
+- a changelog entry calling out the break
+- a migration note or replacement path
+- a deprecation period when both old and new paths can reasonably coexist
+
+## Surfaces That May Still Move
+
+These areas are allowed to change faster while the project learns from real
+adoption:
+
+- generated native binding type details
+- compiled artifact internals
+- package layout for new native platform targets
+- benchmark fixture shape and reporting fields
+- internal package boundaries between plugins and transform/core-node helpers
+- future managed translation workflow bridges
+
+## Deprecation Policy
+
+When a stable surface needs to change, prefer this path:
+
+1. Add the replacement.
+2. Document the replacement in the release notes.
+3. Keep the old path working for at least one minor release when practical.
+4. Emit a clear diagnostic or runtime warning if the old path can be detected.
+5. Remove it in a later minor or the 1.0 cleanup window.
+
+Security fixes, broken behavior, and unsupported preview/internal surfaces may
+skip the full deprecation window when keeping compatibility would be misleading
+or unsafe.
+
+## What 1.0 Means
+
+The 1.0 release should mean:
+
+- app-facing packages follow standard SemVer
+- config, CLI, macro syntax, catalog identity, and runtime APIs are stable
+- platform support is documented in one place
+- preview/internal surfaces are clearly labeled or promoted with tests and docs

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -17,6 +17,15 @@ major/minor/patch sense.
 
 ## Stability Tiers
 
+- **Stable**: app-facing surface that should only change with migration notes
+  and release notes during 0.x.
+- **Preview**: usable, but still allowed to change as real adoption clarifies
+  the API shape.
+- **Internal**: implementation detail. Apps should not import or depend on it
+  directly.
+- **Reserved**: package name or surface intentionally held for future work, with
+  no supported adoption path yet.
+
 | Surface | Tier | Notes |
 | --- | --- | --- |
 | `@palamedes/core` runtime API | Stable | `createI18n`, message descriptors, locale activation, and source-message fallback behavior are app-facing. |


### PR DESCRIPTION
## Summary

Adds a documented stability and versioning policy for Palamedes during the pre-1.0 period.

## Changes

- adds package and surface stability tiers
- documents what is public API, preview, reserved, or internal
- defines deprecation expectations and the intended 1.0 meaning
- links the policy from the README status and docs lists

## Validation

- `git diff --check`

Closes #160