### PR TITLE
feat(core): format ICU number and date arguments

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -28,3 +28,31 @@ For authoring imports, use:
 ```ts
 import { t } from "@palamedes/core/macro"
 ```
+
+## Runtime Formatting
+
+Palamedes supports the common ICU argument types that product UIs usually need
+inside translated sentences:
+
+```ts
+i18n._(
+  {
+    message:
+      "Paid {amount, number, ::currency/EUR} on {when, date, medium} at {when, time, short}",
+  },
+  {
+    amount: 12.3,
+    when: new Date(),
+  }
+)
+```
+
+Supported runtime styles:
+
+- `{value, number}` plus `percent`, `integer`, and `::currency/ISO_CODE`
+- `{value, date, short|medium|long|full}`
+- `{value, time, short|medium|long|full}`
+
+Full ICU skeleton validation belongs in the transform/catalog diagnostics layer;
+unsupported runtime styles fall back to the default `Intl` formatter for the
+argument type.

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -106,6 +106,17 @@ describe("createI18n", () => {
     )
   })
 
+  it("stringifies invalid ICU number arguments instead of formatting them as zero", () => {
+    const i18n = createI18n()
+    i18n.activate("en-US")
+
+    expect(i18n._({ message: "Total: {amount, number, ::currency/EUR}" }, {})).toBe("Total: ")
+    expect(i18n._({ message: "Total: {amount, number, ::currency/EUR}" }, { amount: Number.NaN })).toBe("Total: NaN")
+    expect(i18n._({ message: "Total: {amount, number, ::currency/EUR}" }, { amount: Number.POSITIVE_INFINITY })).toBe(
+      "Total: Infinity"
+    )
+  })
+
   it("formats ICU date and time arguments with locale-aware styles", () => {
     const i18n = createI18n()
     i18n.activate("en-US")
@@ -115,6 +126,9 @@ describe("createI18n", () => {
       `Due ${new Intl.DateTimeFormat("en-US", { dateStyle: "medium" }).format(when)}`
     )
     expect(i18n._({ message: "Starts {when, time, short}" }, { when })).toBe(
+      `Starts ${new Intl.DateTimeFormat("en-US", { timeStyle: "short" }).format(when)}`
+    )
+    expect(i18n._({ message: "Starts {when, time}" }, { when })).toBe(
       `Starts ${new Intl.DateTimeFormat("en-US", { timeStyle: "short" }).format(when)}`
     )
   })

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -90,4 +90,32 @@ describe("createI18n", () => {
       i18n._("ordinal", { count: 3 }, { message: "{count, selectordinal, one {#st} two {#nd} few {#rd} other {#th}}" })
     ).toBe("3rd")
   })
+
+  it("formats ICU number arguments with locale-aware styles", () => {
+    const i18n = createI18n()
+    i18n.activate("en-US")
+
+    expect(i18n._({ message: "Total: {amount, number, ::currency/EUR}" }, { amount: 12.3 })).toBe(
+      `Total: ${new Intl.NumberFormat("en-US", { style: "currency", currency: "EUR" }).format(12.3)}`
+    )
+    expect(i18n._({ message: "Progress: {ratio, number, percent}" }, { ratio: 0.42 })).toBe(
+      `Progress: ${new Intl.NumberFormat("en-US", { style: "percent" }).format(0.42)}`
+    )
+    expect(i18n._({ message: "Rounded: {count, number, integer}" }, { count: 12.8 })).toBe(
+      `Rounded: ${new Intl.NumberFormat("en-US", { maximumFractionDigits: 0 }).format(12.8)}`
+    )
+  })
+
+  it("formats ICU date and time arguments with locale-aware styles", () => {
+    const i18n = createI18n()
+    i18n.activate("en-US")
+    const when = new Date(Date.UTC(2026, 5, 12, 13, 45, 0))
+
+    expect(i18n._({ message: "Due {when, date, medium}" }, { when })).toBe(
+      `Due ${new Intl.DateTimeFormat("en-US", { dateStyle: "medium" }).format(when)}`
+    )
+    expect(i18n._({ message: "Starts {when, time, short}" }, { when })).toBe(
+      `Starts ${new Intl.DateTimeFormat("en-US", { timeStyle: "short" }).format(when)}`
+    )
+  })
 })

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -59,4 +59,10 @@ export function createI18n(): PalamedesI18n {
 }
 
 export { formatMessagePattern, parseMessagePattern }
-export type { MessageNode, MessageChoiceNode, MessageTagNode, MessageVariableNode } from "./messageFormat"
+export type {
+  MessageNode,
+  MessageChoiceNode,
+  MessageFormattedArgumentNode,
+  MessageTagNode,
+  MessageVariableNode,
+} from "./messageFormat"

