### PR TITLE
refactor(transform): share catalog loader diagnostics

### DIFF
--- a/packages/next-plugin/palamedes-po-loader.cjs
+++ b/packages/next-plugin/palamedes-po-loader.cjs
@@ -3,49 +3,7 @@
 const path = require("node:path");
 const { loadPalamedesConfig } = require("@palamedes/config");
 const { compileCatalogArtifact } = require("@palamedes/core-node");
-
-function createMissingErrorMessage(locale, missingMessages) {
-  const lines = missingMessages.map((missing) =>
-    missing.sourceKey.context
-      ? `${missing.sourceKey.message} [context: ${missing.sourceKey.context}]`
-      : missing.sourceKey.message
-  );
-  return `Failed to compile catalog for locale ${locale}!\n\nMissing ${missingMessages.length} translation(s):\n${lines.join("\n")}`;
-}
-
-function createDiagnosticMessage(locale, diagnostics) {
-  const lines = diagnostics.map((diagnostic) => {
-    const source = diagnostic.sourceKey.context
-      ? `${diagnostic.sourceKey.message} [context: ${diagnostic.sourceKey.context}]`
-      : diagnostic.sourceKey.message;
-    return `[${diagnostic.severity}] ${diagnostic.code} (${diagnostic.locale})\n${diagnostic.message}\nSource: ${source}`;
-  });
-  return `Catalog diagnostics for locale ${locale}:\n\n${lines.join("\n\n")}`;
-}
-
-function createCompileErrorMessage(locale, diagnostics) {
-  const lines = diagnostics.map((diagnostic) => {
-    const source = diagnostic.sourceKey.context
-      ? `${diagnostic.sourceKey.message} [context: ${diagnostic.sourceKey.context}]`
-      : diagnostic.sourceKey.message;
-    return `${diagnostic.message}\nCode: ${diagnostic.code}\nLocale: ${diagnostic.locale}\nSource: ${source}`;
-  });
-  return `Failed to compile catalog for locale ${locale}!\n\nCompilation error for ${diagnostics.length} translation(s):\n${lines.join("\n\n")}`;
-}
-
-function warnDiagnostics(locale, diagnostics) {
-  if (diagnostics.length === 0) {
-    return;
-  }
-
-  console.warn(
-    `${createDiagnosticMessage(locale, diagnostics)}\n\nYou can fail the build on error diagnostics by setting \`failOnCompileError=true\` in the Palamedes Next plugin configuration.`
-  );
-}
-
-function renderCatalogModule(messages) {
-  return `export const messages=${JSON.stringify(messages)};export default { messages };`;
-}
+const { createCatalogLoaderResult } = require("@palamedes/transform/catalog-loader");
 
 module.exports = function palamedesPoLoader() {
   const callback = this.async();
@@ -73,24 +31,18 @@ module.exports = function palamedesPoLoader() {
       }
     });
 
-    if (locale !== cfg.pseudoLocale && result.missing.length > 0 && failOnMissing) {
-      throw new Error(createMissingErrorMessage(locale, result.missing));
-    }
+    const loaderResult = createCatalogLoaderResult(result, {
+      locale,
+      pseudoLocale: cfg.pseudoLocale,
+      failOnMissing,
+      failOnCompileError,
+      diagnosticsWarningHint:
+        "You can fail the build on error diagnostics by setting `failOnCompileError=true` in the Palamedes Next plugin configuration.",
+    });
 
-    if (result.diagnostics.length > 0) {
-      const errorDiagnostics = result.diagnostics.filter(
-        (diagnostic) => diagnostic.severity === "error"
-      );
+    loaderResult.warnings.forEach((warning) => console.warn(warning));
 
-      if (failOnCompileError && errorDiagnostics.length > 0) {
-        const message = createCompileErrorMessage(locale, errorDiagnostics);
-        throw new Error(message);
-      }
-
-      warnDiagnostics(locale, result.diagnostics);
-    }
-
-    callback(null, renderCatalogModule(result.messages), null);
+    callback(null, loaderResult.code, null);
   })().catch((error) => {
     callback(error);
   });

