### PR TITLE
chore(deps): update React Router isbot

### DIFF
--- a/examples/react-router-cookie/package.json
+++ b/examples/react-router-cookie/package.json
@@ -16,7 +16,7 @@
     "@palamedes/runtime": "workspace:^",
     "@react-router/node": "7.15.1",
     "@react-router/serve": "7.15.1",
-    "isbot": "^5.1.40",
+    "isbot": "^5.1.43",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "react-router": "7.15.1"

--- a/examples/react-router-route/package.json
+++ b/examples/react-router-route/package.json
@@ -16,7 +16,7 @@
     "@palamedes/runtime": "workspace:^",
     "@react-router/node": "7.15.1",
     "@react-router/serve": "7.15.1",
-    "isbot": "^5.1.40",
+    "isbot": "^5.1.43",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "react-router": "7.15.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -183,8 +183,8 @@ importers:
         specifier: 7.15.1
         version: 7.15.1(react-router@7.15.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@6.0.3)
       isbot:
-        specifier: ^5.1.40
-        version: 5.1.40
+        specifier: ^5.1.43
+        version: 5.1.43
       react:
         specifier: ^19.2.6
         version: 19.2.6
@@ -247,8 +247,8 @@ importers:
         specifier: 7.15.1
         version: 7.15.1(react-router@7.15.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@6.0.3)
       isbot:
-        specifier: ^5.1.40
-        version: 5.1.40
+        specifier: ^5.1.43
+        version: 5.1.43
       react:
         specifier: ^19.2.6
         version: 19.2.6
@@ -6807,8 +6807,8 @@ packages:
   isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
 
-  isbot@5.1.40:
-    resolution: {integrity: sha512-yNeeynhhtIVRBk12tBV4eHNxwB42HzR4Q3Ea7vCOiJhImGaAIdIMrbJtacQlBizGLjUPw+akkFI5Dn9T70XoVQ==}
+  isbot@5.1.43:
+    resolution: {integrity: sha512-drJhFmibra4LO6Wd7D3Oi6UICRK9244vSZkmxzhlZP0TTdwCA2ueK4PEkUkzPYeuqug9+cqqdWPgihjk5+83Cg==}
     engines: {node: '>=18'}
 
   isexe@2.0.0:
@@ -8719,6 +8719,7 @@ packages:
 
   stream-to-promise@2.2.0:
     resolution: {integrity: sha512-HAGUASw8NT0k8JvIVutB2Y/9iBk7gpgEyAudXwNJmZERdMITGdajOa4VJfD/kNiA3TppQpTP4J+CtcHwdzKBAw==}
+    deprecated: Deprecated. Use node:stream/promises and node:stream/consumers instead.
 
   streamx@2.25.0:
     resolution: {integrity: sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==}
@@ -11582,7 +11583,7 @@ snapshots:
       dedent: 1.7.2
       es-module-lexer: 1.7.0
       exit-hook: 2.2.1
-      isbot: 5.1.40
+      isbot: 5.1.43
       jsesc: 3.0.2
       lodash: 4.17.23
       p-map: 7.0.4
@@ -12135,7 +12136,7 @@ snapshots:
       '@tanstack/history': 1.162.0
       '@tanstack/react-store': 0.9.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@tanstack/router-core': 1.171.2
-      isbot: 5.1.40
+      isbot: 5.1.43
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
@@ -15800,7 +15801,7 @@ snapshots:
 
   isarray@2.0.5: {}
 
-  isbot@5.1.40: {}
+  isbot@5.1.43: {}
 
   isexe@2.0.0: {}
 


### PR DESCRIPTION
## Summary
- update `isbot` from `^5.1.40` to `^5.1.43` in both React Router examples
- refresh the lockfile entries used by React Router/TanStack transitive consumers

## Upstream
- `isbot@5.1.43` was published to npm on 2026-06-15
- package metadata keeps the Node engine at `>=18`
- no GitHub release exists for `v5.1.43`, so this PR is based on npm metadata and local validation

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm build`
- `pnpm --filter @palamedes/example-react-router-cookie build`
- `pnpm --filter @palamedes/example-react-router-route build`
- `pnpm exec oxfmt --check examples/react-router-cookie/package.json examples/react-router-route/package.json`
- `git diff --check`