### PR TITLE
[codex] Adopt Ferrocat runtime ICU options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,9 +199,9 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ferrocat"
-version = "1.1.1"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec752a5b60b7f537aa5a82f1a48c49834d325659817bd71854f79154116fec07"
+checksum = "ef826c9078b8f7ec87c105c991f0e0f4e900d5f30de5f4591829d01228ded67e"
 dependencies = [
  "ferrocat-icu",
  "ferrocat-po",
@@ -209,18 +209,18 @@ dependencies = [
 
 [[package]]
 name = "ferrocat-icu"
-version = "1.1.1"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f173ec75d8de91e0e35a407194d08485d2223677454f05b5da2db972b24df974"
+checksum = "72fbe26a76bec82113839d12983804bcbd23f0d16e12a8b16ddfda04dd61e4ed"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "ferrocat-po"
-version = "1.1.1"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2fa50979209270c31048ae3ab02e020b1d9693c0da916b8119a7c627ddcd759"
+checksum = "57ef06cd734d91a47309b8b459c55379ca6e2882523e073d0fdff0132cffeb38"
 dependencies = [
  "ferrocat-icu",
  "icu_locale",
@@ -850,6 +850,7 @@ name = "palamedes"
 version = "0.7.0"
 dependencies = [
  "ferrocat",
+ "ferrocat-po",
  "oxc_allocator",
  "oxc_ast",
  "oxc_ast_visit",

--- a/crates/palamedes/Cargo.toml
+++ b/crates/palamedes/Cargo.toml
@@ -8,7 +8,8 @@ rust-version.workspace = true
 description = "Rust core for Palamedes."
 
 [dependencies]
-ferrocat = "1.1.1"
+ferrocat = "1.2.1"
+ferrocat-po = "1.2.1"
 oxc_allocator = "0.133.0"
 oxc_ast = "0.133.0"
 oxc_ast_visit = "0.133.0"

--- a/crates/palamedes/src/catalog_artifact/compile.rs
+++ b/crates/palamedes/src/catalog_artifact/compile.rs
@@ -1,54 +1,18 @@
-use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 use ferrocat::{
-    compare_icu_messages, validate_icu_formatter_support, CompiledCatalogArtifact,
-    CompiledCatalogDiagnostic, CompiledCatalogIdIndex, DiagnosticSeverity, IcuArgumentKind,
-    IcuCompatibilityOptions, IcuDiagnosticSeverity, IcuFormatter, IcuFormatterSupport,
+    CompileCatalogArtifactIcuOptions, IcuArgumentKind, IcuDiagnosticSeverity, IcuFormatter,
+    IcuFormatterSupport, IcuSyntaxPolicy,
 };
-
-use crate::runtime_icu::parse_runtime_icu;
 
 use super::types::{
     CatalogArtifactDiagnostic, CatalogArtifactMissingMessage, CatalogArtifactResult,
 };
 
-pub(super) fn align_diagnostics_with_runtime_icu_semantics(
-    artifact: &mut CompiledCatalogArtifact,
-    compiled_id_index: &CompiledCatalogIdIndex,
-    requested_locale: &str,
-) {
-    let runtime_message_locales = runtime_message_locales(artifact, requested_locale);
-    let diagnostics = std::mem::take(&mut artifact.diagnostics);
-    let mut aligned = Vec::with_capacity(diagnostics.len());
-    let mut additional = Vec::new();
-
-    for diagnostic in diagnostics {
-        if diagnostic.code == "compile.invalid_icu_message" {
-            if let Some(runtime_message) = artifact.messages.get(&diagnostic.key) {
-                if parse_runtime_icu(runtime_message).is_some()
-                    && push_runtime_icu_compatibility_diagnostics(
-                        &diagnostic,
-                        runtime_message,
-                        &mut additional,
-                    )
-                {
-                    continue;
-                }
-            }
-        }
-
-        aligned.push(diagnostic);
-    }
-
-    aligned.extend(additional);
-    artifact.diagnostics = aligned;
-    push_runtime_icu_formatter_support_diagnostics(
-        artifact,
-        compiled_id_index,
-        &runtime_message_locales,
-        requested_locale,
-    );
+pub(super) fn runtime_icu_options() -> CompileCatalogArtifactIcuOptions {
+    CompileCatalogArtifactIcuOptions::new()
+        .with_syntax_policy(IcuSyntaxPolicy::RuntimeLiteralApostrophes)
+        .with_formatter_support(runtime_icu_formatter_support)
 }
 
 pub(super) fn build_artifact_result(
@@ -82,91 +46,6 @@ pub(super) fn build_artifact_result(
             .collect(),
         resolved_locale_chain: Some(fallback_chain),
     }
-}
-
-fn push_runtime_icu_compatibility_diagnostics(
-    diagnostic: &CompiledCatalogDiagnostic,
-    runtime_message: &str,
-    diagnostics: &mut Vec<CompiledCatalogDiagnostic>,
-) -> bool {
-    let Some(source_icu) = parse_runtime_icu(&diagnostic.msgid) else {
-        return false;
-    };
-    let Some(runtime_icu) = parse_runtime_icu(runtime_message) else {
-        return false;
-    };
-
-    let report = compare_icu_messages(
-        &source_icu,
-        &runtime_icu,
-        &IcuCompatibilityOptions::default(),
-    );
-    for icu_diagnostic in report.diagnostics {
-        diagnostics.push(CompiledCatalogDiagnostic {
-            severity: runtime_icu_diagnostic_severity(icu_diagnostic.severity),
-            code: icu_diagnostic.code,
-            message: icu_diagnostic.message,
-            key: diagnostic.key.clone(),
-            msgid: diagnostic.msgid.clone(),
-            msgctxt: diagnostic.msgctxt.clone(),
-            locale: diagnostic.locale.clone(),
-        });
-    }
-
-    true
-}
-
-fn push_runtime_icu_formatter_support_diagnostics(
-    artifact: &mut CompiledCatalogArtifact,
-    compiled_id_index: &CompiledCatalogIdIndex,
-    runtime_message_locales: &BTreeMap<String, String>,
-    requested_locale: &str,
-) {
-    for (compiled_id, runtime_message) in &artifact.messages {
-        let Some(source_key) = compiled_id_index.get(compiled_id) else {
-            continue;
-        };
-        let Some(runtime_icu) = parse_runtime_icu(runtime_message) else {
-            continue;
-        };
-
-        let report = validate_icu_formatter_support(&runtime_icu, runtime_icu_formatter_support);
-        let locale = runtime_message_locales
-            .get(compiled_id)
-            .map(String::as_str)
-            .unwrap_or(requested_locale);
-
-        for icu_diagnostic in report.diagnostics {
-            artifact.diagnostics.push(CompiledCatalogDiagnostic {
-                severity: runtime_icu_diagnostic_severity(icu_diagnostic.severity),
-                code: icu_diagnostic.code,
-                message: icu_diagnostic.message,
-                key: compiled_id.clone(),
-                msgid: source_key.msgid.clone(),
-                msgctxt: source_key.msgctxt.clone(),
-                locale: locale.to_owned(),
-            });
-        }
-    }
-}
-
-fn runtime_message_locales(
-    artifact: &CompiledCatalogArtifact,
-    requested_locale: &str,
-) -> BTreeMap<String, String> {
-    artifact
-        .missing
-        .iter()
-        .map(|missing| {
-            (
-                missing.key.clone(),
-                missing
-                    .resolved_locale
-                    .clone()
-                    .unwrap_or_else(|| requested_locale.to_owned()),
-            )
-        })
-        .collect()
 }
 
 fn runtime_icu_formatter_support(formatter: &IcuFormatter) -> IcuFormatterSupport {
@@ -219,14 +98,6 @@ fn is_supported_runtime_date_time_style(style: Option<&str>) -> bool {
     };
 
     matches!(style, "short" | "medium" | "long" | "full")
-}
-
-const fn runtime_icu_diagnostic_severity(severity: IcuDiagnosticSeverity) -> DiagnosticSeverity {
-    match severity {
-        IcuDiagnosticSeverity::Info => DiagnosticSeverity::Info,
-        IcuDiagnosticSeverity::Warning => DiagnosticSeverity::Warning,
-        IcuDiagnosticSeverity::Error => DiagnosticSeverity::Error,
-    }
 }
 
 fn pseudolocalize_message(message: &str) -> String {

--- a/crates/palamedes/src/catalog_artifact/mod.rs
+++ b/crates/palamedes/src/catalog_artifact/mod.rs
@@ -9,15 +9,15 @@ mod tests;
 use std::path::PathBuf;
 
 use ferrocat::{
-    compile_catalog_artifact as ferrocat_compile_catalog_artifact,
-    compile_catalog_artifact_selected as ferrocat_compile_catalog_artifact_selected,
+    compile_catalog_artifact_selected_with_icu_options as ferrocat_compile_catalog_artifact_selected,
+    compile_catalog_artifact_with_icu_options as ferrocat_compile_catalog_artifact,
     CompileCatalogArtifactOptions, CompileSelectedCatalogArtifactOptions, CompiledCatalogIdIndex,
     CompiledKeyStrategy,
 };
 
 use crate::error::{PalamedesError, PalamedesResult};
 
-use self::compile::{align_diagnostics_with_runtime_icu_semantics, build_artifact_result};
+use self::compile::{build_artifact_result, runtime_icu_options};
 use self::load::LocaleCatalogs;
 use self::resolve::{ferrocat_fallback_chain, prepare_compilation};
 pub use self::types::{
@@ -52,20 +52,14 @@ pub fn compile_catalog_artifact(
     );
     let mut options =
         CompileCatalogArtifactOptions::new(&prepared.locale, &request.config.source_locale);
-    let compiled_id_index = CompiledCatalogIdIndex::new(&catalogs, CompiledKeyStrategy::FerrocatV1)
-        .map_err(PalamedesError::BuildCompiledIdIndex)?;
     options.fallback_chain = &ferrocat_fallback_chain;
     options.key_strategy = CompiledKeyStrategy::FerrocatV1;
     options.source_fallback = true;
     options.icu_compatibility = true;
 
-    let mut artifact = ferrocat_compile_catalog_artifact(&catalogs, &options)
+    let icu_options = runtime_icu_options();
+    let artifact = ferrocat_compile_catalog_artifact(&catalogs, &options, &icu_options)
         .map_err(PalamedesError::CompileCatalogArtifact)?;
-    align_diagnostics_with_runtime_icu_semantics(
-        &mut artifact,
-        &compiled_id_index,
-        &prepared.locale,
-    );
 
     Ok(build_artifact_result(
         artifact,
@@ -105,14 +99,14 @@ pub fn compile_catalog_artifact_selected(
     options.options.source_fallback = true;
     options.options.icu_compatibility = true;
 
-    let mut artifact =
-        ferrocat_compile_catalog_artifact_selected(&catalogs, &compiled_id_index, &options)
-            .map_err(PalamedesError::CompileSelectedCatalogArtifact)?;
-    align_diagnostics_with_runtime_icu_semantics(
-        &mut artifact,
+    let icu_options = runtime_icu_options();
+    let artifact = ferrocat_compile_catalog_artifact_selected(
+        &catalogs,
         &compiled_id_index,
-        &prepared.locale,
-    );
+        &options,
+        &icu_options,
+    )
+    .map_err(PalamedesError::CompileSelectedCatalogArtifact)?;
 
     Ok(build_artifact_result(
         artifact,

--- a/crates/palamedes/src/catalog_artifact/tests.rs
+++ b/crates/palamedes/src/catalog_artifact/tests.rs
@@ -256,7 +256,7 @@ msgstr "Konnte {firstName}'s Daten nicht laden"
 }
 
 #[test]
-fn compile_catalog_artifact_keeps_invalid_icu_when_source_msgid_cannot_parse() {
+fn compile_catalog_artifact_accepts_runtime_valid_translation_when_source_msgid_cannot_parse() {
     let fixture = create_fixture_dir("catalog-artifact-apostrophe-source-invalid");
     let locale_dir = fixture.join("src/locales");
     fs::create_dir_all(&locale_dir).expect("locale dir");
@@ -300,7 +300,7 @@ msgstr "John's Daten konnten nicht geladen werden"
     };
     let result = compile_catalog_artifact(&request).expect("catalog artifact");
 
-    assert!(result.diagnostics.iter().any(|diagnostic| {
+    assert!(!result.diagnostics.iter().any(|diagnostic| {
         diagnostic.code == "compile.invalid_icu_message"
             && diagnostic.source_key.message == "{unclosed"
             && diagnostic.locale == "de"

--- a/crates/palamedes/src/catalog_audit.rs
+++ b/crates/palamedes/src/catalog_audit.rs
@@ -3,16 +3,17 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use ferrocat::{
-    audit_catalogs as ferrocat_audit_catalogs, parse_catalog, CatalogAuditOptions,
-    CatalogAuditReport, CatalogMessage, CatalogMode, DiagnosticSeverity, EffectiveTranslationRef,
-    NormalizedParsedCatalog, ParseCatalogOptions,
+    parse_catalog, CatalogAuditOptions, CatalogMode, IcuSyntaxPolicy, NormalizedParsedCatalog,
+    ParseCatalogOptions,
+};
+use ferrocat_po::{
+    audit_catalogs_with_icu_options as ferrocat_audit_catalogs, CatalogAuditIcuOptions,
 };
 use serde::{Deserialize, Serialize};
 
 use crate::diagnostic::{CatalogDiagnosticSeverity, CatalogDiagnosticSourceKey};
 use crate::error::{PalamedesError, PalamedesResult};
 use crate::message_metadata::MessageMetadataInput;
-use crate::runtime_icu::parse_runtime_icu;
 
 use super::catalog_artifact::{CatalogArtifactConfig, CatalogConfig};
 
@@ -147,13 +148,10 @@ pub fn audit_catalogs(request: CatalogAuditRequest) -> PalamedesResult<CatalogAu
         options.metadata = &metadata;
         options.checks = request.checks.to_ferrocat_checks();
 
-        let mut report =
-            ferrocat_audit_catalogs(&catalogs, &options).map_err(PalamedesError::from)?;
-        align_report_with_runtime_icu_semantics(
-            &mut report,
-            &catalogs,
-            &request.config.source_locale,
-        );
+        let icu_options = CatalogAuditIcuOptions::new()
+            .with_syntax_policy(IcuSyntaxPolicy::RuntimeLiteralApostrophes);
+        let report = ferrocat_audit_catalogs(&catalogs, &options, &icu_options)
+            .map_err(PalamedesError::from)?;
         add_summary(&mut result.summary, &report.summary);
 
         let paths_by_locale = paths_by_locale(&request.config, catalog);
@@ -303,101 +301,6 @@ fn diagnostic_locale_from_name(code: &str, name: Option<&str>) -> Option<String>
     match code {
         "catalog.missing_locale" | "catalog.missing_source_locale" => name.map(str::to_owned),
         _ => None,
-    }
-}
-
-fn align_report_with_runtime_icu_semantics(
-    report: &mut CatalogAuditReport,
-    catalogs: &[&NormalizedParsedCatalog],
-    source_locale: &str,
-) {
-    let diagnostics = std::mem::take(&mut report.diagnostics);
-    report.diagnostics = diagnostics
-        .into_iter()
-        .filter(|diagnostic| {
-            diagnostic.code != "icu.invalid_syntax"
-                || !diagnostic_matches_runtime_valid_icu(diagnostic, catalogs, source_locale)
-        })
-        .collect();
-    refresh_report_summary(report);
-}
-
-fn diagnostic_matches_runtime_valid_icu(
-    diagnostic: &ferrocat::CatalogAuditDiagnostic,
-    catalogs: &[&NormalizedParsedCatalog],
-    source_locale: &str,
-) -> bool {
-    let Some(source_key) = &diagnostic.source_key else {
-        return false;
-    };
-    let Some(locale) = source_key.locale.as_deref() else {
-        return false;
-    };
-    let Some(catalog) = catalogs
-        .iter()
-        .copied()
-        .find(|catalog| catalog.parsed_catalog().locale.as_deref() == Some(locale))
-    else {
-        return false;
-    };
-    let Some(message) = catalog.get_by_parts(&source_key.msgid, source_key.msgctxt.as_deref())
-    else {
-        return false;
-    };
-
-    runtime_validates_all_strict_invalid_message_strings(message, locale == source_locale)
-}
-
-fn runtime_validates_all_strict_invalid_message_strings(
-    message: &CatalogMessage,
-    include_msgid: bool,
-) -> bool {
-    let mut invalid_values = Vec::new();
-    if include_msgid {
-        push_unique_message_value(&mut invalid_values, message.msgid.as_str());
-    }
-    match message.effective_translation() {
-        EffectiveTranslationRef::Singular(value) => {
-            push_unique_message_value(&mut invalid_values, value);
-        }
-        EffectiveTranslationRef::Plural(translations) => {
-            for value in translations.values().map(String::as_str) {
-                push_unique_message_value(&mut invalid_values, value);
-            }
-        }
-    }
-
-    let mut has_strict_invalid_value = false;
-    let all_strict_invalid_values_are_runtime_valid = invalid_values
-        .into_iter()
-        .filter(|value| !value.trim().is_empty())
-        .filter(|value| {
-            let invalid = ferrocat::parse_icu(value).is_err();
-            has_strict_invalid_value |= invalid;
-            invalid
-        })
-        .all(|value| parse_runtime_icu(value).is_some());
-
-    has_strict_invalid_value && all_strict_invalid_values_are_runtime_valid
-}
-
-fn push_unique_message_value<'a>(values: &mut Vec<&'a str>, value: &'a str) {
-    if !values.contains(&value) {
-        values.push(value);
-    }
-}
-
-fn refresh_report_summary(report: &mut CatalogAuditReport) {
-    report.summary.diagnostics = report.diagnostics.len();
-    report.summary.errors = 0;
-    report.summary.warnings = 0;
-    report.summary.infos = 0;
-    for diagnostic in &report.diagnostics {
-        match diagnostic.severity {
-            DiagnosticSeverity::Error => report.summary.errors += 1,
-            DiagnosticSeverity::Warning => report.summary.warnings += 1,
-            DiagnosticSeverity::Info => report.summary.infos += 1,
-        }
     }
 }
 

--- a/crates/palamedes/src/lib.rs
+++ b/crates/palamedes/src/lib.rs
@@ -210,6 +210,15 @@ mod tests {
     }
 
     #[test]
+    fn ferrocat_version_matches_declared_dependency() {
+        let manifest = include_str!("../Cargo.toml");
+        let declared = dependency_version(manifest, "ferrocat")
+            .expect("ferrocat dependency should be declared");
+
+        assert_eq!(FERROCAT_VERSION, declared);
+    }
+
+    #[test]
     fn generates_internal_lookup_keys_via_ferrocat_v1() {
         assert_eq!(compiled_key("Hello", None), "mCRI2NMFS5Y");
     }
@@ -245,5 +254,45 @@ msgstr "Hallo"
             po.items[0].metadata.get("ferrocat-mt").map(String::as_str),
             Some("model=openai/gpt-5.5-high confidence=95 hash=abc")
         );
+    }
+
+    fn dependency_version<'a>(manifest: &'a str, name: &str) -> Option<&'a str> {
+        let mut in_dependencies = false;
+        for line in manifest.lines().map(str::trim) {
+            if line.starts_with('[') {
+                in_dependencies = line == "[dependencies]";
+                continue;
+            }
+            if !in_dependencies || line.starts_with('#') {
+                continue;
+            }
+
+            let Some((key, value)) = line.split_once('=') else {
+                continue;
+            };
+            if key.trim() == name {
+                return dependency_value_version(value.trim());
+            }
+        }
+        None
+    }
+
+    fn dependency_value_version(value: &str) -> Option<&str> {
+        if let Some(value) = value.strip_prefix('"') {
+            return value.split('"').next();
+        }
+
+        value
+            .trim_start_matches('{')
+            .trim_end_matches('}')
+            .split(',')
+            .find_map(|entry| {
+                let (key, value) = entry.split_once('=')?;
+                if key.trim() == "version" {
+                    value.trim().strip_prefix('"')?.split('"').next()
+                } else {
+                    None
+                }
+            })
     }
 }

--- a/crates/palamedes/src/lib.rs
+++ b/crates/palamedes/src/lib.rs
@@ -26,7 +26,6 @@ mod diagnostic;
 mod error;
 mod extract;
 mod message_metadata;
-mod runtime_icu;
 mod transform;
 
 use ferrocat::{parse_po as ferrocat_parse_po, MsgStr, PoFile, PoItem};
@@ -71,7 +70,7 @@ pub use transform::{
 };
 
 /// Published `ferrocat` version used by the Rust core.
-pub const FERROCAT_VERSION: &str = "0.12.0";
+pub const FERROCAT_VERSION: &str = "1.2.1";
 
 /// Version metadata for the loaded native core.
 #[derive(Debug, Serialize)]

--- a/crates/palamedes/src/runtime_icu.rs
+++ b/crates/palamedes/src/runtime_icu.rs
@@ -1,9 +1,0 @@
-use ferrocat::{parse_icu, IcuMessage};
-
-pub(crate) fn parse_runtime_icu(message: &str) -> Option<IcuMessage> {
-    parse_icu(&runtime_icu_validation_view(message)).ok()
-}
-
-fn runtime_icu_validation_view(message: &str) -> String {
-    message.replace('\'', "''")
-}


### PR DESCRIPTION
## Dependency group
- Packages: `ferrocat` 1.1.1 -> 1.2.1, `ferrocat-icu` 1.1.1 -> 1.2.1, `ferrocat-po` 1.1.1 -> 1.2.1
- Why grouped: the 1.2.x Ferrocat release moves the runtime ICU syntax and formatter-support hooks that Palamedes was previously handling locally into the catalog engine API.

## Upstream changes that matter here
- Ferrocat 1.2.0 added explicit artifact ICU options, including runtime literal apostrophe syntax handling and formatter support callbacks. That covers the Palamedes follow-up from ferrocat issues #132 and #133.
- Ferrocat 1.2.1 only synchronizes the published workspace crate versions after the 1.2.0 feature release.
- Sources: https://github.com/sebastian-software/ferrocat/releases/tag/ferrocat-v1.2.1, https://github.com/sebastian-software/ferrocat/issues/132, https://github.com/sebastian-software/ferrocat/issues/133

## Local impact and code changes
- Artifact compilation now calls Ferrocat's `*_with_icu_options` APIs with `RuntimeLiteralApostrophes` and Palamedes' runtime formatter support policy.
- Catalog audit now calls Ferrocat PO's ICU-aware audit entry point instead of filtering `icu.invalid_syntax` diagnostics after the report is built.
- Removed `crates/palamedes/src/runtime_icu.rs` and the wrapper-side artifact/report diagnostic mutation code.
- Kept the Palamedes-specific formatter allowlist locally as the callback policy, since those runtime capabilities are still product-specific.

## Validation
- `cargo fmt --all --check`: passed
- `cargo check --workspace --locked`: passed
- `cargo test -p palamedes --locked catalog_artifact -- --nocapture`: passed
- `cargo test -p palamedes --locked catalog_audit -- --nocapture`: passed
- `cargo test --workspace --locked`: passed
- `cargo clippy --workspace --all-targets --locked -- -D warnings`: passed

## Risk
- Main risk is audit/artifact diagnostic shape drift, especially around messages with literal apostrophes and formatter support warnings. The existing regression tests now exercise those paths through Ferrocat's API rather than Palamedes post-processing.
- I added a direct `ferrocat-po` dependency because the audit ICU options are exposed there but not through the umbrella `ferrocat` crate in 1.2.1. If Ferrocat re-exports that audit API later, Palamedes can collapse back to the single dependency.