### PR TITLE
Report runtime formatter support diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,9 +189,9 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ferrocat"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93307be6789b486541ef1c39f4bcb87c99d2433c52f19afd63a373f135561427"
+checksum = "70d0c8e7aeb6511c6f3d544540b58ad6c61bf79181f55e2ce7724161f7e0ee7c"
 dependencies = [
  "ferrocat-icu",
  "ferrocat-po",
@@ -199,18 +199,18 @@ dependencies = [
 
 [[package]]
 name = "ferrocat-icu"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "599dfc6c60dd262d1cdec037ceab9700a97641051194ef6c19552e2bf6259633"
+checksum = "dd17fb2690fc26249dd57b1c9c0db61af7aa4dfdd79e4a77b46fa45e55361a6d"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "ferrocat-po"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d6a78c367a6b67d7385e156ec1eabd032ee382bfc8c18a339a63b360251b76e"
+checksum = "558ef350bbffb67fef943accc5c12a9befd0af7804271717fa6e5b396a9232bf"
 dependencies = [
  "ferrocat-icu",
  "icu_locale",

--- a/adr/015-runtime-formatter-subset-diagnostics.md
+++ b/adr/015-runtime-formatter-subset-diagnostics.md
@@ -30,6 +30,9 @@ The supported runtime subset is:
 - `date` and `time` with no style
 - `date` and `time` with `short`, `medium`, `long`, or `full`
 
+Currency formatting intentionally requires the `::currency/ISO` skeleton form;
+bare `currency/ISO` is treated as outside the runtime formatter subset.
+
 Palamedes treats unsupported formatter kinds such as `list`, `duration`, `ago`,
 and `name` as errors because the runtime parser does not render those formatter
 kinds. Unsupported styles on supported formatter kinds are warnings because the

--- a/adr/015-runtime-formatter-subset-diagnostics.md
+++ b/adr/015-runtime-formatter-subset-diagnostics.md
@@ -1,0 +1,76 @@
+# ADR-015: Runtime Formatter Subset Diagnostics
+
+**Status:** Accepted
+**Date:** 2026-06-12
+
+## Context
+
+Palamedes runtime formatting intentionally covers a small ICU formatter subset
+that maps directly to platform `Intl` APIs. The current runtime can render
+plain `number`, `date`, and `time` arguments plus a few common styles, but it
+does not implement every formatter kind or ICU skeleton that translators may
+write in PO files.
+
+Before this decision, catalog artifact compilation validated ICU syntax and
+source/translation compatibility, but it did not make the runtime formatter
+subset explicit. Unsupported formatter kinds could reach runtime artifacts
+without a targeted diagnostic, and unsupported styles were hard to distinguish
+from fully invalid ICU.
+
+## Decision
+
+Palamedes validates final compiled catalog artifacts against the runtime
+formatter subset after Ferrocat compiles the artifact.
+
+The supported runtime subset is:
+
+- `number` with no style
+- `number` with `percent` or `integer`
+- `number` with `::percent`, `::integer`, or `::currency/ISO`
+- `date` and `time` with no style
+- `date` and `time` with `short`, `medium`, `long`, or `full`
+
+Palamedes treats unsupported formatter kinds such as `list`, `duration`, `ago`,
+and `name` as errors because the runtime parser does not render those formatter
+kinds. Unsupported styles on supported formatter kinds are warnings because the
+runtime currently falls back to the default `Intl` formatter for that argument
+type.
+
+Generic ICU formatter support analysis lives in Ferrocat. Palamedes supplies
+only the runtime-specific policy and maps Ferrocat diagnostics back to compiled
+artifact source keys and resolved locales.
+
+This PR does not add standalone `i18n.formatNumber()` or `i18n.formatDate()`
+helpers. Those can be evaluated separately if application authors need direct
+formatting APIs outside translated message patterns.
+
+## Alternatives Considered
+
+### 1. Implement formatter validation entirely inside Palamedes
+
+Rejected because identifying ICU formatter references is generic MessageFormat
+analysis. Keeping that analysis in Ferrocat preserves the catalog boundary from
+ADR-006 and avoids a second local ICU walker.
+
+### 2. Treat unsupported styles as errors
+
+Rejected for now because the runtime still renders supported formatter kinds by
+falling back to default `Intl` options. A warning reflects current behavior and
+lets teams decide whether unsupported style fallback is acceptable.
+
+### 3. Expand the runtime to full ICU skeleton support first
+
+Rejected as larger scope. The immediate need is to make the existing runtime
+contract explicit and reviewable in catalog artifacts.
+
+## Consequences
+
+- Catalog artifact diagnostics now report runtime-incompatible formatter kinds
+  with `icu.unsupported_formatter_kind`.
+- Catalog artifact diagnostics now report unsupported styles on supported
+  runtime formatter kinds with `icu.unsupported_formatter_style`.
+- Diagnostics use the compiled artifact source key and the locale that provided
+  the final runtime message, including source-locale fallbacks for missing
+  translations.
+- Future runtime formatter expansion should update this ADR, the Core runtime
+  docs, and the Palamedes runtime policy together.

--- a/crates/palamedes/Cargo.toml
+++ b/crates/palamedes/Cargo.toml
@@ -8,7 +8,7 @@ rust-version.workspace = true
 description = "Rust core for Palamedes."
 
 [dependencies]
-ferrocat = "0.12.0"
+ferrocat = "0.13.0"
 oxc_allocator = "0.132.0"
 oxc_ast = "0.132.0"
 oxc_ast_visit = "0.132.0"

--- a/crates/palamedes/src/catalog_artifact/compile.rs
+++ b/crates/palamedes/src/catalog_artifact/compile.rs
@@ -195,9 +195,12 @@ fn is_supported_runtime_number_style(style: Option<&str>) -> bool {
     let Some(style) = style.map(str::trim).filter(|style| !style.is_empty()) else {
         return true;
     };
-    let style = style.strip_prefix("::").unwrap_or(style);
 
-    matches!(style, "percent" | "integer") || supported_currency_skeleton(style)
+    if let Some(skeleton) = style.strip_prefix("::") {
+        return matches!(skeleton, "percent" | "integer") || supported_currency_skeleton(skeleton);
+    }
+
+    matches!(style, "percent" | "integer")
 }
 
 fn supported_currency_skeleton(style: &str) -> bool {

--- a/crates/palamedes/src/catalog_artifact/compile.rs
+++ b/crates/palamedes/src/catalog_artifact/compile.rs
@@ -1,15 +1,22 @@
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 use ferrocat::{
-    compare_icu_messages, parse_icu, CompiledCatalogArtifact, CompiledCatalogDiagnostic,
-    DiagnosticSeverity, IcuCompatibilityOptions, IcuDiagnosticSeverity,
+    compare_icu_messages, parse_icu, validate_icu_formatter_support, CompiledCatalogArtifact,
+    CompiledCatalogDiagnostic, CompiledCatalogIdIndex, DiagnosticSeverity, IcuArgumentKind,
+    IcuCompatibilityOptions, IcuDiagnosticSeverity, IcuFormatter, IcuFormatterSupport,
 };
 
 use super::types::{
     CatalogArtifactDiagnostic, CatalogArtifactMissingMessage, CatalogArtifactResult,
 };
 
-pub(super) fn align_diagnostics_with_runtime_icu_semantics(artifact: &mut CompiledCatalogArtifact) {
+pub(super) fn align_diagnostics_with_runtime_icu_semantics(
+    artifact: &mut CompiledCatalogArtifact,
+    compiled_id_index: &CompiledCatalogIdIndex,
+    requested_locale: &str,
+) {
+    let runtime_message_locales = runtime_message_locales(artifact, requested_locale);
     let diagnostics = std::mem::take(&mut artifact.diagnostics);
     let mut aligned = Vec::with_capacity(diagnostics.len());
     let mut additional = Vec::new();
@@ -34,6 +41,12 @@ pub(super) fn align_diagnostics_with_runtime_icu_semantics(artifact: &mut Compil
 
     aligned.extend(additional);
     artifact.diagnostics = aligned;
+    push_runtime_icu_formatter_support_diagnostics(
+        artifact,
+        compiled_id_index,
+        &runtime_message_locales,
+        requested_locale,
+    );
 }
 
 pub(super) fn build_artifact_result(
@@ -99,6 +112,108 @@ fn push_runtime_icu_compatibility_diagnostics(
     }
 
     true
+}
+
+fn push_runtime_icu_formatter_support_diagnostics(
+    artifact: &mut CompiledCatalogArtifact,
+    compiled_id_index: &CompiledCatalogIdIndex,
+    runtime_message_locales: &BTreeMap<String, String>,
+    requested_locale: &str,
+) {
+    for (compiled_id, runtime_message) in &artifact.messages {
+        let Some(source_key) = compiled_id_index.get(compiled_id) else {
+            continue;
+        };
+        let Some(runtime_icu) = parse_runtime_icu(runtime_message) else {
+            continue;
+        };
+
+        let report = validate_icu_formatter_support(&runtime_icu, runtime_icu_formatter_support);
+        let locale = runtime_message_locales
+            .get(compiled_id)
+            .map(String::as_str)
+            .unwrap_or(requested_locale);
+
+        for icu_diagnostic in report.diagnostics {
+            artifact.diagnostics.push(CompiledCatalogDiagnostic {
+                severity: runtime_icu_diagnostic_severity(icu_diagnostic.severity),
+                code: icu_diagnostic.code,
+                message: icu_diagnostic.message,
+                key: compiled_id.clone(),
+                msgid: source_key.msgid.clone(),
+                msgctxt: source_key.msgctxt.clone(),
+                locale: locale.to_owned(),
+            });
+        }
+    }
+}
+
+fn runtime_message_locales(
+    artifact: &CompiledCatalogArtifact,
+    requested_locale: &str,
+) -> BTreeMap<String, String> {
+    artifact
+        .missing
+        .iter()
+        .map(|missing| {
+            (
+                missing.key.clone(),
+                missing
+                    .resolved_locale
+                    .clone()
+                    .unwrap_or_else(|| requested_locale.to_owned()),
+            )
+        })
+        .collect()
+}
+
+fn runtime_icu_formatter_support(formatter: &IcuFormatter) -> IcuFormatterSupport {
+    match formatter.kind {
+        IcuArgumentKind::Number => runtime_icu_style_support(is_supported_runtime_number_style(
+            formatter.style.as_deref(),
+        )),
+        IcuArgumentKind::Date | IcuArgumentKind::Time => runtime_icu_style_support(
+            is_supported_runtime_date_time_style(formatter.style.as_deref()),
+        ),
+        _ => IcuFormatterSupport::UnsupportedKind {
+            severity: IcuDiagnosticSeverity::Error,
+        },
+    }
+}
+
+const fn runtime_icu_style_support(supported: bool) -> IcuFormatterSupport {
+    if supported {
+        IcuFormatterSupport::Supported
+    } else {
+        IcuFormatterSupport::UnsupportedStyle {
+            severity: IcuDiagnosticSeverity::Warning,
+        }
+    }
+}
+
+fn is_supported_runtime_number_style(style: Option<&str>) -> bool {
+    let Some(style) = style.map(str::trim).filter(|style| !style.is_empty()) else {
+        return true;
+    };
+    let style = style.strip_prefix("::").unwrap_or(style);
+
+    matches!(style, "percent" | "integer") || supported_currency_skeleton(style)
+}
+
+fn supported_currency_skeleton(style: &str) -> bool {
+    let Some(currency) = style.strip_prefix("currency/") else {
+        return false;
+    };
+
+    currency.len() == 3 && currency.bytes().all(|byte| byte.is_ascii_alphabetic())
+}
+
+fn is_supported_runtime_date_time_style(style: Option<&str>) -> bool {
+    let Some(style) = style.map(str::trim).filter(|style| !style.is_empty()) else {
+        return true;
+    };
+
+    matches!(style, "short" | "medium" | "long" | "full")
 }
 
 fn parse_runtime_icu(message: &str) -> Option<ferrocat::IcuMessage> {

--- a/crates/palamedes/src/catalog_artifact/mod.rs
+++ b/crates/palamedes/src/catalog_artifact/mod.rs
@@ -52,6 +52,8 @@ pub fn compile_catalog_artifact(
     );
     let mut options =
         CompileCatalogArtifactOptions::new(&prepared.locale, &request.config.source_locale);
+    let compiled_id_index = CompiledCatalogIdIndex::new(&catalogs, CompiledKeyStrategy::FerrocatV1)
+        .map_err(PalamedesError::BuildCompiledIdIndex)?;
     options.fallback_chain = &ferrocat_fallback_chain;
     options.key_strategy = CompiledKeyStrategy::FerrocatV1;
     options.source_fallback = true;
@@ -59,7 +61,11 @@ pub fn compile_catalog_artifact(
 
     let mut artifact = ferrocat_compile_catalog_artifact(&catalogs, &options)
         .map_err(PalamedesError::CompileCatalogArtifact)?;
-    align_diagnostics_with_runtime_icu_semantics(&mut artifact);
+    align_diagnostics_with_runtime_icu_semantics(
+        &mut artifact,
+        &compiled_id_index,
+        &prepared.locale,
+    );
 
     Ok(build_artifact_result(
         artifact,
@@ -102,7 +108,11 @@ pub fn compile_catalog_artifact_selected(
     let mut artifact =
         ferrocat_compile_catalog_artifact_selected(&catalogs, &compiled_id_index, &options)
             .map_err(PalamedesError::CompileSelectedCatalogArtifact)?;
-    align_diagnostics_with_runtime_icu_semantics(&mut artifact);
+    align_diagnostics_with_runtime_icu_semantics(
+        &mut artifact,
+        &compiled_id_index,
+        &prepared.locale,
+    );
 
     Ok(build_artifact_result(
         artifact,

--- a/crates/palamedes/src/catalog_artifact/tests.rs
+++ b/crates/palamedes/src/catalog_artifact/tests.rs
@@ -596,6 +596,7 @@ fn compile_catalog_artifact_reports_runtime_unsupported_formatter_styles() {
         "en",
         &[
             ("Compact {amount, number, ::compact-short}", ""),
+            ("Bare currency {amount, number, currency/EUR}", ""),
             ("Pattern {when, date, yyyy-MM-dd}", ""),
         ],
     );
@@ -606,6 +607,10 @@ fn compile_catalog_artifact_reports_runtime_unsupported_formatter_styles() {
             (
                 "Compact {amount, number, ::compact-short}",
                 "Kompakt {amount, number, ::compact-short}",
+            ),
+            (
+                "Bare currency {amount, number, currency/EUR}",
+                "Bare Waehrung {amount, number, currency/EUR}",
             ),
             (
                 "Pattern {when, date, yyyy-MM-dd}",
@@ -634,7 +639,7 @@ fn compile_catalog_artifact_reports_runtime_unsupported_formatter_styles() {
         .filter(|diagnostic| diagnostic.code == "icu.unsupported_formatter_style")
         .collect::<Vec<_>>();
 
-    assert_eq!(diagnostics.len(), 2);
+    assert_eq!(diagnostics.len(), 3);
     assert!(diagnostics.iter().all(|diagnostic| {
         diagnostic.severity == CatalogArtifactDiagnosticSeverity::Warning
             && diagnostic.locale == "de"
@@ -643,6 +648,10 @@ fn compile_catalog_artifact_reports_runtime_unsupported_formatter_styles() {
         .iter()
         .any(|diagnostic| diagnostic.source_key.message
             == "Compact {amount, number, ::compact-short}"));
+    assert!(diagnostics
+        .iter()
+        .any(|diagnostic| diagnostic.source_key.message
+            == "Bare currency {amount, number, currency/EUR}"));
     assert!(diagnostics
         .iter()
         .any(|diagnostic| diagnostic.source_key.message == "Pattern {when, date, yyyy-MM-dd}"));

--- a/crates/palamedes/src/catalog_artifact/tests.rs
+++ b/crates/palamedes/src/catalog_artifact/tests.rs
@@ -4,8 +4,9 @@ use super::{
     CatalogConfig,
 };
 use ferrocat::compiled_key;
+use std::collections::BTreeSet;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 #[test]
@@ -479,6 +480,213 @@ msgstr "Hallo {firstName}"
 }
 
 #[test]
+fn compile_catalog_artifact_reports_runtime_unsupported_formatter_kinds() {
+    let fixture = create_fixture_dir("catalog-artifact-runtime-unsupported-kinds");
+    let locale_dir = fixture.join("src/locales");
+    fs::create_dir_all(&locale_dir).expect("locale dir");
+
+    let source_entries = unsupported_runtime_formatter_kind_messages()
+        .into_iter()
+        .map(|message| (message, ""))
+        .collect::<Vec<_>>();
+    write_test_catalog(&locale_dir, "en", &source_entries);
+    write_test_catalog(&locale_dir, "de", &[]);
+
+    let request = CatalogArtifactRequest {
+        config: CatalogArtifactConfig {
+            root_dir: fixture.to_string_lossy().into_owned(),
+            locales: vec!["en".to_owned(), "de".to_owned()],
+            source_locale: "en".to_owned(),
+            fallback_locales: None,
+            pseudo_locale: None,
+            catalogs: vec![CatalogConfig {
+                path: "src/locales/{locale}".to_owned(),
+            }],
+        },
+        resource_path: locale_dir.join("de.po").to_string_lossy().into_owned(),
+    };
+    let result = compile_catalog_artifact(&request).expect("catalog artifact");
+    let diagnostics = result
+        .diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.code == "icu.unsupported_formatter_kind")
+        .collect::<Vec<_>>();
+
+    assert_eq!(diagnostics.len(), 4);
+    assert!(diagnostics.iter().all(|diagnostic| {
+        diagnostic.severity == CatalogArtifactDiagnosticSeverity::Error && diagnostic.locale == "en"
+    }));
+    assert_eq!(
+        diagnostics
+            .iter()
+            .map(|diagnostic| diagnostic.source_key.message.as_str())
+            .collect::<BTreeSet<_>>(),
+        unsupported_runtime_formatter_kind_messages()
+            .into_iter()
+            .collect::<BTreeSet<_>>()
+    );
+    assert_eq!(result.missing.len(), 4);
+    assert!(result
+        .missing
+        .iter()
+        .all(|missing| missing.resolved_locale.as_deref() == Some("en")));
+}
+
+#[test]
+fn compile_catalog_artifact_selected_reports_runtime_unsupported_formatter_kinds() {
+    let fixture = create_fixture_dir("catalog-artifact-selected-runtime-unsupported-kinds");
+    let locale_dir = fixture.join("src/locales");
+    fs::create_dir_all(&locale_dir).expect("locale dir");
+
+    let source_entries = unsupported_runtime_formatter_kind_messages()
+        .into_iter()
+        .map(|message| (message, ""))
+        .collect::<Vec<_>>();
+    write_test_catalog(&locale_dir, "en", &source_entries);
+    write_test_catalog(&locale_dir, "de", &[]);
+
+    let request = CatalogArtifactSelectedRequest {
+        config: CatalogArtifactConfig {
+            root_dir: fixture.to_string_lossy().into_owned(),
+            locales: vec!["en".to_owned(), "de".to_owned()],
+            source_locale: "en".to_owned(),
+            fallback_locales: None,
+            pseudo_locale: None,
+            catalogs: vec![CatalogConfig {
+                path: "src/locales/{locale}".to_owned(),
+            }],
+        },
+        resource_path: locale_dir.join("de.po").to_string_lossy().into_owned(),
+        compiled_ids: unsupported_runtime_formatter_kind_messages()
+            .into_iter()
+            .map(|message| compiled_key(message, None))
+            .collect(),
+    };
+    let result = compile_catalog_artifact_selected(&request).expect("selected catalog artifact");
+    let diagnostics = result
+        .diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.code == "icu.unsupported_formatter_kind")
+        .collect::<Vec<_>>();
+
+    assert_eq!(result.messages.len(), 4);
+    assert_eq!(diagnostics.len(), 4);
+    assert!(diagnostics.iter().all(|diagnostic| {
+        diagnostic.severity == CatalogArtifactDiagnosticSeverity::Error && diagnostic.locale == "en"
+    }));
+    assert_eq!(
+        diagnostics
+            .iter()
+            .map(|diagnostic| diagnostic.source_key.message.as_str())
+            .collect::<BTreeSet<_>>(),
+        unsupported_runtime_formatter_kind_messages()
+            .into_iter()
+            .collect::<BTreeSet<_>>()
+    );
+}
+
+#[test]
+fn compile_catalog_artifact_reports_runtime_unsupported_formatter_styles() {
+    let fixture = create_fixture_dir("catalog-artifact-runtime-unsupported-styles");
+    let locale_dir = fixture.join("src/locales");
+    fs::create_dir_all(&locale_dir).expect("locale dir");
+
+    write_test_catalog(
+        &locale_dir,
+        "en",
+        &[
+            ("Compact {amount, number, ::compact-short}", ""),
+            ("Pattern {when, date, yyyy-MM-dd}", ""),
+        ],
+    );
+    write_test_catalog(
+        &locale_dir,
+        "de",
+        &[
+            (
+                "Compact {amount, number, ::compact-short}",
+                "Kompakt {amount, number, ::compact-short}",
+            ),
+            (
+                "Pattern {when, date, yyyy-MM-dd}",
+                "Muster {when, date, yyyy-MM-dd}",
+            ),
+        ],
+    );
+
+    let request = CatalogArtifactRequest {
+        config: CatalogArtifactConfig {
+            root_dir: fixture.to_string_lossy().into_owned(),
+            locales: vec!["en".to_owned(), "de".to_owned()],
+            source_locale: "en".to_owned(),
+            fallback_locales: None,
+            pseudo_locale: None,
+            catalogs: vec![CatalogConfig {
+                path: "src/locales/{locale}".to_owned(),
+            }],
+        },
+        resource_path: locale_dir.join("de.po").to_string_lossy().into_owned(),
+    };
+    let result = compile_catalog_artifact(&request).expect("catalog artifact");
+    let diagnostics = result
+        .diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.code == "icu.unsupported_formatter_style")
+        .collect::<Vec<_>>();
+
+    assert_eq!(diagnostics.len(), 2);
+    assert!(diagnostics.iter().all(|diagnostic| {
+        diagnostic.severity == CatalogArtifactDiagnosticSeverity::Warning
+            && diagnostic.locale == "de"
+    }));
+    assert!(diagnostics
+        .iter()
+        .any(|diagnostic| diagnostic.source_key.message
+            == "Compact {amount, number, ::compact-short}"));
+    assert!(diagnostics
+        .iter()
+        .any(|diagnostic| diagnostic.source_key.message == "Pattern {when, date, yyyy-MM-dd}"));
+}
+
+#[test]
+fn compile_catalog_artifact_allows_supported_runtime_formatter_subset() {
+    let fixture = create_fixture_dir("catalog-artifact-runtime-supported-formatters");
+    let locale_dir = fixture.join("src/locales");
+    fs::create_dir_all(&locale_dir).expect("locale dir");
+    let message = concat!(
+        "Values {plain, number} {percent, number, percent} ",
+        "{integer, number, integer} {percentSkeleton, number, ::percent} ",
+        "{integerSkeleton, number, ::integer} {currency, number, ::currency/EUR} ",
+        "{datePlain, date} {dateShort, date, short} {dateMedium, date, medium} ",
+        "{dateLong, date, long} {dateFull, date, full} {timePlain, time} ",
+        "{timeShort, time, short} {timeMedium, time, medium} {timeLong, time, long} ",
+        "{timeFull, time, full}"
+    );
+
+    write_test_catalog(&locale_dir, "en", &[(message, "")]);
+    write_test_catalog(&locale_dir, "de", &[(message, message)]);
+
+    let request = CatalogArtifactRequest {
+        config: CatalogArtifactConfig {
+            root_dir: fixture.to_string_lossy().into_owned(),
+            locales: vec!["en".to_owned(), "de".to_owned()],
+            source_locale: "en".to_owned(),
+            fallback_locales: None,
+            pseudo_locale: None,
+            catalogs: vec![CatalogConfig {
+                path: "src/locales/{locale}".to_owned(),
+            }],
+        },
+        resource_path: locale_dir.join("de.po").to_string_lossy().into_owned(),
+    };
+    let result = compile_catalog_artifact(&request).expect("catalog artifact");
+
+    assert!(!result.diagnostics.iter().any(|diagnostic| diagnostic.code
+        == "icu.unsupported_formatter_kind"
+        || diagnostic.code == "icu.unsupported_formatter_style"));
+}
+
+#[test]
 fn compile_catalog_artifact_selected_accepts_runtime_literal_apostrophes() {
     let fixture = create_fixture_dir("catalog-artifact-selected-apostrophes");
     let locale_dir = fixture.join("src/locales");
@@ -543,4 +751,33 @@ fn create_fixture_dir(prefix: &str) -> PathBuf {
     let dir = std::env::temp_dir().join(format!("palamedes-{prefix}-{unique}"));
     fs::create_dir_all(&dir).expect("create temp dir");
     dir
+}
+
+fn unsupported_runtime_formatter_kind_messages() -> [&'static str; 4] {
+    [
+        "Items {items, list}",
+        "Elapsed {elapsed, duration}",
+        "Updated {updated, ago}",
+        "Owner {owner, name}",
+    ]
+}
+
+fn write_test_catalog(locale_dir: &Path, locale: &str, entries: &[(&str, &str)]) {
+    let mut catalog = format!("msgid \"\"\nmsgstr \"\"\n\"Language: {locale}\\n\"\n");
+
+    for (msgid, msgstr) in entries {
+        catalog.push('\n');
+        catalog.push_str("msgid ");
+        catalog.push_str(&po_string(msgid));
+        catalog.push('\n');
+        catalog.push_str("msgstr ");
+        catalog.push_str(&po_string(msgstr));
+        catalog.push('\n');
+    }
+
+    fs::write(locale_dir.join(format!("{locale}.po")), catalog).expect("write catalog");
+}
+
+fn po_string(value: &str) -> String {
+    format!("\"{}\"", value.replace('\\', "\\\\").replace('"', "\\\""))
 }

--- a/docs/api/core-node.md
+++ b/docs/api/core-node.md
@@ -21,6 +21,12 @@ core. Most apps use it indirectly through the CLI and plugins.
 - `extractCatalogMessagesFromFiles(request)`
 - `transformMacrosNative(source, filename, options?)`
 
+`compileCatalogArtifact()` and `compileCatalogArtifactSelected()` include
+runtime formatter diagnostics in their `diagnostics` arrays. Unsupported
+formatter kinds such as `list`, `duration`, `ago`, and `name` are errors.
+Unsupported styles on supported `number`, `date`, and `time` formatters are
+warnings because the runtime falls back to default `Intl` formatting.
+
 ## Stability
 
 This package is useful for integration tests and custom tooling, but it is a

--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -80,3 +80,21 @@ Supported macro names:
 - `plural`
 - `select`
 - `selectOrdinal`
+
+## Runtime Formatting
+
+`formatMessagePattern()` and `createI18n()._()` support the formatter subset
+implemented by the Palamedes runtime:
+
+- `{value, number}`
+- `{value, number, percent}` and `{value, number, integer}`
+- `{value, number, ::percent}`, `{value, number, ::integer}`, and
+  `{value, number, ::currency/ISO}`
+- `{value, date}` and `{value, time}`
+- `{value, date, short|medium|long|full}`
+- `{value, time, short|medium|long|full}`
+
+Catalog artifact compilation reports `list`, `duration`, `ago`, `name`, and
+other unsupported formatter kinds as errors. Unsupported styles on `number`,
+`date`, and `time` are warnings because the runtime currently falls back to the
+default `Intl` formatter for that argument type.

--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -94,6 +94,9 @@ implemented by the Palamedes runtime:
 - `{value, date, short|medium|long|full}`
 - `{value, time, short|medium|long|full}`
 
+Currency formatting must use the `::currency/ISO` skeleton form; bare
+`currency/ISO` is outside the supported runtime subset.
+
 Catalog artifact compilation reports `list`, `duration`, `ago`, `name`, and
 other unsupported formatter kinds as errors. Unsupported styles on `number`,
 `date`, and `time` are warnings because the runtime currently falls back to the

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -77,6 +77,9 @@ Supported runtime styles:
 - `{value, date, short|medium|long|full}`
 - `{value, time, short|medium|long|full}`
 
+Currency formatting must use the `::currency/ISO_CODE` skeleton form; bare
+`currency/ISO_CODE` is outside the supported runtime subset.
+
 Catalog artifact compilation reports unsupported formatter kinds such as `list`,
 `duration`, `ago`, and `name` as errors because the runtime does not render
 those kinds. Unsupported styles on `number`, `date`, and `time` are warnings:

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -77,6 +77,7 @@ Supported runtime styles:
 - `{value, date, short|medium|long|full}`
 - `{value, time, short|medium|long|full}`
 
-Full ICU skeleton validation belongs in the transform/catalog diagnostics layer;
-unsupported runtime styles fall back to the default `Intl` formatter for the
-argument type.
+Catalog artifact compilation reports unsupported formatter kinds such as `list`,
+`duration`, `ago`, and `name` as errors because the runtime does not render
+those kinds. Unsupported styles on `number`, `date`, and `time` are warnings:
+the runtime falls back to the default `Intl` formatter for that argument type.

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -214,6 +214,9 @@ describe("createI18n", () => {
     expect(i18n._({ message: "Total: {amount, number, ::currency/EUR}" }, { amount: 12.3 })).toBe(
       `Total: ${new Intl.NumberFormat("en-US", { style: "currency", currency: "EUR" }).format(12.3)}`
     )
+    expect(i18n._({ message: "Bare: {amount, number, currency/EUR}" }, { amount: 12.3 })).toBe(
+      `Bare: ${new Intl.NumberFormat("en-US").format(12.3)}`
+    )
     expect(i18n._({ message: "Progress: {ratio, number, percent}" }, { ratio: 0.42 })).toBe(
       `Progress: ${new Intl.NumberFormat("en-US", { style: "percent" }).format(0.42)}`
     )

--- a/packages/core/src/messageFormat.ts
+++ b/packages/core/src/messageFormat.ts
@@ -383,13 +383,19 @@ function parseNumberFormatOptions(style: string | undefined): Intl.NumberFormatO
     return { maximumFractionDigits: 0 }
   }
 
-  if (skeleton.startsWith("currency/")) {
-    const currency = skeleton.slice("currency/".length).trim().toUpperCase()
-    if (/^[A-Z]{3}$/.test(currency)) {
-      return {
-        style: "currency",
-        currency,
-      }
+  if (!normalized.startsWith("::")) {
+    return {}
+  }
+
+  if (!skeleton.startsWith("currency/")) {
+    return {}
+  }
+
+  const currency = skeleton.slice("currency/".length).trim().toUpperCase()
+  if (/^[A-Z]{3}$/.test(currency)) {
+    return {
+      style: "currency",
+      currency,
     }
   }
 


### PR DESCRIPTION
## Summary

- bump Ferrocat to 0.13.0 and use its generic ICU formatter support diagnostics
- validate compiled catalog artifacts against the Palamedes runtime formatter subset
- report unsupported formatter kinds as errors and unsupported supported-kind styles as warnings
- document the runtime formatter subset in API docs and ADR-015

Closes #147

## Test Plan

- cargo fmt --check
- git diff --check
- cargo test -p palamedes catalog_artifact
- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- pnpm install --frozen-lockfile
- pnpm build
- pnpm check-types
- pnpm format:check
- pnpm lint
- pnpm test