### PR TITLE
fix(extractor): decode JSX entities in message keys

### DIFF
--- a/crates/palamedes/src/extract.rs
+++ b/crates/palamedes/src/extract.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 
 use crate::catalog_update::{CatalogUpdateMessage, CatalogUpdateOrigin};
 use crate::error::{PalamedesError, PalamedesResult};
+use crate::jsx_entities::decode_jsx_entities;
 use oxc_allocator::Allocator;
 use oxc_ast::ast::{
     Argument, CallExpression, Expression, ImportDeclaration, ImportDeclarationSpecifier,
@@ -707,7 +708,9 @@ fn jsx_attributes(opening_element: &JSXOpeningElement<'_>) -> BTreeMap<String, S
 
 fn jsx_attribute_string_value(value: &JSXAttributeValue<'_>) -> Option<String> {
     match value {
-        JSXAttributeValue::StringLiteral(literal) => Some(literal.value.to_string()),
+        JSXAttributeValue::StringLiteral(literal) => {
+            Some(decode_jsx_entities(literal.value.as_str()))
+        }
         JSXAttributeValue::ExpressionContainer(container) => {
             jsx_expression_string_value(&container.expression)
         }
@@ -717,10 +720,10 @@ fn jsx_attribute_string_value(value: &JSXAttributeValue<'_>) -> Option<String> {
 
 fn jsx_expression_string_value(expr: &JSXExpression<'_>) -> Option<String> {
     match expr {
-        JSXExpression::StringLiteral(literal) => Some(literal.value.to_string()),
-        JSXExpression::TemplateLiteral(template) => {
-            template.single_quasi().map(|value| value.to_string())
-        }
+        JSXExpression::StringLiteral(literal) => Some(decode_jsx_entities(literal.value.as_str())),
+        JSXExpression::TemplateLiteral(template) => template
+            .single_quasi()
+            .map(|value| decode_jsx_entities(value.as_str())),
         _ => None,
     }
 }
@@ -786,7 +789,9 @@ fn extract_jsx_children_as_message_with_state(
                 }
             }
             JSXChild::ExpressionContainer(container) => match &container.expression {
-                JSXExpression::StringLiteral(literal) => parts.push(literal.value.to_string()),
+                JSXExpression::StringLiteral(literal) => {
+                    parts.push(decode_jsx_entities(literal.value.as_str()));
+                }
                 expr => {
                     let Some(name) = jsx_expression_name(expr) else {
                         return Err(PalamedesError::UnnamedPlaceholder {
@@ -841,7 +846,7 @@ fn clean_jsx_text(text: &str) -> String {
         }
     }
 
-    result
+    decode_jsx_entities(&result)
 }
 
 fn extract_choice_options_from_jsx(opening_element: &JSXOpeningElement<'_>) -> ChoiceOptions {
@@ -1202,6 +1207,65 @@ mod tests {
             messages[0].message,
             "Accept <0>terms</0> and <1>privacy</1>"
         );
+    }
+
+    #[test]
+    fn decodes_jsx_entities_before_extracting_message_ids() {
+        let messages = extract_messages(
+            r#"
+              import { Trans } from "@palamedes/react/macro"
+              const child = <Trans>Green-e&reg; applies to US &amp; Canada only</Trans>
+              const attr = <Trans message="Decision &quot;Model&quot; &#x26; review" />
+              const expression = <Trans>{"A &amp; B"}</Trans>
+              const rich = <Trans>Accept <a href="/terms">terms &amp; conditions</a></Trans>
+            "#,
+            "test.tsx",
+        )
+        .expect("messages should extract");
+
+        assert_eq!(
+            messages
+                .iter()
+                .map(|message| message.message.as_str())
+                .collect::<Vec<_>>(),
+            vec![
+                "Green-e® applies to US & Canada only",
+                "Decision \"Model\" & review",
+                "A & B",
+                "Accept <0>terms & conditions</0>",
+            ]
+        );
+    }
+
+    #[test]
+    fn decodes_jsx_choice_attribute_entities() {
+        let messages = extract_messages(
+            r##"
+              import { Plural } from "@palamedes/react/macro"
+              const message = <Plural value={count} one="# item &amp; fee" other="# items &amp; fees" />
+            "##,
+            "test.tsx",
+        )
+        .expect("messages should extract");
+
+        assert_eq!(
+            messages[0].message,
+            "{count, plural, one {# item & fee} other {# items & fees}}"
+        );
+    }
+
+    #[test]
+    fn leaves_javascript_string_literal_entities_unchanged() {
+        let messages = extract_messages(
+            r#"
+              import { t } from "@palamedes/core/macro"
+              const message = t({ message: "Fish &amp; Chips" })
+            "#,
+            "test.tsx",
+        )
+        .expect("messages should extract");
+
+        assert_eq!(messages[0].message, "Fish &amp; Chips");
     }
 
     #[test]

--- a/crates/palamedes/src/extract.rs
+++ b/crates/palamedes/src/extract.rs
@@ -720,10 +720,10 @@ fn jsx_attribute_string_value(value: &JSXAttributeValue<'_>) -> Option<String> {
 
 fn jsx_expression_string_value(expr: &JSXExpression<'_>) -> Option<String> {
     match expr {
-        JSXExpression::StringLiteral(literal) => Some(decode_jsx_entities(literal.value.as_str())),
-        JSXExpression::TemplateLiteral(template) => template
-            .single_quasi()
-            .map(|value| decode_jsx_entities(value.as_str())),
+        JSXExpression::StringLiteral(literal) => Some(literal.value.to_string()),
+        JSXExpression::TemplateLiteral(template) => {
+            template.single_quasi().map(|value| value.to_string())
+        }
         _ => None,
     }
 }
@@ -790,7 +790,7 @@ fn extract_jsx_children_as_message_with_state(
             }
             JSXChild::ExpressionContainer(container) => match &container.expression {
                 JSXExpression::StringLiteral(literal) => {
-                    parts.push(decode_jsx_entities(literal.value.as_str()));
+                    parts.push(literal.value.to_string());
                 }
                 expr => {
                     let Some(name) = jsx_expression_name(expr) else {
@@ -1217,6 +1217,7 @@ mod tests {
               const child = <Trans>Green-e&reg; applies to US &amp; Canada only</Trans>
               const attr = <Trans message="Decision &quot;Model&quot; &#x26; review" />
               const expression = <Trans>{"A &amp; B"}</Trans>
+              const expressionAttr = <Trans message={"Literal &amp; Value"} />
               const rich = <Trans>Accept <a href="/terms">terms &amp; conditions</a></Trans>
             "#,
             "test.tsx",
@@ -1231,7 +1232,8 @@ mod tests {
             vec![
                 "Green-e® applies to US & Canada only",
                 "Decision \"Model\" & review",
-                "A & B",
+                "A &amp; B",
+                "Literal &amp; Value",
                 "Accept <0>terms & conditions</0>",
             ]
         );

--- a/crates/palamedes/src/jsx_entities.rs
+++ b/crates/palamedes/src/jsx_entities.rs
@@ -1,0 +1,224 @@
+pub(crate) fn decode_jsx_entities(input: &str) -> String {
+    if !input.contains('&') {
+        return input.to_owned();
+    }
+
+    let mut decoded = String::with_capacity(input.len());
+    let mut index = 0;
+
+    while index < input.len() {
+        let Some(ch) = input[index..].chars().next() else {
+            break;
+        };
+
+        if ch != '&' {
+            decoded.push(ch);
+            index += ch.len_utf8();
+            continue;
+        }
+
+        let entity_start = index + ch.len_utf8();
+        let mut entity_end = None;
+        let mut candidate_is_valid = true;
+        for (offset, entity_ch) in input[entity_start..].char_indices() {
+            if entity_ch == ';' {
+                entity_end = Some(entity_start + offset);
+                break;
+            }
+            if !is_entity_candidate_char(entity_ch) {
+                candidate_is_valid = false;
+                break;
+            }
+        }
+
+        let Some(entity_end) = entity_end else {
+            decoded.push(ch);
+            index += ch.len_utf8();
+            continue;
+        };
+
+        if !candidate_is_valid || entity_end == entity_start {
+            decoded.push(ch);
+            index += ch.len_utf8();
+            continue;
+        }
+
+        let entity = &input[entity_start..entity_end];
+        if let Some(decoded_entity) = decode_entity(entity) {
+            decoded.push(decoded_entity);
+        } else {
+            decoded.push_str(&input[index..=entity_end]);
+        }
+        index = entity_end + 1;
+    }
+
+    decoded
+}
+
+fn is_entity_candidate_char(ch: char) -> bool {
+    ch.is_ascii_alphanumeric() || ch == '#'
+}
+
+fn decode_entity(entity: &str) -> Option<char> {
+    if let Some(hex) = entity
+        .strip_prefix("#x")
+        .or_else(|| entity.strip_prefix("#X"))
+    {
+        return decode_numeric_entity(hex, 16);
+    }
+
+    if let Some(decimal) = entity.strip_prefix('#') {
+        return decode_numeric_entity(decimal, 10);
+    }
+
+    decode_named_entity(entity)
+}
+
+fn decode_numeric_entity(value: &str, radix: u32) -> Option<char> {
+    u32::from_str_radix(value, radix)
+        .ok()
+        .and_then(char::from_u32)
+}
+
+fn decode_named_entity(entity: &str) -> Option<char> {
+    match entity {
+        "AElig" => Some('Æ'),
+        "Aacute" => Some('Á'),
+        "Acirc" => Some('Â'),
+        "Agrave" => Some('À'),
+        "Aring" => Some('Å'),
+        "Atilde" => Some('Ã'),
+        "Auml" => Some('Ä'),
+        "Ccedil" => Some('Ç'),
+        "ETH" => Some('Ð'),
+        "Eacute" => Some('É'),
+        "Ecirc" => Some('Ê'),
+        "Egrave" => Some('È'),
+        "Euml" => Some('Ë'),
+        "Iacute" => Some('Í'),
+        "Icirc" => Some('Î'),
+        "Igrave" => Some('Ì'),
+        "Iuml" => Some('Ï'),
+        "Ntilde" => Some('Ñ'),
+        "Oacute" => Some('Ó'),
+        "Ocirc" => Some('Ô'),
+        "Ograve" => Some('Ò'),
+        "Oslash" => Some('Ø'),
+        "Otilde" => Some('Õ'),
+        "Ouml" => Some('Ö'),
+        "THORN" => Some('Þ'),
+        "Uacute" => Some('Ú'),
+        "Ucirc" => Some('Û'),
+        "Ugrave" => Some('Ù'),
+        "Uuml" => Some('Ü'),
+        "Yacute" => Some('Ý'),
+        "aacute" => Some('á'),
+        "acirc" => Some('â'),
+        "acute" => Some('´'),
+        "aelig" => Some('æ'),
+        "agrave" => Some('à'),
+        "amp" => Some('&'),
+        "apos" => Some('\''),
+        "aring" => Some('å'),
+        "atilde" => Some('ã'),
+        "auml" => Some('ä'),
+        "brvbar" => Some('¦'),
+        "ccedil" => Some('ç'),
+        "cedil" => Some('¸'),
+        "cent" => Some('¢'),
+        "copy" => Some('©'),
+        "curren" => Some('¤'),
+        "deg" => Some('°'),
+        "divide" => Some('÷'),
+        "euro" => Some('€'),
+        "eacute" => Some('é'),
+        "ecirc" => Some('ê'),
+        "egrave" => Some('è'),
+        "eth" => Some('ð'),
+        "euml" => Some('ë'),
+        "frac12" => Some('½'),
+        "frac14" => Some('¼'),
+        "frac34" => Some('¾'),
+        "gt" => Some('>'),
+        "iacute" => Some('í'),
+        "icirc" => Some('î'),
+        "iexcl" => Some('¡'),
+        "igrave" => Some('ì'),
+        "iquest" => Some('¿'),
+        "iuml" => Some('ï'),
+        "laquo" => Some('«'),
+        "ldquo" => Some('“'),
+        "lsaquo" => Some('‹'),
+        "lsquo" => Some('‘'),
+        "lt" => Some('<'),
+        "macr" => Some('¯'),
+        "mdash" => Some('—'),
+        "micro" => Some('µ'),
+        "middot" => Some('·'),
+        "nbsp" => Some('\u{00a0}'),
+        "ndash" => Some('–'),
+        "not" => Some('¬'),
+        "ntilde" => Some('ñ'),
+        "oacute" => Some('ó'),
+        "ocirc" => Some('ô'),
+        "ograve" => Some('ò'),
+        "ordf" => Some('ª'),
+        "ordm" => Some('º'),
+        "oslash" => Some('ø'),
+        "otilde" => Some('õ'),
+        "ouml" => Some('ö'),
+        "para" => Some('¶'),
+        "plusmn" => Some('±'),
+        "pound" => Some('£'),
+        "quot" => Some('"'),
+        "raquo" => Some('»'),
+        "reg" => Some('®'),
+        "rdquo" => Some('”'),
+        "rsaquo" => Some('›'),
+        "rsquo" => Some('’'),
+        "sect" => Some('§'),
+        "shy" => Some('\u{00ad}'),
+        "sup1" => Some('¹'),
+        "sup2" => Some('²'),
+        "sup3" => Some('³'),
+        "szlig" => Some('ß'),
+        "thorn" => Some('þ'),
+        "times" => Some('×'),
+        "trade" => Some('™'),
+        "uacute" => Some('ú'),
+        "ucirc" => Some('û'),
+        "ugrave" => Some('ù'),
+        "uml" => Some('¨'),
+        "uuml" => Some('ü'),
+        "yacute" => Some('ý'),
+        "yen" => Some('¥'),
+        "yuml" => Some('ÿ'),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::decode_jsx_entities;
+
+    #[test]
+    fn decodes_named_and_numeric_entities() {
+        assert_eq!(
+            decode_jsx_entities("Green-e&reg; &amp; Canada &#34;ok&#x22; &rsquo; &mdash;"),
+            "Green-e® & Canada \"ok\" ’ —"
+        );
+    }
+
+    #[test]
+    fn leaves_unknown_or_unfinished_entities_unchanged() {
+        assert_eq!(
+            decode_jsx_entities("R&D &custom; &amp"),
+            "R&D &custom; &amp"
+        );
+    }
+
+    #[test]
+    fn raw_ampersands_do_not_hide_later_entities() {
+        assert_eq!(decode_jsx_entities("R&D &amp; review"), "R&D & review");
+    }
+}

--- a/crates/palamedes/src/jsx_entities.rs
+++ b/crates/palamedes/src/jsx_entities.rs
@@ -19,14 +19,12 @@ pub(crate) fn decode_jsx_entities(input: &str) -> String {
 
         let entity_start = index + ch.len_utf8();
         let mut entity_end = None;
-        let mut candidate_is_valid = true;
         for (offset, entity_ch) in input[entity_start..].char_indices() {
             if entity_ch == ';' {
                 entity_end = Some(entity_start + offset);
                 break;
             }
             if !is_entity_candidate_char(entity_ch) {
-                candidate_is_valid = false;
                 break;
             }
         }
@@ -37,7 +35,7 @@ pub(crate) fn decode_jsx_entities(input: &str) -> String {
             continue;
         };
 
-        if !candidate_is_valid || entity_end == entity_start {
+        if entity_end == entity_start {
             decoded.push(ch);
             index += ch.len_utf8();
             continue;
@@ -123,6 +121,7 @@ fn decode_named_entity(entity: &str) -> Option<char> {
         "atilde" => Some('ã'),
         "auml" => Some('ä'),
         "brvbar" => Some('¦'),
+        "bull" => Some('•'),
         "ccedil" => Some('ç'),
         "cedil" => Some('¸'),
         "cent" => Some('¢'),
@@ -140,6 +139,7 @@ fn decode_named_entity(entity: &str) -> Option<char> {
         "frac14" => Some('¼'),
         "frac34" => Some('¾'),
         "gt" => Some('>'),
+        "hellip" => Some('…'),
         "iacute" => Some('í'),
         "icirc" => Some('î'),
         "iexcl" => Some('¡'),
@@ -155,6 +155,7 @@ fn decode_named_entity(entity: &str) -> Option<char> {
         "mdash" => Some('—'),
         "micro" => Some('µ'),
         "middot" => Some('·'),
+        "minus" => Some('−'),
         "nbsp" => Some('\u{00a0}'),
         "ndash" => Some('–'),
         "not" => Some('¬'),
@@ -204,8 +205,10 @@ mod tests {
     #[test]
     fn decodes_named_and_numeric_entities() {
         assert_eq!(
-            decode_jsx_entities("Green-e&reg; &amp; Canada &#34;ok&#x22; &rsquo; &mdash;"),
-            "Green-e® & Canada \"ok\" ’ —"
+            decode_jsx_entities(
+                "Green-e&reg; &amp; Canada &#34;ok&#x22; &rsquo; &mdash; &bull; &hellip; &minus;"
+            ),
+            "Green-e® & Canada \"ok\" ’ — • … −"
         );
     }
 

--- a/crates/palamedes/src/lib.rs
+++ b/crates/palamedes/src/lib.rs
@@ -25,6 +25,7 @@ mod catalog_update;
 mod diagnostic;
 mod error;
 mod extract;
+mod jsx_entities;
 mod message_metadata;
 mod transform;
 

--- a/crates/palamedes/src/transform/messages.rs
+++ b/crates/palamedes/src/transform/messages.rs
@@ -7,6 +7,7 @@ use oxc_ast::ast::{
 use oxc_span::GetSpan;
 
 use crate::error::{PalamedesError, PalamedesResult};
+use crate::jsx_entities::decode_jsx_entities;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct ValueBinding {
@@ -77,7 +78,9 @@ pub(super) fn extract_choice_options(object: &ObjectExpression<'_>) -> Vec<(Stri
 
 pub(super) fn jsx_attribute_string_value(value: &JSXAttributeValue<'_>) -> Option<String> {
     match value {
-        JSXAttributeValue::StringLiteral(literal) => Some(literal.value.to_string()),
+        JSXAttributeValue::StringLiteral(literal) => {
+            Some(decode_jsx_entities(literal.value.as_str()))
+        }
         JSXAttributeValue::ExpressionContainer(container) => {
             jsx_expression_string_value(&container.expression)
         }
@@ -87,10 +90,10 @@ pub(super) fn jsx_attribute_string_value(value: &JSXAttributeValue<'_>) -> Optio
 
 fn jsx_expression_string_value(expr: &JSXExpression<'_>) -> Option<String> {
     match expr {
-        JSXExpression::StringLiteral(literal) => Some(literal.value.to_string()),
-        JSXExpression::TemplateLiteral(template) => {
-            template.single_quasi().map(|value| value.to_string())
-        }
+        JSXExpression::StringLiteral(literal) => Some(decode_jsx_entities(literal.value.as_str())),
+        JSXExpression::TemplateLiteral(template) => template
+            .single_quasi()
+            .map(|value| decode_jsx_entities(value.as_str())),
         _ => None,
     }
 }
@@ -198,7 +201,7 @@ pub(super) fn clean_jsx_text(text: &str) -> String {
         }
     }
 
-    result
+    decode_jsx_entities(&result)
 }
 
 pub(super) fn opening_element_to_component(
@@ -278,7 +281,9 @@ fn extract_jsx_children_parts_with_state(
                 }
             }
             JSXChild::ExpressionContainer(container) => match &container.expression {
-                JSXExpression::StringLiteral(literal) => parts.push(literal.value.to_string()),
+                JSXExpression::StringLiteral(literal) => {
+                    parts.push(decode_jsx_entities(literal.value.as_str()));
+                }
                 expr => {
                     let binding =
                         jsx_value_binding(expr, source, "JSX expression", used_value_names)?;

--- a/crates/palamedes/src/transform/messages.rs
+++ b/crates/palamedes/src/transform/messages.rs
@@ -90,10 +90,10 @@ pub(super) fn jsx_attribute_string_value(value: &JSXAttributeValue<'_>) -> Optio
 
 fn jsx_expression_string_value(expr: &JSXExpression<'_>) -> Option<String> {
     match expr {
-        JSXExpression::StringLiteral(literal) => Some(decode_jsx_entities(literal.value.as_str())),
-        JSXExpression::TemplateLiteral(template) => template
-            .single_quasi()
-            .map(|value| decode_jsx_entities(value.as_str())),
+        JSXExpression::StringLiteral(literal) => Some(literal.value.to_string()),
+        JSXExpression::TemplateLiteral(template) => {
+            template.single_quasi().map(|value| value.to_string())
+        }
         _ => None,
     }
 }
@@ -282,7 +282,7 @@ fn extract_jsx_children_parts_with_state(
             }
             JSXChild::ExpressionContainer(container) => match &container.expression {
                 JSXExpression::StringLiteral(literal) => {
-                    parts.push(decode_jsx_entities(literal.value.as_str()));
+                    parts.push(literal.value.to_string());
                 }
                 expr => {
                     let binding =

--- a/crates/palamedes/src/transform/tests.rs
+++ b/crates/palamedes/src/transform/tests.rs
@@ -300,6 +300,28 @@ fn trans_jsx_macro_decodes_message_attribute_entities() {
 }
 
 #[test]
+fn trans_jsx_macro_keeps_expression_string_entities_raw() {
+    let result = transform_macros(
+        "import { Trans } from \"@palamedes/react/macro\";\nconst child = <Trans>{\"A &amp; B\"}</Trans>;\nconst attr = <Trans message={\"Literal &amp; Value\"} />;\n",
+        "test.tsx",
+        None,
+    )
+    .expect("transform should succeed");
+    let child_message = "A &amp; B";
+    let attr_message = "Literal &amp; Value";
+
+    assert!(result.code.contains("message={\"A &amp; B\"}"));
+    assert!(result.code.contains("message={\"Literal &amp; Value\"}"));
+    assert_eq!(
+        result.compiled_ids,
+        vec![
+            compiled_key(child_message, None),
+            compiled_key(attr_message, None)
+        ]
+    );
+}
+
+#[test]
 fn choice_jsx_macro_decodes_option_attribute_entities() {
     let result = transform_macros(
         "import { Plural } from \"@palamedes/react/macro\";\nconst el = <Plural value={count} one=\"# item &amp; fee\" other=\"# items &amp; fees\" />;\n",

--- a/crates/palamedes/src/transform/tests.rs
+++ b/crates/palamedes/src/transform/tests.rs
@@ -265,6 +265,55 @@ fn trans_jsx_macro_escapes_double_quotes_in_message_attribute() {
 }
 
 #[test]
+fn trans_jsx_macro_decodes_entities_before_deriving_message_id() {
+    let result = transform_macros(
+        "import { Trans } from \"@palamedes/react/macro\";\nconst el = <Trans>Green-e&reg; applies to US &amp; Canada only</Trans>;\n",
+        "test.tsx",
+        None,
+    )
+    .expect("transform should succeed");
+    let message = "Green-e® applies to US & Canada only";
+
+    assert!(result
+        .code
+        .contains("message={\"Green-e® applies to US & Canada only\"}"));
+    assert!(result
+        .code
+        .contains(&format!("id=\"{}\"", compiled_key(message, None))));
+    assert_eq!(result.compiled_ids, vec![compiled_key(message, None)]);
+}
+
+#[test]
+fn trans_jsx_macro_decodes_message_attribute_entities() {
+    let result = transform_macros(
+        "import { Trans } from \"@palamedes/react/macro\";\nconst el = <Trans message=\"Decision &quot;Model&quot; &#x26; review\" />;\n",
+        "test.tsx",
+        None,
+    )
+    .expect("transform should succeed");
+    let message = "Decision \"Model\" & review";
+
+    assert!(result
+        .code
+        .contains("message={\"Decision \\\"Model\\\" & review\"}"));
+    assert_eq!(result.compiled_ids, vec![compiled_key(message, None)]);
+}
+
+#[test]
+fn choice_jsx_macro_decodes_option_attribute_entities() {
+    let result = transform_macros(
+        "import { Plural } from \"@palamedes/react/macro\";\nconst el = <Plural value={count} one=\"# item &amp; fee\" other=\"# items &amp; fees\" />;\n",
+        "test.tsx",
+        None,
+    )
+    .expect("transform should succeed");
+
+    assert!(result
+        .code
+        .contains("message: \"{count, plural, one {# item & fee} other {# items & fees}}\""));
+}
+
+#[test]
 fn wraps_choice_jsx_macro_when_used_as_jsx_child() {
     let result = transform_macros(
         "import { Plural } from \"@palamedes/react/macro\";\nfunction Demo({ totalRows }) { return <p><Plural value={totalRows} one=\"# row\" other=\"# rows\" /></p>; }\n",

--- a/packages/extractor/src/extractMessages.test.ts
+++ b/packages/extractor/src/extractMessages.test.ts
@@ -61,11 +61,15 @@ describe("extractMessages", () => {
         import { Trans } from "@palamedes/react/macro"
         const a = <Trans>Green-e&reg; applies to US &amp; Canada only</Trans>
         const b = <Trans message="Decision &quot;Model&quot; &#x26; review" />
+        const c = <Trans>{"A &amp; B"}</Trans>
+        const d = <Trans message={"Literal &amp; Value"} />
       `
       const messages = extract(code)
-      expect(messages).toHaveLength(2)
+      expect(messages).toHaveLength(4)
       expect(messages[0].message).toBe("Green-e® applies to US & Canada only")
       expect(messages[1].message).toBe('Decision "Model" & review')
+      expect(messages[2].message).toBe("A &amp; B")
+      expect(messages[3].message).toBe("Literal &amp; Value")
     })
   })
 

--- a/packages/extractor/src/extractMessages.test.ts
+++ b/packages/extractor/src/extractMessages.test.ts
@@ -55,6 +55,18 @@ describe("extractMessages", () => {
       expect(messages).toHaveLength(1)
       expect(messages[0].message).toBe("Hello {name}")
     })
+
+    it("decodes JSX entities before deriving extracted messages", () => {
+      const code = `
+        import { Trans } from "@palamedes/react/macro"
+        const a = <Trans>Green-e&reg; applies to US &amp; Canada only</Trans>
+        const b = <Trans message="Decision &quot;Model&quot; &#x26; review" />
+      `
+      const messages = extract(code)
+      expect(messages).toHaveLength(2)
+      expect(messages[0].message).toBe("Green-e® applies to US & Canada only")
+      expect(messages[1].message).toBe('Decision "Model" & review')
+    })
   })
 
   describe("macro calls", () => {

--- a/packages/transform/src/transform.test.ts
+++ b/packages/transform/src/transform.test.ts
@@ -221,6 +221,18 @@ const el = <Trans>Green-e&reg; applies to US &amp; Canada only</Trans>;
     expect(result.code).not.toContain("&reg;")
   })
 
+  it("keeps JSX expression string entities raw", () => {
+    const code = `
+import { Trans } from "@palamedes/react/macro";
+const child = <Trans>{"A &amp; B"}</Trans>;
+const attr = <Trans message={"Literal &amp; Value"} />;
+`
+    const result = transformPalamedesMacros(code, "test.tsx")
+
+    expect(result.code).toContain('message={"A &amp; B"}')
+    expect(result.code).toContain('message={"Literal &amp; Value"}')
+  })
+
   it("wraps JSX choice macro replacements when used as children", () => {
     const code = `
 import { Plural } from "@palamedes/react/macro";

--- a/packages/transform/src/transform.test.ts
+++ b/packages/transform/src/transform.test.ts
@@ -209,6 +209,18 @@ export function Demo() {
     expect(result.code).not.toContain('message="Upload settlement data file with \\\"')
   })
 
+  it("decodes JSX entities before deriving transformed Trans messages", () => {
+    const code = `
+import { Trans } from "@palamedes/react/macro";
+const el = <Trans>Green-e&reg; applies to US &amp; Canada only</Trans>;
+`
+    const result = transformPalamedesMacros(code, "test.tsx")
+
+    expect(result.code).toContain('message={"Green-e® applies to US & Canada only"}')
+    expect(result.code).not.toContain("&amp;")
+    expect(result.code).not.toContain("&reg;")
+  })
+
   it("wraps JSX choice macro replacements when used as children", () => {
     const code = `
 import { Plural } from "@palamedes/react/macro";


### PR DESCRIPTION
Closes #220.

## Summary

- Decode JSX entity text before extracting Palamedes source message keys.
- Apply the same normalization in macro transforms before deriving compiled runtime IDs.
- Keep ordinary JavaScript descriptor/runtime string literals unchanged.

## Validation

- `cargo fmt --all --check`
- `cargo test --workspace --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `pnpm build`
- `pnpm test`
- `pnpm check-types`
- `pnpm lint`
- `pnpm format:check`
- `pnpm check:release-set`
