### PR TITLE
perf(core): release Ferrocat 1.3.1 catalog optimizations

### DIFF
--- a/docs/proof-and-benchmarks.md
+++ b/docs/proof-and-benchmarks.md
@@ -187,7 +187,7 @@ Median results from that run:
 - catalog artifact compile: `4.04 ms`
 
 This sample is a historical reference point. Current Palamedes builds use
-Ferrocat `0.11.0`; rerun the command above when you need fresh numbers for the
+Ferrocat `1.3.1`; rerun the command above when you need fresh numbers for the
 current release line. The benchmark script also prints the raw sample series and
 sampled peak RSS so the checked median and memory shape are easy to verify.
 


### PR DESCRIPTION
## Summary
- Adds a release-visible `perf(core)` commit after the Ferrocat 1.3.1 dependency update landed in #223.
- Refreshes the benchmark/proof note so it points at the current Ferrocat baseline, `1.3.1`, instead of the stale `0.11.0` reference.

## Release impact
- This is intentionally release-triggering: Release Please hides `chore`/`deps` sections in this repo, while `perf` is a visible patch-release signal.
- The actual dependency update is already on `main` from #223; this follow-up gives Release Please a conventional commit to publish the new release line.

## Validation
- `git diff --check`: passed

No runtime code changed in this PR.