### PR TITLE
test: cover plugin loaders and native bridge

### DIFF
--- a/packages/core-node/package.json
+++ b/packages/core-node/package.json
@@ -38,6 +38,7 @@
     "generate-native-types": "node ./scripts/generate-native-types.mjs",
     "check-native-types": "node ./scripts/generate-native-types.mjs --check",
     "build": "unbuild",
+    "test": "vitest run --globals src/index.test.ts",
     "stub": "unbuild --stub"
   },
   "engines": {
@@ -55,6 +56,7 @@
   "devDependencies": {
     "@types/node": "^25.9.0",
     "typescript": "^6.0.3",
-    "unbuild": "^3.6.1"
+    "unbuild": "^3.6.1",
+    "vitest": "^4.1.6"
   }
 }

--- a/packages/core-node/src/index.test.ts
+++ b/packages/core-node/src/index.test.ts
@@ -6,6 +6,13 @@ import {
   transformMacrosNative,
 } from "./index"
 
+interface SourceMapLike {
+  mappings?: string
+  sources?: string[]
+  sourcesContent?: Array<string | null>
+  version?: number
+}
+
 describe("@palamedes/core-node", () => {
   it("loads native bindings and exposes version information", () => {
     const info = getNativeInfo()
@@ -44,10 +51,24 @@ const msg = t\`Hello \${name}\`;
     expect(result.hasChanged).toBe(true)
     expect(result.code).toContain('getI18n()._("')
     expect(result.compiledIds).toHaveLength(1)
-    expect(result.map).toMatchObject({
+    const map = normalizeSourceMap(result.map)
+    expect(map).toMatchObject({
       version: 3,
       sources: ["sample.ts"],
       sourcesContent: [source],
     })
+    expect(map.mappings).not.toBe("")
   })
 })
+
+function normalizeSourceMap(map: unknown): SourceMapLike {
+  if (typeof map === "string") {
+    return JSON.parse(map) as SourceMapLike
+  }
+
+  if (map === null || map === undefined) {
+    throw new Error("Expected native transform to return a source map")
+  }
+
+  return map as SourceMapLike
+}

--- a/packages/core-node/src/index.test.ts
+++ b/packages/core-node/src/index.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  getNativeInfo,
+  parsePo,
+  transformMacrosNative,
+} from "./index"
+
+describe("@palamedes/core-node", () => {
+  it("loads native bindings and exposes version information", () => {
+    const info = getNativeInfo()
+
+    expect(info.palamedesVersion).toMatch(/^\d+\.\d+\.\d+/)
+    expect(info.ferrocatVersion).toMatch(/^\d+\.\d+\.\d+/)
+  })
+
+  it("parses PO content across the NAPI boundary", () => {
+    const parsed = parsePo(`msgid ""
+msgstr ""
+"Language: de\\n"
+
+#, fuzzy
+msgctxt "nav"
+msgid "Open"
+msgstr "Oeffnen"
+`)
+
+    expect(parsed.headers.Language).toBe("de")
+    expect(parsed.items).toHaveLength(1)
+    expect(parsed.items[0]).toMatchObject({
+      msgctxt: "nav",
+      msgid: "Open",
+      msgstr: ["Oeffnen"],
+      flags: { fuzzy: true },
+    })
+  })
+
+  it("maps native transform results into JavaScript strings and source maps", () => {
+    const source = `import { t } from "@palamedes/core/macro";
+const msg = t\`Hello \${name}\`;
+`
+    const result = transformMacrosNative(source, "sample.ts")
+
+    expect(result.hasChanged).toBe(true)
+    expect(result.code).toContain('getI18n()._("')
+    expect(result.compiledIds).toHaveLength(1)
+    expect(result.map).toMatchObject({
+      version: 3,
+      sources: ["sample.ts"],
+      sourcesContent: [source],
+    })
+  })
+})

