### PR TITLE
benchmarks: add large catalog fixture

### DIFF
--- a/benchmarks/large-catalog/README.md
+++ b/benchmarks/large-catalog/README.md
@@ -1,0 +1,20 @@
+# Large Catalog Benchmark Fixture
+
+This directory contains the deterministic generator used by
+`scripts/benchmark-proof.mjs` when the `--large-messages` option is set.
+
+The fixture is generated in memory instead of checked in as a 10k or 50k PO
+file. That keeps the repository small while making large-catalog runs
+reproducible.
+
+Example:
+
+```bash
+node ./scripts/benchmark-proof.mjs --warmup 1 --runs 3 --large-messages 10000
+```
+
+For a larger stress run:
+
+```bash
+node ./scripts/benchmark-proof.mjs --warmup 1 --runs 3 --large-messages 50000 --large-source-files 50
+```

--- a/benchmarks/large-catalog/fixture.mjs
+++ b/benchmarks/large-catalog/fixture.mjs
@@ -1,0 +1,98 @@
+const DEFAULT_MESSAGE_COUNT = 10_000
+const DEFAULT_SOURCE_FILE_COUNT = 20
+
+const SUBJECTS = [
+  "shipment",
+  "invoice",
+  "approval",
+  "task",
+  "review",
+  "order",
+  "customer",
+  "handoff",
+]
+
+const AREAS = [
+  "dashboard",
+  "inbox",
+  "workflow",
+  "timeline",
+  "settings",
+  "notifications",
+  "reporting",
+  "audit",
+]
+
+export function createLargeCatalogFixture(options = {}) {
+  const messageCount = normalizePositiveInteger(options.messageCount, DEFAULT_MESSAGE_COUNT)
+  const sourceFileCount = normalizePositiveInteger(options.sourceFileCount, DEFAULT_SOURCE_FILE_COUNT)
+  const messages = []
+  const sourceFiles = Array.from({ length: sourceFileCount }, (_, index) => ({
+    filename: `benchmarks/large-catalog/generated/part-${String(index + 1).padStart(3, "0")}.tsx`,
+    lines: [
+      'import { t } from "@palamedes/react/macro"',
+      "",
+      "export function renderMessages(count: number, name: string, status: string) {",
+      "  return [",
+    ],
+  }))
+
+  for (let index = 0; index < messageCount; index += 1) {
+    const sourceFile = sourceFiles[index % sourceFileCount]
+    const message = createMessage(index)
+    const context = index % 7 === 0 ? `${AREAS[index % AREAS.length]}.panel` : undefined
+
+    messages.push({
+      message,
+      context,
+      extractedComments: [`Synthetic large-catalog benchmark message ${index + 1}`],
+      origins: [
+        {
+          file: sourceFile.filename,
+          line: sourceFile.lines.length + 1,
+        },
+      ],
+    })
+
+    const descriptor = context ? `{ message: ${JSON.stringify(message)}, context: ${JSON.stringify(context)} }` : `{ message: ${JSON.stringify(message)} }`
+    sourceFile.lines.push(`    t(${descriptor}, { count, name, status }),`)
+  }
+
+  for (const sourceFile of sourceFiles) {
+    sourceFile.lines.push("  ]")
+    sourceFile.lines.push("}")
+  }
+
+  return {
+    messageCount,
+    sourceFileCount,
+    messages,
+    fixtures: sourceFiles.map((sourceFile) => ({
+      filename: sourceFile.filename,
+      source: `${sourceFile.lines.join("\n")}\n`,
+    })),
+  }
+}
+
+function createMessage(index) {
+  const subject = SUBJECTS[index % SUBJECTS.length]
+  const area = AREAS[index % AREAS.length]
+  const id = String(index + 1).padStart(5, "0")
+
+  switch (index % 5) {
+    case 0:
+      return `Benchmark ${area} ${id}: ${subject} assigned to {name}`
+    case 1:
+      return `Benchmark ${area} ${id}: {count, plural, one {# ${subject}} other {# ${subject}s}} ready`
+    case 2:
+      return `Benchmark ${area} ${id}: status is {status, select, open {open} closed {closed} other {unknown}}`
+    case 3:
+      return `Benchmark ${area} ${id}: {count, plural, =0 {no ${subject}s} one {one ${subject}} other {# ${subject}s}} for {name}`
+    default:
+      return `Benchmark ${area} ${id}: review ${subject} with <strong>{name}</strong>`
+  }
+}
+
+function normalizePositiveInteger(value, fallback) {
+  return Number.isInteger(value) && value > 0 ? value : fallback
+}

