### PR TITLE
refactor(core): use Ferrocat pseudolocalization

### DIFF
--- a/crates/palamedes/src/catalog_artifact/compile.rs
+++ b/crates/palamedes/src/catalog_artifact/compile.rs
@@ -1,9 +1,12 @@
 use std::path::PathBuf;
 
 use ferrocat::{
-    CompileCatalogArtifactIcuOptions, IcuArgumentKind, IcuDiagnosticSeverity, IcuFormatter,
-    IcuFormatterSupport, IcuSyntaxPolicy,
+    pseudolocalize_compiled_catalog_artifact_with_syntax_policy, CompileCatalogArtifactIcuOptions,
+    IcuArgumentKind, IcuDiagnosticSeverity, IcuFormatter, IcuFormatterSupport,
+    IcuPseudolocalizationOptions, IcuSyntaxPolicy,
 };
+
+use crate::error::PalamedesResult;
 
 use super::types::{
     CatalogArtifactDiagnostic, CatalogArtifactMissingMessage, CatalogArtifactResult,
@@ -16,19 +19,23 @@ pub(super) fn runtime_icu_options() -> CompileCatalogArtifactIcuOptions {
 }
 
 pub(super) fn build_artifact_result(
-    mut artifact: ferrocat::CompiledCatalogArtifact,
+    artifact: ferrocat::CompiledCatalogArtifact,
     watch_files: Vec<PathBuf>,
     fallback_chain: Vec<String>,
     pseudo_locale: Option<&str>,
     locale: &str,
-) -> CatalogArtifactResult {
-    if pseudo_locale == Some(locale) {
-        for value in artifact.messages.values_mut() {
-            *value = pseudolocalize_message(value);
-        }
-    }
+) -> PalamedesResult<CatalogArtifactResult> {
+    let artifact = if pseudo_locale == Some(locale) {
+        pseudolocalize_compiled_catalog_artifact_with_syntax_policy(
+            &artifact,
+            &IcuPseudolocalizationOptions::new(),
+            IcuSyntaxPolicy::RuntimeLiteralApostrophes,
+        )?
+    } else {
+        artifact
+    };
 
-    CatalogArtifactResult {
+    Ok(CatalogArtifactResult {
         messages: artifact.messages,
         watch_files: watch_files
             .into_iter()
@@ -45,7 +52,7 @@ pub(super) fn build_artifact_result(
             .map(CatalogArtifactDiagnostic::from)
             .collect(),
         resolved_locale_chain: Some(fallback_chain),
-    }
+    })
 }
 
 fn runtime_icu_formatter_support(formatter: &IcuFormatter) -> IcuFormatterSupport {
@@ -98,65 +105,4 @@ fn is_supported_runtime_date_time_style(style: Option<&str>) -> bool {
     };
 
     matches!(style, "short" | "medium" | "long" | "full")
-}
-
-fn pseudolocalize_message(message: &str) -> String {
-    message
-        .chars()
-        .map(|ch| match ch {
-            'a' => 'á',
-            'b' => 'ƀ',
-            'c' => 'ç',
-            'd' => 'ď',
-            'e' => 'ē',
-            'f' => 'ƒ',
-            'g' => 'ğ',
-            'h' => 'ħ',
-            'i' => 'ī',
-            'j' => 'ĵ',
-            'k' => 'ķ',
-            'l' => 'ľ',
-            'm' => 'ɱ',
-            'n' => 'ń',
-            'o' => 'ō',
-            'p' => 'ƥ',
-            'q' => 'ʠ',
-            'r' => 'ř',
-            's' => 'ş',
-            't' => 'ŧ',
-            'u' => 'ū',
-            'v' => 'ṽ',
-            'w' => 'ŵ',
-            'x' => 'ẋ',
-            'y' => 'ŷ',
-            'z' => 'ž',
-            'A' => 'Å',
-            'B' => 'ß',
-            'C' => 'Ç',
-            'D' => 'Đ',
-            'E' => 'Ē',
-            'F' => 'Ƒ',
-            'G' => 'Ğ',
-            'H' => 'Ħ',
-            'I' => 'Ī',
-            'J' => 'Ĵ',
-            'K' => 'Ķ',
-            'L' => 'Ŀ',
-            'M' => 'Ṁ',
-            'N' => 'Ń',
-            'O' => 'Ø',
-            'P' => 'Ƥ',
-            'Q' => 'Ǫ',
-            'R' => 'Ř',
-            'S' => 'Š',
-            'T' => 'Ŧ',
-            'U' => 'Ū',
-            'V' => 'Ṽ',
-            'W' => 'Ŵ',
-            'X' => 'Ẋ',
-            'Y' => 'Ŷ',
-            'Z' => 'Ž',
-            other => other,
-        })
-        .collect()
 }

--- a/crates/palamedes/src/catalog_artifact/compile.rs
+++ b/crates/palamedes/src/catalog_artifact/compile.rs
@@ -6,7 +6,7 @@ use ferrocat::{
     IcuPseudolocalizationOptions, IcuSyntaxPolicy,
 };
 
-use crate::error::PalamedesResult;
+use crate::error::{PalamedesError, PalamedesResult};
 
 use super::types::{
     CatalogArtifactDiagnostic, CatalogArtifactMissingMessage, CatalogArtifactResult,
@@ -30,7 +30,8 @@ pub(super) fn build_artifact_result(
             &artifact,
             &IcuPseudolocalizationOptions::new(),
             IcuSyntaxPolicy::RuntimeLiteralApostrophes,
-        )?
+        )
+        .map_err(PalamedesError::PseudolocalizeCatalogArtifact)?
     } else {
         artifact
     };

--- a/crates/palamedes/src/catalog_artifact/mod.rs
+++ b/crates/palamedes/src/catalog_artifact/mod.rs
@@ -61,13 +61,13 @@ pub fn compile_catalog_artifact(
     let artifact = ferrocat_compile_catalog_artifact(&catalogs, &options, &icu_options)
         .map_err(PalamedesError::CompileCatalogArtifact)?;
 
-    Ok(build_artifact_result(
+    build_artifact_result(
         artifact,
         prepared.watch_files,
         prepared.fallback_chain,
         request.config.pseudo_locale.as_deref(),
         &prepared.locale,
-    ))
+    )
 }
 
 /// Compiles a selected subset of runtime IDs for the requested locale.
@@ -108,11 +108,11 @@ pub fn compile_catalog_artifact_selected(
     )
     .map_err(PalamedesError::CompileSelectedCatalogArtifact)?;
 
-    Ok(build_artifact_result(
+    build_artifact_result(
         artifact,
         prepared.watch_files,
         prepared.fallback_chain,
         request.config.pseudo_locale.as_deref(),
         &prepared.locale,
-    ))
+    )
 }

