### PR TITLE
docs: add community contribution files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,71 @@
+name: Bug report
+description: Report a reproducible Palamedes problem
+title: "bug: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. Please include enough detail for maintainers to reproduce it.
+  - type: input
+    id: package
+    attributes:
+      label: Package
+      description: Which Palamedes package is affected?
+      placeholder: "@palamedes/vite-plugin"
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      placeholder: "0.6.0"
+    validations:
+      required: true
+  - type: dropdown
+    id: framework
+    attributes:
+      label: Framework or runtime
+      options:
+        - Vite
+        - Next.js
+        - React Router
+        - TanStack Start
+        - SolidStart
+        - Waku
+        - Node.js
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: Link a repository or paste the smallest code/config sample that reproduces the issue.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: Include exact error output when possible.
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Node.js, pnpm, OS, CPU architecture, libc if Linux, and Rust version if native builds are involved.
+      render: text
+  - type: textarea
+    id: checks
+    attributes:
+      label: Checks tried
+      description: Commands you already ran, such as `pnpm build`, `pnpm test`, or `pmds audit`.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/sebastian-software/palamedes/security/advisories/new
+    about: Report vulnerabilities privately instead of opening a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,47 @@
+name: Feature request
+description: Propose a Palamedes capability or workflow improvement
+title: "feat: "
+labels:
+  - enhancement
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What adoption, workflow, or runtime problem should this solve?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe the smallest useful shape of the feature.
+    validations:
+      required: true
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Affected surface
+      options:
+        - CLI
+        - Core runtime
+        - Config
+        - React or Solid integration
+        - Vite plugin
+        - Next plugin
+        - Native core
+        - Documentation
+        - Examples
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What workaround or existing tool are you using today?
+  - type: textarea
+    id: compatibility
+    attributes:
+      label: Compatibility notes
+      description: Mention migration, SemVer, platform, or catalog-format implications if known.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## Summary
+
+<!-- What changed and why? -->
+
+## Issue
+
+<!-- Closes #123, Refs #123, or explain why no issue exists. -->
+
+## Validation
+
+<!-- Commands run, screenshots captured, or docs-only note. -->
+
+## Follow-up
+
+<!-- Anything intentionally left for later. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,103 @@
+# Contributing
+
+Thanks for taking the time to improve Palamedes. This project spans TypeScript
+packages, a Rust core, framework examples, and release automation, so small,
+well-scoped changes are easiest to review.
+
+## Prerequisites
+
+- Node.js `>=22`
+- pnpm via Corepack
+- Rust stable toolchain
+- GitHub CLI if you work on issue or PR automation locally
+
+```bash
+corepack enable
+pnpm install --frozen-lockfile
+```
+
+## Repository Shape
+
+- `packages/*` contains the published JavaScript and TypeScript packages.
+- `crates/*` contains the Rust core and Node native binding.
+- `examples/*` contains framework verification apps.
+- `docs/` and `adr/` explain product, architecture, and adoption decisions.
+- `.github/workflows/` contains CI, release, screenshot, and deployment
+  automation.
+
+## Local Checks
+
+Run the smallest relevant check while iterating, then broaden before opening a
+PR.
+
+```bash
+pnpm build
+pnpm test
+pnpm check-types
+cargo test --workspace
+```
+
+Other useful checks:
+
+```bash
+cargo fmt --all --check
+cargo clippy --workspace --all-targets -- -D warnings
+pnpm verify:examples:smoke
+pnpm check:release-set
+```
+
+Use `pnpm verify:examples` when a change touches framework integration,
+runtime wiring, or `.po` loading. It is intentionally broader and slower than
+the package unit tests.
+
+## Development Notes
+
+- Keep changes scoped to one issue or one behavior.
+- Prefer existing package boundaries over new shared packages unless the
+  duplication is already causing real drift.
+- For catalog behavior, preserve the source-string-first identity model:
+  `message + context`.
+- For server runtimes, keep request-local i18n concerns in
+  `@palamedes/runtime/server`.
+- Add or update tests when behavior changes, especially across package
+  boundaries.
+
+## Documentation
+
+User-facing behavior should be discoverable from the README, package READMEs,
+or `docs/`. Architecture decisions that constrain future work belong in
+`adr/`.
+
+When adding a feature, include:
+
+- the public API or CLI shape
+- the failure mode or diagnostics users will see
+- the migration note if behavior changes
+- a short validation command
+
+## Pull Requests
+
+PRs should include:
+
+- what changed
+- why it changed
+- which issue it closes or references
+- which checks were run
+- any follow-up work that is intentionally left out
+
+Draft PRs are fine for early review, but keep them reviewable. Avoid mixing
+format-only churn with behavior changes unless the PR is explicitly about
+formatting.
+
+## Releases
+
+Releases are driven by Release Please. Use conventional commit-style messages
+when possible, for example:
+
+- `fix(core): handle missing descriptor fallback`
+- `feat(cli): add catalog report command`
+- `docs: add troubleshooting guide`
+- `ci: expand native build matrix`
+
+Do not edit generated changelog entries by hand unless the release automation
+requires a specific correction.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,50 @@
+# Security Policy
+
+Palamedes is build-time and runtime infrastructure for JavaScript applications.
+Please report security issues privately so maintainers can assess and fix them
+before public disclosure.
+
+## Supported Versions
+
+Palamedes currently ships pre-1.0 packages in lockstep. Security fixes target
+the latest released version.
+
+| Version | Supported |
+| --- | --- |
+| Latest 0.x | Yes |
+| Older 0.x | Best effort |
+
+## Reporting A Vulnerability
+
+Use GitHub private vulnerability reporting when it is available for this
+repository. If that is not available, email:
+
+```text
+security@sebastian-software.de
+```
+
+Please include:
+
+- affected package and version
+- environment details
+- reproduction steps or proof of concept
+- expected impact
+- whether the issue is already public
+
+Do not open a public GitHub issue for a vulnerability.
+
+## Scope
+
+Security-relevant areas include:
+
+- macro transformation and generated runtime code
+- `.po` catalog parsing and compilation
+- native binding loading
+- CLI commands that read or write project files
+- GitHub Actions release and publish automation
+
+## Disclosure
+
+Maintainers will acknowledge reports as soon as practical, investigate the
+impact, and coordinate a fix and release. Public disclosure should wait until a
+patched version is available unless there is an active public exploit.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security Policy
 
-Palamedes is build-time and runtime infrastructure for JavaScript applications.
+Palamedes is a build-time and runtime infrastructure for JavaScript applications.
 Please report security issues privately so maintainers can assess and fix them
 before public disclosure.
 


### PR DESCRIPTION
## Summary

Adds the standard community scaffolding for contributors, security reports, issues, and pull requests.

## Changes

- adds `CONTRIBUTING.md` with setup, repo shape, checks, docs, PR, and release guidance
- adds `SECURITY.md` with supported versions and private reporting guidance
- adds bug and feature issue forms
- adds a small pull request template

## Validation

- `git diff --check`
- `gh label list --limit 100 --json name,color,description`

Closes #161