--- a/docs/proof-and-benchmarks.md
+++ b/docs/proof-and-benchmarks.md
@@ -52,7 +52,7 @@ The benchmark flow here focuses on the operations Palamedes claims to improve:
 - catalog artifact compile
 
 It uses a checked-in fixture corpus under
-[`benchmarks/proof-fixtures`](/Users/sebastian/Workspace/business/palamedes/benchmarks/proof-fixtures),
+[`benchmarks/proof-fixtures`](../benchmarks/proof-fixtures),
 not runnable demo applications.
 
 ## Exact Commands
@@ -150,7 +150,7 @@ That gives the benchmark:
 - catalog artifact compilation on plain checked-in source fixtures
 
 Large-catalog runs use a deterministic generator under
-[`benchmarks/large-catalog`](/Users/sebastian/Workspace/business/palamedes/benchmarks/large-catalog)
+[`benchmarks/large-catalog`](../benchmarks/large-catalog)
 instead of checking in a 10k or 50k message catalog. The generator creates
 synthetic TSX source files and matching catalog message metadata so the same
 run can measure:

--- a/docs/proof-and-benchmarks.md
+++ b/docs/proof-and-benchmarks.md
@@ -75,6 +75,24 @@ For a quicker sample run:
 node ./scripts/benchmark-proof.mjs --warmup 1 --runs 3
 ```
 
+For a generated large-catalog run:
+
+```bash
+pnpm benchmark:proof:large
+```
+
+Equivalent direct command:
+
+```bash
+node ./scripts/benchmark-proof.mjs --warmup 1 --runs 3 --large-messages 10000
+```
+
+For a larger stress run:
+
+```bash
+node ./scripts/benchmark-proof.mjs --warmup 1 --runs 3 --large-messages 50000 --large-source-files 50
+```
+
 For the separate Lingui v6 preview comparison harness:
 
 ```bash
@@ -105,6 +123,7 @@ SWC lanes instead of folding them into one number.
 - warmup runs before measurement
 - median reported for each operation
 - operations measured independently, not as a blended total
+- sampled peak RSS reported from Node's `process.memoryUsage().rss`
 
 This is meant to be reproducible and honest, not a "best possible marketing
 number."
@@ -129,6 +148,20 @@ That gives the benchmark:
 - JSX and tagged template paths
 - client-oriented and server-oriented render shapes
 - catalog artifact compilation on plain checked-in source fixtures
+
+Large-catalog runs use a deterministic generator under
+[`benchmarks/large-catalog`](/Users/sebastian/Workspace/business/palamedes/benchmarks/large-catalog)
+instead of checking in a 10k or 50k message catalog. The generator creates
+synthetic TSX source files and matching catalog message metadata so the same
+run can measure:
+
+- macro transform time across the generated source files
+- extraction time across the generated source files
+- catalog update time for the generated message set
+- catalog artifact compile time for the generated PO catalog
+
+Set `--large-messages` to enable that section. The default benchmark remains
+small and quick so it is still useful during routine local checks.
 
 ## Local Baseline
 
@@ -155,8 +188,8 @@ Median results from that run:
 
 This sample is a historical reference point. Current Palamedes builds use
 Ferrocat `0.11.0`; rerun the command above when you need fresh numbers for the
