### PR TITLE
chore(deps): adopt Ferrocat file combine workflow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,9 +199,9 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ferrocat"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef826c9078b8f7ec87c105c991f0e0f4e900d5f30de5f4591829d01228ded67e"
+checksum = "b1eaa6ab44981713ec2c1fc9161eb1fdf2a6ab1d507221fdd4af946f3cc2a0cf"
 dependencies = [
  "ferrocat-icu",
  "ferrocat-po",
@@ -209,18 +209,18 @@ dependencies = [
 
 [[package]]
 name = "ferrocat-icu"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72fbe26a76bec82113839d12983804bcbd23f0d16e12a8b16ddfda04dd61e4ed"
+checksum = "f16b4019d1062585a9ad5d56c90963f338181992c6d87c2c99441c41fec70dc5"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "ferrocat-po"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57ef06cd734d91a47309b8b459c55379ca6e2882523e073d0fdff0132cffeb38"
+checksum = "6cfe0d8503d5b5eb2c20a9cb0d974ede77227705539fd4498d9debc4d86a5428"
 dependencies = [
  "ferrocat-icu",
  "icu_locale",

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ driver:
 
 ```bash
 git config merge.palamedes-catalog.driver \
-  'pmds catalog merge --format=po --strategy=use-first --output %A %A %B'
+  'pmds catalog merge --format=po --conflict-strategy=use-first --output %A %A %B'
 ```
 
 For the full copy-paste path, including `.po` loading and the first translated

--- a/crates/palamedes-node/src/catalog.rs
+++ b/crates/palamedes-node/src/catalog.rs
@@ -89,7 +89,7 @@ pub struct CatalogCombineInput {
 }
 
 #[napi(string_enum)]
-pub enum CatalogCombineConflictStrategy {
+pub enum CatalogConflictStrategy {
     UseFirst,
     UseLast,
     Error,
@@ -112,7 +112,7 @@ pub struct CatalogCombineRequest {
     pub inputs: Vec<CatalogCombineInput>,
     pub source_locale: String,
     pub locale: Option<String>,
-    pub conflict_strategy: Option<CatalogCombineConflictStrategy>,
+    pub conflict_strategy: Option<CatalogConflictStrategy>,
     pub selection: Option<Either<CatalogCombineSelectionName, CatalogCombineSelectionThreshold>>,
     pub include_obsolete: Option<bool>,
 }
@@ -135,30 +135,25 @@ pub struct CatalogCombineResult {
 }
 
 #[napi(string_enum)]
-pub enum CatalogMergeFormat {
+pub enum CatalogFileFormat {
     Po,
-    Json,
-}
-
-#[napi(string_enum)]
-pub enum CatalogMergeStrategy {
-    UseFirst,
+    Ndjson,
 }
 
 #[napi(object)]
-pub struct CatalogMergeRequest {
+pub struct CatalogFileCombineRequest {
     pub input_paths: Vec<String>,
     pub output_path: String,
-    pub format: Option<CatalogMergeFormat>,
+    pub format: Option<CatalogFileFormat>,
     pub source_locale: String,
     pub locale: Option<String>,
-    pub strategy: Option<CatalogMergeStrategy>,
+    pub conflict_strategy: Option<CatalogConflictStrategy>,
 }
 
 #[napi(object)]
-pub struct CatalogMergeResult {
+pub struct CatalogFileCombineResult {
     pub output_path: String,
-    pub format: CatalogMergeFormat,
+    pub format: CatalogFileFormat,
     pub stats: CatalogCombineStats,
     pub diagnostics: Vec<CatalogDiagnostic>,
 }
@@ -511,12 +506,12 @@ impl From<CatalogCombineInput> for palamedes::CatalogCombineInput {
     }
 }
 
-impl From<CatalogCombineConflictStrategy> for palamedes::CatalogCombineConflictStrategy {
-    fn from(value: CatalogCombineConflictStrategy) -> Self {
+impl From<CatalogConflictStrategy> for palamedes::CatalogConflictStrategy {
+    fn from(value: CatalogConflictStrategy) -> Self {
         match value {
-            CatalogCombineConflictStrategy::UseFirst => Self::UseFirst,
-            CatalogCombineConflictStrategy::UseLast => Self::UseLast,
-            CatalogCombineConflictStrategy::Error => Self::Error,
+            CatalogConflictStrategy::UseFirst => Self::UseFirst,
+            CatalogConflictStrategy::UseLast => Self::UseLast,
+            CatalogConflictStrategy::Error => Self::Error,
         }
     }
 }
@@ -534,8 +529,8 @@ impl TryFrom<CatalogCombineRequest> for palamedes::CatalogCombineRequest {
             source_locale: value.source_locale,
             locale: value.locale,
             conflict_strategy: value.conflict_strategy.map_or(
-                palamedes::CatalogCombineConflictStrategy::UseFirst,
-                palamedes::CatalogCombineConflictStrategy::from,
+                palamedes::CatalogConflictStrategy::UseFirst,
+                palamedes::CatalogConflictStrategy::from,
             ),
             selection: combine_selection(value.selection)?,
             include_obsolete: value.include_obsolete.unwrap_or(false),
@@ -568,66 +563,68 @@ impl TryFrom<palamedes::CatalogCombineResult> for CatalogCombineResult {
             diagnostics: value
                 .diagnostics
                 .into_iter()
-                .map(CatalogDiagnostic::from)
+                .map(|diagnostic| {
+                    CatalogDiagnostic::from(palamedes::CatalogDiagnostic::from(diagnostic))
+                })
                 .collect(),
         })
     }
 }
 
-impl From<CatalogMergeFormat> for palamedes::CatalogMergeFormat {
-    fn from(value: CatalogMergeFormat) -> Self {
+impl From<CatalogFileFormat> for palamedes::CatalogFileFormat {
+    fn from(value: CatalogFileFormat) -> Self {
         match value {
-            CatalogMergeFormat::Po => Self::Po,
-            CatalogMergeFormat::Json => Self::Json,
+            CatalogFileFormat::Po => Self::Po,
+            CatalogFileFormat::Ndjson => Self::Ndjson,
         }
     }
 }
 
-impl From<palamedes::CatalogMergeFormat> for CatalogMergeFormat {
-    fn from(value: palamedes::CatalogMergeFormat) -> Self {
+impl TryFrom<palamedes::CatalogFileFormat> for CatalogFileFormat {
+    type Error = napi::Error;
+
+    fn try_from(value: palamedes::CatalogFileFormat) -> Result<Self> {
         match value {
-            palamedes::CatalogMergeFormat::Po => Self::Po,
-            palamedes::CatalogMergeFormat::Json => Self::Json,
+            palamedes::CatalogFileFormat::Po => Ok(Self::Po),
+            palamedes::CatalogFileFormat::Ndjson => Ok(Self::Ndjson),
+            // Ferrocat may add formats before Palamedes exposes them through
+            // the Node API. Fail explicitly until the TypeScript surface is extended.
+            _ => Err(napi::Error::from_reason(format!(
+                "Unsupported catalog file combine format: {value:?}. Expected `po` or `ndjson`."
+            ))),
         }
     }
 }
 
-impl From<CatalogMergeStrategy> for palamedes::CatalogMergeStrategy {
-    fn from(value: CatalogMergeStrategy) -> Self {
-        match value {
-            CatalogMergeStrategy::UseFirst => Self::UseFirst,
-        }
-    }
-}
-
-impl From<CatalogMergeRequest> for palamedes::CatalogMergeRequest {
-    fn from(value: CatalogMergeRequest) -> Self {
+impl From<CatalogFileCombineRequest> for palamedes::CatalogFileCombineRequest {
+    fn from(value: CatalogFileCombineRequest) -> Self {
         Self {
             input_paths: value.input_paths.into_iter().map(PathBuf::from).collect(),
             output_path: PathBuf::from(value.output_path),
-            format: value.format.map(palamedes::CatalogMergeFormat::from),
+            format: value.format.map(palamedes::CatalogFileFormat::from),
             source_locale: value.source_locale,
             locale: value.locale,
-            strategy: value.strategy.map_or(
-                palamedes::CatalogMergeStrategy::UseFirst,
-                palamedes::CatalogMergeStrategy::from,
-            ),
+            conflict_strategy: value
+                .conflict_strategy
+                .map_or(palamedes::CatalogConflictStrategy::UseFirst, Into::into),
         }
     }
 }
 
-impl TryFrom<palamedes::CatalogMergeResult> for CatalogMergeResult {
+impl TryFrom<palamedes::CatalogFileCombineResult> for CatalogFileCombineResult {
     type Error = napi::Error;
 
-    fn try_from(value: palamedes::CatalogMergeResult) -> Result<Self> {
+    fn try_from(value: palamedes::CatalogFileCombineResult) -> Result<Self> {
         Ok(Self {
             output_path: value.output_path.display().to_string(),
-            format: value.format.into(),
+            format: value.format.try_into()?,
             stats: value.stats.try_into()?,
             diagnostics: value
                 .diagnostics
                 .into_iter()
-                .map(CatalogDiagnostic::from)
+                .map(|diagnostic| {
+                    CatalogDiagnostic::from(palamedes::CatalogDiagnostic::from(diagnostic))
+                })
                 .collect(),
         })
     }
@@ -1174,16 +1171,18 @@ pub fn combine_catalogs(request: CatalogCombineRequest) -> Result<CatalogCombine
 
 #[napi]
 #[allow(clippy::needless_pass_by_value)]
-/// Merges exactly two catalog files and replaces the output after a successful merge.
+/// Combines exactly two catalog files and replaces the output after a successful combine.
 ///
 /// # Errors
 ///
 /// Returns an error when inputs are invalid, cannot be parsed, contain rejected
 /// conflicts, or the output cannot be replaced.
-pub fn merge_catalog_files(request: CatalogMergeRequest) -> Result<CatalogMergeResult> {
-    palamedes::merge_catalog_files(request.into())
+pub fn combine_catalog_files(
+    request: CatalogFileCombineRequest,
+) -> Result<CatalogFileCombineResult> {
+    palamedes::combine_catalog_files(request.into())
         .map_err(to_napi_error)
-        .and_then(CatalogMergeResult::try_from)
+        .and_then(CatalogFileCombineResult::try_from)
 }
 
 #[napi]

--- a/crates/palamedes/Cargo.toml
+++ b/crates/palamedes/Cargo.toml
@@ -8,8 +8,8 @@ rust-version.workspace = true
 description = "Rust core for Palamedes."
 
 [dependencies]
-ferrocat = "1.2.1"
-ferrocat-po = "1.2.1"
+ferrocat = "1.3.0"
+ferrocat-po = "1.3.0"
 oxc_allocator = "0.133.0"
 oxc_ast = "0.133.0"
 oxc_ast_visit = "0.133.0"

--- a/crates/palamedes/src/catalog_combine.rs
+++ b/crates/palamedes/src/catalog_combine.rs
@@ -1,19 +1,20 @@
-use std::fs;
-use std::path::{Path, PathBuf};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::path::PathBuf;
 
 use ferrocat::{
+    combine_catalog_files as ferrocat_combine_catalog_files,
     combine_catalogs as ferrocat_combine_catalogs, CatalogCombineInput as FerrocatCombineInput,
-    CatalogMode, CombineCatalogOptions, OrderBy,
+    CatalogMode, CombineCatalogFilesOptions, CombineCatalogOptions, OrderBy,
 };
-use serde::{Deserialize, Serialize};
 
-use crate::diagnostic::CatalogDiagnostic;
 use crate::error::{PalamedesError, PalamedesResult};
 
+pub use ferrocat::{
+    CatalogCombineResult, CatalogCombineSelection, CatalogCombineStats, CatalogConflictStrategy,
+    CatalogFileCombineResult, CatalogFileFormat,
+};
+
 /// Request for combining multiple catalog contents into one catalog.
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug)]
 pub struct CatalogCombineRequest {
     /// Input catalog contents in precedence order.
     pub inputs: Vec<CatalogCombineInput>,
@@ -22,7 +23,7 @@ pub struct CatalogCombineRequest {
     /// Locale of the combined catalog. When `None`, Ferrocat uses the first input locale if present.
     pub locale: Option<String>,
     /// Strategy for resolving conflicting non-empty translations.
-    pub conflict_strategy: CatalogCombineConflictStrategy,
+    pub conflict_strategy: CatalogConflictStrategy,
     /// Message identity selection rule applied after all inputs are read.
     pub selection: CatalogCombineSelection,
     /// Whether obsolete definitions should participate in the combine operation.
@@ -30,8 +31,7 @@ pub struct CatalogCombineRequest {
 }
 
 /// One catalog input for a combine operation.
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug)]
 pub struct CatalogCombineInput {
     /// Catalog content to parse and include.
     pub content: String,
@@ -39,110 +39,21 @@ pub struct CatalogCombineInput {
     pub label: Option<String>,
 }
 
-/// Strategy used when multiple catalogs define conflicting translations for one identity.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub enum CatalogCombineConflictStrategy {
-    /// Keep the first translation encountered for each identity.
-    UseFirst,
-    /// Replace the current translation with the latest definition.
-    UseLast,
-    /// Return an error when two non-empty translations differ.
-    Error,
-}
-
-/// Selection rule used after definitions from all inputs have been counted.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub enum CatalogCombineSelection {
-    /// Keep every message identity.
-    All,
-    /// Keep identities defined only once.
-    Unique,
-    /// Keep identities with more than the provided number of definitions.
-    MoreThan(usize),
-    /// Keep identities with less than the provided number of definitions.
-    LessThan(usize),
-}
-
-/// Result returned by catalog combine operations.
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct CatalogCombineResult {
-    /// Final catalog content after combining the inputs.
-    pub content: String,
-    /// Summary counters for the operation.
-    pub stats: CatalogCombineStats,
-    /// Non-fatal diagnostics collected during processing.
-    pub diagnostics: Vec<CatalogDiagnostic>,
-}
-
-/// Basic counters describing a catalog combine operation.
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct CatalogCombineStats {
-    /// Number of input catalogs parsed.
-    pub inputs: usize,
-    /// Total message definitions considered after obsolete filtering.
-    pub definitions: usize,
-    /// Message identities written to the final catalog.
-    pub selected: usize,
-    /// Message identities removed by the selection rule.
-    pub skipped: usize,
-    /// Translation conflicts resolved according to the selected strategy.
-    pub conflicts_resolved: usize,
-    /// Total messages in the final catalog.
-    pub total: usize,
-}
-
-/// File storage format used by catalog merge operations.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub enum CatalogMergeFormat {
-    /// Classic gettext PO catalog files.
-    Po,
-    /// Ferrocat source-first NDJSON catalog files, exposed as JSON for Palamedes V1.
-    Json,
-}
-
-/// Strategy used by catalog merge operations.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub enum CatalogMergeStrategy {
-    /// Keep the first input's translator-facing content for duplicate identities.
-    UseFirst,
-}
-
-/// Request for merging exactly two catalog files and writing the result.
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct CatalogMergeRequest {
+/// Request for combining exactly two catalog files and writing the result.
+#[derive(Debug)]
+pub struct CatalogFileCombineRequest {
     /// Input catalog file paths in precedence order.
     pub input_paths: Vec<PathBuf>,
-    /// Output catalog file path to replace after a successful merge.
+    /// Output catalog file path to replace after a successful combine.
     pub output_path: PathBuf,
     /// Optional explicit format. When absent, the format is inferred from file paths.
-    pub format: Option<CatalogMergeFormat>,
+    pub format: Option<CatalogFileFormat>,
     /// Source locale used for source-side semantics and validation.
     pub source_locale: String,
-    /// Locale of the merged catalog. When `None`, Ferrocat uses the first input locale if present.
+    /// Locale of the combined catalog. When `None`, Ferrocat uses the first input locale if present.
     pub locale: Option<String>,
-    /// Merge strategy. V1 supports only `useFirst`.
-    pub strategy: CatalogMergeStrategy,
-}
-
-/// Result returned by catalog merge operations.
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct CatalogMergeResult {
-    /// Output path that was replaced.
-    pub output_path: PathBuf,
-    /// Format used for the merge.
-    pub format: CatalogMergeFormat,
-    /// Summary counters for the operation.
-    pub stats: CatalogCombineStats,
-    /// Non-fatal diagnostics collected during processing.
-    pub diagnostics: Vec<CatalogDiagnostic>,
+    /// Strategy for resolving conflicting non-empty translations.
+    pub conflict_strategy: CatalogConflictStrategy,
 }
 
 /// Combines multiple catalogs into one deterministic catalog.
@@ -171,214 +82,47 @@ fn combine_catalog_contents(
     let mut options = CombineCatalogOptions::new(&inputs, &request.source_locale);
     options.locale = request.locale.as_deref();
     options.mode = mode;
-    options.conflict_strategy = request.conflict_strategy.into();
-    options.selection = request.selection.into();
+    options.conflict_strategy = request.conflict_strategy;
+    options.selection = request.selection;
     options.order_by = OrderBy::Msgid;
     options.include_origins = true;
     options.include_line_numbers = true;
     options.include_obsolete = request.include_obsolete;
 
-    let result = ferrocat_combine_catalogs(options).map_err(PalamedesError::from)?;
-
-    Ok(CatalogCombineResult {
-        content: result.content,
-        stats: result.stats.into(),
-        diagnostics: result
-            .diagnostics
-            .into_iter()
-            .map(CatalogDiagnostic::from)
-            .collect(),
-    })
+    ferrocat_combine_catalogs(options).map_err(PalamedesError::from)
 }
 
-/// Merges exactly two catalog files and atomically replaces the requested output path.
+/// Combines exactly two catalog files and atomically replaces the requested output path.
 ///
 /// # Errors
 ///
-/// Returns an error when paths are invalid, inputs cannot be parsed, formats
-/// cannot be inferred, or the output file cannot be replaced.
-pub fn merge_catalog_files(request: CatalogMergeRequest) -> PalamedesResult<CatalogMergeResult> {
+/// Returns an error from Ferrocat when paths are invalid, inputs cannot be
+/// parsed, formats cannot be inferred or do not match, or the output file
+/// cannot be replaced.
+pub fn combine_catalog_files(
+    request: CatalogFileCombineRequest,
+) -> PalamedesResult<CatalogFileCombineResult> {
     if request.input_paths.len() != 2 {
-        return Err(PalamedesError::InvalidCatalogMergeInputCount {
+        return Err(PalamedesError::InvalidCatalogFileCombineInputCount {
             count: request.input_paths.len(),
         });
     }
 
-    let format = match request.format {
-        Some(format) => format,
-        None => infer_merge_format(&request.input_paths, &request.output_path)?,
-    };
-    let inputs = request
-        .input_paths
-        .iter()
-        .map(|path| {
-            fs::read_to_string(path).map_err(|source| PalamedesError::ReadFile {
-                path: path.clone(),
-                source,
-            })
-        })
-        .collect::<PalamedesResult<Vec<_>>>()?;
+    let mut options = CombineCatalogFilesOptions::new(
+        &request.input_paths,
+        &request.output_path,
+        &request.source_locale,
+    );
+    options.format = request.format;
+    options.locale = request.locale.as_deref();
+    options.conflict_strategy = request.conflict_strategy;
+    options.selection = ferrocat::CatalogCombineSelection::All;
+    options.order_by = OrderBy::Msgid;
+    options.include_origins = true;
+    options.include_line_numbers = true;
+    options.include_obsolete = false;
 
-    let combine = combine_catalog_contents(
-        CatalogCombineRequest {
-            inputs: inputs
-                .into_iter()
-                .zip(request.input_paths.iter())
-                .map(|(content, path)| CatalogCombineInput {
-                    content,
-                    label: Some(path.display().to_string()),
-                })
-                .collect(),
-            source_locale: request.source_locale,
-            locale: request.locale,
-            conflict_strategy: match request.strategy {
-                CatalogMergeStrategy::UseFirst => CatalogCombineConflictStrategy::UseFirst,
-            },
-            selection: CatalogCombineSelection::All,
-            include_obsolete: false,
-        },
-        format.into(),
-    )?;
-
-    let temp_path = temp_output_path(&request.output_path);
-    if let Err(source) = fs::write(&temp_path, &combine.content) {
-        return Err(PalamedesError::WriteFile {
-            path: temp_path,
-            source,
-        });
-    }
-    replace_output(&temp_path, &request.output_path)?;
-
-    Ok(CatalogMergeResult {
-        output_path: request.output_path,
-        format,
-        stats: combine.stats,
-        diagnostics: combine.diagnostics,
-    })
-}
-
-impl From<CatalogCombineConflictStrategy> for ferrocat::CatalogConflictStrategy {
-    fn from(value: CatalogCombineConflictStrategy) -> Self {
-        match value {
-            CatalogCombineConflictStrategy::UseFirst => Self::UseFirst,
-            CatalogCombineConflictStrategy::UseLast => Self::UseLast,
-            CatalogCombineConflictStrategy::Error => Self::Error,
-        }
-    }
-}
-
-impl From<CatalogCombineSelection> for ferrocat::CatalogCombineSelection {
-    fn from(value: CatalogCombineSelection) -> Self {
-        match value {
-            CatalogCombineSelection::All => Self::All,
-            CatalogCombineSelection::Unique => Self::Unique,
-            CatalogCombineSelection::MoreThan(limit) => Self::MoreThan(limit),
-            CatalogCombineSelection::LessThan(limit) => Self::LessThan(limit),
-        }
-    }
-}
-
-impl From<CatalogMergeFormat> for CatalogMode {
-    fn from(value: CatalogMergeFormat) -> Self {
-        match value {
-            CatalogMergeFormat::Po => Self::IcuPo,
-            CatalogMergeFormat::Json => Self::IcuNdjson,
-        }
-    }
-}
-
-impl From<ferrocat::CatalogCombineStats> for CatalogCombineStats {
-    fn from(value: ferrocat::CatalogCombineStats) -> Self {
-        Self {
-            inputs: value.inputs,
-            definitions: value.definitions,
-            selected: value.selected,
-            skipped: value.skipped,
-            conflicts_resolved: value.conflicts_resolved,
-            total: value.total,
-        }
-    }
-}
-
-fn infer_merge_format(
-    input_paths: &[PathBuf],
-    output_path: &Path,
-) -> PalamedesResult<CatalogMergeFormat> {
-    let mut paths = input_paths.to_vec();
-    paths.push(output_path.to_owned());
-    let mut formats = paths
-        .iter()
-        .map(|path| infer_format_from_path(path))
-        .collect::<PalamedesResult<Vec<_>>>()?;
-    let first = formats
-        .pop()
-        .expect("format list contains output path plus at least one input");
-    if formats.into_iter().all(|format| format == first) {
-        Ok(first)
-    } else {
-        Err(PalamedesError::MixedCatalogMergeFormats)
-    }
-}
-
-fn infer_format_from_path(path: &Path) -> PalamedesResult<CatalogMergeFormat> {
-    let name = path
-        .file_name()
-        .and_then(|name| name.to_str())
-        .unwrap_or_default()
-        .to_ascii_lowercase();
-    if name.ends_with(".po") {
-        return Ok(CatalogMergeFormat::Po);
-    }
-    if name.ends_with(".json") || name.ends_with(".ndjson") || name.ends_with(".fcat.ndjson") {
-        return Ok(CatalogMergeFormat::Json);
-    }
-    Err(PalamedesError::CouldNotInferCatalogMergeFormat {
-        path: path.to_owned(),
-    })
-}
-
-fn temp_output_path(output_path: &Path) -> PathBuf {
-    let stamp = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_or(0, |duration| duration.as_nanos());
-    let filename = output_path
-        .file_name()
-        .and_then(|name| name.to_str())
-        .unwrap_or("catalog");
-    output_path.with_file_name(format!(".{filename}.{}.{}.tmp", std::process::id(), stamp))
-}
-
-fn replace_output(temp_path: &Path, output_path: &Path) -> PalamedesResult<()> {
-    match fs::rename(temp_path, output_path) {
-        Ok(()) => Ok(()),
-        Err(source) => {
-            if output_path.exists() {
-                fs::remove_file(output_path).map_err(|source| PalamedesError::ReplaceFile {
-                    path: output_path.to_owned(),
-                    temp_path: {
-                        let _ = fs::remove_file(temp_path);
-                        temp_path.to_owned()
-                    },
-                    source,
-                })?;
-                fs::rename(temp_path, output_path).map_err(|source| {
-                    let _ = fs::remove_file(temp_path);
-                    PalamedesError::ReplaceFile {
-                        path: output_path.to_owned(),
-                        temp_path: temp_path.to_owned(),
-                        source,
-                    }
-                })
-            } else {
-                let _ = fs::remove_file(temp_path);
-                Err(PalamedesError::ReplaceFile {
-                    path: output_path.to_owned(),
-                    temp_path: temp_path.to_owned(),
-                    source,
-                })
-            }
-        }
-    }
+    ferrocat_combine_catalog_files(options).map_err(PalamedesError::from)
 }
 
 #[cfg(test)]
@@ -388,9 +132,9 @@ mod tests {
     use std::time::{SystemTime, UNIX_EPOCH};
 
     use super::{
-        combine_catalogs, merge_catalog_files, CatalogCombineConflictStrategy, CatalogCombineInput,
-        CatalogCombineRequest, CatalogCombineSelection, CatalogMergeFormat, CatalogMergeRequest,
-        CatalogMergeStrategy,
+        combine_catalog_files, combine_catalogs, CatalogCombineInput, CatalogCombineRequest,
+        CatalogCombineSelection, CatalogConflictStrategy, CatalogFileCombineRequest,
+        CatalogFileFormat,
     };
 
     #[test]
@@ -408,7 +152,7 @@ mod tests {
             ],
             source_locale: "en".to_owned(),
             locale: Some("de".to_owned()),
-            conflict_strategy: CatalogCombineConflictStrategy::UseFirst,
+            conflict_strategy: CatalogConflictStrategy::UseFirst,
             selection: CatalogCombineSelection::All,
             include_obsolete: false,
         })
@@ -438,7 +182,7 @@ mod tests {
             ],
             source_locale: "en".to_owned(),
             locale: Some("en".to_owned()),
-            conflict_strategy: CatalogCombineConflictStrategy::UseFirst,
+            conflict_strategy: CatalogConflictStrategy::UseFirst,
             selection: CatalogCombineSelection::Unique,
             include_obsolete: false,
         })
@@ -478,17 +222,17 @@ mod tests {
         )
         .expect("write theirs");
 
-        let result = merge_catalog_files(CatalogMergeRequest {
+        let result = combine_catalog_files(CatalogFileCombineRequest {
             input_paths: vec![ours.clone(), theirs],
             output_path: ours.clone(),
             format: None,
             source_locale: "en".to_owned(),
             locale: Some("de".to_owned()),
-            strategy: CatalogMergeStrategy::UseFirst,
+            conflict_strategy: CatalogConflictStrategy::UseFirst,
         })
         .expect("merge");
 
-        assert_eq!(result.format, CatalogMergeFormat::Po);
+        assert_eq!(result.format, CatalogFileFormat::Po);
         let parsed = ferrocat::parse_po(&fs::read_to_string(&ours).expect("read output"))
             .expect("parse output");
         assert_eq!(
@@ -537,13 +281,13 @@ mod tests {
         )
         .expect("write theirs");
 
-        merge_catalog_files(CatalogMergeRequest {
+        combine_catalog_files(CatalogFileCombineRequest {
             input_paths: vec![ours, theirs],
             output_path: output.clone(),
             format: None,
             source_locale: "en".to_owned(),
             locale: Some("de".to_owned()),
-            strategy: CatalogMergeStrategy::UseFirst,
+            conflict_strategy: CatalogConflictStrategy::UseFirst,
         })
         .expect("merge");
 
@@ -565,7 +309,7 @@ mod tests {
     }
 
     #[test]
-    fn merges_ndjson_files_when_public_format_is_json() {
+    fn combines_ndjson_files_with_ndjson_format() {
         let dir = temp_dir("ndjson");
         let ours = dir.join("ours.json");
         let theirs = dir.join("theirs.json");
@@ -596,22 +340,60 @@ mod tests {
         )
         .expect("write theirs");
 
-        let result = merge_catalog_files(CatalogMergeRequest {
+        let result = combine_catalog_files(CatalogFileCombineRequest {
             input_paths: vec![ours, theirs],
             output_path: output.clone(),
-            format: Some(CatalogMergeFormat::Json),
+            format: Some(CatalogFileFormat::Ndjson),
             source_locale: "en".to_owned(),
             locale: Some("de".to_owned()),
-            strategy: CatalogMergeStrategy::UseFirst,
+            conflict_strategy: CatalogConflictStrategy::UseFirst,
         })
         .expect("merge");
 
-        assert_eq!(result.format, CatalogMergeFormat::Json);
+        assert_eq!(result.format, CatalogFileFormat::Ndjson);
         let merged = fs::read_to_string(output).expect("read output");
         assert!(merged.contains("format: ferrocat.ndjson.v1"));
         assert!(merged.contains("\"id\":\"Hello\",\"str\":\"Hallo\""));
         assert!(merged.contains("\"id\":\"New\",\"str\":\"Neu\",\"ctx\":\"nav\""));
         assert!(!merged.contains("Servus"));
+    }
+
+    #[test]
+    fn mixed_inferred_formats_leave_output_unchanged() {
+        let dir = temp_dir("mixed-format");
+        let ours = dir.join("ours.po");
+        let theirs = dir.join("theirs.ndjson");
+        let output = dir.join("merged.po");
+        fs::write(&ours, "msgid \"Hello\"\nmsgstr \"Hallo\"\n").expect("write ours");
+        fs::write(
+            &theirs,
+            concat!(
+                "---\n",
+                "format: ferrocat.ndjson.v1\n",
+                "source_locale: en\n",
+                "locale: de\n",
+                "---\n",
+                "{\"id\":\"New\",\"str\":\"Neu\"}\n",
+            ),
+        )
+        .expect("write theirs");
+        fs::write(&output, "unchanged").expect("write output");
+
+        let error = combine_catalog_files(CatalogFileCombineRequest {
+            input_paths: vec![ours, theirs],
+            output_path: output.clone(),
+            format: None,
+            source_locale: "en".to_owned(),
+            locale: Some("de".to_owned()),
+            conflict_strategy: CatalogConflictStrategy::UseFirst,
+        })
+        .expect_err("mixed formats");
+
+        assert!(error.to_string().contains("uses"));
+        assert_eq!(
+            fs::read_to_string(output).expect("read output"),
+            "unchanged"
+        );
     }
 
     #[test]
@@ -624,19 +406,19 @@ mod tests {
         fs::write(&theirs, "msgid \"New\"\nmsgstr \"Neu\"\n").expect("write theirs");
         fs::write(&output, "unchanged").expect("write output");
 
-        let error = merge_catalog_files(CatalogMergeRequest {
+        let error = combine_catalog_files(CatalogFileCombineRequest {
             input_paths: vec![ours, theirs],
             output_path: output.clone(),
             format: None,
             source_locale: "en".to_owned(),
             locale: Some("de".to_owned()),
-            strategy: CatalogMergeStrategy::UseFirst,
+            conflict_strategy: CatalogConflictStrategy::UseFirst,
         })
         .expect_err("unsupported format");
 
         assert!(error
             .to_string()
-            .contains("Could not infer catalog merge format"));
+            .contains("could not infer catalog file format"));
         assert_eq!(
             fs::read_to_string(output).expect("read output"),
             "unchanged"

--- a/crates/palamedes/src/error.rs
+++ b/crates/palamedes/src/error.rs
@@ -26,43 +26,12 @@ pub enum PalamedesError {
         /// Underlying filesystem error.
         source: std::io::Error,
     },
-    /// Writing a file to disk failed.
-    #[error("Failed to write {path}: {source}")]
-    WriteFile {
-        /// Path that was written.
-        path: PathBuf,
-        #[source]
-        /// Underlying filesystem error.
-        source: std::io::Error,
-    },
-    /// Replacing a file on disk failed.
-    #[error("Failed to replace {path} with {temp_path}: {source}")]
-    ReplaceFile {
-        /// Final path that should have been replaced.
-        path: PathBuf,
-        /// Temporary path that should have been moved into place.
-        temp_path: PathBuf,
-        #[source]
-        /// Underlying filesystem error.
-        source: std::io::Error,
-    },
-    /// A catalog merge request must include exactly two inputs.
-    #[error("Catalog merge requires exactly two input files, received {count}.")]
-    InvalidCatalogMergeInputCount {
+    /// A catalog file-combine request must include exactly two inputs.
+    #[error("Catalog file combine requires exactly two input files, received {count}.")]
+    InvalidCatalogFileCombineInputCount {
         /// Number of input files provided.
         count: usize,
     },
-    /// A catalog merge format could not be inferred from a path.
-    #[error("Could not infer catalog merge format from {path}. Expected .po, .json, .ndjson, or .fcat.ndjson.")]
-    CouldNotInferCatalogMergeFormat {
-        /// Path whose extension was inspected.
-        path: PathBuf,
-    },
-    /// A catalog merge request inferred multiple formats.
-    #[error(
-        "Catalog merge inputs and output must use the same format unless --format is provided."
-    )]
-    MixedCatalogMergeFormats,
     /// A configured catalog glob/path could not be compiled to a matcher.
     #[error("Invalid catalog path pattern {pattern}: {source}")]
     InvalidCatalogPathPattern {

--- a/crates/palamedes/src/lib.rs
+++ b/crates/palamedes/src/lib.rs
@@ -42,9 +42,9 @@ pub use catalog_audit::{
     CatalogAuditResult, CatalogAuditSummary,
 };
 pub use catalog_combine::{
-    combine_catalogs, merge_catalog_files, CatalogCombineConflictStrategy, CatalogCombineInput,
-    CatalogCombineRequest, CatalogCombineResult, CatalogCombineSelection, CatalogCombineStats,
-    CatalogMergeFormat, CatalogMergeRequest, CatalogMergeResult, CatalogMergeStrategy,
+    combine_catalog_files, combine_catalogs, CatalogCombineInput, CatalogCombineRequest,
+    CatalogCombineResult, CatalogCombineSelection, CatalogCombineStats, CatalogConflictStrategy,
+    CatalogFileCombineRequest, CatalogFileCombineResult, CatalogFileFormat,
 };
 pub use catalog_update::{
     parse_catalog, update_catalog_file, CatalogParseRequest, CatalogParseResult,
@@ -70,7 +70,7 @@ pub use transform::{
 };
 
 /// Published `ferrocat` version used by the Rust core.
-pub const FERROCAT_VERSION: &str = "1.2.1";
+pub const FERROCAT_VERSION: &str = "1.3.0";
 
 /// Version metadata for the loaded native core.
 #[derive(Debug, Serialize)]

--- a/docs/api/core-node.md
+++ b/docs/api/core-node.md
@@ -14,7 +14,7 @@ core. Most apps use it indirectly through the CLI and plugins.
 - `normalizeMessageMetadata(input)`
 - `validateMessageMetadata(input)`
 - `combineCatalogs(request)`
-- `mergeCatalogFiles(request)`
+- `combineCatalogFiles(request)`
 - `compileCatalogArtifact(request)`
 - `compileCatalogArtifactSelected(request)`
 - `extractMessagesNative(source, filename)`

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -51,19 +51,19 @@ Git merge-driver workflows.
 
 ```bash
 pmds catalog merge ours.po theirs.po --output merged.po
-pmds catalog merge %A %B --output %A --format po --strategy use-first
+pmds catalog merge %A %B --output %A --format po --conflict-strategy use-first
 ```
 
 Options:
 
-| Option                     | Description                                                      |
-| -------------------------- | ---------------------------------------------------------------- |
-| `--output <path>`          | Required output path.                                            |
-| `-c, --config <path>`      | Use a specific config file when inferring `sourceLocale`.        |
-| `--format <format>`        | `po` or `json`. Inferred from paths when omitted.                |
-| `--strategy <strategy>`    | Currently `use-first`.                                           |
-| `--source-locale <locale>` | Source locale for catalog semantics. Defaults to config or `en`. |
-| `--locale <locale>`        | Locale of the merged catalog.                                    |
+| Option                           | Description                                                      |
+| -------------------------------- | ---------------------------------------------------------------- |
+| `--output <path>`                | Required output path.                                            |
+| `-c, --config <path>`            | Use a specific config file when inferring `sourceLocale`.        |
+| `--format <format>`              | `po` or `ndjson`. Inferred from paths when omitted.              |
+| `--conflict-strategy <strategy>` | `use-first`, `use-last`, or `error`.                             |
+| `--source-locale <locale>`       | Source locale for catalog semantics. Defaults to config or `en`. |
+| `--locale <locale>`              | Locale of the merged catalog.                                    |
 
 ## `pmds version`
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -77,32 +77,31 @@ locale is below the threshold.
 
 ### Catalog Merge
 
-`pmds catalog merge` merges exactly two catalog files with V1 `use-first`
-semantics. When both inputs contain the same semantic identity, the first input
-wins for translator-facing content; messages that only exist in the second
+`pmds catalog merge` combines exactly two catalog files. When both inputs
+contain the same semantic identity, `--conflict-strategy` controls how
+translator-facing conflicts are handled; messages that only exist in the second
 input are added.
 
 ```bash
-pnpm exec pmds catalog merge --format=po --strategy=use-first --output %A %A %B
+pnpm exec pmds catalog merge --format=po --conflict-strategy=use-first --output %A %A %B
 ```
 
 `--format` can be omitted when all input and output extensions are supported
 and match. `.po` maps to `po`; `.json`, `.ndjson`, and `.fcat.ndjson` map to
-`json`. The public `json` format is Ferrocat's source-first
-`ferrocat.ndjson.v1` storage format.
+Ferrocat's `ndjson` storage format.
 
 For Git merge-driver usage:
 
 ```gitattributes
 *.po merge=palamedes-catalog
-*.fcat.ndjson merge=palamedes-catalog-json
+*.fcat.ndjson merge=palamedes-catalog-ndjson
 ```
 
 ```bash
 git config merge.palamedes-catalog.driver \
-  'pmds catalog merge --format=po --strategy=use-first --output %A %A %B'
-git config merge.palamedes-catalog-json.driver \
-  'pmds catalog merge --format=json --strategy=use-first --output %A %A %B'
+  'pmds catalog merge --format=po --conflict-strategy=use-first --output %A %A %B'
+git config merge.palamedes-catalog-ndjson.driver \
+  'pmds catalog merge --format=ndjson --conflict-strategy=use-first --output %A %A %B'
 ```
 
 `--source-locale` is optional. The command uses an explicit value first, then

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -76,8 +76,8 @@ catalog
   .argument("<inputs...>", "Input catalog files in precedence order")
   .requiredOption("--output <path>", "Output catalog path")
   .option("-c, --config <path>", "Path to palamedes.config.ts")
-  .option("--format <format>", "Catalog format: po or json")
-  .option("--strategy <strategy>", "Merge strategy", "use-first")
+  .option("--format <format>", "Catalog format: po or ndjson")
+  .option("--conflict-strategy <strategy>", "Catalog conflict strategy", "use-first")
   .option("--source-locale <locale>", "Source locale for catalog semantics")
   .option("--locale <locale>", "Locale of the merged catalog")
   .action(async (inputs: string[], options) => {

--- a/packages/cli/src/commands/catalog.test.ts
+++ b/packages/cli/src/commands/catalog.test.ts
@@ -9,7 +9,7 @@ import { mergeCatalog } from "./catalog"
 vi.mock("@palamedes/core-node", async () => {
   const { readFileSync, writeFileSync } = await import("node:fs")
 
-  function inferFormat(inputPaths: string[], outputPath: string): "po" | "json" {
+  function inferFormat(inputPaths: string[], outputPath: string): "po" | "ndjson" {
     const formats = [...inputPaths, outputPath].map((filePath) => {
       if (filePath.endsWith(".po")) {
         return "po"
@@ -19,7 +19,7 @@ vi.mock("@palamedes/core-node", async () => {
         filePath.endsWith(".ndjson") ||
         filePath.endsWith(".fcat.ndjson")
       ) {
-        return "json"
+        return "ndjson"
       }
       throw new Error("Could not infer catalog merge format")
     })
@@ -59,17 +59,18 @@ vi.mock("@palamedes/core-node", async () => {
       .filter((entry) => entry.length > 0)
   }
 
-  function countMessages(content: string, format: "po" | "json"): number {
+  function countMessages(content: string, format: "po" | "ndjson"): number {
     return format === "po"
       ? [...content.matchAll(/\n?msgid "([^"]+)"/g)].length
       : [...content.matchAll(/"id":"([^"]*)"/g)].length
   }
 
   return {
-    mergeCatalogFiles(request: {
+    combineCatalogFiles(request: {
       inputPaths: string[]
       outputPath: string
-      format?: "po" | "json"
+      format?: "po" | "ndjson"
+      conflictStrategy?: "useFirst" | "useLast" | "error"
     }) {
       const format = request.format ?? inferFormat(request.inputPaths, request.outputPath)
       const [firstPath, secondPath] = request.inputPaths
@@ -160,8 +161,8 @@ msgstr "Neu"
     expect(merged).toContain('msgid "New"')
   })
 
-  it("merges ferrocat ndjson catalogs through public json format", async () => {
-    const dir = await tempDir("json")
+  it("merges ferrocat ndjson catalogs through public ndjson format", async () => {
+    const dir = await tempDir("ndjson")
     const ours = path.join(dir, "ours.json")
     const theirs = path.join(dir, "theirs.json")
     const output = path.join(dir, "merged.json")
@@ -189,11 +190,11 @@ locale: de
 
     const result = await mergeCatalog([ours, theirs], {
       output,
-      format: "json",
+      format: "ndjson",
       sourceLocale: "en",
     })
 
-    expect(result.format).toBe("json")
+    expect(result.format).toBe("ndjson")
     const merged = await readFile(output, "utf8")
     expect(merged).toContain("format: ferrocat.ndjson.v1")
     expect(merged).toContain('"id":"Hello","str":"Hallo"')

--- a/packages/cli/src/commands/catalog.ts
+++ b/packages/cli/src/commands/catalog.ts
@@ -1,23 +1,24 @@
 import { loadPalamedesConfig } from "@palamedes/config"
 import {
-  mergeCatalogFiles,
-  type CatalogMergeFormat,
-  type CatalogMergeResult,
+  combineCatalogFiles,
+  type CatalogConflictStrategy,
+  type CatalogFileCombineResult,
+  type CatalogFileFormat,
 } from "@palamedes/core-node"
 
-export type CatalogMergeOptions = {
+export type CatalogFileCombineOptions = {
   config?: string
   output: string
   format?: string
-  strategy?: string
+  conflictStrategy?: string
   sourceLocale?: string
   locale?: string
 }
 
 export async function mergeCatalog(
   inputPaths: string[],
-  options: CatalogMergeOptions
-): Promise<CatalogMergeResult> {
+  options: CatalogFileCombineOptions
+): Promise<CatalogFileCombineResult> {
   if (!options.output) {
     throw new Error("Missing required --output path.")
   }
@@ -27,34 +28,42 @@ export async function mergeCatalog(
     )
   }
 
-  return mergeCatalogFiles({
+  return combineCatalogFiles({
     inputPaths,
     outputPath: options.output,
     format: normalizeFormat(options.format),
     sourceLocale: await resolveSourceLocale(options),
     locale: options.locale,
-    strategy: normalizeStrategy(options.strategy),
+    conflictStrategy: normalizeConflictStrategy(options.conflictStrategy),
   })
 }
 
-function normalizeFormat(value: string | undefined): CatalogMergeFormat | undefined {
+function normalizeFormat(value: string | undefined): CatalogFileFormat | undefined {
   if (value === undefined) {
     return undefined
   }
-  if (value === "po" || value === "json") {
+  if (value === "po" || value === "ndjson") {
     return value
   }
-  throw new Error("Invalid --format value. Expected `po` or `json`.")
+  throw new Error("Invalid --format value. Expected `po` or `ndjson`.")
 }
 
-function normalizeStrategy(value: string | undefined): "useFirst" {
+function normalizeConflictStrategy(value: string | undefined): CatalogConflictStrategy {
   if (value === undefined || value === "use-first") {
     return "useFirst"
   }
-  throw new Error("Invalid --strategy value. Expected `use-first`.")
+  if (value === "use-last") {
+    return "useLast"
+  }
+  if (value === "error") {
+    return "error"
+  }
+  throw new Error(
+    "Invalid --conflict-strategy value. Expected `use-first`, `use-last`, or `error`."
+  )
 }
 
-async function resolveSourceLocale(options: CatalogMergeOptions): Promise<string> {
+async function resolveSourceLocale(options: CatalogFileCombineOptions): Promise<string> {
   if (options.sourceLocale) {
     return options.sourceLocale
   }

--- a/packages/core-node/README.md
+++ b/packages/core-node/README.md
@@ -52,7 +52,12 @@ targets Alpine-style environments.
 ## Example
 
 ```ts
-import { getNativeInfo, mergeCatalogFiles, parsePo, updateCatalogFile } from "@palamedes/core-node"
+import {
+  combineCatalogFiles,
+  getNativeInfo,
+  parsePo,
+  updateCatalogFile,
+} from "@palamedes/core-node"
 
 const info = getNativeInfo()
 const po = parsePo(`
@@ -67,7 +72,7 @@ updateCatalogFile({
   clean: false,
   messages: [{ message: "Hello {name}", extractedComments: [], origins: [] }],
 })
-mergeCatalogFiles({
+combineCatalogFiles({
   inputPaths: ["src/locales/de.po", "incoming/de.po"],
   outputPath: "src/locales/de.po",
   format: "po",
@@ -89,7 +94,7 @@ console.log(po.headers.Language)
 - `normalizeMessageMetadata(input)`
 - `validateMessageMetadata(input)`
 - `combineCatalogs(request)`
-- `mergeCatalogFiles(request)`
+- `combineCatalogFiles(request)`
 - `compileCatalogArtifact(config, resourcePath)`
 - `compileCatalogArtifactSelected(config, resourcePath, compiledIds)`
 - `extractMessagesNative(source, filename)`

--- a/packages/core-node/src/generated/palamedes-node-types.ts
+++ b/packages/core-node/src/generated/palamedes-node-types.ts
@@ -62,7 +62,7 @@ export interface CatalogCombineInput {
   content: string;
   label?: string;
 }
-export type CatalogCombineConflictStrategy = "UseFirst" | "UseLast" | "Error"
+export type CatalogConflictStrategy = "UseFirst" | "UseLast" | "Error"
 export type CatalogCombineSelectionName = "All" | "Unique"
 export interface CatalogCombineSelectionThreshold {
   moreThan?: number;
@@ -72,7 +72,7 @@ export interface CatalogCombineRequest {
   inputs: Array<CatalogCombineInput>;
   sourceLocale: string;
   locale?: string;
-  conflictStrategy?: CatalogCombineConflictStrategy;
+  conflictStrategy?: CatalogConflictStrategy;
   selection?: CatalogCombineSelectionName | CatalogCombineSelectionThreshold;
   includeObsolete?: boolean;
 }
@@ -89,19 +89,18 @@ export interface CatalogCombineResult {
   stats: CatalogCombineStats;
   diagnostics: Array<CatalogDiagnostic>;
 }
-export type CatalogMergeFormat = "Po" | "Json"
-export type CatalogMergeStrategy = "UseFirst"
-export interface CatalogMergeRequest {
+export type CatalogFileFormat = "Po" | "Ndjson"
+export interface CatalogFileCombineRequest {
   inputPaths: Array<string>;
   outputPath: string;
-  format?: CatalogMergeFormat;
+  format?: CatalogFileFormat;
   sourceLocale: string;
   locale?: string;
-  strategy?: CatalogMergeStrategy;
+  conflictStrategy?: CatalogConflictStrategy;
 }
-export interface CatalogMergeResult {
+export interface CatalogFileCombineResult {
   outputPath: string;
-  format: CatalogMergeFormat;
+  format: CatalogFileFormat;
   stats: CatalogCombineStats;
   diagnostics: Array<CatalogDiagnostic>;
 }
@@ -336,7 +335,7 @@ export interface NativeBindings {
   normalizeMessageMetadata(input: MessageMetadataInput): MessageMetadata;
   validateMessageMetadata(input: MessageMetadataInput): MessageMetadataValidationReport;
   combineCatalogs(request: CatalogCombineRequest): CatalogCombineResult;
-  mergeCatalogFiles(request: CatalogMergeRequest): CatalogMergeResult;
+  combineCatalogFiles(request: CatalogFileCombineRequest): CatalogFileCombineResult;
   compileCatalogArtifact(request: CatalogArtifactRequest): CatalogArtifactResult;
   compileCatalogArtifactSelected(request: CatalogArtifactSelectedRequest): CatalogArtifactResult;
   extractMessages(source: string, filename: string): Array<NativeExtractedMessage>;

--- a/packages/core-node/src/index.ts
+++ b/packages/core-node/src/index.ts
@@ -7,10 +7,10 @@ import type {
   CatalogAuditRequest as GeneratedCatalogAuditRequest,
   CatalogAuditResult as GeneratedCatalogAuditResult,
   CatalogAuditSummary as GeneratedCatalogAuditSummary,
+  CatalogFileCombineRequest as GeneratedCatalogFileCombineRequest,
+  CatalogFileCombineResult as GeneratedCatalogFileCombineResult,
   CatalogCombineRequest as GeneratedCatalogCombineRequest,
   CatalogCombineResult as GeneratedCatalogCombineResult,
-  CatalogMergeRequest as GeneratedCatalogMergeRequest,
-  CatalogMergeResult as GeneratedCatalogMergeResult,
   CatalogArtifactConfig as GeneratedCatalogArtifactConfig,
   CatalogArtifactDiagnostic as GeneratedCatalogArtifactDiagnostic,
   CatalogArtifactMissingMessage as GeneratedCatalogArtifactMissingMessage,
@@ -88,31 +88,33 @@ export type CatalogCombineInput = {
   content: string
   label?: string
 }
-export type CatalogCombineConflictStrategy = "useFirst" | "useLast" | "error"
+export type CatalogConflictStrategy = "useFirst" | "useLast" | "error"
 export type CatalogCombineSelection = "all" | "unique" | { moreThan: number } | { lessThan: number }
 export type CatalogCombineRequest = {
   inputs: CatalogCombineInput[]
   sourceLocale: string
   locale?: string
-  conflictStrategy?: CatalogCombineConflictStrategy
+  conflictStrategy?: CatalogConflictStrategy
   selection?: CatalogCombineSelection
   includeObsolete?: boolean
 }
 export type CatalogCombineResult = Omit<GeneratedCatalogCombineResult, "diagnostics"> & {
   diagnostics: CatalogDiagnostic[]
 }
-export type CatalogMergeFormat = "po" | "json"
-export type CatalogMergeStrategy = "useFirst"
-export type CatalogMergeRequest = {
+export type CatalogFileFormat = "po" | "ndjson"
+export type CatalogFileCombineRequest = {
   inputPaths: string[]
   outputPath: string
-  format?: CatalogMergeFormat
+  format?: CatalogFileFormat
   sourceLocale: string
   locale?: string
-  strategy?: CatalogMergeStrategy
+  conflictStrategy?: CatalogConflictStrategy
 }
-export type CatalogMergeResult = Omit<GeneratedCatalogMergeResult, "format" | "diagnostics"> & {
-  format: CatalogMergeFormat
+export type CatalogFileCombineResult = Omit<
+  GeneratedCatalogFileCombineResult,
+  "format" | "diagnostics"
+> & {
+  format: CatalogFileFormat
   diagnostics: CatalogDiagnostic[]
 }
 export type CatalogAuditOptions = {
@@ -164,7 +166,7 @@ export type CatalogArtifactResult = Omit<GeneratedCatalogArtifactResult, "diagno
 type NativeBindings = GeneratedNativeBindings
 type NativeCatalogAuditRequest = GeneratedCatalogAuditRequest
 type NativeCatalogCombineRequest = GeneratedCatalogCombineRequest
-type NativeCatalogMergeRequest = GeneratedCatalogMergeRequest
+type NativeCatalogFileCombineRequest = GeneratedCatalogFileCombineRequest
 type NativeCatalogArtifactRequest = GeneratedCatalogArtifactRequest
 type NativeCatalogArtifactSelectedRequest = GeneratedCatalogArtifactSelectedRequest
 
@@ -350,11 +352,11 @@ export function combineCatalogs(request: CatalogCombineRequest): CatalogCombineR
   }
 }
 
-export function mergeCatalogFiles(request: CatalogMergeRequest): CatalogMergeResult {
-  const result = native.mergeCatalogFiles(toNativeMergeRequest(request))
+export function combineCatalogFiles(request: CatalogFileCombineRequest): CatalogFileCombineResult {
+  const result = native.combineCatalogFiles(toNativeFileCombineRequest(request))
   return {
     ...result,
-    format: fromNativeMergeFormat(result.format),
+    format: fromNativeFileFormat(result.format),
     diagnostics: mapCatalogDiagnostics(result.diagnostics),
   }
 }
@@ -373,7 +375,7 @@ function toNativeCombineRequest(request: CatalogCombineRequest): NativeCatalogCo
 }
 
 function toNativeConflictStrategy(
-  strategy: CatalogCombineConflictStrategy
+  strategy: CatalogConflictStrategy
 ): NonNullable<NativeCatalogCombineRequest["conflictStrategy"]> {
   switch (strategy) {
     case "useFirst": {
@@ -388,47 +390,43 @@ function toNativeConflictStrategy(
   }
 }
 
-function toNativeMergeRequest(request: CatalogMergeRequest): NativeCatalogMergeRequest {
+function toNativeFileCombineRequest(
+  request: CatalogFileCombineRequest
+): NativeCatalogFileCombineRequest {
   return {
     inputPaths: request.inputPaths,
     outputPath: request.outputPath,
-    format: request.format ? toNativeMergeFormat(request.format) : undefined,
+    format: request.format ? toNativeFileFormat(request.format) : undefined,
     sourceLocale: request.sourceLocale,
     locale: request.locale,
-    strategy: request.strategy ? toNativeMergeStrategy(request.strategy) : undefined,
+    conflictStrategy: request.conflictStrategy
+      ? toNativeConflictStrategy(request.conflictStrategy)
+      : undefined,
   }
 }
 
-function toNativeMergeFormat(
-  format: CatalogMergeFormat
-): NonNullable<NativeCatalogMergeRequest["format"]> {
+function toNativeFileFormat(
+  format: CatalogFileFormat
+): NonNullable<NativeCatalogFileCombineRequest["format"]> {
   switch (format) {
     case "po": {
       return "Po"
     }
-    case "json": {
-      return "Json"
+    case "ndjson": {
+      return "Ndjson"
     }
   }
 }
 
-function fromNativeMergeFormat(format: GeneratedCatalogMergeResult["format"]): CatalogMergeFormat {
+function fromNativeFileFormat(
+  format: GeneratedCatalogFileCombineResult["format"]
+): CatalogFileFormat {
   switch (format) {
     case "Po": {
       return "po"
     }
-    case "Json": {
-      return "json"
-    }
-  }
-}
-
-function toNativeMergeStrategy(
-  strategy: CatalogMergeStrategy
-): NonNullable<NativeCatalogMergeRequest["strategy"]> {
-  switch (strategy) {
-    case "useFirst": {
-      return "UseFirst"
+    case "Ndjson": {
+      return "ndjson"
     }
   }
 }


### PR DESCRIPTION
## Dependency group
- Packages: `ferrocat` 1.2.1 -> 1.3.0, `ferrocat-po` 1.2.1 -> 1.3.0
- Lockfile: transitive `ferrocat-icu` 1.2.1 -> 1.3.0
- Why grouped: the public `ferrocat` facade and `ferrocat-po` catalog API ship the same file-combine workflow and need to be reviewed together.

## Upstream changes that matter here
- Ferrocat 1.3.0 adds the catalog file combine workflow planned in sebastian-software/ferrocat#152: https://github.com/sebastian-software/ferrocat/releases/tag/ferrocat-v1.3.0
- The new API handles input path reads, path-based format inference, format consistency checks, combine semantics, diagnostics, and atomic output replacement inside Ferrocat.
- Gaps: the release notes list the feature twice; I checked the 1.3.0 crate API and used `combine_catalog_files` / `CombineCatalogFilesOptions` directly.

## Local impact and code changes
- Replaced Palamedes-local file merge orchestration with `ferrocat::combine_catalog_files` while preserving Palamedes' two-input CLI guard.
- Removed Palamedes-local catalog file format inference, file reads, temp output path generation, replace/rename fallback logic, and stale file-merge error variants.
- Moved the Rust core surface closer to Ferrocat: `combine_catalog_files`, `CatalogFileCombineRequest`, `CatalogFileCombineResult`, `CatalogFileFormat`, and `CatalogConflictStrategy`.
- Moved the native Node/TypeScript surface in the same direction: `combineCatalogFiles`, `CatalogFileCombineRequest`, `CatalogFileCombineResult`, `CatalogFileFormat = "po" | "ndjson"`, and `CatalogConflictStrategy`.
- Updated the CLI to call the file-combine API while keeping the Git-facing command as `pmds catalog merge`; options now use `--format ndjson` and `--conflict-strategy`.
- Updated docs and tests to use Ferrocat's `ndjson` naming instead of the previous Palamedes-local public `json` alias.
- Added a Palamedes-level mixed-format regression test so future Ferrocat changes cannot silently turn `.po` + `.ndjson` inference into auto-conversion.
- Updated `FERROCAT_VERSION` so native version metadata matches the declared dependency.

## Validation
- `cargo fmt --all --check`: pass
- `cargo test -p palamedes catalog_combine --locked`: pass
- `cargo test --workspace --locked`: pass
- `cargo clippy --workspace --all-targets --locked -- -D warnings`: pass
- `pnpm format:check`: pass
- `pnpm --filter @palamedes/core-node check-native-types`: pass
- `pnpm --filter @palamedes/core-node test`: pass
- `pnpm --filter @palamedes/cli test`: pass
- `pnpm check-types`: pass
- `pnpm build`: pass

## Risk
- This intentionally changes the pre-1.0 Rust and Node file-combine API names to match Ferrocat rather than maintaining Palamedes-local mirror vocabulary. Palamedes is still effectively new and has no known external consumers, so this PR does not bump the crate/package version as a breaking release.
- The invalid-format and mixed-format error text now comes from Ferrocat instead of the old Palamedes helper. Regression tests still cover that failed inference does not replace the target file.