--- a/packages/next-plugin/package.json
+++ b/packages/next-plugin/package.json
@@ -18,6 +18,7 @@
   ],
   "scripts": {
     "build": "unbuild",
+    "test": "vitest run --globals src/*.test.ts",
     "stub": "unbuild --stub"
   },
   "homepage": "https://github.com/sebastian-software/palamedes",
@@ -62,6 +63,7 @@
   "devDependencies": {
     "next": "^16.2.6",
     "typescript": "^6.0.3",
-    "unbuild": "^3.6.1"
+    "unbuild": "^3.6.1",
+    "vitest": "^4.1.6"
   }
 }

--- a/packages/next-plugin/src/palamedes-po-loader.test.ts
+++ b/packages/next-plugin/src/palamedes-po-loader.test.ts
@@ -4,6 +4,8 @@ import Module from "node:module"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 const require = createRequire(import.meta.url)
+// The package ships this loader as a hand-authored CJS entrypoint, so the test
+// intentionally exercises the published loader path directly.
 const loaderPath = "../palamedes-po-loader.cjs"
 const moduleLoader = Module as unknown as {
   _load: (request: string, parent: unknown, isMain: boolean) => unknown
@@ -91,6 +93,28 @@ describe("palamedes-po-loader.cjs", () => {
     await runLoader()
 
     expect(console.warn).toHaveBeenCalledWith(expect.stringContaining("Catalog diagnostics for locale de"))
+  })
+
+  it("fails compile diagnostics when configured", async () => {
+    compileCatalogArtifact.mockReturnValue({
+      messages: {},
+      missing: [],
+      diagnostics: [
+        {
+          severity: "error",
+          code: "icu.missing_argument",
+          message: "Missing argument",
+          sourceKey: { message: "Hello {name}" },
+          locale: "de",
+        },
+      ],
+      watchFiles: [],
+    })
+
+    await expect(runLoader({ failOnCompileError: true })).rejects.toThrow(
+      /Compilation error for 1 translation/
+    )
+    expect(console.warn).not.toHaveBeenCalled()
   })
 })
 

