### PR TITLE
fix(transform): validate descriptor macro values

### DIFF
--- a/crates/palamedes/src/error.rs
+++ b/crates/palamedes/src/error.rs
@@ -163,4 +163,14 @@ pub enum PalamedesError {
         /// Human-readable source shape that failed placeholder naming.
         syntax: &'static str,
     },
+    /// A macro values object literal does not match the placeholders used by the source message.
+    #[error(
+        "Macro values do not match message placeholders. Missing value(s): {missing}; extra value(s): {extra}."
+    )]
+    MacroValuesMismatch {
+        /// Placeholder names referenced by the message but not provided by values.
+        missing: String,
+        /// Value names provided by values but not referenced by the message.
+        extra: String,
+    },
 }

--- a/crates/palamedes/src/transform/runtime.rs
+++ b/crates/palamedes/src/transform/runtime.rs
@@ -123,8 +123,7 @@ fn descriptor_values_argument(
     match extract_descriptor_values(argument, source) {
         DescriptorValues::Bindings(bindings) => {
             validate_message_values(message, &bindings)?;
-            Ok((!bindings.is_empty())
-                .then(|| format!("{{ {} }}", render_value_bindings(&bindings))))
+            Ok(Some(render_values_object(&bindings)))
         }
         DescriptorValues::Raw(source) => Ok(Some(source)),
     }
@@ -163,15 +162,15 @@ fn validate_message_values(message: &str, values: &[ValueBinding]) -> PalamedesR
     let placeholders = collect_message_placeholders(message);
     let value_names = values
         .iter()
-        .map(|binding| binding.name.as_str())
+        .map(|binding| binding.name.clone())
         .collect::<BTreeSet<_>>();
     let missing = placeholders
         .difference(&value_names)
-        .copied()
+        .cloned()
         .collect::<Vec<_>>();
     let extra = value_names
         .difference(&placeholders)
-        .copied()
+        .cloned()
         .collect::<Vec<_>>();
 
     if missing.is_empty() && extra.is_empty() {
@@ -184,7 +183,19 @@ fn validate_message_values(message: &str, values: &[ValueBinding]) -> PalamedesR
     })
 }
 
