### PR TITLE
feat(cli): add catalog completeness report

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -46,6 +46,9 @@ pnpm exec pmds extract --verbose
 pnpm exec pmds audit
 pnpm exec pmds audit --json
 pnpm exec pmds audit --fail-on warning
+pnpm exec pmds report
+pnpm exec pmds report --locale de,fr --fail-if-below 95
+pnpm exec pmds report --json
 pnpm exec pmds catalog merge --output src/locales/de.po src/locales/de.po other.po
 ```
 
@@ -56,6 +59,21 @@ catalog engine that powers Palamedes builds.
 For local performance checks, set `PALAMEDES_TIMING_JSON=1` on `pmds extract`.
 The command prints a machine-readable timing line with total, glob, extract,
 and catalog-write timings.
+
+### Completeness Report
+
+`pmds report` prints a per-locale translation-management view:
+
+```text
+Locale  Translated  Missing  Fuzzy  Complete
+de      480/520     37       3      92.3%
+fr      510/520     10       0      98.1%
+```
+
+By default, it reports configured target locales and skips the source locale
+and pseudo-locale. Use `--locale de,fr` to select locales, `--json` for bots
+and dashboards, and `--fail-if-below 95` to make CI fail when any reported
+locale is below the threshold.
 
 ### Catalog Merge
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -7,6 +7,7 @@ import chalk from "chalk"
 import { audit } from "./commands/audit"
 import { mergeCatalog } from "./commands/catalog"
 import { extract } from "./commands/extract"
+import { report } from "./commands/report"
 
 const require = createRequire(import.meta.url)
 const VERSION = require("../package.json").version as string
@@ -42,6 +43,22 @@ program
   .action(async (options) => {
     try {
       await audit(options)
+    } catch (error) {
+      console.error(chalk.red("Error:"), error instanceof Error ? error.message : error)
+      process.exit(1)
+    }
+  })
+
+program
+  .command("report")
+  .description("Report per-locale catalog translation completeness")
+  .option("-c, --config <path>", "Path to palamedes.config.ts")
+  .option("--locale <locale...>", "Only report selected target locale(s); comma-separated values are supported")
+  .option("--json", "Print the machine-readable report as JSON")
+  .option("--fail-if-below <percent>", "Fail when any reported locale is below this translated percentage")
+  .action(async (options) => {
+    try {
+      await report(options)
     } catch (error) {
       console.error(chalk.red("Error:"), error instanceof Error ? error.message : error)
       process.exit(1)

--- a/packages/cli/src/commands/report.test.ts
+++ b/packages/cli/src/commands/report.test.ts
@@ -1,0 +1,187 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { report } from "./report"
+
+vi.mock("@palamedes/core-node", () => ({
+  parsePo: parseTestPo,
+}))
+
+const tempDirs: string[] = []
+
+beforeEach(() => {
+  vi.spyOn(console, "log").mockImplementation(() => undefined)
+  vi.spyOn(console, "error").mockImplementation(() => undefined)
+})
+
+afterEach(async () => {
+  vi.restoreAllMocks()
+
+  await Promise.all(
+    tempDirs.splice(0).map(async (dir) => {
+      await rm(dir, { recursive: true, force: true })
+    })
+  )
+})
+
+describe("report", () => {
+  it("prints JSON completeness by locale", async () => {
+    const fixtureDir = await createReportFixture()
+
+    const result = await report({
+      config: path.join(fixtureDir, "palamedes.config.ts"),
+      locale: ["de,fr"],
+      json: true,
+    })
+
+    expect(result.locales[0]).toMatchObject({
+      locale: "de",
+      total: 3,
+      translated: 1,
+      missing: 1,
+      fuzzy: 1,
+    })
+    expect(result.locales[0]?.percent).toBeCloseTo(100 / 3)
+    expect(result.locales[1]).toEqual({
+      locale: "fr",
+      total: 3,
+      translated: 0,
+      missing: 3,
+      fuzzy: 0,
+      percent: 0,
+    })
+
+    const parsed = JSON.parse(String(vi.mocked(console.log).mock.calls[0]?.[0]))
+    expect(parsed.locales[0].locale).toBe("de")
+    expect(parsed.locales[1].missing).toBe(3)
+  })
+
+  it("prints a table for configured target locales and skips source and pseudo locales", async () => {
+    const fixtureDir = await createReportFixture()
+
+    await report({
+      config: path.join(fixtureDir, "palamedes.config.ts"),
+    })
+
+    const output = vi.mocked(console.log).mock.calls.map((call) => String(call[0]))
+    expect(output[0]).toBe("Locale  Translated  Missing  Fuzzy  Complete")
+    expect(output.some((line) => line.startsWith("de"))).toBe(true)
+    expect(output.some((line) => line.startsWith("fr"))).toBe(true)
+    expect(output.some((line) => line.startsWith("en"))).toBe(false)
+    expect(output.some((line) => line.startsWith("pseudo"))).toBe(false)
+  })
+
+  it("fails when a reported locale is below the threshold", async () => {
+    const fixtureDir = await createReportFixture()
+
+    await expect(
+      report({
+        config: path.join(fixtureDir, "palamedes.config.ts"),
+        locale: ["de"],
+        failIfBelow: "90",
+      })
+    ).rejects.toThrow("Catalog completeness below 90%")
+  })
+})
+
+async function createReportFixture(): Promise<string> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "palamedes-cli-report-"))
+  tempDirs.push(dir)
+  await mkdir(path.join(dir, "src/locales"), { recursive: true })
+
+  await writeFile(
+    path.join(dir, "palamedes.config.ts"),
+    `export default {
+  locales: ["en", "de", "fr", "pseudo"],
+  sourceLocale: "en",
+  pseudoLocale: "pseudo",
+  catalogs: [
+    {
+      path: "src/locales/{locale}",
+      include: ["src/**/*.{ts,tsx}"],
+    },
+  ],
+}
+`
+  )
+  await writeFile(
+    path.join(dir, "src/locales/en.po"),
+    `msgid ""
+msgstr ""
+"Language: en\\n"
+
+msgid "Hello"
+msgstr ""
+
+msgctxt "nav"
+msgid "Open"
+msgstr ""
+
+msgid "Bye"
+msgstr ""
+`
+  )
+  await writeFile(
+    path.join(dir, "src/locales/de.po"),
+    `msgid ""
+msgstr ""
+"Language: de\\n"
+
+msgid "Hello"
+msgstr "Hallo"
+
+msgctxt "nav"
+msgid "Open"
+msgstr ""
+
+#, fuzzy
+msgid "Bye"
+msgstr "Tschuess"
+`
+  )
+
+  return dir
+}
+
+function parseTestPo(source: string) {
+  return {
+    comments: [],
+    extractedComments: [],
+    headers: {},
+    headerOrder: [],
+    items: source
+      .split(/\n\s*\n/)
+      .map((entry) => parseEntry(entry))
+      .filter((item) => item !== undefined),
+  }
+}
+
+function parseEntry(entry: string) {
+  const msgid = entry.match(/^msgid "((?:[^"\\]|\\.)*)"/m)?.[1]
+  if (msgid === undefined) {
+    return undefined
+  }
+
+  const msgctxt = entry.match(/^msgctxt "((?:[^"\\]|\\.)*)"/m)?.[1]
+  const msgstr = [...entry.matchAll(/^msgstr(?:\[\d+\])? "((?:[^"\\]|\\.)*)"/gm)].map(
+    (match) => match[1] ?? ""
+  )
+
+  return {
+    msgid,
+    ...(msgctxt ? { msgctxt } : {}),
+    references: [],
+    msgstr,
+    comments: [],
+    extractedComments: [],
+    flags: {
+      fuzzy: entry.includes("#, fuzzy"),
+    },
+    metadata: {},
+    obsolete: false,
+    nplurals: msgstr.length,
+  }
+}

--- a/packages/cli/src/commands/report.test.ts
+++ b/packages/cli/src/commands/report.test.ts
@@ -74,6 +74,19 @@ describe("report", () => {
     expect(output.some((line) => line.startsWith("pseudo"))).toBe(false)
   })
 
+  it("widens the locale column for long locale codes", async () => {
+    const fixtureDir = await createReportFixture()
+
+    await report({
+      config: path.join(fixtureDir, "palamedes.config.ts"),
+      locale: ["zh-Hans-CN"],
+    })
+
+    const output = vi.mocked(console.log).mock.calls.map((call) => String(call[0]))
+    expect(output[0]).toBe("Locale      Translated  Missing  Fuzzy  Complete")
+    expect(output[1]).toMatch(/^zh-Hans-CN\s+0\/3\s+3\s+0\s+0%$/)
+  })
+
   it("fails when a reported locale is below the threshold", async () => {
     const fixtureDir = await createReportFixture()
 
@@ -84,6 +97,17 @@ describe("report", () => {
         failIfBelow: "90",
       })
     ).rejects.toThrow("Catalog completeness below 90%")
+  })
+
+  it("validates threshold values before loading config or printing output", async () => {
+    await expect(
+      report({
+        config: path.join("missing", "palamedes.config.ts"),
+        failIfBelow: "invalid",
+      })
+    ).rejects.toThrow("Invalid --fail-if-below value")
+
+    expect(console.log).not.toHaveBeenCalled()
   })
 })
 

--- a/packages/cli/src/commands/report.ts
+++ b/packages/cli/src/commands/report.ts
@@ -45,6 +45,7 @@ interface MutableLocaleStats {
 }
 
 export async function report(options: ReportOptions): Promise<CompletenessReport> {
+  const threshold = normalizeThreshold(options.failIfBelow)
   const config = await loadPalamedesConfig({ configPath: options.config })
   const locales = resolveLocales(config, options.locale)
   const result = await buildReport(config, locales)
@@ -55,7 +56,6 @@ export async function report(options: ReportOptions): Promise<CompletenessReport
     printReport(result)
   }
 
-  const threshold = normalizeThreshold(options.failIfBelow)
   if (threshold !== undefined) {
     const failing = result.locales.filter((locale) => locale.percent < threshold)
     if (failing.length > 0) {
@@ -226,11 +226,16 @@ function printReport(result: CompletenessReport): void {
     return
   }
 
-  console.log("Locale  Translated  Missing  Fuzzy  Complete")
+  const localeColumnWidth = Math.max(
+    "Locale".length,
+    ...result.locales.map((locale) => locale.locale.length)
+  ) + 2
+
+  console.log(`${"Locale".padEnd(localeColumnWidth)}Translated  Missing  Fuzzy  Complete`)
   for (const locale of result.locales) {
     const complete = locale.percent === 100 ? chalk.green(formatPercent(locale.percent)) : formatPercent(locale.percent)
     console.log(
-      `${locale.locale.padEnd(7)} ${`${locale.translated}/${locale.total}`.padEnd(11)} ${String(locale.missing).padEnd(8)} ${String(locale.fuzzy).padEnd(6)} ${complete}`
+      `${locale.locale.padEnd(localeColumnWidth)}${`${locale.translated}/${locale.total}`.padEnd(11)} ${String(locale.missing).padEnd(8)} ${String(locale.fuzzy).padEnd(6)} ${complete}`
     )
   }
 }

--- a/packages/cli/src/commands/report.ts
+++ b/packages/cli/src/commands/report.ts
@@ -1,0 +1,241 @@
+import { readFile } from "node:fs/promises"
+import chalk from "chalk"
+import {
+  loadPalamedesConfig,
+  resolveCatalogPath,
+  type LoadedPalamedesConfig,
+} from "@palamedes/config"
+import {
+  parsePo,
+  type ParsedPoFile,
+  type ParsedPoItem,
+} from "@palamedes/core-node"
+
+export interface ReportOptions {
+  config?: string
+  locale?: string[]
+  json?: boolean
+  failIfBelow?: string
+}
+
+export interface LocaleCompletenessReport {
+  locale: string
+  total: number
+  translated: number
+  missing: number
+  fuzzy: number
+  percent: number
+}
+
+export interface CompletenessReport {
+  locales: LocaleCompletenessReport[]
+}
+
+interface MessageKey {
+  message: string
+  context?: string
+}
+
+interface MutableLocaleStats {
+  locale: string
+  total: number
+  translated: number
+  missing: number
+  fuzzy: number
+}
+
+export async function report(options: ReportOptions): Promise<CompletenessReport> {
+  const config = await loadPalamedesConfig({ configPath: options.config })
+  const locales = resolveLocales(config, options.locale)
+  const result = await buildReport(config, locales)
+
+  if (options.json) {
+    console.log(JSON.stringify(result, null, 2))
+  } else {
+    printReport(result)
+  }
+
+  const threshold = normalizeThreshold(options.failIfBelow)
+  if (threshold !== undefined) {
+    const failing = result.locales.filter((locale) => locale.percent < threshold)
+    if (failing.length > 0) {
+      throw new Error(
+        `Catalog completeness below ${formatPercent(threshold)} for ${failing
+          .map((locale) => `${locale.locale} (${formatPercent(locale.percent)})`)
+          .join(", ")}.`
+      )
+    }
+  }
+
+  return result
+}
+
+async function buildReport(
+  config: LoadedPalamedesConfig,
+  locales: string[]
+): Promise<CompletenessReport> {
+  const stats = new Map<string, MutableLocaleStats>()
+  for (const locale of locales) {
+    stats.set(locale, {
+      locale,
+      total: 0,
+      translated: 0,
+      missing: 0,
+      fuzzy: 0,
+    })
+  }
+
+  for (const catalog of config.catalogs) {
+    const sourcePath = `${resolveCatalogPath(config, catalog.path, config.sourceLocale)}.po`
+    const sourceCatalog = await readCatalog(sourcePath)
+    const sourceMessages = sourceCatalog.items
+      .filter(isReportableMessage)
+      .map(toMessageKey)
+
+    for (const locale of locales) {
+      const localeStats = stats.get(locale)
+      if (!localeStats) {
+        continue
+      }
+
+      localeStats.total += sourceMessages.length
+
+      if (locale === config.sourceLocale) {
+        localeStats.translated += sourceMessages.length
+        continue
+      }
+
+      const targetPath = `${resolveCatalogPath(config, catalog.path, locale)}.po`
+      const targetCatalog = await readCatalogIfExists(targetPath)
+      const targetMessages = targetCatalog
+        ? new Map(
+          targetCatalog.items
+            .filter(isReportableMessage)
+            .map((item) => [serializeMessageKey(toMessageKey(item)), item])
+        )
+        : new Map<string, ParsedPoItem>()
+
+      for (const sourceMessage of sourceMessages) {
+        const target = targetMessages.get(serializeMessageKey(sourceMessage))
+        if (!target) {
+          localeStats.missing += 1
+          continue
+        }
+
+        if (target.flags.fuzzy) {
+          localeStats.fuzzy += 1
+          continue
+        }
+
+        if (isTranslated(target)) {
+          localeStats.translated += 1
+        } else {
+          localeStats.missing += 1
+        }
+      }
+    }
+  }
+
+  return {
+    locales: [...stats.values()].map((locale) => ({
+      ...locale,
+      percent: locale.total === 0 ? 100 : (locale.translated / locale.total) * 100,
+    })),
+  }
+}
+
+async function readCatalog(catalogPath: string): Promise<ParsedPoFile> {
+  return parsePo(await readFile(catalogPath, "utf8"))
+}
+
+async function readCatalogIfExists(catalogPath: string): Promise<ParsedPoFile | undefined> {
+  try {
+    return await readCatalog(catalogPath)
+  } catch (error) {
+    if (isFileMissing(error)) {
+      return undefined
+    }
+    throw error
+  }
+}
+
+function isFileMissing(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    "code" in error &&
+    (error as NodeJS.ErrnoException).code === "ENOENT"
+  )
+}
+
+function isReportableMessage(item: ParsedPoItem): boolean {
+  return !item.obsolete && item.msgid.length > 0
+}
+
+function toMessageKey(item: ParsedPoItem): MessageKey {
+  return {
+    message: item.msgid,
+    ...(item.msgctxt ? { context: item.msgctxt } : {}),
+  }
+}
+
+function serializeMessageKey(key: MessageKey): string {
+  return `${key.context ?? ""}\u0000${key.message}`
+}
+
+function isTranslated(item: ParsedPoItem): boolean {
+  return item.msgstr.length > 0 && item.msgstr.every((value) => value.trim().length > 0)
+}
+
+function resolveLocales(config: LoadedPalamedesConfig, selectedLocales: string[] | undefined): string[] {
+  if (selectedLocales && selectedLocales.length > 0) {
+    return normalizeLocaleList(selectedLocales)
+  }
+
+  return config.locales.filter(
+    (locale) => locale !== config.sourceLocale && locale !== config.pseudoLocale
+  )
+}
+
+function normalizeLocaleList(values: string[]): string[] {
+  return [
+    ...new Set(
+      values
+        .flatMap((value) => value.split(","))
+        .map((value) => value.trim())
+        .filter((value) => value.length > 0)
+    ),
+  ]
+}
+
+function normalizeThreshold(value: string | undefined): number | undefined {
+  if (value === undefined) {
+    return undefined
+  }
+
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 100) {
+    throw new Error("Invalid --fail-if-below value. Expected a percent from 0 to 100.")
+  }
+
+  return parsed
+}
+
+function printReport(result: CompletenessReport): void {
+  if (result.locales.length === 0) {
+    console.log(chalk.gray("No target locales configured."))
+    return
+  }
+
+  console.log("Locale  Translated  Missing  Fuzzy  Complete")
+  for (const locale of result.locales) {
+    const complete = locale.percent === 100 ? chalk.green(formatPercent(locale.percent)) : formatPercent(locale.percent)
+    console.log(
+      `${locale.locale.padEnd(7)} ${`${locale.translated}/${locale.total}`.padEnd(11)} ${String(locale.missing).padEnd(8)} ${String(locale.fuzzy).padEnd(6)} ${complete}`
+    )
+  }
+}
+
+function formatPercent(value: number): string {
+  const rounded = Math.round(value * 10) / 10
+  return Number.isInteger(rounded) ? `${rounded}%` : `${rounded.toFixed(1)}%`
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -7,3 +7,9 @@
 export { audit } from "./commands/audit"
 export { mergeCatalog } from "./commands/catalog"
 export { extract } from "./commands/extract"
+export { report } from "./commands/report"
+export type {
+  CompletenessReport,
+  LocaleCompletenessReport,
+  ReportOptions,
+} from "./commands/report"


### PR DESCRIPTION
## Summary
- add `pmds report` with per-locale translated/missing/fuzzy completeness table
- support `--json`, comma-separated `--locale`, and `--fail-if-below` CI thresholding
- export the report API from `@palamedes/cli` and document usage
- add focused report tests with mocked PO parsing

Closes #155

## Validation
- pnpm --filter @palamedes/config build
- pnpm --filter @palamedes/core-node build
- pnpm --filter @palamedes/cli exec vitest run --globals src/commands/report.test.ts
- pnpm --filter @palamedes/cli exec tsc --noEmit -p tsconfig.json
- pnpm --filter @palamedes/core-node-darwin-arm64 build
- pnpm --filter @palamedes/cli test
- pnpm --filter @palamedes/cli build
- git diff --cached --check