--- a/packages/next-plugin/src/palamedes-po-loader.test.ts
+++ b/packages/next-plugin/src/palamedes-po-loader.test.ts
@@ -1,0 +1,126 @@
+import { createRequire } from "node:module"
+import Module from "node:module"
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const require = createRequire(import.meta.url)
+const loaderPath = "../palamedes-po-loader.cjs"
+const moduleLoader = Module as unknown as {
+  _load: (request: string, parent: unknown, isMain: boolean) => unknown
+}
+const originalLoad = moduleLoader._load
+
+const loadPalamedesConfig = vi.fn()
+const compileCatalogArtifact = vi.fn()
+
+beforeEach(() => {
+  loadPalamedesConfig.mockResolvedValue({
+    rootDir: "/repo",
+    locales: ["en", "de", "pseudo"],
+    sourceLocale: "en",
+    pseudoLocale: "pseudo",
+    fallbackLocales: undefined,
+    catalogs: [{ path: "src/locales/{locale}", include: ["src"] }],
+  })
+  compileCatalogArtifact.mockReturnValue({
+    messages: { greeting: "Hallo" },
+    missing: [],
+    diagnostics: [],
+    watchFiles: ["/repo/src/locales/en.po"],
+  })
+  vi.spyOn(console, "warn").mockImplementation(() => undefined)
+
+  moduleLoader._load = (request, parent, isMain) => {
+    if (request === "@palamedes/config") {
+      return { loadPalamedesConfig }
+    }
+    if (request === "@palamedes/core-node") {
+      return { compileCatalogArtifact }
+    }
+    return originalLoad.call(Module, request, parent, isMain)
+  }
+})
+
+afterEach(() => {
+  moduleLoader._load = originalLoad
+  vi.restoreAllMocks()
+  delete require.cache[require.resolve(loaderPath)]
+})
+
+describe("palamedes-po-loader.cjs", () => {
+  it("compiles a PO file into a catalog module and tracks dependencies", async () => {
+    const result = await runLoader()
+
+    expect(result.code).toBe('export const messages={"greeting":"Hallo"};export default { messages };')
+    expect(result.dependencies).toEqual(["/repo/src/locales/en.po"])
+    expect(compileCatalogArtifact).toHaveBeenCalledWith(
+      expect.objectContaining({ rootDir: "/repo", sourceLocale: "en" }),
+      "/repo/src/locales/de.po"
+    )
+  })
+
+  it("fails missing translations when configured", async () => {
+    compileCatalogArtifact.mockReturnValue({
+      messages: {},
+      missing: [{ sourceKey: { message: "Hello" } }],
+      diagnostics: [],
+      watchFiles: [],
+    })
+
+    await expect(runLoader({ failOnMissing: true })).rejects.toThrow(
+      /Missing 1 translation/
+    )
+  })
+
+  it("warns diagnostics when compile errors are not fatal", async () => {
+    compileCatalogArtifact.mockReturnValue({
+      messages: {},
+      missing: [],
+      diagnostics: [
+        {
+          severity: "error",
+          code: "icu.missing_argument",
+          message: "Missing argument",
+          sourceKey: { message: "Hello {name}" },
+          locale: "de",
+        },
+      ],
+      watchFiles: [],
+    })
+
+    await runLoader()
+
+    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining("Catalog diagnostics for locale de"))
+  })
+})
+
+async function runLoader(options: Record<string, unknown> = {}) {
+  delete require.cache[require.resolve(loaderPath)]
+  const loader = require(loaderPath) as (this: unknown) => void
+  const dependencies: string[] = []
+
+  const code = await new Promise<string>((resolve, reject) => {
+    const context = {
+      resourcePath: "/repo/src/locales/de.po",
+      async() {
+        return (error: Error | null, output?: string) => {
+          if (error) {
+            reject(error)
+            return
+          }
+          resolve(output ?? "")
+        }
+      },
+      getOptions() {
+        return options
+      },
+      addDependency(file: string) {
+        dependencies.push(file)
+      },
+    }
+
+    loader.call(context)
+  })
+
+  return { code, dependencies }
+}

--- a/packages/transform/src/transform.test.ts
+++ b/packages/transform/src/transform.test.ts
@@ -1,5 +1,13 @@
 import { transformPalamedesMacros } from "./transform"
 
