### PR TITLE
chore(deps): update Ferrocat catalog API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,6 +182,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -189,9 +199,9 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ferrocat"
-version = "0.13.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70d0c8e7aeb6511c6f3d544540b58ad6c61bf79181f55e2ce7724161f7e0ee7c"
+checksum = "ec752a5b60b7f537aa5a82f1a48c49834d325659817bd71854f79154116fec07"
 dependencies = [
  "ferrocat-icu",
  "ferrocat-po",
@@ -199,18 +209,18 @@ dependencies = [
 
 [[package]]
 name = "ferrocat-icu"
-version = "0.13.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd17fb2690fc26249dd57b1c9c0db61af7aa4dfdd79e4a77b46fa45e55361a6d"
+checksum = "f173ec75d8de91e0e35a407194d08485d2223677454f05b5da2db972b24df974"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "ferrocat-po"
-version = "0.13.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "558ef350bbffb67fef943accc5c12a9befd0af7804271717fa6e5b396a9232bf"
+checksum = "e2fa50979209270c31048ae3ab02e020b1d9693c0da916b8119a7c627ddcd759"
 dependencies = [
  "ferrocat-icu",
  "icu_locale",
@@ -219,6 +229,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "tempfile",
 ]
 
 [[package]]
@@ -318,6 +329,17 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
 ]
 
 [[package]]
@@ -452,6 +474,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -559,6 +587,12 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "outref"
@@ -922,6 +956,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rayon"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -975,6 +1015,19 @@ name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
 
 [[package]]
 name = "rustversion"
@@ -1127,6 +1180,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1221,6 +1287,15 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "writeable"

--- a/crates/palamedes/Cargo.toml
+++ b/crates/palamedes/Cargo.toml
@@ -8,7 +8,7 @@ rust-version.workspace = true
 description = "Rust core for Palamedes."
 
 [dependencies]
-ferrocat = "0.13.0"
+ferrocat = "1.1.1"
 oxc_allocator = "0.133.0"
 oxc_ast = "0.133.0"
 oxc_ast_visit = "0.133.0"

--- a/crates/palamedes/src/catalog_artifact/load.rs
+++ b/crates/palamedes/src/catalog_artifact/load.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 use std::fs;
 use std::path::Path;
 
-use ferrocat::{parse_catalog, NormalizedParsedCatalog, ParseCatalogOptions, PluralEncoding};
+use ferrocat::{parse_catalog, CatalogMode, NormalizedParsedCatalog, ParseCatalogOptions};
 
 use crate::error::{PalamedesError, PalamedesResult};
 
@@ -31,15 +31,11 @@ pub(super) fn load_catalogs(
             path: file.clone(),
             source,
         })?;