-current release line. The benchmark script also prints the raw sample series so
-the checked median is easy to verify.
+current release line. The benchmark script also prints the raw sample series and
+sampled peak RSS so the checked median and memory shape are easy to verify.
 
 ## What This Page Does Not Claim
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "verify:examples:smoke": "node ./scripts/verify-examples.mjs",
     "verify:examples:browser": "node ./scripts/verify-examples-browser.mjs",
     "benchmark:proof": "pnpm build && node ./scripts/benchmark-proof.mjs",
+    "benchmark:proof:large": "pnpm build && node ./scripts/benchmark-proof.mjs --large-messages 10000",
     "benchmark:lingui-v6": "pnpm build && pnpm --filter @palamedes/benchmark-lingui-v6 benchmark",
     "benchmark:lingui-v6:quick": "pnpm build && pnpm --filter @palamedes/benchmark-lingui-v6 benchmark:quick",
     "test": "pnpm -r --filter \"./packages/**\" --if-present test",

--- a/scripts/benchmark-proof.mjs
+++ b/scripts/benchmark-proof.mjs
@@ -3,6 +3,8 @@ import os from "node:os"
 import path from "node:path"
 import { fileURLToPath, pathToFileURL } from "node:url"
 
+import { createLargeCatalogFixture } from "../benchmarks/large-catalog/fixture.mjs"
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const repoRoot = path.resolve(__dirname, "..")
 const fixtureRoot = path.join(repoRoot, "benchmarks", "proof-fixtures")
@@ -45,6 +47,10 @@ function parseArg(name, fallback) {
   return Number.isFinite(value) ? value : fallback
 }
 
