### PR TITLE
chore: add JS lint and format tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Check release package set
         run: pnpm check:release-set
 
+      - name: Run JavaScript and TypeScript lint
+        run: pnpm lint
+
       - name: Build packages
         run: pnpm build
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,17 @@
+node_modules/
+.pnpm-store/
+dist/
+target/
+.next/
+.tanstack/
+.vinxi/
+.nitro/
+.output/
+.vercel/
+coverage/
+docs/example-screenshots/
+benchmarks/*/results/
+pnpm-lock.yaml
+Cargo.lock
+*.tsbuildinfo
+*.node

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,5 @@
+{
+  "printWidth": 100,
+  "semi": false,
+  "trailingComma": "es5"
+}

--- a/examples/nextjs-cookie/src/components/ServerActionProbe.tsx
+++ b/examples/nextjs-cookie/src/components/ServerActionProbe.tsx
@@ -16,7 +16,7 @@ interface ServerActionProbeProps {
   locale: Locale
 }
 
-export function ServerActionProbe({ locale }: ServerActionProbeProps) {
+export function ServerActionProbe({ locale: _locale }: ServerActionProbeProps) {
   const [result, setResult] = useState<ServerActionProof | null>(null)
   const [isPending, startTransition] = useTransition()
 

--- a/examples/react-router-cookie/app/routes/home.tsx
+++ b/examples/react-router-cookie/app/routes/home.tsx
@@ -13,7 +13,7 @@ import {
   syncClientI18n,
 } from "~/lib/i18n"
 
-export function meta({}: Route.MetaArgs) {
+export function meta() {
   return [
     { title: "React Router Cookie Locale Example" },
     { name: "description", content: "Cookie-driven Palamedes locale proof for React Router framework mode." },

--- a/examples/react-router-cookie/app/routes/home.tsx
+++ b/examples/react-router-cookie/app/routes/home.tsx
@@ -13,7 +13,7 @@ import {
   syncClientI18n,
 } from "~/lib/i18n"
 
-export function meta() {
+export function meta(_args: Route.MetaArgs) {
   return [
     { title: "React Router Cookie Locale Example" },
     { name: "description", content: "Cookie-driven Palamedes locale proof for React Router framework mode." },

--- a/examples/tanstack-cookie/src/components/Counter.tsx
+++ b/examples/tanstack-cookie/src/components/Counter.tsx
@@ -7,7 +7,7 @@ interface CounterProps {
   locale: Locale
 }
 
-export function Counter({ locale }: CounterProps) {
+export function Counter({ locale: _locale }: CounterProps) {
   const [count, setCount] = useState(0)
 
   return (

--- a/examples/tanstack-cookie/src/lib/server-functions.ts
+++ b/examples/tanstack-cookie/src/lib/server-functions.ts
@@ -3,7 +3,7 @@ import { getRequestHeader, setCookie } from "@tanstack/react-start/server"
 import { t } from "@palamedes/core/macro"
 import { resolveCookieLocale } from "@palamedes/example-locale-shared"
 import { activateServerI18n } from "./i18n.server"
-import { getLocaleLabel, LOCALE_COOKIE, type Locale, normalizeLocale } from "./i18n"
+import { getLocaleLabel, LOCALE_COOKIE, normalizeLocale } from "./i18n"
 
 function getResolvedLocale() {
   return resolveCookieLocale({

--- a/examples/tanstack-route/src/components/Counter.tsx
+++ b/examples/tanstack-route/src/components/Counter.tsx
@@ -7,7 +7,7 @@ interface CounterProps {
   locale: Locale
 }
 
-export function Counter({ locale }: CounterProps) {
+export function Counter({ locale: _locale }: CounterProps) {
   const [count, setCount] = useState(0)
 
   return (

--- a/examples/tanstack-route/src/lib/server-functions.ts
+++ b/examples/tanstack-route/src/lib/server-functions.ts
@@ -8,7 +8,7 @@ import {
   normalizeLocale as normalizeSharedLocale,
 } from "@palamedes/example-locale-shared"
 import { activateServerI18n } from "./i18n.server"
-import { getLocaleLabel, ROUTE_HOSTS, type Locale, normalizeLocale } from "./i18n"
+import { getLocaleLabel, ROUTE_HOSTS, normalizeLocale } from "./i18n"
 
 export const resolveRootRedirect = createServerFn({ method: "GET" })
   .handler(async () => {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "check:release-set": "node ./scripts/check-release-set.mjs",
     "check-types": "pnpm check:native-types && pnpm -r --filter \"./packages/**\" exec tsc --noEmit -p tsconfig.json",
     "lint": "oxlint --ignore-path .gitignore --deny-warnings .",
-    "lint:fix": "oxlint --ignore-path .gitignore --fix .",
+    "lint:fix": "oxlint --ignore-path .gitignore --fix --deny-warnings .",
     "format": "prettier --write .",
     "build:native": "cargo build --workspace",
     "check:rust": "cargo check --workspace",

--- a/package.json
+++ b/package.json
@@ -28,12 +28,17 @@
     "check:native-types": "pnpm --filter @palamedes/core-node check-native-types",
     "check:release-set": "node ./scripts/check-release-set.mjs",
     "check-types": "pnpm check:native-types && pnpm -r --filter \"./packages/**\" exec tsc --noEmit -p tsconfig.json",
+    "lint": "oxlint --ignore-path .gitignore --deny-warnings .",
+    "lint:fix": "oxlint --ignore-path .gitignore --fix .",
+    "format": "prettier --write .",
     "build:native": "cargo build --workspace",
     "check:rust": "cargo check --workspace",
     "test:rust": "cargo test --workspace"
   },
   "devDependencies": {
     "@playwright/test": "^1.60.0",
+    "oxlint": "^1.69.0",
+    "prettier": "^3.8.4",
     "typescript": "^6.0.3",
     "vercel": "^54.1.0",
     "vitest": "^4.1.6"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,12 @@ importers:
       '@playwright/test':
         specifier: ^1.60.0
         version: 1.60.0
+      oxlint:
+        specifier: ^1.69.0
+        version: 1.69.0
+      prettier:
+        specifier: ^3.8.4
+        version: 3.8.4
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -2081,6 +2087,128 @@ packages:
 
   '@oxc-transform/binding-win32-x64-msvc@0.111.0':
     resolution: {integrity: sha512-QddKW4kBH0Wof6Y65eYCNHM4iOGmCTWLLcNYY1FGswhzmTYOUVXajNROR+iCXAOFnOF0ldtsR79SyqgyHH1Bgg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxlint/binding-android-arm-eabi@1.69.0':
+    resolution: {integrity: sha512-DKQQbD5cZ/MYfDgDI7YGyGD9FSxABlsBsYFo5p26lloob543tP9+4N3guwdXIYJN+7HSZxLe8YJuwcOWw5qnHg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxlint/binding-android-arm64@1.69.0':
+    resolution: {integrity: sha512-lEhb+I5pr4inux+JFwfCa1HRq3Os7NirEFQ0H1I35SVEHPm6byX0Ah47xmRha3qi6LAkxUcxViL8o/9PivjzBg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxlint/binding-darwin-arm64@1.69.0':
+    resolution: {integrity: sha512-GY2YE8lOZW59BW1Ia1y+1gR0XyjrZRvVWHAr8LGeGhYHE0OQJ/7cRKXTkx1P+E9/6awEc3SX8a68SFTjh/E//A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxlint/binding-darwin-x64@1.69.0':
+    resolution: {integrity: sha512-ax1oZnOjHX3LB7myQyHEaQkDwfLb6str3/nSP6O7EVUviQGNkEGzGV0EqcBJWK+Ufwx0l4xPgyYayurvhAdl2Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxlint/binding-freebsd-x64@1.69.0':
+    resolution: {integrity: sha512-kHWeHv4g2h8NY+mpCxzCtY4uerMJWTN/TSnNj1CPbakFpHEJ6cTya2wWV0pDSYWOJ2+0UiEbhn3AtXxHtsnKjg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxlint/binding-linux-arm-gnueabihf@1.69.0':
+    resolution: {integrity: sha512-gq84vM1a1oEehXo27YCDzGVcxPsZDI1yswZwz2Da1/cbnWtrL16XZZnz0G/+gIU8edtHpfjxq5c+vWEHqJfWoQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm-musleabihf@1.69.0':
+    resolution: {integrity: sha512-kIqEa98JQ0VRyrcncxA417m2AzasqTlD+FyVT1AksjvjkqQcvm7pBWYvoW3/mpyOP2XYvi5nSCCTIe6De1yu5g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm64-gnu@1.69.0':
+    resolution: {integrity: sha512-j+xYiXozxGWx2cpjCrwwGR4awTxPFsRv3JZrv23RCogEPMc4R7UqjHW47p/RG0aRlbWiROCJ8coUfCwy0dvzHA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-arm64-musl@1.69.0':
+    resolution: {integrity: sha512-xEPpNppTfN1l/nM7gYSf9iocscu/as+p/7vxkLeLEKnYU+09Dm+5V6IhDYDh+Uz6FajEupWwCLt5SOG0y1PCKg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxlint/binding-linux-ppc64-gnu@1.69.0':
+    resolution: {integrity: sha512-Ug0+eU7HJBlek+SjklYH62IlOMirEJsdxpihH0kSqX0XdrDD4NdHpQc10fK1JC35yn6KrrcN+uYzlHD38XAf8Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-riscv64-gnu@1.69.0':
+    resolution: {integrity: sha512-iEyI3GIg0l/s3G4qy2TlaaWKdzj4PJJStwtlocpDTC00PY9hZueotf6OKUj9+yfQh0lrpBW/pLMgTztbAHKJEg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-riscv64-musl@1.69.0':
+    resolution: {integrity: sha512-NjHjpiI4WIKSMwuoJSZi5VToPeoYOS1FR52HLIDG6lidMdqquusgtODb4iLk0+lb1q3Z0nv2/aPRcC/olmpQGg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxlint/binding-linux-s390x-gnu@1.69.0':
+    resolution: {integrity: sha512-Ai/prDewoItkDXbp38gwGZi41DycZbUTZJ3UidwoHgQC0/DaqC2TGdtBTQLJ6hSD+SAxASzh8+/eSBPmxfOacA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-x64-gnu@1.69.0':
+    resolution: {integrity: sha512-Gt3KHgp46mRKz4sJeaASmKvD8ayXookRw07RMf+NowhEztGGDZ7VrXpoW96XuKJLjFukWizOFVNjmYb/u7caNQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-x64-musl@1.69.0':
+    resolution: {integrity: sha512-7tQhJ2+p/oHv1zcfnjYI7YVzC/7iBaVOfIvFYtxdJ5F45mWgEdrCyXZXZGfiLey5t/5JhOhsaMnnv1kAzckd7g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxlint/binding-openharmony-arm64@1.69.0':
+    resolution: {integrity: sha512-vmWz6TKp/3hfA4lksR0zHBv/6xuX1jhym6eqOjdH2DXsDDHZWcp2f0KG0VCAnlVbIrjk29G4wAWMXb/Hn1YobA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxlint/binding-win32-arm64-msvc@1.69.0':
+    resolution: {integrity: sha512-9RExaLgmaw6IoIkU9cTpT71mLfI0xZ86iZH8x518LVsOkjquJMYqb9P7KpC8lgd1t0Dxs41p2pxynq4XR3Ttzw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxlint/binding-win32-ia32-msvc@1.69.0':
+    resolution: {integrity: sha512-1907kRPF8/PrcIw1E7LMs9JbVrpgnt/MvFdss3an8oDkYNAACXzTntV3t3869ZZhMZxb2AzRGbz1pA/jdFatXA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxlint/binding-win32-x64-msvc@1.69.0':
+    resolution: {integrity: sha512-w8SOXv3mT9Fi6jY8OXdXCfnvX/3KNLXGNr4HEz2TA7S4Mv/PYAOmpB8y/ge40mxvBMgGNaSaaDwZpAsQn7HtWA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -5469,6 +5597,19 @@ packages:
     resolution: {integrity: sha512-oa5KKSDNLHZGaiqIGAbCWXeN9IJUAz9MElWcQX90epDxdKc9Hrt/BsLj3K4gDqfAYa5dwdH+ZCFJG9hR74fiGg==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
+  oxlint@1.69.0:
+    resolution: {integrity: sha512-ypZkK/aDc5NQV8zIR6s2H2Tl3aNW8FmJ1m9+2qsaYuRenl8vgnHNCGwTHviWJdUQzglOlHFchgopdtGhSy17Rw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      oxlint-tsgolint: '>=0.22.1'
+      vite-plus: '*'
+    peerDependenciesMeta:
+      oxlint-tsgolint:
+        optional: true
+      vite-plus:
+        optional: true
+
   p-finally@2.0.1:
     resolution: {integrity: sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==}
     engines: {node: '>=8'}
@@ -5780,6 +5921,11 @@ packages:
 
   prettier@3.8.1:
     resolution: {integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==}
+    engines: {node: '>=14'}
+    hasBin: true
+
+  prettier@3.8.4:
+    resolution: {integrity: sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -8124,6 +8270,63 @@ snapshots:
     optional: true
 
   '@oxc-transform/binding-win32-x64-msvc@0.111.0':
+    optional: true
+
+  '@oxlint/binding-android-arm-eabi@1.69.0':
+    optional: true
+
+  '@oxlint/binding-android-arm64@1.69.0':
+    optional: true
+
+  '@oxlint/binding-darwin-arm64@1.69.0':
+    optional: true
+
+  '@oxlint/binding-darwin-x64@1.69.0':
+    optional: true
+
+  '@oxlint/binding-freebsd-x64@1.69.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm-gnueabihf@1.69.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm-musleabihf@1.69.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm64-gnu@1.69.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm64-musl@1.69.0':
+    optional: true
+
+  '@oxlint/binding-linux-ppc64-gnu@1.69.0':
+    optional: true
+
+  '@oxlint/binding-linux-riscv64-gnu@1.69.0':
+    optional: true
+
+  '@oxlint/binding-linux-riscv64-musl@1.69.0':
+    optional: true
+
+  '@oxlint/binding-linux-s390x-gnu@1.69.0':
+    optional: true
+
+  '@oxlint/binding-linux-x64-gnu@1.69.0':
+    optional: true
+
+  '@oxlint/binding-linux-x64-musl@1.69.0':
+    optional: true
+
+  '@oxlint/binding-openharmony-arm64@1.69.0':
+    optional: true
+
+  '@oxlint/binding-win32-arm64-msvc@1.69.0':
+    optional: true
+
+  '@oxlint/binding-win32-ia32-msvc@1.69.0':
+    optional: true
+
+  '@oxlint/binding-win32-x64-msvc@1.69.0':
     optional: true
 
   '@parcel/watcher-android-arm64@2.5.6':
@@ -11141,7 +11344,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.9.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -11805,6 +12008,28 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
+  oxlint@1.69.0:
+    optionalDependencies:
+      '@oxlint/binding-android-arm-eabi': 1.69.0
+      '@oxlint/binding-android-arm64': 1.69.0
+      '@oxlint/binding-darwin-arm64': 1.69.0
+      '@oxlint/binding-darwin-x64': 1.69.0
+      '@oxlint/binding-freebsd-x64': 1.69.0
+      '@oxlint/binding-linux-arm-gnueabihf': 1.69.0
+      '@oxlint/binding-linux-arm-musleabihf': 1.69.0
+      '@oxlint/binding-linux-arm64-gnu': 1.69.0
+      '@oxlint/binding-linux-arm64-musl': 1.69.0
+      '@oxlint/binding-linux-ppc64-gnu': 1.69.0
+      '@oxlint/binding-linux-riscv64-gnu': 1.69.0
+      '@oxlint/binding-linux-riscv64-musl': 1.69.0
+      '@oxlint/binding-linux-s390x-gnu': 1.69.0
+      '@oxlint/binding-linux-x64-gnu': 1.69.0
+      '@oxlint/binding-linux-x64-musl': 1.69.0
+      '@oxlint/binding-openharmony-arm64': 1.69.0
+      '@oxlint/binding-win32-arm64-msvc': 1.69.0
+      '@oxlint/binding-win32-ia32-msvc': 1.69.0
+      '@oxlint/binding-win32-x64-msvc': 1.69.0
+
   p-finally@2.0.1: {}
 
   p-map@7.0.4: {}
@@ -12092,6 +12317,8 @@ snapshots:
   powershell-utils@0.1.0: {}
 
   prettier@3.8.1: {}
+
+  prettier@3.8.4: {}
 
   pretty-bytes@7.1.0: {}
 
@@ -13532,7 +13759,7 @@ snapshots:
       browserslist: 4.28.1
       chrome-trace-event: 1.0.4
       enhanced-resolve: 5.20.1
-      es-module-lexer: 2.0.0
+      es-module-lexer: 2.1.0
       eslint-scope: 5.1.1
       events: 3.3.0
       glob-to-regexp: 0.4.1

--- a/scripts/deploy-examples.mjs
+++ b/scripts/deploy-examples.mjs
@@ -141,7 +141,7 @@ function getCommandCwd(example) {
   return example.cwd
 }
 
-function getVercelCwdArgs(example) {
+function getVercelCwdArgs() {
   return []
 }
 

--- a/scripts/deploy-examples.mjs
+++ b/scripts/deploy-examples.mjs
@@ -105,7 +105,7 @@ async function ensureVercelLink(example, env, token) {
     return
   }
 
-  const vercelCwdArgs = getVercelCwdArgs(example)
+  const vercelCwdArgs = getVercelCwdArgs()
   const args = [
     "exec",
     "vercel",
@@ -194,7 +194,7 @@ async function deployExample(example, options) {
 
   await ensureVercelLink(example, env, token)
 
-  const baseArgs = ["exec", "vercel", ...getVercelCwdArgs(example)]
+  const baseArgs = ["exec", "vercel", ...getVercelCwdArgs()]
   const environmentArgs = ["--yes", `--environment=${options.environment}`, `--token=${token}`]
   const buildArgs = ["build", `--token=${token}`]
   const deployArgs = ["deploy", "--prebuilt", "--yes", `--token=${token}`]


### PR DESCRIPTION
## Summary

Adds a root JS/TS lint gate and formatter tooling without mixing in a repo-wide format-only rewrite.

## Changes

- adds `oxlint` and `prettier` as root dev dependencies
- adds `pnpm lint`, `pnpm lint:fix`, and `pnpm format` scripts
- runs `pnpm lint` in CI
- adds Prettier config and ignore file
- fixes the initial Oxlint warnings so the lint gate starts green

## Validation

- `pnpm lint`
- `git diff --check`

## Note

`prettier --check .` currently reports 142 existing files that would be reformatted. I did not include that one-shot format churn in this PR so the new CI gate stays reviewable.

Refs #151