--- a/crates/palamedes/src/catalog_artifact/tests.rs
+++ b/crates/palamedes/src/catalog_artifact/tests.rs
@@ -248,6 +248,64 @@ msgstr ""
 }
 
 #[test]
+fn compile_catalog_artifact_selected_pseudolocalizes_with_ferrocat_runtime_syntax_policy() {
+    let fixture = create_fixture_dir("selected-catalog-artifact-pseudo-ferrocat");
+    let locale_dir = fixture.join("src/locales");
+    fs::create_dir_all(&locale_dir).expect("locale dir");
+
+    fs::write(
+        locale_dir.join("en.po"),
+        r#"msgid ""
+msgstr ""
+"Language: en\n"
+
+msgid "You're {name}"
+msgstr ""
+
+msgid "Other"
+msgstr ""
+"#,
+    )
+    .expect("write en");
+
+    fs::write(
+        locale_dir.join("pseudo.po"),
+        r#"msgid ""
+msgstr ""
+"Language: pseudo\n"
+"#,
+    )
+    .expect("write pseudo");
+
+    let request = CatalogArtifactSelectedRequest {
+        config: CatalogArtifactConfig {
+            root_dir: fixture.to_string_lossy().into_owned(),
+            locales: vec!["en".to_owned(), "pseudo".to_owned()],
+            source_locale: "en".to_owned(),
+            fallback_locales: None,
+            pseudo_locale: Some("pseudo".to_owned()),
+            catalogs: vec![CatalogConfig {
+                path: "src/locales/{locale}".to_owned(),
+            }],
+        },
+        resource_path: locale_dir.join("pseudo.po").to_string_lossy().into_owned(),
+        compiled_ids: vec![compiled_key("You're {name}", None)],
+    };
+    let result = compile_catalog_artifact_selected(&request).expect("selected catalog artifact");
+    let message = result
+        .messages
+        .get(&compiled_key("You're {name}", None))
+        .expect("pseudolocalized message");
+
+    assert_eq!(result.messages.len(), 1);
+    assert!(message.starts_with("[!! "));
+    assert!(message.ends_with(" !!]"));
+    assert!(message.contains("{name}"));
+    assert_ne!(message, "You're {name}");
+    assert!(result.diagnostics.is_empty());
+}
+
+#[test]
 fn compile_catalog_artifact_keeps_icu_compatibility_diagnostics_with_apostrophes() {
     let fixture = create_fixture_dir("catalog-artifact-apostrophe-compatibility");
     let locale_dir = fixture.join("src/locales");

--- a/crates/palamedes/src/catalog_artifact/tests.rs
+++ b/crates/palamedes/src/catalog_artifact/tests.rs
@@ -195,6 +195,59 @@ msgstr ""
 }
 
 #[test]
