### PR TITLE
chore(deps): update Ferrocat to 1.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,9 +199,9 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ferrocat"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1eaa6ab44981713ec2c1fc9161eb1fdf2a6ab1d507221fdd4af946f3cc2a0cf"
+checksum = "9becff2c63214c6fa75c646b6e9563586a88191e214b245702b684b36970eb12"
 dependencies = [
  "ferrocat-icu",
  "ferrocat-po",
@@ -209,18 +209,19 @@ dependencies = [
 
 [[package]]
 name = "ferrocat-icu"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f16b4019d1062585a9ad5d56c90963f338181992c6d87c2c99441c41fec70dc5"
+checksum = "cd4b4408c08d713fc3481c2021abce20de1013e6ba239b247cced67fd8e0fe5c"
 dependencies = [
+ "memchr",
  "serde",
 ]
 
 [[package]]
 name = "ferrocat-po"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cfe0d8503d5b5eb2c20a9cb0d974ede77227705539fd4498d9debc4d86a5428"
+checksum = "9c7fc4a25fc10199c0f025ce1e509bdc40ae39864849a724ff5ffd1df8f28806"
 dependencies = [
  "ferrocat-icu",
  "icu_locale",

--- a/crates/palamedes/Cargo.toml
+++ b/crates/palamedes/Cargo.toml
@@ -8,8 +8,8 @@ rust-version.workspace = true
 description = "Rust core for Palamedes."
 
 [dependencies]
-ferrocat = "1.3.0"
-ferrocat-po = "1.3.0"
+ferrocat = "1.3.1"
+ferrocat-po = "1.3.1"
 oxc_allocator = "0.133.0"
 oxc_ast = "0.133.0"
 oxc_ast_visit = "0.133.0"

--- a/crates/palamedes/src/lib.rs
+++ b/crates/palamedes/src/lib.rs
@@ -71,7 +71,7 @@ pub use transform::{
 };
 
 /// Published `ferrocat` version used by the Rust core.
-pub const FERROCAT_VERSION: &str = "1.3.0";
+pub const FERROCAT_VERSION: &str = "1.3.1";
 
 /// Version metadata for the loaded native core.
 #[derive(Debug, Serialize)]


### PR DESCRIPTION
## Dependency group
- Packages: `ferrocat` 1.3.0 -> 1.3.1, `ferrocat-po` 1.3.0 -> 1.3.1, transitive `ferrocat-icu` 1.3.0 -> 1.3.1
- Why grouped: these crates are released from the same Ferrocat workspace and Palamedes uses `ferrocat` plus `ferrocat-po` together for catalog parsing, updates, merging, NDJSON, and ICU diagnostics.

## Upstream changes that matter here
- `ferrocat`: workspace version sync to 1.3.1 and dependency bumps to `ferrocat-po`/`ferrocat-icu` 1.3.1. Release: https://github.com/sebastian-software/ferrocat/releases/tag/ferrocat-v1.3.1
- `ferrocat-po`: performance work for catalog merge, plural profile construction, NDJSON line-buffer reuse, and parser/merge benchmarks. Release: https://github.com/sebastian-software/ferrocat/releases/tag/ferrocat-po-v1.3.1
- `ferrocat-icu`: performance work for ICU parser scanning/literal handling. Release: https://github.com/sebastian-software/ferrocat/releases/tag/ferrocat-icu-v1.3.1

## Local impact and code changes
- Bumped the direct Palamedes Rust dependencies to `1.3.1` and regenerated `Cargo.lock`.
- Updated `FERROCAT_VERSION` so `get_native_info()` continues to report the linked Ferrocat version correctly.
- Checked local usage of the affected merge, NDJSON, and ICU surfaces; no API migration was required.

## Validation
- `cargo test --workspace`: passed
- `pnpm build`: passed
- `pnpm check-types`: passed
- `pnpm test`: passed
- `git diff --check`: passed

## Risk
- Low runtime/API risk. The upstream release is a patch release focused on performance and workspace version synchronization; Palamedes coverage exercises catalog merge, NDJSON, ICU diagnostics, native version metadata, and JS package surfaces.