### PR TITLE
feat(core): add runtime fallback hooks

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -23,6 +23,28 @@ const i18n = createI18n()
 setClientI18n(i18n)
 ```
 
+## Runtime Fallback Hooks
+
+`createI18n` accepts optional hooks for production telemetry. Missing active-locale
+catalog entries still render the source message, but `onMissing` lets apps count
+them. Malformed runtime patterns fall back to the source message instead of
+throwing through the component tree, and `onError` receives the parse/format
+failure.
+
+```ts
+const i18n = createI18n({
+  onMissing({ id, locale }) {
+    reportMetric("palamedes.missing", { id, locale })
+  },
+  onError({ id, locale, error }) {
+    captureException(error, { tags: { id, locale } })
+  },
+})
+```
+
+Use `pmds audit --fail-on error` in CI for checked-in catalogs, then wire these
+hooks to observe runtime-loaded catalogs or fast-moving translation changes.
+
 For authoring imports, use:
 
 ```ts

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -44,6 +44,9 @@ const i18n = createI18n({
 
 Use `pmds audit --fail-on error` in CI for checked-in catalogs, then wire these
 hooks to observe runtime-loaded catalogs or fast-moving translation changes.
+`getMessage(id, descriptor)` uses the same missing-catalog lookup path as `_()`,
+so `onMissing` also fires when callers ask for a raw pattern by id and the
+active catalog does not contain that id.
 
 For authoring imports, use:
 

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -68,6 +68,97 @@ describe("createI18n", () => {
     ).toBe("2 messages for Ada")
   })
 
+  it("reports missing catalog messages when an active locale is missing an id", () => {
+    const missing: Array<{ id: string; locale: string }> = []
+    const i18n = createI18n({
+      onMissing(info) {
+        missing.push({ id: info.id, locale: info.locale })
+      },
+    })
+
+    i18n.activate("de")
+
+    expect(i18n._("missing-key", {}, { message: "Fallback" })).toBe("Fallback")
+    expect(missing).toEqual([{ id: "missing-key", locale: "de" }])
+  })
+
+  it("does not report missing messages for loaded empty-string translations", () => {
+    const missing: string[] = []
+    const i18n = createI18n({
+      onMissing(info) {
+        missing.push(info.id)
+      },
+    })
+
+    i18n.load("de", {
+      intentionallyEmpty: "",
+    })
+    i18n.activate("de")
+
+    expect(i18n._("intentionallyEmpty", {}, { message: "Fallback" })).toBe("")
+    expect(missing).toEqual([])
+  })
+
+  it("reports malformed catalog patterns and falls back to the formatted source message", () => {
+    const errors: Array<{ id?: string; locale?: string; pattern: string; fallback: string }> = []
+    const i18n = createI18n({
+      onError(info) {
+        errors.push({
+          id: info.id,
+          locale: info.locale,
+          pattern: info.pattern,
+          fallback: info.fallback,
+        })
+      },
+    })
+
+    i18n.load("de", {
+      "broken.message": "{count, plural one {# Datei} other {# Dateien}}",
+    })
+    i18n.activate("de")
+
+    expect(
+      i18n._("broken.message", { count: 2 }, { message: "{count, plural, one {# file} other {# files}}" })
+    ).toBe("2 files")
+    expect(errors).toEqual([
+      {
+        id: "broken.message",
+        locale: "de",
+        pattern: "{count, plural one {# Datei} other {# Dateien}}",
+        fallback: "{count, plural, one {# file} other {# files}}",
+      },
+    ])
+  })
+
+  it("returns the raw source message when the source pattern is malformed", () => {
+    const errors: string[] = []
+    const i18n = createI18n({
+      onError(info) {
+        errors.push(info.pattern)
+      },
+    })
+
+    expect(i18n._({ message: "{count, plural one {# file} other {# files}}" }, { count: 2 })).toBe(
+      "{count, plural one {# file} other {# files}}"
+    )
+    expect(errors).toEqual(["{count, plural one {# file} other {# files}}"])
+  })
+
+  it("keeps rendering resilient when hooks throw", () => {
+    const i18n = createI18n({
+      onMissing() {
+        throw new Error("missing telemetry failed")
+      },
+      onError() {
+        throw new Error("error telemetry failed")
+      },
+    })
+
+    i18n.activate("de")
+
+    expect(i18n._("broken", {}, { message: "{name" })).toBe("{name")
+  })
+
   it("keeps descriptors without ids message-only", () => {
     const i18n = createI18n()
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -111,6 +111,8 @@ export function createI18n(options: CreateI18nOptions = {}): PalamedesI18n {
       })
     }
 
+    // Keep rendering resilient after telemetry: try the source fallback, then
+    // return the raw source message if that pattern is malformed too.
     if (message.pattern !== message.fallback) {
       try {
         return formatMessagePattern(message.fallback, values, activeLocale)

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,6 +9,26 @@ export interface MessageDescriptor {
 
 export type CatalogMessages = Record<string, string>
 
+export interface MissingMessageInfo {
+  id: string
+  locale: string
+  descriptor?: MessageDescriptor
+}
+
+export interface MessageFormatErrorInfo {
+  id?: string
+  locale?: string
+  error: Error
+  pattern: string
+  fallback: string
+  descriptor?: MessageDescriptor
+}
+
+export interface CreateI18nOptions {
+  onMissing?: (info: MissingMessageInfo) => void
+  onError?: (info: MessageFormatErrorInfo) => void
+}
+
 export interface PalamedesI18n {
   locale?: string
   _: (
@@ -21,9 +41,86 @@ export interface PalamedesI18n {
   getMessage: (id: string, descriptor?: MessageDescriptor) => string
 }
 
-export function createI18n(): PalamedesI18n {
+interface ResolvedMessage {
+  pattern: string
+  fallback: string
+}
+
+export function createI18n(options: CreateI18nOptions = {}): PalamedesI18n {
   const catalogs = new Map<string, CatalogMessages>()
   let activeLocale: string | undefined
+
+  function notifyMissing(info: MissingMessageInfo): void {
+    try {
+      options.onMissing?.(info)
+    } catch {
+      // Telemetry hooks should not make message rendering fail.
+    }
+  }
+
+  function notifyError(info: MessageFormatErrorInfo): void {
+    try {
+      options.onError?.(info)
+    } catch {
+      // Telemetry hooks should not make message rendering fail.
+    }
+  }
+
+  function resolveMessage(id: string, descriptor?: MessageDescriptor): ResolvedMessage {
+    const catalog = activeLocale ? catalogs.get(activeLocale) : undefined
+    const catalogMessage = catalog?.[id]
+    const fallback = descriptor?.message ?? id
+
+    if (catalogMessage !== undefined) {
+      return {
+        pattern: catalogMessage,
+        fallback,
+      }
+    }
+
+    if (activeLocale) {
+      notifyMissing({
+        id,
+        locale: activeLocale,
+        descriptor,
+      })
+    }
+
+    return {
+      pattern: fallback,
+      fallback,
+    }
+  }
+
+  function renderMessage(
+    message: ResolvedMessage,
+    values: Record<string, unknown>,
+    id?: string,
+    descriptor?: MessageDescriptor
+  ): string {
+    try {
+      return formatMessagePattern(message.pattern, values, activeLocale)
+    } catch (error) {
+      notifyError({
+        id,
+        locale: activeLocale,
+        error: normalizeError(error),
+        pattern: message.pattern,
+        fallback: message.fallback,
+        descriptor,
+      })
+    }
+
+    if (message.pattern !== message.fallback) {
+      try {
+        return formatMessagePattern(message.fallback, values, activeLocale)
+      } catch {
+        return message.fallback
+      }
+    }
+
+    return message.fallback
+  }
 
   return {
     get locale() {
@@ -40,22 +137,31 @@ export function createI18n(): PalamedesI18n {
     },
 
     getMessage(id, descriptor) {
-      const catalog = activeLocale ? catalogs.get(activeLocale) : undefined
-      return catalog?.[id] ?? descriptor?.message ?? id
+      return resolveMessage(id, descriptor).pattern
     },
 
     _(idOrDescriptor, values = {}, descriptor) {
       if (typeof idOrDescriptor === "string") {
-        return formatMessagePattern(this.getMessage(idOrDescriptor, descriptor), values, activeLocale)
+        return renderMessage(resolveMessage(idOrDescriptor, descriptor), values, idOrDescriptor, descriptor)
       }
 
       if (idOrDescriptor.id !== undefined) {
-        return formatMessagePattern(this.getMessage(idOrDescriptor.id, idOrDescriptor), values, activeLocale)
+        return renderMessage(
+          resolveMessage(idOrDescriptor.id, idOrDescriptor),
+          values,
+          idOrDescriptor.id,
+          idOrDescriptor
+        )
       }
 
-      return formatMessagePattern(idOrDescriptor.message ?? "", values, activeLocale)
+      const pattern = idOrDescriptor.message ?? ""
+      return renderMessage({ pattern, fallback: pattern }, values, undefined, idOrDescriptor)
     },
   }
+}
+
+function normalizeError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error))
 }
 
 export { formatMessagePattern, parseMessagePattern }


### PR DESCRIPTION
## Summary
- add optional createI18n onMissing/onError hooks for runtime telemetry
- keep rendering resilient when missing translations or malformed runtime patterns are encountered
- document the hooks and add regression coverage for missing messages, malformed patterns, and hook failures

Closes #146

## Validation
- pnpm --filter @palamedes/core test
- pnpm --filter @palamedes/core exec tsc --noEmit -p tsconfig.json
- git diff --check