### PR TITLE
docs: add API reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ easier to review, and easier to carry from one framework to the next.
 ## Start Here
 
 - [First working translation in 5 minutes](https://github.com/sebastian-software/palamedes/blob/main/docs/first-working-translation.md)
+- [API reference](https://github.com/sebastian-software/palamedes/blob/main/docs/api/README.md)
+- [Configuration reference](https://github.com/sebastian-software/palamedes/blob/main/docs/configuration.md)
+- [CLI reference](https://github.com/sebastian-software/palamedes/blob/main/docs/cli.md)
 - [Backend servers with Hono, Express, and request-local i18n](https://github.com/sebastian-software/palamedes/blob/main/docs/backend-servers.md)
 - [`llms.txt`](https://github.com/sebastian-software/palamedes/blob/main/llms.txt) and [`llms-full.txt`](https://github.com/sebastian-software/palamedes/blob/main/llms-full.txt) for AI coding assistants
 - [`@palamedes/vite-plugin`](https://www.npmjs.com/package/@palamedes/vite-plugin) for Vite projects
@@ -206,6 +209,9 @@ The same foundation also matters for future translation workflows:
 ## Proof And Adoption Docs
 
 - [MDX-ready messaging source for homepage/docs](https://github.com/sebastian-software/palamedes/blob/main/docs/site/index.mdx)
+- [API reference](https://github.com/sebastian-software/palamedes/blob/main/docs/api/README.md)
+- [Configuration reference](https://github.com/sebastian-software/palamedes/blob/main/docs/configuration.md)
+- [CLI reference](https://github.com/sebastian-software/palamedes/blob/main/docs/cli.md)
 - [Proof, benchmarks, and current maturity](https://github.com/sebastian-software/palamedes/blob/main/docs/proof-and-benchmarks.md)
 - [Example matrix and local/CI verification story](https://github.com/sebastian-software/palamedes/blob/main/examples/README.md)
 - [Versioned example screenshots](https://github.com/sebastian-software/palamedes/blob/main/docs/example-screenshots/README.md)

--- a/README.md
+++ b/README.md
@@ -209,9 +209,6 @@ The same foundation also matters for future translation workflows:
 ## Proof And Adoption Docs
 
 - [MDX-ready messaging source for homepage/docs](https://github.com/sebastian-software/palamedes/blob/main/docs/site/index.mdx)
-- [API reference](https://github.com/sebastian-software/palamedes/blob/main/docs/api/README.md)
-- [Configuration reference](https://github.com/sebastian-software/palamedes/blob/main/docs/configuration.md)
-- [CLI reference](https://github.com/sebastian-software/palamedes/blob/main/docs/cli.md)
 - [Proof, benchmarks, and current maturity](https://github.com/sebastian-software/palamedes/blob/main/docs/proof-and-benchmarks.md)
 - [Example matrix and local/CI verification story](https://github.com/sebastian-software/palamedes/blob/main/examples/README.md)
 - [Versioned example screenshots](https://github.com/sebastian-software/palamedes/blob/main/docs/example-screenshots/README.md)

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,0 +1,21 @@
+# API Reference
+
+This directory documents the public Palamedes package surface that app teams are
+expected to use directly.
+
+- [`@palamedes/core`](./core.md)
+- [`@palamedes/runtime`](./runtime.md)
+- [`@palamedes/react`](./react.md)
+- [`@palamedes/solid`](./solid.md)
+- [`@palamedes/config`](./config.md)
+- [`@palamedes/cli`](./cli.md)
+- [`@palamedes/vite-plugin`](./vite-plugin.md)
+- [`@palamedes/next-plugin`](./next-plugin.md)
+- [`@palamedes/core-node`](./core-node.md)
+- [`@palamedes/transform`](./transform.md)
+- [`@palamedes/extractor`](./extractor.md)
+
+Related references:
+
+- [Configuration reference](../configuration.md)
+- [CLI reference](../cli.md)

--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -1,0 +1,23 @@
+# `@palamedes/cli`
+
+`@palamedes/cli` publishes the `pmds` command.
+
+## Commands
+
+- `pmds extract`
+- `pmds audit`
+- `pmds catalog merge`
+- `pmds version`
+
+See the [CLI reference](../cli.md) for flags and examples.
+
+## Programmatic Exports
+
+The package also exports:
+
+- `extract(options)`
+- `audit(options)`
+- `mergeCatalog(inputPaths, options)`
+
+These are mostly useful for tests and local automation. The CLI is the public
+user-facing workflow.

--- a/docs/api/config.md
+++ b/docs/api/config.md
@@ -1,0 +1,51 @@
+# `@palamedes/config`
+
+`@palamedes/config` loads and validates `palamedes.config.*` files.
+
+## Exports
+
+- `defineConfig(config)`
+- `loadPalamedesConfig(options?)`
+- `CONFIG_FILENAMES`
+- `expandFallbackLocales(locales, fallbackLocales?)`
+- `resolveCatalogPath(config, catalogPath, locale)`
+- `resolveConfigPattern(config, pattern)`
+- `PalamedesConfig`
+- `LoadedPalamedesConfig`
+- `PalamedesCatalogConfig`
+- `PalamedesFallbackLocales`
+
+## Config Files
+
+Supported file names:
+
+- `palamedes.config.ts`
+- `palamedes.config.js`
+- `palamedes.config.mjs`
+- `palamedes.config.cjs`
+
+See the [configuration reference](../configuration.md) for every field.
+
+## `defineConfig(config)`
+
+Returns the config unchanged while giving TypeScript users a typed authoring
+surface.
+
+```ts
+import { defineConfig } from "@palamedes/config"
+
+export default defineConfig({
+  locales: ["en", "de"],
+  sourceLocale: "en",
+  catalogs: [{ path: "src/locales/{locale}", include: ["src"] }],
+})
+```
+
+## `loadPalamedesConfig(options?)`
+
+Searches from `cwd` for a supported config file unless `configPath` is passed.
+The returned object includes `configPath` and `rootDir`.
+
+```ts
+const config = await loadPalamedesConfig({ cwd: process.cwd() })
+```

--- a/docs/api/core-node.md
+++ b/docs/api/core-node.md
@@ -1,0 +1,31 @@
+# `@palamedes/core-node`
+
+`@palamedes/core-node` is the JavaScript wrapper around the native Palamedes
+core. Most apps use it indirectly through the CLI and plugins.
+
+## Runtime Exports
+
+- `getNativeInfo()`
+- `parsePo(source)`
+- `parseCatalog(request)`
+- `updateCatalogFile(request)`
+- `auditCatalogs(request, options?)`
+- `deriveMessageMetadata(input)`
+- `normalizeMessageMetadata(input)`
+- `validateMessageMetadata(input)`
+- `combineCatalogs(request)`
+- `mergeCatalogFiles(request)`
+- `compileCatalogArtifact(request)`
+- `compileCatalogArtifactSelected(request)`
+- `extractMessagesNative(source, filename)`
+- `extractCatalogMessagesFromFiles(request)`
+- `transformMacrosNative(source, filename, options?)`
+
+## Stability
+
+This package is useful for integration tests and custom tooling, but it is a
+preview surface before 1.0. Generated type details may change as the native
+boundary evolves.
+
+Use `@palamedes/cli`, `@palamedes/vite-plugin`, or `@palamedes/next-plugin`
+when you do not need direct native access.

--- a/docs/api/core-node.md
+++ b/docs/api/core-node.md
@@ -10,7 +10,7 @@ core. Most apps use it indirectly through the CLI and plugins.
 - `parseCatalog(request)`
 - `updateCatalogFile(request)`
 - `auditCatalogs(request, options?)`
-- `deriveMessageMetadata(input)`
+- `deriveMessageMetadata(message, context?)`
 - `normalizeMessageMetadata(input)`
 - `validateMessageMetadata(input)`
 - `combineCatalogs(request)`

--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -1,0 +1,82 @@
+# `@palamedes/core`
+
+`@palamedes/core` owns the app-facing i18n instance and the macro entry point
+package names.
+
+## Exports
+
+- `createI18n()`
+- `formatMessagePattern(pattern, values, locale?)`
+- `parseMessagePattern(pattern)`
+- `MessageDescriptor`
+- `CatalogMessages`
+- `PalamedesI18n`
+- `MessageNode`
+- `MessageChoiceNode`
+- `MessageTagNode`
+- `MessageVariableNode`
+
+## `createI18n()`
+
+Creates an in-memory i18n instance.
+
+```ts
+import { createI18n } from "@palamedes/core"
+
+const i18n = createI18n()
+i18n.load("de", {
+  "Hello {name}": "Hallo {name}",
+})
+i18n.activate("de")
+
+const label = i18n._("Hello {name}", { name: "Ada" })
+```
+
+## `PalamedesI18n`
+
+```ts
+interface PalamedesI18n {
+  locale?: string
+  _(idOrDescriptor, values?, descriptor?): string
+  load(locale: string, messages: CatalogMessages): void
+  activate(locale: string): void
+  getMessage(id: string, descriptor?: MessageDescriptor): string
+}
+```
+
+`load()` merges messages into the locale catalog. `activate()` selects the
+locale used by `_()` and `getMessage()`.
+
+Fallback order for `getMessage(id, descriptor)`:
+
+1. active catalog entry for `id`
+2. `descriptor.message`
+3. `id`
+
+## `MessageDescriptor`
+
+```ts
+interface MessageDescriptor {
+  id?: string
+  message?: string
+  context?: string
+  comment?: string
+}
+```
+
+Palamedes source authoring is source-string-first. Use `context` when the same
+source message needs different translations in different UI contexts.
+
+## Macro Entry Point
+
+Macros are imported from `@palamedes/core/macro` and must be compiled by a
+Palamedes plugin before runtime.
+
+Supported macro names:
+
+- `t`
+- `msg`
+- `defineMessage`
+- `plural`
+- `select`
+- `selectOrdinal`

--- a/docs/api/extractor.md
+++ b/docs/api/extractor.md
@@ -1,0 +1,26 @@
+# `@palamedes/extractor`
+
+`@palamedes/extractor` exposes the native message extractor for Palamedes macro
+syntax.
+
+## Exports
+
+- `extractMessages(source, filename)`
+- `extractor`
+- default export `extractor`
+- `ExtractedMessageInfo`
+- `PalamedesExtractor`
+
+## `extractMessages(source, filename)`
+
+Returns extracted source-string-first messages from a JavaScript or TypeScript
+module.
+
+```ts
+import { extractMessages } from "@palamedes/extractor"
+
+const messages = extractMessages(source, "App.tsx")
+```
+
+The CLI uses this capability through the native core when running
+`pmds extract`.

--- a/docs/api/next-plugin.md
+++ b/docs/api/next-plugin.md
@@ -1,0 +1,45 @@
+# `@palamedes/next-plugin`
+
+`@palamedes/next-plugin` wires Palamedes macro transformation and `.po` loading
+into Next.js.
+
+## Exports
+
+- `withPalamedes(baseConfig?, options?)`
+- default export `withPalamedes`
+- `WithPalamedesOptions`
+
+## Options
+
+```ts
+interface WithPalamedesOptions {
+  include?: RegExp
+  exclude?: RegExp
+  enablePoLoader?: boolean
+  configPath?: string
+  failOnMissing?: boolean
+  failOnCompileError?: boolean
+  runtimeModule?: string
+  workspaceRoot?: string
+}
+```
+
+Defaults:
+
+- `include`: `/\.[jt]sx?$/`
+- `exclude`: `/node_modules/`
+- `enablePoLoader`: `true`
+- `failOnMissing`: `false`
+- `failOnCompileError`: `false`
+- `runtimeModule`: `"@palamedes/runtime"`
+
+## Usage
+
+```js
+const { withPalamedes } = require("@palamedes/next-plugin")
+
+module.exports = withPalamedes({})
+```
+
+The plugin configures both Turbopack and webpack paths. `workspaceRoot` can be
+set explicitly in monorepos when automatic root detection is not correct.

--- a/docs/api/react.md
+++ b/docs/api/react.md
@@ -12,6 +12,9 @@ points, and headless locale-switch helpers.
 - `buildLocaleSwitchItems(options)`
 - `Fragment`
 
+`Fragment` is re-exported from React for generated/runtime component rendering
+paths that need the same import surface as other React helpers.
+
 The client subpath `@palamedes/react/client` exports:
 
 - `useClientLocale(locale, sync)`

--- a/docs/api/react.md
+++ b/docs/api/react.md
@@ -1,0 +1,59 @@
+# `@palamedes/react`
+
+`@palamedes/react` provides provider-free React runtime components, macro entry
+points, and headless locale-switch helpers.
+
+## Exports
+
+- `Trans`
+- `Plural`
+- `Select`
+- `SelectOrdinal`
+- `buildLocaleSwitchItems(options)`
+- `Fragment`
+
+The client subpath `@palamedes/react/client` exports:
+
+- `useClientLocale(locale, sync)`
+
+The macro subpath `@palamedes/react/macro` exports compile-time macro
+components:
+
+- `Trans`
+- `Plural`
+- `Select`
+- `SelectOrdinal`
+
+## Runtime Components
+
+Runtime components read the active i18n instance through
+`@palamedes/runtime`.
+
+```tsx
+import { Trans } from "@palamedes/react"
+
+<Trans
+  id="footer"
+  message="Powered by <0>Palamedes</0>"
+  components={{ 0: <strong /> }}
+/>
+```
+
+For authoring source strings, prefer macro imports from
+`@palamedes/react/macro` so the build can extract and transform messages.
+
+## Locale Switch Helpers
+
+```ts
+import { buildLocaleSwitchItems } from "@palamedes/react"
+
+const items = buildLocaleSwitchItems({
+  currentLocale: "de",
+  labels: { de: "Deutsch", en: "English" },
+  locales: ["en", "de"],
+})
+```
+
+`useClientLocale(locale, sync)` calls `sync(locale)` from a client component.
+The sync function may return a promise; the hook intentionally does not own
+loading UI or routing policy.

--- a/docs/api/runtime.md
+++ b/docs/api/runtime.md
@@ -36,6 +36,9 @@ automatically.
 On the client, `getI18n()` reads the instance registered with
 `setClientI18n()`. On the server, it reads the active server getter.
 
+`getI18n()` throws a descriptive error when no active client instance or server
+getter result is available. Initialize the runtime before translated code runs.
+
 ## Server Runtime
 
 For request-local server rendering, prefer `@palamedes/runtime/server`:

--- a/docs/api/runtime.md
+++ b/docs/api/runtime.md
@@ -1,0 +1,58 @@
+# `@palamedes/runtime`
+
+`@palamedes/runtime` provides the active i18n instance lookup used by transformed
+macro output.
+
+## Exports
+
+- `getI18n<T>()`
+- `setClientI18n(i18n)`
+- `setServerI18nGetter(getter)`
+- `resetI18nRuntime()`
+- `I18nInstance`
+
+The server subpath `@palamedes/runtime/server` exports:
+
+- `createServerI18nScope<T>()`
+- `ServerI18nScope`
+
+## Client Runtime
+
+```ts
+import { createI18n } from "@palamedes/core"
+import { setClientI18n } from "@palamedes/runtime"
+
+const i18n = createI18n()
+setClientI18n(i18n)
+```
+
+Call `setClientI18n()` before translated client UI renders.
+
+## `getI18n<T>()`
+
+Returns the active runtime instance. Transformed macro code calls this
+automatically.
+
+On the client, `getI18n()` reads the instance registered with
+`setClientI18n()`. On the server, it reads the active server getter.
+
+## Server Runtime
+
+For request-local server rendering, prefer `@palamedes/runtime/server`:
+
+```ts
+import { createServerI18nScope } from "@palamedes/runtime/server"
+import type { PalamedesI18n } from "@palamedes/core"
+
+export const serverI18n = createServerI18nScope<PalamedesI18n>()
+
+serverI18n.activate(i18n)
+```
+
+`createServerI18nScope()` uses Node `AsyncLocalStorage`, so keep it out of
+client bundles and Edge-only runtime paths.
+
+## Test Reset
+
+`resetI18nRuntime()` clears the active client and server runtime state. It is
+intended for tests.

--- a/docs/api/solid.md
+++ b/docs/api/solid.md
@@ -1,0 +1,47 @@
+# `@palamedes/solid`
+
+`@palamedes/solid` mirrors the React package for Solid applications.
+
+## Exports
+
+- `Trans`
+- `Plural`
+- `Select`
+- `SelectOrdinal`
+- `buildLocaleSwitchItems(options)`
+
+The client subpath `@palamedes/solid/client` exports:
+
+- `createClientLocaleEffect(localeAccessor, sync)`
+
+The macro subpath `@palamedes/solid/macro` exports compile-time macro
+components:
+
+- `Trans`
+- `Plural`
+- `Select`
+- `SelectOrdinal`
+
+## Runtime Components
+
+Runtime components read the active i18n instance through
+`@palamedes/runtime`.
+
+```tsx
+import { Trans } from "@palamedes/solid"
+
+<Trans id="title" message="Welcome to Palamedes" />
+```
+
+For source authoring, prefer macro imports from `@palamedes/solid/macro`.
+
+## Client Locale Effect
+
+```ts
+import { createClientLocaleEffect } from "@palamedes/solid/client"
+
+createClientLocaleEffect(() => props.locale, syncClientI18n)
+```
+
+The sync function may return a promise. Routing, cookies, and loading UI stay in
+the host app.

--- a/docs/api/transform.md
+++ b/docs/api/transform.md
@@ -1,0 +1,18 @@
+# `@palamedes/transform`
+
+`@palamedes/transform` exposes the low-level macro transformer used by the
+plugins.
+
+## Exports
+
+- `transformPalamedesMacros(source, filename, options?)`
+- `mightContainPalamedesMacros(source)`
+- `findMacroImports(source)`
+- `PALAMEDES_MACRO_PACKAGES`
+- `JS_MACROS`
+- `JSX_MACROS`
+- `TransformOptions`
+- `TransformResult`
+- `SourceMap`
+
+Most apps should use a framework plugin instead of this package directly.

--- a/docs/api/vite-plugin.md
+++ b/docs/api/vite-plugin.md
@@ -1,0 +1,46 @@
+# `@palamedes/vite-plugin`
+
+`@palamedes/vite-plugin` transforms Palamedes macro imports and compiles `.po`
+imports inside Vite builds.
+
+## Exports
+
+- `palamedes(options?)`
+- default export `palamedes`
+- `PalamedesPluginOptions`
+
+## Options
+
+```ts
+interface PalamedesPluginOptions {
+  include?: FilterPattern
+  exclude?: FilterPattern
+  enablePoLoader?: boolean
+  configPath?: string
+  cwd?: string
+  skipValidation?: boolean
+  failOnMissing?: boolean
+  failOnCompileError?: boolean
+  runtimeModule?: string
+}
+```
+
+Defaults:
+
+- `include`: `/\.(tsx?|jsx?|mjs|cjs)$/`
+- `exclude`: `/node_modules/`
+- `enablePoLoader`: `true`
+- `failOnMissing`: `false`
+- `failOnCompileError`: `false`
+- `runtimeModule`: `"@palamedes/runtime"`
+
+## Usage
+
+```ts
+import { defineConfig } from "vite"
+import { palamedes } from "@palamedes/vite-plugin"
+
+export default defineConfig({
+  plugins: [palamedes()],
+})
+```

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,74 @@
+# CLI Reference
+
+The `@palamedes/cli` package publishes `pmds`.
+
+## `pmds extract`
+
+Extracts messages from configured source files and writes source-string-first
+catalogs.
+
+```bash
+pmds extract
+pmds extract --config ./palamedes.config.ts
+pmds extract --clean
+pmds extract --watch
+pmds extract --verbose
+```
+
+Options:
+
+| Option | Description |
+| --- | --- |
+| `-c, --config <path>` | Use a specific config file. |
+| `-w, --watch` | Re-run extraction on file changes. |
+| `--clean` | Remove obsolete catalog entries instead of marking them obsolete. |
+| `-v, --verbose` | Print verbose extraction details. |
+
+## `pmds audit`
+
+Audits catalogs for missing translations and ICU authoring issues.
+
+```bash
+pmds audit
+pmds audit --locale de fr
+pmds audit --json
+pmds audit --fail-on warning
+```
+
+Options:
+
+| Option | Description |
+| --- | --- |
+| `-c, --config <path>` | Use a specific config file. |
+| `--locale <locale...>` | Audit only selected target locales. |
+| `--json` | Print the machine-readable audit result. |
+| `--fail-on <level>` | Fail on `error` or `warning`. Default: `error`. |
+
+## `pmds catalog merge`
+
+Merges two catalog files with Palamedes catalog semantics. This is suitable for
+Git merge-driver workflows.
+
+```bash
+pmds catalog merge ours.po theirs.po --output merged.po
+pmds catalog merge %A %B --output %A --format po --strategy use-first
+```
+
+Options:
+
+| Option | Description |
+| --- | --- |
+| `--output <path>` | Required output path. |
+| `-c, --config <path>` | Use a specific config file when inferring `sourceLocale`. |
+| `--format <format>` | `po` or `json`. Inferred from paths when omitted. |
+| `--strategy <strategy>` | Currently `use-first`. |
+| `--source-locale <locale>` | Source locale for catalog semantics. Defaults to config or `en`. |
+| `--locale <locale>` | Locale of the merged catalog. |
+
+## `pmds version`
+
+Prints the installed CLI version.
+
+```bash
+pmds version
+```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,88 @@
+# Configuration Reference
+
+Palamedes config files are loaded by `@palamedes/config`, the CLI, and the
+framework plugins.
+
+Supported file names:
+
+- `palamedes.config.ts`
+- `palamedes.config.js`
+- `palamedes.config.mjs`
+- `palamedes.config.cjs`
+
+## Minimal Config
+
+```ts
+import { defineConfig } from "@palamedes/config"
+
+export default defineConfig({
+  locales: ["en", "de"],
+  sourceLocale: "en",
+  catalogs: [
+    {
+      path: "src/locales/{locale}",
+      include: ["src"],
+    },
+  ],
+})
+```
+
+## Fields
+
+| Field | Required | Type | Notes |
+| --- | --- | --- | --- |
+| `locales` | Yes | `string[]` | All locale codes known to the project. Must include `sourceLocale`. |
+| `sourceLocale` | Yes | `string` | Locale used by source messages. |
+| `catalogs` | Yes | `PalamedesCatalogConfig[]` | Catalog locations and source scan patterns. |
+| `fallbackLocales` | No | `string[] \| Record<string, string[]>` | Shared or per-locale fallback chain. |
+| `pseudoLocale` | No | `string` | Locale code used for pseudo-localized UI testing. |
+
+## Catalogs
+
+```ts
+interface PalamedesCatalogConfig {
+  path: string
+  include: string[]
+  exclude?: string[]
+}
+```
+
+`path` should include `{locale}` and points to the catalog path without the
+`.po` extension.
+
+`include` and `exclude` are resolved relative to the config file directory.
+When an include entry is a directory-like path, extraction scans JavaScript and
+TypeScript files below it.
+
+## Fallback Locales
+
+One shared fallback chain:
+
+```ts
+fallbackLocales: ["en"]
+```
+
+Per-locale fallback chain:
+
+```ts
+fallbackLocales: {
+  "de-CH": ["de", "en"],
+  de: ["en"],
+}
+```
+
+The config helper removes self-fallbacks from a locale chain.
+
+## Pseudo Locale
+
+```ts
+export default defineConfig({
+  locales: ["en", "de", "pseudo"],
+  sourceLocale: "en",
+  pseudoLocale: "pseudo",
+  catalogs: [{ path: "src/locales/{locale}", include: ["src"] }],
+})
+```
+
+Plugin integrations pass `pseudoLocale` through to catalog compilation and skip
+`failOnMissing` failures for that locale.


### PR DESCRIPTION
## Summary

Adds a hand-written API reference for the public Palamedes package surface, plus dedicated configuration and CLI reference pages.

## Changes

- adds `docs/api/` with package-level reference pages
- adds `docs/configuration.md` for config fields and examples
- adds `docs/cli.md` for `pmds` commands and flags
- links the new references from the README

## Validation

- `git diff --check`

Closes #148