--- a/packages/core/src/messageFormat.ts
+++ b/packages/core/src/messageFormat.ts
@@ -8,6 +8,13 @@ export interface MessageVariableNode {
   name: string
 }
 
+export interface MessageFormattedArgumentNode {
+  type: "formatted"
+  variable: string
+  format: "number" | "date" | "time"
+  style?: string
+}
+
 export interface MessageChoiceNode {
   type: "choice"
   variable: string
@@ -24,10 +31,13 @@ export interface MessageTagNode {
 export type MessageNode =
   | MessageTextNode
   | MessageVariableNode
+  | MessageFormattedArgumentNode
   | MessageChoiceNode
   | MessageTagNode
 
 const parseCache = new Map<string, MessageNode[]>()
+const numberFormatCache = new Map<string, Intl.NumberFormat>()
+const dateTimeFormatCache = new Map<string, Intl.DateTimeFormat>()
 
 interface ParserState {
   input: string
@@ -125,7 +135,20 @@ function parseBraceExpression(state: ParserState): MessageNode {
 
   expectChar(state, ",")
   skipWhitespace(state)
-  const kind = readUntil(state, [",", "}"]).trim() as MessageChoiceNode["kind"]
+  const kind = readUntil(state, [",", "}"]).trim()
+
+  if (isFormattedArgumentKind(kind)) {
+    const style = readOptionalStyle(state)
+    expectChar(state, "}")
+
+    return {
+      type: "formatted",
+      variable: name,
+      format: kind,
+      style,
+    }
+  }
+
   expectChar(state, ",")
 
   const options: Record<string, MessageNode[]> = {}
@@ -144,9 +167,23 @@ function parseBraceExpression(state: ParserState): MessageNode {
   return {
     type: "choice",
     variable: name,
-    kind,
+    kind: kind as MessageChoiceNode["kind"],
     options,
   }
+}
+
+function isFormattedArgumentKind(kind: string): kind is MessageFormattedArgumentNode["format"] {
+  return kind === "number" || kind === "date" || kind === "time"
+}
+
+function readOptionalStyle(state: ParserState): string | undefined {
+  if (state.input[state.index] !== ",") {
+    return undefined
+  }
+
+  state.index += 1
+  const style = readUntil(state, ["}"]).trim()
+  return style.length > 0 ? style : undefined
 }
 
 function parseNodesUntilBrace(state: ParserState): MessageNode[] {
@@ -279,6 +316,8 @@ function renderNodeToString(
       return pluralValue === undefined ? node.value : replacePound(node.value, pluralValue, locale)
     case "variable":
       return stringifyValue(values[node.name])
+    case "formatted":
+      return formatArgument(node, values[node.variable], locale)
     case "tag":
       return renderNodesToString(node.children, values, locale, pluralValue)
     case "choice": {
@@ -288,6 +327,107 @@ function renderNodeToString(
       return renderNodesToString(selectChoice(node, value, locale), values, locale, nextPluralValue)
     }
   }
+}
+
+function formatArgument(
+  node: MessageFormattedArgumentNode,
+  value: unknown,
+  locale?: string
+): string {
+  if (node.format === "number") {
+    const numericValue = normalizeNumericValue(value)
+    return getNumberFormatter(locale, node.style).format(numericValue)
+  }
+
+  const dateValue = normalizeDateValue(value)
+  if (!dateValue) {
+    return stringifyValue(value)
+  }
+
+  return getDateTimeFormatter(locale, node.format, node.style).format(dateValue)
+}
+
+function getNumberFormatter(locale: string | undefined, style: string | undefined): Intl.NumberFormat {
+  const cacheKey = `${locale ?? ""}\0${style ?? ""}`
+  const cached = numberFormatCache.get(cacheKey)
+  if (cached) {
+    return cached
+  }
+
+  const formatter = new Intl.NumberFormat(locale, parseNumberFormatOptions(style))
+  numberFormatCache.set(cacheKey, formatter)
+  return formatter
+}
+
+function parseNumberFormatOptions(style: string | undefined): Intl.NumberFormatOptions {
+  const normalized = style?.trim()
+  if (!normalized) {
+    return {}
+  }
+
+  const skeleton = normalized.startsWith("::") ? normalized.slice(2) : normalized
+
+  if (skeleton === "percent") {
+    return { style: "percent" }
+  }
+
+  if (skeleton === "integer") {
+    return { maximumFractionDigits: 0 }
+  }
+
+  if (skeleton.startsWith("currency/")) {
+    const currency = skeleton.slice("currency/".length).trim().toUpperCase()
+    if (/^[A-Z]{3}$/.test(currency)) {
+      return {
+        style: "currency",
+        currency,
+      }
+    }
+  }
+
+  return {}
+}
+
+function normalizeDateValue(value: unknown): Date | undefined {
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? undefined : value
+  }
+
+  if (typeof value === "string" || typeof value === "number") {
+    const date = new Date(value)
+    return Number.isNaN(date.getTime()) ? undefined : date
+  }
+
+  return undefined
+}
+
+function getDateTimeFormatter(
+  locale: string | undefined,
+  format: "date" | "time",
+  style: string | undefined
+): Intl.DateTimeFormat {
+  const normalizedStyle = normalizeDateTimeStyle(style)
+  const cacheKey = `${locale ?? ""}\0${format}\0${normalizedStyle ?? ""}`
+  const cached = dateTimeFormatCache.get(cacheKey)
+  if (cached) {
+    return cached
+  }
+
+  const options: Intl.DateTimeFormatOptions =
+    format === "date"
+      ? { dateStyle: normalizedStyle }
+      : { timeStyle: normalizedStyle }
+  const formatter = new Intl.DateTimeFormat(locale, options)
+  dateTimeFormatCache.set(cacheKey, formatter)
+  return formatter
+}
+
+function normalizeDateTimeStyle(style: string | undefined): "full" | "long" | "medium" | "short" | undefined {
+  if (style === "full" || style === "long" || style === "medium" || style === "short") {
+    return style
+  }
+
+  return undefined
 }
 
 function selectChoice(node: MessageChoiceNode, value: unknown, locale?: string): MessageNode[] {

--- a/packages/core/src/messageFormat.ts
+++ b/packages/core/src/messageFormat.ts
@@ -38,6 +38,7 @@ export type MessageNode =
 const parseCache = new Map<string, MessageNode[]>()
 const numberFormatCache = new Map<string, Intl.NumberFormat>()
 const dateTimeFormatCache = new Map<string, Intl.DateTimeFormat>()
+const FORMATTER_CACHE_LIMIT = 64
 
 interface ParserState {
   input: string
@@ -335,7 +336,11 @@ function formatArgument(
   locale?: string
 ): string {
   if (node.format === "number") {
-    const numericValue = normalizeNumericValue(value)
+    const numericValue = normalizeFormattedNumberValue(value)
+    if (numericValue === undefined) {
+      return stringifyValue(value)
+    }
+
     return getNumberFormatter(locale, node.style).format(numericValue)
   }
 
@@ -355,8 +360,7 @@ function getNumberFormatter(locale: string | undefined, style: string | undefine
   }
 
   const formatter = new Intl.NumberFormat(locale, parseNumberFormatOptions(style))
-  numberFormatCache.set(cacheKey, formatter)
-  return formatter
+  return rememberFormatter(numberFormatCache, cacheKey, formatter)
 }
 
 function parseNumberFormatOptions(style: string | undefined): Intl.NumberFormatOptions {
@@ -406,7 +410,7 @@ function getDateTimeFormatter(
   format: "date" | "time",
   style: string | undefined
 ): Intl.DateTimeFormat {
-  const normalizedStyle = normalizeDateTimeStyle(style)
+  const normalizedStyle = normalizeDateTimeStyle(style, format)
   const cacheKey = `${locale ?? ""}\0${format}\0${normalizedStyle ?? ""}`
   const cached = dateTimeFormatCache.get(cacheKey)
   if (cached) {
@@ -418,16 +422,18 @@ function getDateTimeFormatter(
       ? { dateStyle: normalizedStyle }
       : { timeStyle: normalizedStyle }
   const formatter = new Intl.DateTimeFormat(locale, options)
-  dateTimeFormatCache.set(cacheKey, formatter)
-  return formatter
+  return rememberFormatter(dateTimeFormatCache, cacheKey, formatter)
 }
 
-function normalizeDateTimeStyle(style: string | undefined): "full" | "long" | "medium" | "short" | undefined {
+function normalizeDateTimeStyle(
+  style: string | undefined,
+  format: "date" | "time"
+): "full" | "long" | "medium" | "short" | undefined {
   if (style === "full" || style === "long" || style === "medium" || style === "short") {
     return style
   }
 
-  return undefined
+  return format === "time" ? "short" : undefined
 }
 
 function selectChoice(node: MessageChoiceNode, value: unknown, locale?: string): MessageNode[] {
@@ -458,6 +464,35 @@ function normalizeNumericValue(value: unknown): number {
 
   const parsed = Number(value)
   return Number.isFinite(parsed) ? parsed : 0
+}
+
+function normalizeFormattedNumberValue(value: unknown): number | undefined {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : undefined
+  }
+
+  if (typeof value === "string" && value.trim().length > 0) {
+    const parsed = Number(value)
+    return Number.isFinite(parsed) ? parsed : undefined
+  }
+
+  return undefined
+}
+
+function rememberFormatter<TFormatter>(
+  cache: Map<string, TFormatter>,
+  key: string,
+  formatter: TFormatter
+): TFormatter {
+  if (!cache.has(key) && cache.size >= FORMATTER_CACHE_LIMIT) {
+    const oldestKey = cache.keys().next().value
+    if (oldestKey !== undefined) {
+      cache.delete(oldestKey)
+    }
+  }
+
+  cache.set(key, formatter)
+  return formatter
 }
 
 function replacePound(value: string, numericValue: number, locale?: string): string {

--- a/packages/react/src/index.test.tsx
+++ b/packages/react/src/index.test.tsx
@@ -42,6 +42,18 @@ describe("@palamedes/react", () => {
     expect(html).toBe("2 items")
   })
 
+  it("renders formatted ICU arguments through Trans", () => {
+    const i18n = createI18n()
+    i18n.activate("en-US")
+    setClientI18n(i18n)
+
+    const html = renderToStaticMarkup(
+      <Trans id="total" message="Total: {amount, number, ::currency/EUR}" values={{ amount: 12.3 }} />
+    )
+
+    expect(html).toBe(`Total: ${new Intl.NumberFormat("en-US", { style: "currency", currency: "EUR" }).format(12.3)}`)
+  })
+
   it("builds locale switch items headlessly", () => {
     expect(
       buildLocaleSwitchItems({

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -3,7 +3,7 @@ import { cloneElement, Fragment, isValidElement } from "react"
 import type { ReactElement, ReactNode } from "react"
 
 import { getI18n } from "@palamedes/runtime"
-import { parseMessagePattern } from "@palamedes/core"
+import { formatMessagePattern, parseMessagePattern } from "@palamedes/core"
 import type { MessageChoiceNode, MessageDescriptor, MessageNode, PalamedesI18n } from "@palamedes/core"
 
 export interface TransProps extends MessageDescriptor {
@@ -120,6 +120,8 @@ function renderNode(
       return [pluralValue === undefined ? node.value : node.value.replaceAll("#", formatNumber(pluralValue, locale))]
     case "variable":
       return [renderVariable(values[node.name])]
+    case "formatted":
+      return [formatMessagePattern(buildFormattedMessage(node), values, locale)]
     case "tag": {
       const children = renderNodes(node.children, values, components, locale, pluralValue)
       const component = components[node.name]
@@ -136,6 +138,12 @@ function renderNode(
       return renderNodes(choice, values, components, locale, nextPluralValue)
     }
   }
+
+  return []
+}
+
+function buildFormattedMessage(node: Extract<MessageNode, { type: "formatted" }>): string {
+  return `{${node.variable}, ${node.format}${node.style ? `, ${node.style}` : ""}}`
 }
 
 function selectChoice(node: MessageChoiceNode, value: unknown, locale?: string): MessageNode[] {

--- a/packages/solid/src/index.tsx
+++ b/packages/solid/src/index.tsx
@@ -1,6 +1,6 @@
 import type { JSX } from "solid-js"
 
-import { parseMessagePattern } from "@palamedes/core"
+import { formatMessagePattern, parseMessagePattern } from "@palamedes/core"
 import type { MessageChoiceNode, MessageDescriptor, MessageNode, PalamedesI18n } from "@palamedes/core"
 import { getI18n } from "@palamedes/runtime"
 
@@ -121,6 +121,8 @@ function renderNode(
       return [pluralValue === undefined ? node.value : node.value.replaceAll("#", formatNumber(pluralValue, locale))]
     case "variable":
       return [renderVariable(values[node.name])]
+    case "formatted":
+      return [formatMessagePattern(buildFormattedMessage(node), values, locale)]
     case "tag": {
       const children = renderNodes(node.children, values, components, locale, pluralValue)
       const component = components[node.name]
@@ -143,6 +145,12 @@ function renderNode(
       return renderNodes(choice, values, components, locale, nextPluralValue)
     }
   }
+
+  return []
+}
+
+function buildFormattedMessage(node: Extract<MessageNode, { type: "formatted" }>): string {
+  return `{${node.variable}, ${node.format}${node.style ? `, ${node.style}` : ""}}`
 }
 
 function selectChoice(node: MessageChoiceNode, value: unknown, locale?: string): MessageNode[] {


### PR DESCRIPTION
## Summary
- add runtime AST support for ICU formatted arguments
- support `{value, number}`, `percent`, `integer`, and `::currency/ISO_CODE` styles
- support `{value, date|time, short|medium|long|full}` via cached Intl formatters
- document the supported runtime subset

Refs #147

## Scope note
This is the runtime slice only. Transform/catalog diagnostics for unsupported styles and a broader ADR remain outside this PR.

## Validation
- pnpm --filter @palamedes/core test
- pnpm --filter @palamedes/core exec tsc --noEmit -p tsconfig.json
- git diff --check