+interface SourceMapLike {
+  file?: string
+  mappings?: string
+  sources?: string[]
+  sourcesContent?: Array<string | null>
+  version?: number
+}
+
 describe("transformPalamedesMacros", () => {
   it("returns unchanged code without Palamedes macro imports", () => {
     const code = `const x = 1;`
@@ -24,13 +32,14 @@ const msg = t\`Hello \${name}\`;
     expect(result.code).toContain('import { getI18n } from "@palamedes/runtime"')
     expect(result.code).not.toContain("@palamedes/core/macro")
     expect(result.compiledIds).toHaveLength(1)
-    expect(result.map).toMatchObject({
+    const map = normalizeSourceMap(result.map)
+    expect(map).toMatchObject({
       version: 3,
       sources: ["test.ts"],
       sourcesContent: [code],
       file: "test.ts",
     })
-    expect(result.map?.mappings).not.toBe("")
+    expect(map.mappings).not.toBe("")
   })
 
   it("preserves member expression values in tagged templates", () => {
@@ -96,13 +105,14 @@ const y = <Trans>Hallo Welt</Trans>;
     expect(result.code).toContain('import { Trans } from "@palamedes/react"')
     expect(result.code).toContain('const x = "äöü";')
     expect(result.code).toContain('message={"Hallo Welt"}')
-    expect(result.map).toMatchObject({
+    const map = normalizeSourceMap(result.map)
+    expect(map).toMatchObject({
       version: 3,
       sources: ["test.tsx"],
       sourcesContent: [code],
       file: "test.tsx",
     })
-    expect(result.map?.mappings).not.toBe("")
+    expect(map.mappings).not.toBe("")
   })
 
   it("transforms Solid <Trans> macros to @palamedes/solid imports", () => {
@@ -259,3 +269,15 @@ const msg = t\`Hello\`;
     expect(result.code).toBe(code)
   })
 })
+
+function normalizeSourceMap(map: unknown): SourceMapLike {
+  if (typeof map === "string") {
+    return JSON.parse(map) as SourceMapLike
+  }
+
+  if (map === null || map === undefined) {
+    throw new Error("Expected transform to return a source map")
+  }
+
+  return map as SourceMapLike
+}

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -18,6 +18,7 @@
   ],
   "scripts": {
     "build": "unbuild",
+    "test": "vitest run --globals src/*.test.ts",
     "stub": "unbuild --stub"
   },
   "homepage": "https://github.com/sebastian-software/palamedes",
@@ -58,6 +59,7 @@
   "devDependencies": {
     "typescript": "^6.0.3",
     "unbuild": "^3.6.1",
-    "vite": "^8.0.13"
+    "vite": "^8.0.13",
+    "vitest": "^4.1.6"
   }
 }

--- a/packages/vite-plugin/src/index.test.ts
+++ b/packages/vite-plugin/src/index.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  loadPalamedesConfig: vi.fn(),
+  compileCatalogArtifact: vi.fn(),
+  transformPalamedesMacros: vi.fn(),
+}))
+
+vi.mock("@palamedes/config", () => ({
+  loadPalamedesConfig: mocks.loadPalamedesConfig,
+}))
+
+vi.mock("@palamedes/core-node", () => ({
+  compileCatalogArtifact: mocks.compileCatalogArtifact,
+}))
+
+vi.mock("@palamedes/transform", () => ({
+  PALAMEDES_MACRO_PACKAGES: ["@palamedes/core/macro", "@palamedes/react/macro"],
+  transformPalamedesMacros: mocks.transformPalamedesMacros,
+}))
+
+import { palamedes } from "./index"
+
+beforeEach(() => {
+  mocks.loadPalamedesConfig.mockResolvedValue({
+    rootDir: "/repo",
+    locales: ["en", "de", "pseudo"],
+    sourceLocale: "en",
+    pseudoLocale: "pseudo",
+    fallbackLocales: undefined,
+    catalogs: [{ path: "src/locales/{locale}", include: ["src"] }],
+  })
+  mocks.compileCatalogArtifact.mockReturnValue({
+    messages: { greeting: "Hallo" },
+    missing: [],
+    diagnostics: [],
+    watchFiles: ["/repo/src/locales/en.po"],
+  })
+  vi.spyOn(console, "warn").mockImplementation(() => undefined)
+})
+
+describe("palamedes vite plugin", () => {
+  it("compiles PO files and registers watch dependencies", async () => {
+    const addWatchFile = vi.fn()
+    const result = await runPoTransform({ addWatchFile })
+
+    expect(result).toEqual({
+      code: 'export const messages={"greeting":"Hallo"};export default { messages };',
+      map: null,
+    })
+    expect(addWatchFile).toHaveBeenCalledWith("/repo/src/locales/en.po")
+    expect(mocks.compileCatalogArtifact).toHaveBeenCalledWith(
+      expect.objectContaining({ rootDir: "/repo", sourceLocale: "en" }),
+      "/repo/src/locales/de.po"
+    )
+  })
+
+  it("fails missing translations when configured", async () => {
+    mocks.compileCatalogArtifact.mockReturnValue({
+      messages: {},
+      missing: [{ sourceKey: { message: "Hello" } }],
+      diagnostics: [],
+      watchFiles: [],
+    })
+
+    await expect(runPoTransform({}, { failOnMissing: true })).rejects.toThrow(
+      /Missing 1 translation/
+    )
+  })
+
+  it("warns diagnostics when compile errors are not fatal", async () => {
+    mocks.compileCatalogArtifact.mockReturnValue({
+      messages: {},
+      missing: [],
+      diagnostics: [
+        {
+          severity: "error",
+          code: "icu.missing_argument",
+          message: "Missing argument",
+          sourceKey: { message: "Hello {name}" },
+          locale: "de",
+        },
+      ],
+      watchFiles: [],
+    })
+
+    await runPoTransform()
+
+    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining("Catalog diagnostics for locale de"))
+  })
+})
+
+async function runPoTransform(
+  context: Record<string, unknown> = {},
+  options: Parameters<typeof palamedes>[0] = {}
+) {
+  const plugins = palamedes(options)
+  const poLoader = plugins.find((plugin) => plugin.name === "palamedes:po-loader")
+  const transform = poLoader?.transform
+
+  if (typeof transform !== "function") {
+    throw new Error("Expected palamedes:po-loader transform hook")
+  }
+
+  return transform.call(
+    {
+      addWatchFile() {},
+      ...context,
+    } as any,
+    "",
+    "/repo/src/locales/de.po"
+  )
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -663,6 +663,9 @@ importers:
       unbuild:
         specifier: ^3.6.1
         version: 3.6.1(typescript@6.0.3)
+      vitest:
+        specifier: ^4.1.6
+        version: 4.1.6(@edge-runtime/vm@3.2.0)(@types/node@25.9.0)(jsdom@29.1.1)(vite@8.0.13(@types/node@25.9.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.1)(tsx@4.21.0))
     optionalDependencies:
       '@palamedes/core-node-darwin-arm64':
         specifier: workspace:^
@@ -739,6 +742,9 @@ importers:
       unbuild:
         specifier: ^3.6.1
         version: 3.6.1(typescript@6.0.3)
+      vitest:
+        specifier: ^4.1.6
+        version: 4.1.6(@edge-runtime/vm@3.2.0)(@types/node@25.9.0)(jsdom@29.1.1)(vite@8.0.13(@types/node@25.9.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.1)(tsx@4.21.0))
 
   packages/palamedes: {}
 
@@ -865,6 +871,9 @@ importers:
       vite:
         specifier: ^8.0.13
         version: 8.0.13(@types/node@25.9.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.1)(tsx@4.21.0)
+      vitest:
+        specifier: ^4.1.6
+        version: 4.1.6(@edge-runtime/vm@3.2.0)(@types/node@25.9.0)(jsdom@29.1.1)(vite@8.0.13(@types/node@25.9.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.1)(tsx@4.21.0))
 
 packages:
 


### PR DESCRIPTION
## Summary
- add package-level tests for the core-node native bridge, the Next CJS PO loader, and the Vite PO loader
- cover PO parse/transform behavior, compile success, failOnMissing, diagnostics warnings, and watch dependency registration
- add package test scripts and Vitest dev dependencies for the previously uncovered packages

Closes #144

## Validation
- pnpm install --lockfile-only
- pnpm --filter @palamedes/core-node-darwin-arm64 build
- pnpm --filter @palamedes/core-node build
- pnpm --filter @palamedes/core-node test
- pnpm --filter @palamedes/next-plugin test
- pnpm --filter @palamedes/vite-plugin test
- pnpm --filter @palamedes/core-node exec tsc --noEmit -p tsconfig.json
- pnpm --filter @palamedes/core-node build
- pnpm --filter @palamedes/next-plugin exec tsc --noEmit -p tsconfig.json
- pnpm --filter @palamedes/next-plugin build
- pnpm --filter @palamedes/config build
- pnpm --filter @palamedes/runtime build
- pnpm --filter @palamedes/transform build
- pnpm --filter @palamedes/vite-plugin exec tsc --noEmit -p tsconfig.json
- pnpm --filter @palamedes/vite-plugin build
- git diff --cached --check