+function formatBytes(bytes) {
+  return `${(bytes / 1024 / 1024).toFixed(1)} MiB`
+}
+
 async function loadFixtures() {
   return Promise.all(
     fixtureFiles.map(async (filename) => ({
@@ -80,8 +86,11 @@ async function collectMessages(fixtures) {
 }
 
 async function benchmark(name, fn, warmup, runs) {
+  let peakRssBytes = process.memoryUsage().rss
+
   for (let i = 0; i < warmup; i += 1) {
     await fn()
+    peakRssBytes = Math.max(peakRssBytes, process.memoryUsage().rss)
   }
 
   const samples = []
@@ -91,6 +100,7 @@ async function benchmark(name, fn, warmup, runs) {
     await fn()
     const end = process.hrtime.bigint()
     samples.push(Number(end - start) / 1_000_000)
+    peakRssBytes = Math.max(peakRssBytes, process.memoryUsage().rss)
   }
 
   samples.sort((a, b) => a - b)
@@ -100,22 +110,11 @@ async function benchmark(name, fn, warmup, runs) {
     name,
     medianMs: median,
     samplesMs: samples,
+    peakRssBytes,
   }
 }
 
-async function main() {
-  const warmup = parseArg("warmup", 3)
-  const runs = parseArg("runs", 7)
-  const fixtures = await loadFixtures()
-  const messages = await collectMessages(fixtures)
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), "palamedes-bench-"))
-  const benchmarkRoot = path.join(tempDir, "fixture")
-  const benchmarkLocaleDir = path.join(benchmarkRoot, "src", "locales")
-  const compileResourcePath = path.join(benchmarkLocaleDir, "de.po")
-  const updateTargetPath = path.join(tempDir, "de-update.po")
-
-  await mkdir(benchmarkLocaleDir, { recursive: true })
-
+async function writeCatalogs({ benchmarkLocaleDir, compileResourcePath, messages }) {
   updateCatalogFile({
     targetPath: path.join(benchmarkLocaleDir, "en.po"),
     locale: "en",
@@ -131,6 +130,132 @@ async function main() {
     clean: true,
     messages,
   })
+}
+
+function printResults(results) {
+  for (const result of results) {
+    console.log(
+      `- ${result.name}: median ${result.medianMs.toFixed(2)} ms; sampled peak RSS ${formatBytes(result.peakRssBytes)} (${result.samplesMs
+        .map((value) => value.toFixed(2))
+        .join(", ")})`
+    )
+  }
+}
+
+async function runLargeCatalogBenchmark({
+  messageCount,
+  sourceFileCount,
+  warmup,
+  runs,
+  tempDir,
+}) {
+  if (messageCount <= 0) {
+    return
+  }
+
+  const largeFixture = createLargeCatalogFixture({ messageCount, sourceFileCount })
+  const benchmarkRoot = path.join(tempDir, "large-fixture")
+  const benchmarkLocaleDir = path.join(benchmarkRoot, "src", "locales")
+  const compileResourcePath = path.join(benchmarkLocaleDir, "de.po")
+  const updateTargetPath = path.join(tempDir, "de-large-update.po")
+  const totalBytes = largeFixture.fixtures.reduce((sum, fixture) => sum + fixture.source.length, 0)
+
+  await mkdir(benchmarkLocaleDir, { recursive: true })
+  await writeCatalogs({
+    benchmarkLocaleDir,
+    compileResourcePath,
+    messages: largeFixture.messages,
+  })
+
+  const baselineCatalog = await readFile(compileResourcePath, "utf8")
+  const catalogConfig = {
+    ...catalogShape,
+    rootDir: benchmarkRoot,
+  }
+
+  const transformResult = await benchmark(
+    "large-transform",
+    () => {
+      for (const fixture of largeFixture.fixtures) {
+        transformMacrosNative(fixture.source, fixture.filename)
+      }
+    },
+    warmup,
+    runs
+  )
+
+  const extractResult = await benchmark(
+    "large-extract",
+    () => {
+      for (const fixture of largeFixture.fixtures) {
+        extractMessagesNative(fixture.source, fixture.filename)
+      }
+    },
+    warmup,
+    runs
+  )
+
+  const updateResult = await benchmark(
+    "large-catalog-update",
+    async () => {
+      await writeFile(updateTargetPath, baselineCatalog, "utf8")
+      updateCatalogFile({
+        targetPath: updateTargetPath,
+        locale: "de",
+        sourceLocale: "en",
+        clean: false,
+        messages: largeFixture.messages,
+      })
+    },
+    warmup,
+    runs
+  )
+
+  const artifactResult = await benchmark(
+    "large-catalog-artifact-compile",
+    async () => {
+      compileCatalogArtifact(catalogConfig, compileResourcePath)
+    },
+    warmup,
+    runs
+  )
+
+  console.log("")
+  console.log("## Large Catalog Fixture")
+  console.log("")
+  console.log(
+    `Generated: ${largeFixture.messageCount} messages across ${largeFixture.sourceFileCount} source files, ${totalBytes} source bytes`
+  )
+  console.log("Fixture generator: benchmarks/large-catalog/fixture.mjs")
+  console.log("")
+  printResults([
+    transformResult,
+    extractResult,
+    updateResult,
+    artifactResult,
+  ])
+}
+
+async function main() {
+  const warmup = parseArg("warmup", 3)
+  const runs = parseArg("runs", 7)
+  const largeMessages = parseArg("large-messages", 0)
+  const largeSourceFiles = parseArg("large-source-files", 20)
+  const fixtures = await loadFixtures()
+  const messages = await collectMessages(fixtures)
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "palamedes-bench-"))
+  const benchmarkRoot = path.join(tempDir, "fixture")
+  const benchmarkLocaleDir = path.join(benchmarkRoot, "src", "locales")
+  const compileResourcePath = path.join(benchmarkLocaleDir, "de.po")
+  const updateTargetPath = path.join(tempDir, "de-update.po")
+
+  await mkdir(benchmarkLocaleDir, { recursive: true })
+
+  await writeCatalogs({
+    benchmarkLocaleDir,
+    compileResourcePath,
+    messages,
+  })
 
   const baselineCatalog = await readFile(compileResourcePath, "utf8")
   const catalogConfig = {
@@ -140,7 +265,7 @@ async function main() {
 
   try {
     const transformResult = await benchmark(
-        "transform",
+      "transform",
       () => {
         for (const fixture of fixtures) {
           transformMacrosNative(fixture.source, fixture.filename)
@@ -151,7 +276,7 @@ async function main() {
     )
 
     const extractResult = await benchmark(
-        "extract",
+      "extract",
       () => {
         for (const fixture of fixtures) {
           extractMessagesNative(fixture.source, fixture.filename)
@@ -162,7 +287,7 @@ async function main() {
     )
 
     const updateResult = await benchmark(
-        "catalog-update",
+      "catalog-update",
       async () => {
         await writeFile(updateTargetPath, baselineCatalog, "utf8")
         updateCatalogFile({
@@ -178,7 +303,7 @@ async function main() {
     )
 
     const artifactResult = await benchmark(
-        "catalog-artifact-compile",
+      "catalog-artifact-compile",
       async () => {
         compileCatalogArtifact(catalogConfig, compileResourcePath)
       },
@@ -197,22 +322,25 @@ async function main() {
     console.log(`Ferrocat: ${nativeInfo.ferrocatVersion}`)
     console.log(`Fixtures: ${fixtures.length} files, ${totalBytes} source bytes`)
     console.log(`Catalog messages for update: ${messages.length}`)
+    console.log(`Large catalog messages: ${largeMessages > 0 ? largeMessages : "disabled"}`)
     console.log(`Warmup: ${warmup}`)
     console.log(`Runs: ${runs}`)
     console.log("")
 
-    for (const result of [
+    printResults([
       transformResult,
       extractResult,
       updateResult,
       artifactResult,
-    ]) {
-      console.log(
-        `- ${result.name}: median ${result.medianMs.toFixed(2)} ms (${result.samplesMs
-          .map((value) => value.toFixed(2))
-          .join(", ")})`
-      )
-    }
+    ])
+
+    await runLargeCatalogBenchmark({
+      messageCount: largeMessages,
+      sourceFileCount: largeSourceFiles,
+      warmup,
+      runs,
+      tempDir,
+    })
   } finally {
     await rm(tempDir, { recursive: true, force: true })
   }

--- a/scripts/benchmark-proof.mjs
+++ b/scripts/benchmark-proof.mjs
@@ -114,7 +114,7 @@ async function benchmark(name, fn, warmup, runs) {
   }
 }
 
-async function writeCatalogs({ benchmarkLocaleDir, compileResourcePath, messages }) {
+function writeCatalogs({ benchmarkLocaleDir, compileResourcePath, messages }) {
   updateCatalogFile({
     targetPath: path.join(benchmarkLocaleDir, "en.po"),
     locale: "en",
@@ -161,7 +161,7 @@ async function runLargeCatalogBenchmark({
   const totalBytes = largeFixture.fixtures.reduce((sum, fixture) => sum + fixture.source.length, 0)
 
   await mkdir(benchmarkLocaleDir, { recursive: true })
-  await writeCatalogs({
+  writeCatalogs({
     benchmarkLocaleDir,
     compileResourcePath,
     messages: largeFixture.messages,
@@ -251,7 +251,7 @@ async function main() {
 
   await mkdir(benchmarkLocaleDir, { recursive: true })
 
-  await writeCatalogs({
+  writeCatalogs({
     benchmarkLocaleDir,
     compileResourcePath,
     messages,


### PR DESCRIPTION
## Summary
- add a deterministic generated large-catalog fixture under `benchmarks/large-catalog`
- extend `benchmark-proof` with optional `--large-messages` and `--large-source-files` modes
- report sampled peak RSS alongside median timings
- add `benchmark:proof:large` and document 10k/50k commands

Closes #154

## Validation
- node --check scripts/benchmark-proof.mjs
- node --check benchmarks/large-catalog/fixture.mjs
- generator smoke via `createLargeCatalogFixture({ messageCount: 12, sourceFileCount: 3 })`
- pnpm --filter @palamedes/core-node-darwin-arm64 build
- pnpm --filter @palamedes/core-node build
- node ./scripts/benchmark-proof.mjs --warmup 0 --runs 1 --large-messages 10 --large-source-files 2
- git diff --cached --check

## Smoke output
Mini run produced the normal proof section plus `## Large Catalog Fixture` with 10 generated messages across 2 source files and timing/RSS rows for transform, extract, catalog update, and catalog artifact compile.