-        let parsed = parse_catalog(ParseCatalogOptions {
-            content: &content,
-            locale: Some(locale.as_str()),
-            source_locale: &config.source_locale,
-            plural_encoding: PluralEncoding::Icu,
-            strict: false,
-            ..ParseCatalogOptions::default()
-        })
-        .map_err(|source| PalamedesError::ParseCatalog {
+        let mut options = ParseCatalogOptions::new(&content, &config.source_locale);
+        options.locale = Some(locale.as_str());
+        options.mode = CatalogMode::IcuPo;
+
+        let parsed = parse_catalog(options).map_err(|source| PalamedesError::ParseCatalog {
             path: file.clone(),
             source,
         })?;

--- a/crates/palamedes/src/catalog_artifact/mod.rs
+++ b/crates/palamedes/src/catalog_artifact/mod.rs
@@ -100,10 +100,10 @@ pub fn compile_catalog_artifact_selected(
         &request.config.source_locale,
         &request.compiled_ids,
     );
-    options.fallback_chain = &ferrocat_fallback_chain;
-    options.key_strategy = CompiledKeyStrategy::FerrocatV1;
-    options.source_fallback = true;
-    options.icu_compatibility = true;
+    options.options.fallback_chain = &ferrocat_fallback_chain;
+    options.options.key_strategy = CompiledKeyStrategy::FerrocatV1;
+    options.options.source_fallback = true;
+    options.options.icu_compatibility = true;
 
     let mut artifact =
         ferrocat_compile_catalog_artifact_selected(&catalogs, &compiled_id_index, &options)

--- a/crates/palamedes/src/catalog_audit.rs
+++ b/crates/palamedes/src/catalog_audit.rs
@@ -3,8 +3,8 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use ferrocat::{
-    audit_catalogs as ferrocat_audit_catalogs, parse_catalog, CatalogAuditOptions,
-    NormalizedParsedCatalog, ParseCatalogOptions, PluralEncoding,
+    audit_catalogs as ferrocat_audit_catalogs, parse_catalog, CatalogAuditOptions, CatalogMode,
+    NormalizedParsedCatalog, ParseCatalogOptions,
 };
 use serde::{Deserialize, Serialize};
 
@@ -249,15 +249,11 @@ fn load_audit_catalogs(
             path: path.clone(),
             source,
         })?;
-        let parsed = parse_catalog(ParseCatalogOptions {
-            content: &content,
-            locale: Some(locale.as_str()),
-            source_locale: &config.source_locale,
-            plural_encoding: PluralEncoding::Icu,
-            strict: false,
-            ..ParseCatalogOptions::default()
-        })
-        .map_err(|source| PalamedesError::ParseCatalog {
+        let mut options = ParseCatalogOptions::new(&content, &config.source_locale);
+        options.locale = Some(locale.as_str());
+        options.mode = CatalogMode::IcuPo;
+
+        let parsed = parse_catalog(options).map_err(|source| PalamedesError::ParseCatalog {
             path: path.clone(),
             source,
         })?;

--- a/crates/palamedes/src/catalog_combine.rs
+++ b/crates/palamedes/src/catalog_combine.rs
@@ -4,7 +4,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use ferrocat::{
     combine_catalogs as ferrocat_combine_catalogs, CatalogCombineInput as FerrocatCombineInput,
-    CatalogStorageFormat, CombineCatalogOptions, OrderBy, PluralEncoding,
+    CatalogMode, CombineCatalogOptions, OrderBy,
 };
 use serde::{Deserialize, Serialize};
 
@@ -152,12 +152,12 @@ pub struct CatalogMergeResult {
 /// Returns an error when inputs are invalid, cannot be parsed, or contain
 /// rejected translation conflicts.
 pub fn combine_catalogs(request: CatalogCombineRequest) -> PalamedesResult<CatalogCombineResult> {
-    combine_catalog_contents(request, CatalogStorageFormat::Po)
+    combine_catalog_contents(request, CatalogMode::IcuPo)
 }
 
 fn combine_catalog_contents(
     request: CatalogCombineRequest,
-    storage_format: CatalogStorageFormat,
+    mode: CatalogMode,
 ) -> PalamedesResult<CatalogCombineResult> {
     let inputs = request
         .inputs
@@ -168,21 +168,17 @@ fn combine_catalog_contents(
         })
         .collect::<Vec<_>>();
 
-    let result = ferrocat_combine_catalogs(CombineCatalogOptions {
-        inputs: &inputs,
-        locale: request.locale.as_deref(),
-        source_locale: &request.source_locale,
-        storage_format,
-        plural_encoding: PluralEncoding::Icu,
-        conflict_strategy: request.conflict_strategy.into(),
-        selection: request.selection.into(),
-        order_by: OrderBy::Msgid,
-        include_origins: true,
-        include_line_numbers: true,
-        include_obsolete: request.include_obsolete,
-        ..CombineCatalogOptions::default()
-    })
-    .map_err(PalamedesError::from)?;
+    let mut options = CombineCatalogOptions::new(&inputs, &request.source_locale);
+    options.locale = request.locale.as_deref();
+    options.mode = mode;
+    options.conflict_strategy = request.conflict_strategy.into();
+    options.selection = request.selection.into();
+    options.order_by = OrderBy::Msgid;
+    options.include_origins = true;
+    options.include_line_numbers = true;
+    options.include_obsolete = request.include_obsolete;
+
+    let result = ferrocat_combine_catalogs(options).map_err(PalamedesError::from)?;
 
     Ok(CatalogCombineResult {
         content: result.content,
@@ -282,11 +278,11 @@ impl From<CatalogCombineSelection> for ferrocat::CatalogCombineSelection {
     }
 }
 
-impl From<CatalogMergeFormat> for CatalogStorageFormat {
+impl From<CatalogMergeFormat> for CatalogMode {
     fn from(value: CatalogMergeFormat) -> Self {
         match value {
-            CatalogMergeFormat::Po => Self::Po,
-            CatalogMergeFormat::Json => Self::Ndjson,
+            CatalogMergeFormat::Po => Self::IcuPo,
+            CatalogMergeFormat::Json => Self::IcuNdjson,
         }
     }
 }

--- a/crates/palamedes/src/catalog_update.rs
+++ b/crates/palamedes/src/catalog_update.rs
@@ -6,8 +6,8 @@ use crate::error::{PalamedesError, PalamedesResult};
 use ferrocat::MachineTranslationMetadata as FerrocatMachineTranslationMetadata;
 use ferrocat::{
     parse_catalog as ferrocat_parse_catalog, update_catalog_file as ferrocat_update_catalog_file,
-    CatalogOrigin, CatalogStats, CatalogUpdateInput, CatalogUpdateResult, ObsoleteStrategy,
-    ParseCatalogOptions, ParsedCatalog, PlaceholderCommentMode, PluralEncoding,
+    CatalogMode, CatalogOrigin, CatalogStats, CatalogUpdateInput, CatalogUpdateResult,
+    ObsoleteStrategy, ParseCatalogOptions, ParsedCatalog, PlaceholderCommentMode,
     SourceExtractedMessage, UpdateCatalogFileOptions,
 };
 use serde::{Deserialize, Serialize};
@@ -190,15 +190,11 @@ pub fn parse_catalog(request: &CatalogParseRequest) -> PalamedesResult<CatalogPa
             path: target_path,
             source,
         })?;
-    let parsed = ferrocat_parse_catalog(ParseCatalogOptions {
-        content: &content,
-        locale: Some(&request.locale),
-        source_locale: &request.source_locale,
-        plural_encoding: PluralEncoding::Icu,
-        strict: false,
-        ..ParseCatalogOptions::default()
-    })
-    .map_err(PalamedesError::from)?;
+    let mut options = ParseCatalogOptions::new(&content, &request.source_locale);
+    options.locale = Some(&request.locale);
+    options.mode = CatalogMode::IcuPo;
+
+    let parsed = ferrocat_parse_catalog(options).map_err(PalamedesError::from)?;
 
     Ok(public_parse_result(parsed))
 }
@@ -217,25 +213,22 @@ fn update_catalog_file_source_first(
             .collect::<Result<Vec<_>, _>>()?,
     );
 
-    let result = ferrocat_update_catalog_file(UpdateCatalogFileOptions {
-        target_path: &target_path,
-        locale: Some(&request.locale),
-        source_locale: &request.source_locale,
-        input,
-        plural_encoding: PluralEncoding::Icu,
-        obsolete_strategy: if request.clean {
-            ObsoleteStrategy::Delete
-        } else {
-            ObsoleteStrategy::Mark
-        },
-        overwrite_source_translations: true,
-        custom_header_attributes: Some(&custom_header_attributes),
-        include_origins: true,
-        include_line_numbers: true,
-        print_placeholders_in_comments: PlaceholderCommentMode::Enabled { limit: 3 },
-        ..UpdateCatalogFileOptions::default()
-    })
-    .map_err(PalamedesError::from)?;
+    let mut options = UpdateCatalogFileOptions::new(&target_path, &request.source_locale, input);
+    options.options.locale = Some(&request.locale);
+    options.options.mode = CatalogMode::IcuPo;
+    options.options.obsolete_strategy = if request.clean {
+        ObsoleteStrategy::Delete
+    } else {
+        ObsoleteStrategy::Mark
+    };
+    options.options.overwrite_source_translations = true;
+    options.options.render.custom_header_attributes = Some(&custom_header_attributes);
+    options.options.render.include_origins = true;
+    options.options.render.include_line_numbers = true;
+    options.options.render.print_placeholders_in_comments =
+        PlaceholderCommentMode::Enabled { limit: 3 };
+
+    let result = ferrocat_update_catalog_file(options).map_err(PalamedesError::from)?;
 
     Ok(public_update_result(result))
 }


### PR DESCRIPTION
## Dependency group
- Packages: `ferrocat`, `ferrocat-icu`, `ferrocat-po` `0.13.0` -> `1.1.1`
- Why grouped: Ferrocat owns the catalog parse/update/audit/combine/artifact API surface, and the workspace crates move together.

## Upstream changes that matter here
- Ferrocat 1.0.0 introduced the relevant breaking API change: redundant parse/update/combine option fields were collapsed into `CatalogMode`: https://github.com/sebastian-software/ferrocat/releases/tag/ferrocat-v1.0.0
- Ferrocat 1.1.0 re-exported NDJSON streaming APIs; Palamedes does not use those streaming APIs directly in this PR: https://github.com/sebastian-software/ferrocat/releases/tag/ferrocat-v1.1.0
- Ferrocat 1.1.1 is a dependency-maintenance patch over 1.1.0: https://github.com/sebastian-software/ferrocat/releases/tag/ferrocat-v1.1.1
- `ferrocat@1.1.1` still declares `rust-version = 1.93.0`, matching this repository's Rust floor.

## Local impact and code changes
- Migrated parse, update, audit, combine, and catalog artifact call sites from old field literals/defaults to the new constructors.
- Preserved existing behavior by setting `CatalogMode::IcuPo` for PO flows and `CatalogMode::IcuNdjson` for JSON/NDJSON merge flows.
- Updated selected artifact options through the new nested `.options` field.
- Kept source fallback, placeholder comments, origin rendering, line numbers, obsolete handling, and Ferrocat v1 key strategy aligned with the previous calls.

## Validation
- `cargo +1.93.0 check --workspace --locked`: passed
- `cargo fmt --all --check`: passed
- `cargo clippy --workspace --all-targets --locked -- -D warnings`: passed
- `cargo test --workspace --locked`: passed, 73 library tests and 1 doctest

## Risk
- Higher catalog-path risk because this crosses a major Ferrocat API boundary.
- Existing catalog update, combine, audit, artifact, ICU compatibility, transform, extraction, and metadata tests all pass after the migration.