### PR TITLE
chore(deps): update Commander CLI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ well-scoped changes are easiest to review.
 
 ## Prerequisites
 
-- Node.js `>=22`
+- Node.js `>=22.12`
 - pnpm via Corepack
 - Rust stable toolchain
 - GitHub CLI if you work on issue or PR automation locally

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Palamedes
 
 [![CI](https://github.com/sebastian-software/palamedes/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/sebastian-software/palamedes/actions/workflows/ci.yml)
-[![Node >=22](https://img.shields.io/badge/node-%3E%3D22-0f172a.svg?logo=node.js)](https://github.com/sebastian-software/palamedes/blob/main/package.json)
+[![Node >=22.12](https://img.shields.io/badge/node-%3E%3D22.12-0f172a.svg?logo=node.js)](https://github.com/sebastian-software/palamedes/blob/main/package.json)
 [![Sponsored by Sebastian Software](https://img.shields.io/badge/Sponsored%20by-Sebastian%20Software-0f172a.svg)](https://oss.sebastian-software.com/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-0f172a.svg)](https://github.com/sebastian-software/palamedes/blob/main/LICENSE)
 
@@ -59,7 +59,7 @@ easier to review, and easier to carry from one framework to the next.
 ## Current Status
 
 - Recommended for new projects and teams that want cleaner i18n foundations
-- Verified today across Next.js, TanStack Start, SolidStart, Waku, and React Router on Node.js `>=22`
+- Verified today across Next.js, TanStack Start, SolidStart, Waku, and React Router on Node.js `>=22.12`
 - Source-string-first catalogs are stable and powered by `ferrocat`, including structured audits and ICU authoring diagnostics
 - Placeholder top-level packages exist, but there is no `palamedes` or `create-palamedes` first-run entry yet
 - Pre-1.0 stability tiers and public API expectations are documented in [Stability and versioning](https://github.com/sebastian-software/palamedes/blob/main/docs/stability.md)

--- a/docs/proof-and-benchmarks.md
+++ b/docs/proof-and-benchmarks.md
@@ -27,7 +27,7 @@ evidence easy to inspect.
 | Catalog model         | Source-string-first, `.po`, `message + context` identity                          |
 | Native core           | Rust + `napi-rs`                                                                  |
 | Catalog semantics     | Delegated to `ferrocat`, including audit and ICU diagnostics                      |
-| Node requirement      | `>=22`                                                                            |
+| Node requirement      | `>=22.12`                                                                         |
 | Not yet productized   | Top-level `palamedes` install, `create-palamedes` scaffold                        |
 
 ## What Counts As Proof In This Repo

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "bugs": "https://github.com/sebastian-software/palamedes/issues",
   "packageManager": "pnpm@11.1.3",
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=22.12.0"
   },
   "scripts": {
     "build": "pnpm -r --filter \"./packages/**\" build",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -42,7 +42,7 @@
     "stub": "unbuild --stub"
   },
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=22.12.0"
   },
   "publishConfig": {
     "access": "public"
@@ -52,7 +52,7 @@
     "@palamedes/core-node": "workspace:^",
     "chalk": "^5.6.2",
     "chokidar": "^5.0.0",
-    "commander": "^14.0.3",
+    "commander": "^15.0.0",
     "glob": "^13.0.6"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -614,8 +614,8 @@ importers:
         specifier: ^5.0.0
         version: 5.0.0
       commander:
-        specifier: ^14.0.3
-        version: 14.0.3
+        specifier: ^15.0.0
+        version: 15.0.0
       glob:
         specifier: ^13.0.6
         version: 13.0.6
@@ -5202,6 +5202,10 @@ packages:
   commander@14.0.3:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
     engines: {node: '>=20'}
+
+  commander@15.0.0:
+    resolution: {integrity: sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==}
+    engines: {node: '>=22.12.0'}
 
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
@@ -13842,6 +13846,8 @@ snapshots:
   commander@11.1.0: {}
 
   commander@14.0.3: {}
+
+  commander@15.0.0: {}
 
   commander@2.20.3: {}
 


### PR DESCRIPTION
## Dependency group
- Packages: `commander` `14.0.3` -> `15.0.0`
- Why grouped: Commander is only used by `@palamedes/cli`, and the major upgrade carries its own Node engine change.

## Upstream changes that matter here
- Commander 15 is ESM-only and removes the deprecated `commander/esm.mjs` export: https://github.com/tj/commander.js/releases/tag/v15.0.0
- Commander 15 requires Node.js `>=22.12.0`: https://www.npmjs.com/package/commander/v/15.0.0
- The lone `--no-*` option default behavior changed in Commander 15, but `pmds` does not define any `--no-*` options.
- Commander 14 is now in maintenance with security updates through May 2027.

## Local impact and code changes
- Updated `@palamedes/cli` to `commander@^15.0.0`.
- Raised the root workspace and CLI package Node floor to `>=22.12.0`, then aligned README, CONTRIBUTING, and proof docs.
- Checked local CLI usage: `packages/cli/src/cli.ts` already imports Commander from ESM and does not use `commander/esm.mjs`, CommonJS `require("commander")`, or affected `--no-*` option definitions.

## Validation
- `node --version`: `v24.16.0`
- `pnpm install --frozen-lockfile`: passed
- `pnpm build`: passed
- `pnpm --filter @palamedes/cli test`: passed, 4 files / 15 tests
- `pnpm --filter @palamedes/cli exec tsc --noEmit -p tsconfig.json`: passed
- `pnpm --filter @palamedes/cli exec node dist/cli.mjs --help`: passed
- `pnpm --filter @palamedes/cli exec node dist/cli.mjs version`: passed
- `pnpm --filter @palamedes/cli exec node dist/cli.mjs catalog merge --help`: passed
- `pnpm --filter @palamedes/cli exec node dist/cli.mjs extract --help`: passed
- `pnpm exec oxfmt --check package.json packages/cli/package.json CONTRIBUTING.md README.md docs/proof-and-benchmarks.md`: passed
- `git diff --check`: passed

## Risk
- Main risk is CLI argument parsing after the Commander major. Existing command registration, nested `catalog merge`, and built `dist/cli.mjs` smoke paths passed locally.