-fn collect_message_placeholders(message: &str) -> BTreeSet<&str> {
+fn collect_message_placeholders(message: &str) -> BTreeSet<String> {
+    if let Ok(metadata) = ferrocat::derive_message_metadata_from_icu(message, None) {
+        return metadata
+            .args
+            .into_keys()
+            .filter(|name| is_placeholder_name(name.as_str()))
+            .collect();
+    }
+
+    collect_message_placeholders_from_braces(message)
+}
+
+fn collect_message_placeholders_from_braces(message: &str) -> BTreeSet<String> {
     let mut placeholders = BTreeSet::new();
     let mut index = 0usize;
 
@@ -196,7 +207,7 @@ fn collect_message_placeholders(message: &str) -> BTreeSet<&str> {
         let end = start + relative_end;
         let name = message[start..end].trim();
         if is_placeholder_name(name) {
-            placeholders.insert(name);
+            placeholders.insert(name.to_string());
         }
         index = end + 1;
     }
@@ -215,7 +226,7 @@ fn is_placeholder_name(name: &str) -> bool {
     chars.all(|ch| ch == '_' || ch == '$' || ch.is_ascii_alphanumeric())
 }
 
-fn format_names(names: &[&str]) -> String {
+fn format_names(names: &[String]) -> String {
     if names.is_empty() {
         "none".to_string()
     } else {
@@ -474,6 +485,14 @@ fn render_value_bindings(values: &[ValueBinding]) -> String {
         })
         .collect::<Vec<_>>()
         .join(", ")
+}
+
+fn render_values_object(values: &[ValueBinding]) -> String {
+    if values.is_empty() {
+        "{}".to_string()
+    } else {
+        format!("{{ {} }}", render_value_bindings(values))
+    }
 }
 
 fn build_runtime_descriptor(

--- a/crates/palamedes/src/transform/runtime.rs
+++ b/crates/palamedes/src/transform/runtime.rs
@@ -1,13 +1,18 @@
 use ferrocat::compiled_key;
-use oxc_ast::ast::{CallExpression, JSXElement, ObjectExpression, TemplateLiteral};
+use std::collections::BTreeSet;
+
+use oxc_ast::ast::{
+    Argument, CallExpression, JSXElement, ObjectExpression, ObjectPropertyKind, TemplateLiteral,
+};
+use oxc_span::GetSpan;
 
 use crate::error::{PalamedesError, PalamedesResult};
 
 use super::messages::{
-    build_icu_message, escape_string, expression_binding, extract_choice_options,
-    extract_choice_options_from_jsx, extract_jsx_children_parts, extract_jsx_value_binding,
-    extract_object_properties, first_argument_object, jsx_attributes, template_to_message,
-    ValueBinding,
+    build_icu_message, escape_string, expression_binding, expression_source,
+    extract_choice_options, extract_choice_options_from_jsx, extract_jsx_children_parts,
+    extract_jsx_value_binding, extract_object_properties, first_argument_object, jsx_attributes,
+    template_to_message, ValueBinding,
 };
 use super::NativeTransformOptions;
 
@@ -37,6 +42,7 @@ pub(super) fn transform_tagged_template(
 
 pub(super) fn transform_descriptor_call(
     call: &CallExpression<'_>,
+    source: &str,
     macro_name: &str,
     options: &NativeTransformOptions,
 ) -> PalamedesResult<Option<(String, String)>> {
@@ -44,11 +50,13 @@ pub(super) fn transform_descriptor_call(
         return Ok(None);
     };
 
-    transform_descriptor_object(object, macro_name, options)
+    transform_descriptor_object(call, object, source, macro_name, options)
 }
 
 fn transform_descriptor_object(
+    call: &CallExpression<'_>,
     object: &ObjectExpression<'_>,
+    source: &str,
     macro_name: &str,
     options: &NativeTransformOptions,
 ) -> PalamedesResult<Option<(String, String)>> {
@@ -83,17 +91,135 @@ fn transform_descriptor_object(
     if macro_name == "defineMessage" {
         Ok(Some((descriptor, lookup_key)))
     } else {
+        let values_text = descriptor_values_argument(call, source, &message)?;
         Ok(Some((
-            build_runtime_call(
+            build_runtime_call_with_values_text(
                 &lookup_key,
                 Some(&message),
-                None,
+                values_text.as_deref(),
                 context.as_deref(),
                 comment.as_deref(),
                 options,
             ),
             lookup_key,
         )))
+    }
+}
+
+enum DescriptorValues {
+    Bindings(Vec<ValueBinding>),
+    Raw(String),
+}
+
+fn descriptor_values_argument(
+    call: &CallExpression<'_>,
+    source: &str,
+    message: &str,
+) -> PalamedesResult<Option<String>> {
+    let Some(argument) = call.arguments.get(1) else {
+        return Ok(None);
+    };
+
+    match extract_descriptor_values(argument, source) {
+        DescriptorValues::Bindings(bindings) => {
+            validate_message_values(message, &bindings)?;
+            Ok((!bindings.is_empty())
+                .then(|| format!("{{ {} }}", render_value_bindings(&bindings))))
+        }
+        DescriptorValues::Raw(source) => Ok(Some(source)),
+    }
+}
+
+fn extract_descriptor_values(argument: &Argument<'_>, source: &str) -> DescriptorValues {
+    let Argument::ObjectExpression(object) = argument else {
+        return DescriptorValues::Raw(argument_source(argument, source));
+    };
+
+    let mut bindings = Vec::new();
+
+    for property in &object.properties {
+        let ObjectPropertyKind::ObjectProperty(property) = property else {
+            return DescriptorValues::Raw(argument_source(argument, source));
+        };
+        let Some(key) = property.key.static_name() else {
+            return DescriptorValues::Raw(argument_source(argument, source));
+        };
+
+        bindings.push(ValueBinding {
+            name: key.into_owned(),
+            expression: expression_source(&property.value, source),
+        });
+    }
+
+    DescriptorValues::Bindings(bindings)
+}
+
+fn argument_source(argument: &Argument<'_>, source: &str) -> String {
+    let span = argument.span();
+    source[span.start as usize..span.end as usize].to_string()
+}
+
+fn validate_message_values(message: &str, values: &[ValueBinding]) -> PalamedesResult<()> {
+    let placeholders = collect_message_placeholders(message);
+    let value_names = values
+        .iter()
+        .map(|binding| binding.name.as_str())
+        .collect::<BTreeSet<_>>();
+    let missing = placeholders
+        .difference(&value_names)
+        .copied()
+        .collect::<Vec<_>>();
+    let extra = value_names
+        .difference(&placeholders)
+        .copied()
+        .collect::<Vec<_>>();
+
+    if missing.is_empty() && extra.is_empty() {
+        return Ok(());
+    }
+
+    Err(PalamedesError::MacroValuesMismatch {
+        missing: format_names(&missing),
+        extra: format_names(&extra),
+    })
+}
+
+fn collect_message_placeholders(message: &str) -> BTreeSet<&str> {
+    let mut placeholders = BTreeSet::new();
+    let mut index = 0usize;
+
+    while let Some(relative_start) = message[index..].find('{') {
+        let start = index + relative_start + 1;
+        let Some(relative_end) = message[start..].find([',', '}']) else {
+            break;
+        };
+        let end = start + relative_end;
+        let name = message[start..end].trim();
+        if is_placeholder_name(name) {
+            placeholders.insert(name);
+        }
+        index = end + 1;
+    }
+
+    placeholders
+}
+
+fn is_placeholder_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !(first == '_' || first == '$' || first.is_ascii_alphabetic()) {
+        return false;
+    }
+    chars.all(|ch| ch == '_' || ch == '$' || ch.is_ascii_alphanumeric())
+}
+
+fn format_names(names: &[&str]) -> String {
+    if names.is_empty() {
+        "none".to_string()
+    } else {
+        names.join(", ")
     }
 }
 
@@ -289,11 +415,30 @@ fn build_runtime_call(
     comment: Option<&str>,
     options: &NativeTransformOptions,
 ) -> String {
-    let runtime_import_name = options.runtime_import_name.as_deref().unwrap_or("getI18n");
-    let descriptor = build_runtime_descriptor(message, context, comment, options);
     let values_text = values
         .filter(|values| !values.is_empty())
         .map(|values| format!("{{ {} }}", render_value_bindings(values)));
+
+    build_runtime_call_with_values_text(
+        lookup_key,
+        message,
+        values_text.as_deref(),
+        context,
+        comment,
+        options,
+    )
+}
+
+fn build_runtime_call_with_values_text(
+    lookup_key: &str,
+    message: Option<&str>,
+    values_text: Option<&str>,
+    context: Option<&str>,
+    comment: Option<&str>,
+    options: &NativeTransformOptions,
+) -> String {
+    let runtime_import_name = options.runtime_import_name.as_deref().unwrap_or("getI18n");
+    let descriptor = build_runtime_descriptor(message, context, comment, options);
 
     match (values_text, descriptor) {
         (None, None) => format!(

--- a/crates/palamedes/src/transform/tests.rs
+++ b/crates/palamedes/src/transform/tests.rs
@@ -332,6 +332,43 @@ fn rejects_explicit_ids() {
 }
 
 #[test]
+fn descriptor_call_forwards_values_object() {
+    let result = transform_macros(
+        "import { t } from \"@palamedes/core/macro\";\nconst msg = t({ message: \"Hello {name}\" }, { name });\n",
+        "test.ts",
+        None,
+    )
+    .expect("transform should succeed");
+
+    assert!(result.code.contains("message: \"Hello {name}\""));
+    assert!(result.code.contains(", { name },"));
+}
+
+#[test]
+fn descriptor_call_rejects_missing_values() {
+    let error = transform_macros(
+        "import { t } from \"@palamedes/core/macro\";\nconst msg = t({ message: \"Hello {name}\" }, { naem: user.name });\n",
+        "test.ts",
+        None,
+    )
+    .expect_err("placeholder mismatch should fail");
+
+    assert!(error.to_string().contains("Missing value(s): name"));
+}
+
+#[test]
+fn descriptor_call_rejects_extra_values() {
+    let error = transform_macros(
+        "import { t } from \"@palamedes/core/macro\";\nconst msg = t({ message: \"Hello\" }, { name });\n",
+        "test.ts",
+        None,
+    )
+    .expect_err("extra values should fail");
+
+    assert!(error.to_string().contains("extra value(s): name"));
+}
+
+#[test]
 fn rejects_unnamed_template_placeholders() {
     let error = transform_macros(
         "import { t } from \"@palamedes/core/macro\";\nconst msg = t`Hello ${firstName + lastName}`;\n",

--- a/crates/palamedes/src/transform/tests.rs
+++ b/crates/palamedes/src/transform/tests.rs
@@ -345,6 +345,30 @@ fn descriptor_call_forwards_values_object() {
 }
 
 #[test]
+fn descriptor_call_validates_placeholders_inside_choice_bodies() {
+    let result = transform_macros(
+        "import { t } from \"@palamedes/core/macro\";\nconst msg = t({ message: \"{count, plural, one {{name} item} other {{name} items}}\" }, { count, name });\n",
+        "test.ts",
+        None,
+    )
+    .expect("choice body placeholders should validate");
+
+    assert!(result.code.contains(", { count, name },"));
+}
+
+#[test]
+fn descriptor_call_preserves_empty_values_object() {
+    let result = transform_macros(
+        "import { t } from \"@palamedes/core/macro\";\nconst msg = t({ message: \"Hello\" }, {});\n",
+        "test.ts",
+        None,
+    )
+    .expect("empty values object should succeed");
+
+    assert!(result.code.contains(", {},"));
+}
+
+#[test]
 fn descriptor_call_rejects_missing_values() {
     let error = transform_macros(
         "import { t } from \"@palamedes/core/macro\";\nconst msg = t({ message: \"Hello {name}\" }, { naem: user.name });\n",
@@ -352,6 +376,18 @@ fn descriptor_call_rejects_missing_values() {
         None,
     )
     .expect_err("placeholder mismatch should fail");
+
+    assert!(error.to_string().contains("Missing value(s): name"));
+}
+
+#[test]
+fn descriptor_call_rejects_missing_values_from_empty_object() {
+    let error = transform_macros(
+        "import { t } from \"@palamedes/core/macro\";\nconst msg = t({ message: \"Hello {name}\" }, {});\n",
+        "test.ts",
+        None,
+    )
+    .expect_err("empty values object should still validate placeholders");
 
     assert!(error.to_string().contains("Missing value(s): name"));
 }

--- a/crates/palamedes/src/transform/visitor.rs
+++ b/crates/palamedes/src/transform/visitor.rs
@@ -203,7 +203,12 @@ impl<'a> Visit<'a> for TransformVisitor<'a> {
 
         match macro_info.imported_name.as_str() {
             "t" | "msg" | "defineMessage" => {
-                match transform_descriptor_call(it, &macro_info.imported_name, self.options) {
+                match transform_descriptor_call(
+                    it,
+                    self.source,
+                    &macro_info.imported_name,
+                    self.options,
+                ) {
                     Ok(Some((text, compiled_id))) => {
                         self.replacements.push(Replacement {
                             start: it.span.start as usize,

--- a/packages/transform/src/transform.test.ts
+++ b/packages/transform/src/transform.test.ts
@@ -58,6 +58,35 @@ const msg = t({ message: "Hello", context: "informal", comment: "A greeting" });
     expect(result.code).not.toContain('id: "greeting"')
   })
 
+  it("forwards descriptor macro values object literals", () => {
+    const code = `
+import { t } from "@palamedes/core/macro";
+const msg = t({ message: "Hello {name}" }, { name });
+`
+    const result = transformPalamedesMacros(code, "test.ts")
+
+    expect(result.code).toContain('message: "Hello {name}"')
+    expect(result.code).toContain("{ name }")
+  })
+
+  it("rejects descriptor macro values missing message placeholders", () => {
+    const code = `
+import { t } from "@palamedes/core/macro";
+const msg = t({ message: "Hello {name}" }, { naem: user.name });
+`
+
+    expect(() => transformPalamedesMacros(code, "test.ts")).toThrow(/Missing value\(s\): name/)
+  })
+
+  it("rejects descriptor macro values not used by the message", () => {
+    const code = `
+import { t } from "@palamedes/core/macro";
+const msg = t({ message: "Hello" }, { name });
+`
+
+    expect(() => transformPalamedesMacros(code, "test.ts")).toThrow(/extra value\(s\): name/)
+  })
+
   it("transforms defineMessage to a descriptor with an internal lookup key", () => {
     const code = `
 import { defineMessage } from "@palamedes/core/macro";


### PR DESCRIPTION
## Summary
- preserve descriptor macro values in `t({ message }, values)` runtime calls
- validate static values object literals against ICU placeholders in the source message
- fail the transform for missing or extra values like `{ naem: user.name }` when the message uses `{name}`
- keep dynamic values variables pass-through without static validation
- add Rust core and JS wrapper regression tests

Closes #156

## Validation
- cargo fmt
- cargo fmt --check
- cargo test -p palamedes transform::tests
- pnpm --filter @palamedes/core-node-darwin-arm64 build
- pnpm --filter @palamedes/core-node build
- pnpm --filter @palamedes/transform test
- git diff --cached --check

## Note
`cargo clippy -p palamedes --all-targets -- -D warnings` currently fails on two pre-existing lints outside this PR diff: `collapsible_if` in `crates/palamedes/src/catalog_artifact/compile.rs` and `only_used_in_recursion` in `crates/palamedes/src/extract.rs`.