### PR TITLE
examples: load active locale catalogs dynamically

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -78,6 +78,18 @@ Shared locale and routing proof logic lives in the internal package:
 
 - [packages/example-locale-shared](/Users/sebastian/Workspace/business/palamedes/packages/example-locale-shared)
 
+## Catalog Loading And Bundle Size
+
+Examples should load only the active locale catalog on client-reachable paths.
+Use dynamic imports such as `await import(\`../locales/${locale}.po\`)` when
+the browser only needs one locale at a time. That gives bundlers a chance to
+split catalogs into per-locale chunks.
+
+Static imports are still useful for tiny demos or server-only modules, but they
+make every imported locale reachable from that module. In copied app code with
+large catalogs, prefer the dynamic import pattern unless all locales are
+intentionally needed at once.
+
 ## Verification
 
 Workspace-level example builds:

--- a/examples/nextjs-cookie/src/lib/i18n.client.ts
+++ b/examples/nextjs-cookie/src/lib/i18n.client.ts
@@ -1,19 +1,11 @@
-import { createExampleI18n, type Locale } from "./i18n"
+import { createExampleI18n, loadMessages, type Locale } from "./i18n"
 import { setClientI18n, setServerI18nGetter } from "@palamedes/runtime"
-import { messages as enMessages } from "../locales/en.po"
-import { messages as deMessages } from "../locales/de.po"
-import { messages as esMessages } from "../locales/es.po"
-
-const localeMessages = {
-  en: enMessages,
-  de: deMessages,
-  es: esMessages,
-} as const
 
 const clientI18n = createExampleI18n()
 
