### PR TITLE
chore(deps): update string_wizard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -458,9 +458,9 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "napi"
@@ -697,6 +697,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb3e6120999627ec9703025eab7c9f410ebb7e95557632a8902ca48210416c2b"
 dependencies = [
  "nonmax",
+ "serde",
+]
+
+[[package]]
+name = "oxc_index"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "191884bee6c3744909a51acc7d78d4ae370d817b25875b10642f632327b6296e"
+dependencies = [
  "rayon",
  "serde",
 ]
@@ -744,9 +753,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_sourcemap"
-version = "6.1.1"
+version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d378eb8bad20e89d66276aebab51f6a5408571092cac94abdd3eabb773713d6"
+checksum = "9ac6db7d8c33f46a0b9ebb702c077364abcd6b64c3a3a97bb86b9f5b3554833c"
 dependencies = [
  "base64-simd",
  "json-escape-simd",
@@ -794,7 +803,7 @@ dependencies = [
  "oxc_allocator",
  "oxc_ast_macros",
  "oxc_estree",
- "oxc_index",
+ "oxc_index 4.1.0",
  "oxc_span",
  "oxc_str",
  "phf",
@@ -933,9 +942,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -956,9 +965,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rustc-hash"
@@ -1082,13 +1091,14 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "string_wizard"
-version = "0.0.27"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49077a960de0ac40075720160a3afb2bfac54ee2b744f245730b811c6fc95ed7"
+checksum = "062809a33f90b3216e9fcadb95e0a6d41794ac5e23663ea96c47d23f13bdcea4"
 dependencies = [
  "memchr",
- "oxc_index",
+ "oxc_index 5.0.0",
  "oxc_sourcemap",
+ "regex",
  "rustc-hash",
  "serde",
 ]

--- a/crates/palamedes/Cargo.toml
+++ b/crates/palamedes/Cargo.toml
@@ -16,5 +16,5 @@ oxc_parser = "0.132.0"
 oxc_span = "0.132.0"
 regex = "1.12.3"
 serde = { version = "1.0.228", features = ["derive"] }
-string_wizard = "0.0.27"
+string_wizard = "1.1.2"
 thiserror = "2.0.18"

--- a/crates/palamedes/src/error.rs
+++ b/crates/palamedes/src/error.rs
@@ -150,6 +150,18 @@ pub enum PalamedesError {
         /// Joined parser diagnostics.
         messages: String,
     },
+    /// A transform source offset exceeded the source-map backend's supported range.
+    #[error("Transform source offset {offset} exceeds the supported 32-bit range.")]
+    TransformOffsetTooLarge {
+        /// Source byte offset that could not be represented.
+        offset: usize,
+    },
+    /// Applying a transform edit failed in the source-map backend.
+    #[error("Failed to apply transform edit: {reason}")]
+    TransformEditFailed {
+        /// Source-map backend error.
+        reason: String,
+    },
     /// Explicit author-facing message IDs are no longer supported.
     #[error(
         "Explicit message ids are no longer supported. Remove `id` and rely on message/context instead."

--- a/crates/palamedes/src/transform/mod.rs
+++ b/crates/palamedes/src/transform/mod.rs
@@ -208,7 +208,7 @@ pub fn transform_macros(
 
     let mut magic_string = MagicString::new(source);
     for replacement in &replacements {
-        apply_replacement(&mut magic_string, replacement);
+        apply_replacement(&mut magic_string, replacement)?;
     }
 
     let code = magic_string.to_string();
@@ -241,12 +241,26 @@ pub fn transform_macros(
     })
 }
 
-fn apply_replacement(magic_string: &mut MagicString<'_>, replacement: &Replacement) {
+fn apply_replacement(
+    magic_string: &mut MagicString<'_>,
+    replacement: &Replacement,
+) -> PalamedesResult<()> {
+    let start = string_wizard_offset(replacement.start)?;
+    let end = string_wizard_offset(replacement.end)?;
+
     if replacement.start == replacement.end {
-        magic_string.append_left(replacement.start, replacement.text.clone());
+        magic_string.append_left(start, replacement.text.clone());
     } else {
-        magic_string.update(replacement.start, replacement.end, replacement.text.clone());
+        magic_string
+            .update(start, end, replacement.text.clone())
+            .map_err(|reason| PalamedesError::TransformEditFailed { reason })?;
     }
+
+    Ok(())
+}
+
+fn string_wizard_offset(offset: usize) -> PalamedesResult<u32> {
+    u32::try_from(offset).map_err(|_| PalamedesError::TransformOffsetTooLarge { offset })
 }
 
 fn import_insertion_offset(program: &oxc_ast::ast::Program<'_>) -> usize {

--- a/crates/palamedes/src/transform/mod.rs
+++ b/crates/palamedes/src/transform/mod.rs
@@ -246,11 +246,12 @@ fn apply_replacement(
     replacement: &Replacement,
 ) -> PalamedesResult<()> {
     let start = string_wizard_offset(replacement.start)?;
-    let end = string_wizard_offset(replacement.end)?;
 
     if replacement.start == replacement.end {
         magic_string.append_left(start, replacement.text.clone());
     } else {
+        let end = string_wizard_offset(replacement.end)?;
+
         magic_string
             .update(start, end, replacement.text.clone())
             .map_err(|reason| PalamedesError::TransformEditFailed { reason })?;


### PR DESCRIPTION
## Dependency group
- Packages: `string_wizard` `0.0.27` -> `1.1.2`
- Required lockfile graph: `oxc_sourcemap` `6.1.1` -> `8.0.2`, `oxc_index` `5.0.0`, `regex` `1.12.4`, `regex-syntax` `0.8.11`, `memchr` `2.8.2`
- Why grouped: `string_wizard` owns the transform source-edit/source-map backend, and the extra lockfile updates are required by its published dependency requirements.

## Upstream changes that matter here
- `string_wizard` does not publish GitHub release notes or a repository link in crate metadata; checked crates.io/docs metadata and compiled the local API surface instead: https://crates.io/crates/string_wizard/1.1.2 and https://docs.rs/string_wizard/1.1.2/string_wizard/
- The local impact is API-level: edit offsets now use `u32`, and `MagicString::update` is fallible.

## Local impact and code changes
- Existing usage checked: `MagicString`, `SourceMapOptions`, `Hires`, transform source maps, and transform replacement application.
- Added checked `usize -> u32` offset conversion with a typed `TransformOffsetTooLarge` error instead of panicking on oversized input.
- Propagated `MagicString::update` failures through `TransformEditFailed`.

## Validation
- `cargo +1.93.0 check --workspace --locked`: passed
- `cargo fmt --all --check`: passed
- `cargo clippy --workspace --all-targets --locked -- -D warnings`: passed
- `cargo test --workspace --locked`: passed, 73 library tests and 1 doctest

## Risk
- Moderate transform-path risk because the source-map backend API changed, but existing transform/source-map tests pass.
- Changelog gap: no upstream release notes were available from crate metadata, so this PR relies on metadata, docs/API compile errors, and local tests.