+fn compile_catalog_artifact_pseudolocalizes_with_ferrocat_runtime_syntax_policy() {
+    let fixture = create_fixture_dir("catalog-artifact-pseudo-ferrocat");
+    let locale_dir = fixture.join("src/locales");
+    fs::create_dir_all(&locale_dir).expect("locale dir");
+
+    fs::write(
+        locale_dir.join("en.po"),
+        r#"msgid ""
+msgstr ""
+"Language: en\n"
+
+msgid "You're {name}"
+msgstr ""
+"#,
+    )
+    .expect("write en");
+
+    fs::write(
+        locale_dir.join("pseudo.po"),
+        r#"msgid ""
+msgstr ""
+"Language: pseudo\n"
+"#,
+    )
+    .expect("write pseudo");
+
+    let request = CatalogArtifactRequest {
+        config: CatalogArtifactConfig {
+            root_dir: fixture.to_string_lossy().into_owned(),
+            locales: vec!["en".to_owned(), "pseudo".to_owned()],
+            source_locale: "en".to_owned(),
+            fallback_locales: None,
+            pseudo_locale: Some("pseudo".to_owned()),
+            catalogs: vec![CatalogConfig {
+                path: "src/locales/{locale}".to_owned(),
+            }],
+        },
+        resource_path: locale_dir.join("pseudo.po").to_string_lossy().into_owned(),
+    };
+    let result = compile_catalog_artifact(&request).expect("catalog artifact");
+    let message = result
+        .messages
+        .get(&compiled_key("You're {name}", None))
+        .expect("pseudolocalized message");
+
+    assert!(message.starts_with("[!! "));
+    assert!(message.ends_with(" !!]"));
+    assert!(message.contains("{name}"));
+    assert_ne!(message, "You're {name}");
+    assert!(result.diagnostics.is_empty());
+}
+
+#[test]
 fn compile_catalog_artifact_keeps_icu_compatibility_diagnostics_with_apostrophes() {
     let fixture = create_fixture_dir("catalog-artifact-apostrophe-compatibility");
     let locale_dir = fixture.join("src/locales");

--- a/crates/palamedes/src/error.rs
+++ b/crates/palamedes/src/error.rs
@@ -133,6 +133,9 @@ pub enum PalamedesError {
     /// Compiling a selected catalog artifact failed.
     #[error("Failed to compile selected catalog artifact: {0}")]
     CompileSelectedCatalogArtifact(ferrocat::ApiError),
+    /// Pseudolocalizing a compiled catalog artifact failed.
+    #[error("Failed to pseudolocalize catalog artifact: {0}")]
+    PseudolocalizeCatalogArtifact(ferrocat::ApiError),
     /// Catalog updates require non-empty messages.
     #[error("Catalog messages must not be empty")]
     EmptyCatalogMessage,


### PR DESCRIPTION
## Summary
- replace the Palamedes-local pseudo-locale string mapping with Ferrocat artifact pseudolocalization
- keep pseudolocalization aligned with the runtime literal apostrophe ICU syntax policy
- add regression coverage for pseudo-locale source fallback with placeholders

## Validation
- cargo fmt --all --check
- cargo test -p palamedes --locked