-export function syncClientI18n(locale: Locale) {
-  clientI18n.load(locale, localeMessages[locale])
+export async function syncClientI18n(locale: Locale) {
+  const messages = await loadMessages(locale)
+  clientI18n.load(locale, messages)
   clientI18n.activate(locale)
 
   if (typeof window === "undefined") {

--- a/examples/nextjs-route/src/lib/i18n.client.ts
+++ b/examples/nextjs-route/src/lib/i18n.client.ts
@@ -1,19 +1,11 @@
-import { createExampleI18n, type Locale } from "./i18n"
+import { createExampleI18n, loadMessages, type Locale } from "./i18n"
 import { setClientI18n, setServerI18nGetter } from "@palamedes/runtime"
-import { messages as enMessages } from "../locales/en.po"
-import { messages as deMessages } from "../locales/de.po"
-import { messages as esMessages } from "../locales/es.po"
-
-const localeMessages = {
-  en: enMessages,
-  de: deMessages,
-  es: esMessages,
-} as const
 
 const clientI18n = createExampleI18n()
 
-export function syncClientI18n(locale: Locale) {
-  clientI18n.load(locale, localeMessages[locale])
+export async function syncClientI18n(locale: Locale) {
+  const messages = await loadMessages(locale)
+  clientI18n.load(locale, messages)
   clientI18n.activate(locale)
 
   if (typeof window === "undefined") {

--- a/examples/solidstart-cookie/src/entry-client.tsx
+++ b/examples/solidstart-cookie/src/entry-client.tsx
@@ -18,7 +18,7 @@ function resolveInitialLocale() {
 }
 
 function ClientEntry() {
-  syncClientI18n(resolveInitialLocale())
+  void syncClientI18n(resolveInitialLocale())
   return <StartClient />
 }
 

--- a/examples/solidstart-cookie/src/lib/i18n.server.ts
+++ b/examples/solidstart-cookie/src/lib/i18n.server.ts
@@ -1,10 +1,11 @@
 import { setServerI18nGetter } from "@palamedes/runtime"
-import { createExampleI18n, localeMessages, type Locale } from "./i18n"
+import { createExampleI18n, loadMessages, type Locale } from "./i18n"
 
-export function activateServerI18n(locale: Locale) {
+export async function activateServerI18n(locale: Locale) {
   const i18n = createExampleI18n()
+  const messages = await loadMessages(locale)
 
-  i18n.load(locale, localeMessages[locale])
+  i18n.load(locale, messages)
   i18n.activate(locale)
   setServerI18nGetter(() => i18n)
 

--- a/examples/solidstart-cookie/src/lib/i18n.ts
+++ b/examples/solidstart-cookie/src/lib/i18n.ts
@@ -8,9 +8,6 @@ import {
   LOCALE_LABELS,
   type Locale,
 } from "@palamedes/example-locale-shared"
-import { messages as deMessages } from "../locales/de.po"
-import { messages as enMessages } from "../locales/en.po"
-import { messages as esMessages } from "../locales/es.po"
 
 export {
   DEFAULT_LOCALE,
@@ -20,10 +17,9 @@ export {
   type Locale,
 }
 
-export const localeMessages: Record<Locale, CatalogMessages> = {
-  en: enMessages,
-  de: deMessages,
-  es: esMessages,
+export async function loadMessages(locale: Locale): Promise<CatalogMessages> {
+  const { messages } = await import(`../locales/${locale}.po`)
+  return messages
 }
 
 const clientI18n = createI18n()
@@ -42,12 +38,13 @@ export function getLocaleLabel(locale: Locale): string {
   return LOCALE_LABELS[locale]
 }
 
-export function syncClientI18n(locale: Locale) {
+export async function syncClientI18n(locale: Locale) {
   if (typeof window === "undefined") {
     return
   }
 
-  clientI18n.load(locale, localeMessages[locale])
+  const messages = await loadMessages(locale)
+  clientI18n.load(locale, messages)
   clientI18n.activate(locale)
   setClientI18n(clientI18n)
 }
@@ -64,7 +61,7 @@ function bootstrapClientI18n() {
     ?.slice(`${LOCALE_COOKIE}=`.length)
 
   const preferredLanguage = navigator.language.split("-")[0] ?? DEFAULT_LOCALE
-  syncClientI18n(normalizeLocale(cookieValue ?? preferredLanguage))
+  void syncClientI18n(normalizeLocale(cookieValue ?? preferredLanguage))
 }
 
 bootstrapClientI18n()

--- a/examples/solidstart-cookie/src/lib/server.ts
+++ b/examples/solidstart-cookie/src/lib/server.ts
@@ -14,7 +14,7 @@ export const loadHomePageData = query(async () => {
     cookieHeader: event?.request.headers.get("cookie"),
   })
 
-  activateServerI18n(resolved.locale)
+  await activateServerI18n(resolved.locale)
 
   return {
     locale: resolved.locale,
@@ -33,7 +33,7 @@ export const getLocalizedServerStatus = query(async () => {
     cookieHeader: event?.request.headers.get("cookie"),
   })
 
-  activateServerI18n(resolved.locale)
+  await activateServerI18n(resolved.locale)
 
   return {
     locale: resolved.locale,

--- a/examples/tanstack-cookie/src/lib/i18n.server.ts
+++ b/examples/tanstack-cookie/src/lib/i18n.server.ts
@@ -1,10 +1,11 @@
 import { setServerI18nGetter } from "@palamedes/runtime"
-import { createExampleI18n, localeMessages, type Locale } from "./i18n"
+import { createExampleI18n, loadMessages, type Locale } from "./i18n"
 
-export function activateServerI18n(locale: Locale) {
+export async function activateServerI18n(locale: Locale) {
   const i18n = createExampleI18n()
+  const messages = await loadMessages(locale)
 
-  i18n.load(locale, localeMessages[locale])
+  i18n.load(locale, messages)
   i18n.activate(locale)
   setServerI18nGetter(() => i18n)
 

--- a/examples/tanstack-cookie/src/lib/i18n.ts
+++ b/examples/tanstack-cookie/src/lib/i18n.ts
@@ -8,9 +8,6 @@ import {
   LOCALE_LABELS,
   type Locale,
 } from "@palamedes/example-locale-shared"
-import { messages as deMessages } from "../locales/de.po"
-import { messages as enMessages } from "../locales/en.po"
-import { messages as esMessages } from "../locales/es.po"
 
 export {
   DEFAULT_LOCALE,
@@ -20,10 +17,9 @@ export {
   type Locale,
 }
 
-export const localeMessages: Record<Locale, CatalogMessages> = {
-  en: enMessages,
-  de: deMessages,
-  es: esMessages,
+export async function loadMessages(locale: Locale): Promise<CatalogMessages> {
+  const { messages } = await import(`../locales/${locale}.po`)
+  return messages
 }
 
 const clientI18n = createI18n()
@@ -42,12 +38,13 @@ export function getLocaleLabel(locale: Locale): string {
   return LOCALE_LABELS[locale]
 }
 
-export function syncClientI18n(locale: Locale) {
+export async function syncClientI18n(locale: Locale) {
   if (typeof window === "undefined") {
     return
   }
 
-  clientI18n.load(locale, localeMessages[locale])
+  const messages = await loadMessages(locale)
+  clientI18n.load(locale, messages)
   clientI18n.activate(locale)
   setClientI18n(clientI18n)
 }

--- a/examples/tanstack-cookie/src/lib/server-functions.ts
+++ b/examples/tanstack-cookie/src/lib/server-functions.ts
@@ -15,7 +15,7 @@ function getResolvedLocale() {
 export const loadHomePageData = createServerFn({ method: "GET" })
   .handler(async () => {
     const resolved = getResolvedLocale()
-    activateServerI18n(resolved.locale)
+    await activateServerI18n(resolved.locale)
 
     return {
       locale: resolved.locale,
@@ -43,7 +43,7 @@ export const setLocaleCookie = createServerFn({ method: "POST" })
 export const getLocalizedServerStatus = createServerFn({ method: "GET" })
   .handler(async () => {
     const resolved = getResolvedLocale()
-    activateServerI18n(resolved.locale)
+    await activateServerI18n(resolved.locale)
 
     return {
       locale: resolved.locale,

--- a/examples/waku-cookie/src/lib/i18n.ts
+++ b/examples/waku-cookie/src/lib/i18n.ts
@@ -1,4 +1,5 @@
 import { createI18n } from "@palamedes/core"
+import type { CatalogMessages } from "@palamedes/core"
 import { setClientI18n, setServerI18nGetter } from "@palamedes/runtime"
 import {
   DEFAULT_LOCALE,
@@ -7,9 +8,6 @@ import {
   LOCALE_LABELS,
   type Locale,
 } from "@palamedes/example-locale-shared"
-import { messages as deMessages } from "../locales/de.po"
-import { messages as enMessages } from "../locales/en.po"
-import { messages as esMessages } from "../locales/es.po"
 
 export {
   DEFAULT_LOCALE,
@@ -23,24 +21,25 @@ export function getLocaleLabel(locale: Locale) {
   return LOCALE_LABELS[locale]
 }
 
-const localeMessages = {
-  en: enMessages,
-  de: deMessages,
-  es: esMessages,
-} as const
+export async function loadMessages(locale: Locale): Promise<CatalogMessages> {
+  const { messages } = await import(`../locales/${locale}.po`)
+  return messages
+}
 
 const clientI18n = createI18n()
 
-export function activateServerI18n(locale: Locale) {
+export async function activateServerI18n(locale: Locale) {
+  const messages = await loadMessages(locale)
   const i18n = createI18n()
-  i18n.load(locale, localeMessages[locale])
+  i18n.load(locale, messages)
   i18n.activate(locale)
   setServerI18nGetter(() => i18n)
   return i18n
 }
 
-export function syncClientI18n(locale: Locale) {
-  clientI18n.load(locale, localeMessages[locale])
+export async function syncClientI18n(locale: Locale) {
+  const messages = await loadMessages(locale)
+  clientI18n.load(locale, messages)
   clientI18n.activate(locale)
 
   if (typeof window === "undefined") {

--- a/examples/waku-cookie/src/pages/index.tsx
+++ b/examples/waku-cookie/src/pages/index.tsx
@@ -22,12 +22,12 @@ export default async function CookiePage() {
   })
   const localeLabel = getLocaleLabel(locale)
 
-  activateServerI18n(locale)
+  await activateServerI18n(locale)
 
   async function runProbe(): Promise<ProbeResult> {
     "use server"
 
-    activateServerI18n(locale)
+    await activateServerI18n(locale)
 
     return {
       handledAt: new Date().toISOString(),


### PR DESCRIPTION
## Summary

Switches the client-reachable example locale loaders from static imports of every `.po` file to per-locale dynamic imports.

## Changes

- updates Next.js cookie and route client i18n loaders to use shared `loadMessages()`
- updates Waku, TanStack Start, and SolidStart cookie loaders to import only the active locale catalog
- makes server activation async where it now shares the dynamic loader
- documents the static vs dynamic catalog loading trade-off in `examples/README.md`

## Validation

- `pnpm build`
- `pnpm -r --filter @palamedes/example-nextjs-cookie --filter @palamedes/example-nextjs-route --filter @palamedes/example-waku-cookie --filter @palamedes/example-tanstack-cookie build`
- `git diff --check`

## Validation note

`pnpm -r --filter @palamedes/example-solidstart-cookie build` is still blocked by the existing SolidStart counter macro shape: `plural(count(), ...)` fails with `Could not infer a stable placeholder name for choice value expression`. I left that out of this PR because it is unrelated to catalog loading.

Closes #153