--- a/packages/transform/build.config.ts
+++ b/packages/transform/build.config.ts
@@ -1,7 +1,7 @@
 import { defineBuildConfig } from "unbuild"
 
 export default defineBuildConfig({
-  entries: ["./src/index"],
+  entries: ["./src/index", "./src/catalogLoader"],
   declaration: true,
   failOnWarn: false,
   rollup: {

--- a/packages/transform/package.json
+++ b/packages/transform/package.json
@@ -23,6 +23,11 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
+    },
+    "./catalog-loader": {
+      "types": "./dist/catalogLoader.d.ts",
+      "import": "./dist/catalogLoader.mjs",
+      "require": "./dist/catalogLoader.cjs"
     }
   },
   "main": "./dist/index.cjs",
@@ -36,7 +41,7 @@
   ],
   "scripts": {
     "build": "unbuild",
-    "test": "vitest run --globals src/transform.test.ts",
+    "test": "vitest run --globals src/*.test.ts",
     "stub": "unbuild --stub"
   },
   "engines": {

--- a/packages/transform/src/catalogLoader.test.ts
+++ b/packages/transform/src/catalogLoader.test.ts
@@ -68,6 +68,13 @@ describe("catalog loader helpers", () => {
 
     expect(
       createCatalogLoaderResult(result, {
+        locale: "de",
+        failOnMissing: false,
+      }).code
+    ).toBe(renderCatalogModule(baseResult.messages))
+
+    expect(
+      createCatalogLoaderResult(result, {
         locale: "pseudo",
         pseudoLocale: "pseudo",
         failOnMissing: true,
@@ -105,5 +112,28 @@ describe("catalog loader helpers", () => {
     ).toEqual([
       "Catalog diagnostics for locale de:\n\n[error] icu (de)\nBroken ICU\nSource: Inbox\n\nwarning hint",
     ])
+  })
+
+  it("omits compile failure guidance when warning diagnostics do not fail the build", () => {
+    const result: CatalogCompileArtifactResult = {
+      ...baseResult,
+      diagnostics: [
+        {
+          severity: "warning",
+          code: "icu",
+          message: "Suspicious ICU",
+          sourceKey: { message: "Inbox" },
+          locale: "de",
+        },
+      ],
+    }
+
+    expect(
+      createCatalogLoaderResult(result, {
+        locale: "de",
+        failOnCompileError: true,
+        diagnosticsWarningHint: "set failOnCompileError",
+      }).warnings
+    ).toEqual(["Catalog diagnostics for locale de:\n\n[warning] icu (de)\nSuspicious ICU\nSource: Inbox"])
   })
 })

--- a/packages/transform/src/catalogLoader.test.ts
+++ b/packages/transform/src/catalogLoader.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  createCatalogLoaderResult,
+  createCompileErrorMessage,
+  createDiagnosticMessage,
+  createMissingErrorMessage,
+  renderCatalogModule,
+  type CatalogCompileArtifactResult,
+} from "./catalogLoader"
+
+const baseResult: CatalogCompileArtifactResult = {
+  messages: {
+    greeting: "Hallo",
+  },
+  missing: [],
+  diagnostics: [],
+}
+
+describe("catalog loader helpers", () => {
+  it("renders catalog modules consistently", () => {
+    expect(renderCatalogModule({ greeting: "Hallo" })).toBe(
+      'export const messages={"greeting":"Hallo"};export default { messages };'
+    )
+  })
+
+  it("formats missing translations with context", () => {
+    expect(
+      createMissingErrorMessage("de", [
+        { sourceKey: { message: "Hello" } },
+        { sourceKey: { message: "Open", context: "verb" } },
+      ])
+    ).toBe("Failed to compile catalog for locale de!\n\nMissing 2 translation(s):\nHello\nOpen [context: verb]")
+  })
+
+  it("formats diagnostics and compile errors with the same source key rendering", () => {
+    const diagnostics = [
+      {
+        severity: "error" as const,
+        code: "icu",
+        message: "Broken ICU",
+        sourceKey: { message: "Inbox", context: "nav" },
+        locale: "de",
+      },
+    ]
+
+    expect(createDiagnosticMessage("de", diagnostics)).toBe(
+      "Catalog diagnostics for locale de:\n\n[error] icu (de)\nBroken ICU\nSource: Inbox [context: nav]"
+    )
+    expect(createCompileErrorMessage("de", diagnostics)).toBe(
+      "Failed to compile catalog for locale de!\n\nCompilation error for 1 translation(s):\nBroken ICU\nCode: icu\nLocale: de\nSource: Inbox [context: nav]"
+    )
+  })
+
+  it("fails missing translations outside the pseudo locale only when configured", () => {
+    const result: CatalogCompileArtifactResult = {
+      ...baseResult,
+      missing: [{ sourceKey: { message: "Hello" } }],
+    }
+
+    expect(() =>
+      createCatalogLoaderResult(result, {
+        locale: "de",
+        failOnMissing: true,
+        missingFailureHint: "configured failOnMissing",
+      })
+    ).toThrow(/configured failOnMissing/)
+
+    expect(
+      createCatalogLoaderResult(result, {
+        locale: "pseudo",
+        pseudoLocale: "pseudo",
+        failOnMissing: true,
+      }).code
+    ).toBe(renderCatalogModule(baseResult.messages))
+  })
+
+  it("fails compile diagnostics or emits warnings depending on configuration", () => {
+    const result: CatalogCompileArtifactResult = {
+      ...baseResult,
+      diagnostics: [
+        {
+          severity: "error",
+          code: "icu",
+          message: "Broken ICU",
+          sourceKey: { message: "Inbox" },
+          locale: "de",
+        },
+      ],
+    }
+
+    expect(() =>
+      createCatalogLoaderResult(result, {
+        locale: "de",
+        failOnCompileError: true,
+        compileFailureHint: "configured failOnCompileError",
+      })
+    ).toThrow(/configured failOnCompileError/)
+
+    expect(
+      createCatalogLoaderResult(result, {
+        locale: "de",
+        diagnosticsWarningHint: "warning hint",
+      }).warnings
+    ).toEqual([
+      "Catalog diagnostics for locale de:\n\n[error] icu (de)\nBroken ICU\nSource: Inbox\n\nwarning hint",
+    ])
+  })
+})

--- a/packages/transform/src/catalogLoader.ts
+++ b/packages/transform/src/catalogLoader.ts
@@ -1,0 +1,116 @@
+export interface CatalogSourceKey {
+  message: string
+  context?: string
+}
+
+export interface MissingCatalogMessage {
+  sourceKey: CatalogSourceKey
+}
+
+export interface CatalogDiagnostic {
+  severity: "info" | "warning" | "error"
+  code: string
+  message: string
+  sourceKey: CatalogSourceKey
+  locale: string
+}
+
+export interface CatalogCompileArtifactResult {
+  messages: Record<string, string>
+  missing: MissingCatalogMessage[]
+  diagnostics: CatalogDiagnostic[]
+}
+
+export interface CatalogLoaderOptions {
+  locale: string
+  pseudoLocale?: string
+  failOnMissing?: boolean
+  failOnCompileError?: boolean
+  missingFailureHint?: string
+  compileFailureHint?: string
+  diagnosticsWarningHint?: string
+}
+
+export interface CatalogLoaderResult {
+  code: string
+  warnings: string[]
+}
+
+export function createCatalogLoaderResult(
+  result: CatalogCompileArtifactResult,
+  options: CatalogLoaderOptions
+): CatalogLoaderResult {
+  const warnings: string[] = []
+  const {
+    locale,
+    pseudoLocale,
+    failOnMissing = false,
+    failOnCompileError = false,
+    missingFailureHint,
+    compileFailureHint,
+    diagnosticsWarningHint,
+  } = options
+
+  if (locale !== pseudoLocale && result.missing.length > 0 && failOnMissing) {
+    throw new Error(
+      appendHint(createMissingErrorMessage(locale, result.missing), missingFailureHint)
+    )
+  }
+
+  if (result.diagnostics.length > 0) {
+    const errorDiagnostics = result.diagnostics.filter(
+      (diagnostic) => diagnostic.severity === "error"
+    )
+
+    if (failOnCompileError && errorDiagnostics.length > 0) {
+      throw new Error(
+        appendHint(createCompileErrorMessage(locale, errorDiagnostics), compileFailureHint)
+      )
+    }
+
+    warnings.push(appendHint(createDiagnosticMessage(locale, result.diagnostics), diagnosticsWarningHint))
+  }
+
+  return {
+    code: renderCatalogModule(result.messages),
+    warnings,
+  }
+}
+
+export function createMissingErrorMessage(
+  locale: string,
+  missingMessages: MissingCatalogMessage[]
+): string {
+  const lines = missingMessages.map((missing) => renderSourceKey(missing.sourceKey))
+  return `Failed to compile catalog for locale ${locale}!\n\nMissing ${missingMessages.length} translation(s):\n${lines.join("\n")}`
+}
+
+export function createDiagnosticMessage(locale: string, diagnostics: CatalogDiagnostic[]): string {
+  const lines = diagnostics.map((diagnostic) => {
+    const source = renderSourceKey(diagnostic.sourceKey)
+    return `[${diagnostic.severity}] ${diagnostic.code} (${diagnostic.locale})\n${diagnostic.message}\nSource: ${source}`
+  })
+  return `Catalog diagnostics for locale ${locale}:\n\n${lines.join("\n\n")}`
+}
+
+export function createCompileErrorMessage(locale: string, diagnostics: CatalogDiagnostic[]): string {
+  const lines = diagnostics.map((diagnostic) => {
+    const source = renderSourceKey(diagnostic.sourceKey)
+    return `${diagnostic.message}\nCode: ${diagnostic.code}\nLocale: ${diagnostic.locale}\nSource: ${source}`
+  })
+  return `Failed to compile catalog for locale ${locale}!\n\nCompilation error for ${diagnostics.length} translation(s):\n${lines.join("\n\n")}`
+}
+
+export function renderCatalogModule(messages: Record<string, string>): string {
+  return `export const messages=${JSON.stringify(messages)};export default { messages };`
+}
+
+function renderSourceKey(sourceKey: CatalogSourceKey): string {
+  return sourceKey.context
+    ? `${sourceKey.message} [context: ${sourceKey.context}]`
+    : sourceKey.message
+}
+
+function appendHint(message: string, hint: string | undefined): string {
+  return hint ? `${message}\n\n${hint}` : message
+}

--- a/packages/transform/src/catalogLoader.ts
+++ b/packages/transform/src/catalogLoader.ts
@@ -68,7 +68,12 @@ export function createCatalogLoaderResult(
       )
     }
 
-    warnings.push(appendHint(createDiagnosticMessage(locale, result.diagnostics), diagnosticsWarningHint))
+    warnings.push(
+      appendHint(
+        createDiagnosticMessage(locale, result.diagnostics),
+        failOnCompileError ? undefined : diagnosticsWarningHint
+      )
+    )
   }
 
   return {

--- a/packages/transform/src/index.ts
+++ b/packages/transform/src/index.ts
@@ -9,3 +9,18 @@ export { transformPalamedesMacros } from "./transform"
 export type { TransformOptions, TransformResult, SourceMap } from "./types"
 export { PALAMEDES_MACRO_PACKAGES, JS_MACROS, JSX_MACROS } from "./types"
 export { mightContainPalamedesMacros, findMacroImports } from "./detect"
+export {
+  createCatalogLoaderResult,
+  createCompileErrorMessage,
+  createDiagnosticMessage,
+  createMissingErrorMessage,
+  renderCatalogModule,
+} from "./catalogLoader"
+export type {
+  CatalogCompileArtifactResult,
+  CatalogDiagnostic,
+  CatalogLoaderOptions,
+  CatalogLoaderResult,
+  CatalogSourceKey,
+  MissingCatalogMessage,
+} from "./catalogLoader"

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -13,6 +13,7 @@ import {
   type LoadedPalamedesConfig,
 } from "@palamedes/config"
 import { compileCatalogArtifact } from "@palamedes/core-node"
+import { createCatalogLoaderResult } from "@palamedes/transform/catalog-loader"
 import { transformPalamedesMacros } from "@palamedes/transform"
 import { PALAMEDES_MACRO_PACKAGES } from "@palamedes/transform"
 
@@ -75,75 +76,6 @@ export interface PalamedesPluginOptions {
    * @default "@palamedes/runtime"
    */
   runtimeModule?: string
-}
-
-function createMissingErrorMessage(
-  locale: string,
-  missingMessages: Array<{ sourceKey: { message: string; context?: string } }>
-): string {
-  const lines = missingMessages.map((missing) =>
-    missing.sourceKey.context
-      ? `${missing.sourceKey.message} [context: ${missing.sourceKey.context}]`
-      : missing.sourceKey.message
-  )
-  return `Failed to compile catalog for locale ${locale}!\n\nMissing ${missingMessages.length} translation(s):\n${lines.join("\n")}`
-}
-
-function createDiagnosticMessage(
-  locale: string,
-  diagnostics: Array<{
-    severity: "info" | "warning" | "error"
-    code: string
-    message: string
-    sourceKey: { message: string; context?: string }
-    locale: string
-  }>
-): string {
-  const lines = diagnostics.map((diagnostic) => {
-    const source = diagnostic.sourceKey.context
-      ? `${diagnostic.sourceKey.message} [context: ${diagnostic.sourceKey.context}]`
-      : diagnostic.sourceKey.message
-    return `[${diagnostic.severity}] ${diagnostic.code} (${diagnostic.locale})\n${diagnostic.message}\nSource: ${source}`
-  })
-  return `Catalog diagnostics for locale ${locale}:\n\n${lines.join("\n\n")}`
-}
-
-function createCompileErrorMessage(
-  locale: string,
-  diagnostics: Array<{
-    code: string
-    message: string
-    sourceKey: { message: string; context?: string }
-    locale: string
-  }>
-): string {
-  const lines = diagnostics.map((diagnostic) => {
-    const source = diagnostic.sourceKey.context
-      ? `${diagnostic.sourceKey.message} [context: ${diagnostic.sourceKey.context}]`
-      : diagnostic.sourceKey.message
-    return `${diagnostic.message}\nCode: ${diagnostic.code}\nLocale: ${diagnostic.locale}\nSource: ${source}`
-  })
-  return `Failed to compile catalog for locale ${locale}!\n\nCompilation error for ${diagnostics.length} translation(s):\n${lines.join("\n\n")}`
-}
-
-function warnDiagnostics(locale: string, diagnostics: Array<{
-  severity: "info" | "warning" | "error"
-  code: string
-  message: string
-  sourceKey: { message: string; context?: string }
-  locale: string
-}>): void {
-  if (diagnostics.length === 0) {
-    return
-  }
-
-  console.warn(
-    `${createDiagnosticMessage(locale, diagnostics)}\n\nYou can fail the build on error diagnostics by setting \`failOnCompileError=true\` in the Palamedes Vite plugin configuration.`
-  )
-}
-
-function renderCatalogModule(messages: Record<string, string>): string {
-  return `export const messages=${JSON.stringify(messages)};export default { messages };`
 }
 
 /**
@@ -303,40 +235,23 @@ export function palamedes(options: PalamedesPluginOptions = {}): Plugin[] {
         result.watchFiles.forEach((file: string) => this.addWatchFile(file))
         const locale = path.basename(cleanId, ".po")
 
-        // Check for missing translations
-        if (
-          failOnMissing &&
-          locale !== cfg.pseudoLocale &&
-          result.missing.length > 0
-        ) {
-          const message = createMissingErrorMessage(
-            locale,
-            result.missing
-          )
-          throw new Error(
-            `${message}\nYou see this error because \`failOnMissing=true\` in Vite Plugin configuration.`
-          )
-        }
+        const loaderResult = createCatalogLoaderResult(result, {
+          locale,
+          pseudoLocale: cfg.pseudoLocale,
+          failOnMissing,
+          failOnCompileError,
+          missingFailureHint:
+            "You see this error because `failOnMissing=true` in Vite plugin configuration.",
+          compileFailureHint:
+            "These errors fail the build because `failOnCompileError=true` in the Palamedes Vite plugin configuration.",
+          diagnosticsWarningHint:
+            "You can fail the build on error diagnostics by setting `failOnCompileError=true` in the Palamedes Vite plugin configuration.",
+        })
 
-        // Handle compilation errors
-        if (result.diagnostics.length) {
-          const errorDiagnostics = result.diagnostics.filter(
-            (diagnostic) => diagnostic.severity === "error"
-          )
-
-          if (failOnCompileError && errorDiagnostics.length > 0) {
-            const message = createCompileErrorMessage(locale, errorDiagnostics)
-            throw new Error(
-              message +
-                `These errors fail build because \`failOnCompileError=true\` in the Palamedes Vite plugin configuration.`
-            )
-          }
-
-          warnDiagnostics(locale, result.diagnostics)
-        }
+        loaderResult.warnings.forEach((warning) => console.warn(warning))
 
         return {
-          code: renderCatalogModule(result.messages),
+          code: loaderResult.code,
           map: null,
         }
       },


### PR DESCRIPTION
## Summary
- extract shared catalog loader diagnostics, fail decisions, and module rendering into `@palamedes/transform/catalog-loader`
- switch Vite and Next PO loaders to the same implementation
- add focused tests for missing translations, diagnostics, compile failures, pseudo-locale skips, and module rendering

Closes #152

## Validation
- pnpm --filter @palamedes/transform exec vitest run --globals src/catalogLoader.test.ts
- pnpm --filter @palamedes/config build
- pnpm --filter @palamedes/runtime build
- pnpm --filter @palamedes/core-node build
- pnpm --filter @palamedes/transform build
- pnpm --filter @palamedes/vite-plugin exec tsc --noEmit -p tsconfig.json
- pnpm --filter @palamedes/next-plugin exec tsc --noEmit -p tsconfig.json
- pnpm --filter @palamedes/vite-plugin build
- pnpm --filter @palamedes/next-plugin build
- node require smoke test from `packages/next-plugin` and `packages/vite-plugin` for `@palamedes/transform/catalog-loader`
- git diff --cached --check

## Note
`pnpm --filter @palamedes/transform test` also runs the existing macro transform test. In this fresh worktree it fails before this change path because the local native `@palamedes/core-node-darwin-arm64/palamedes-node.node` build artifact is absent. The new catalog-loader test passes in isolation.