### PR TITLE
fix(transform): normalize rich-text placeholder whitespace

### DIFF
--- a/crates/palamedes/src/transform/messages.rs
+++ b/crates/palamedes/src/transform/messages.rs
@@ -204,6 +204,69 @@ pub(super) fn clean_jsx_text(text: &str) -> String {
     decode_jsx_entities(&result)
 }
 
+fn join_jsx_message_parts(parts: &[String]) -> String {
+    let mut message = String::new();
+
+    for part in parts {
+        push_jsx_message_part(&mut message, part);
+    }
+
+    message.trim().to_string()
+}
+
+fn push_jsx_message_part(message: &mut String, part: &str) {
+    if part.is_empty() {
+        return;
+    }
+
+    let mut next = part;
+
+    if !message.is_empty() {
+        if message.ends_with(char::is_whitespace) && next.starts_with(char::is_whitespace) {
+            next = next.trim_start_matches(char::is_whitespace);
+        }
+
+        if ends_with_component_placeholder(message) && starts_with_whitespace_then_punctuation(next)
+        {
+            next = next.trim_start_matches(char::is_whitespace);
+        }
+    }
+
+    message.push_str(next);
+}
+
+fn ends_with_component_placeholder(value: &str) -> bool {
+    let Some(before_closing_angle) = value.strip_suffix('>') else {
+        return false;
+    };
+    let Some(tag_start) = before_closing_angle.rfind("</") else {
+        return false;
+    };
+
+    before_closing_angle[tag_start + 2..]
+        .chars()
+        .all(|ch| ch.is_ascii_digit())
+}
+
+fn starts_with_whitespace_then_punctuation(value: &str) -> bool {
+    let mut chars = value.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+
+    if !first.is_whitespace() {
+        return false;
+    }
+
+    chars
+        .find(|ch| !ch.is_whitespace())
+        .is_some_and(is_message_punctuation)
+}
+
+fn is_message_punctuation(ch: char) -> bool {
+    matches!(ch, '.' | ',' | ';' | ':' | '!' | '?' | ')' | ']' | '}')
+}
+
 pub(super) fn opening_element_to_component(
     opening_element: &JSXOpeningElement<'_>,
     source: &str,
@@ -341,7 +404,7 @@ fn extract_jsx_children_parts_with_state(
         }
     }
 
-    Ok((parts.join("").trim().to_string(), values, components))
+    Ok((join_jsx_message_parts(&parts), values, components))
 }
 
 fn push_unique_binding(bindings: &mut Vec<ValueBinding>, binding: ValueBinding) {

--- a/crates/palamedes/src/transform/tests.rs
+++ b/crates/palamedes/src/transform/tests.rs
@@ -194,6 +194,34 @@ fn deduplicates_same_tag_component_placeholders_with_identical_markup() {
 }
 
 #[test]
+fn normalizes_trans_jsx_placeholder_boundary_whitespace() {
+    let result = transform_macros(
+        "import { Trans } from \"@palamedes/react/macro\";\nconst el = <Trans>Reach out to your {\" \"}<a href=\"/advisor\">advisor</a>{\" \"} for help.</Trans>;\n",
+        "test.tsx",
+        None,
+    )
+    .expect("transform should succeed");
+
+    assert!(result
+        .code
+        .contains("message={\"Reach out to your <0>advisor</0> for help.\"}"));
+}
+
+#[test]
+fn normalizes_trans_jsx_placeholder_before_punctuation() {
+    let result = transform_macros(
+        "import { Trans } from \"@palamedes/react/macro\";\nconst el = <Trans>Delete {\" \"}<strong>{selectedProjectName}</strong> ? This action cannot be undone.</Trans>;\n",
+        "test.tsx",
+        None,
+    )
+    .expect("transform should succeed");
+
+    assert!(result.code.contains(
+        "message={\"Delete <0>{selectedProjectName}</0>? This action cannot be undone.\"}"
+    ));
+}
+
+#[test]
 fn preserves_use_client_directive_before_injected_imports() {
     let result = transform_macros(
         "\"use client\";\nimport { Trans } from \"@palamedes/react/macro\";\nconst el = <Trans>Hello</Trans>;\n",

--- a/packages/transform/src/transform.test.ts
+++ b/packages/transform/src/transform.test.ts
@@ -181,6 +181,20 @@ const el = <Trans><strong>A</strong> and <strong>B</strong></Trans>;
     expect(result.code).toContain("components={{ 0: <strong />, 1: <strong /> }}")
   })
 
+  it("normalizes rich-text placeholder boundary whitespace", () => {
+    const code = `
+import { Trans } from "@palamedes/react/macro";
+const helper = <Trans>Reach out to your {" "}<a href="/advisor">advisor</a>{" "} for help.</Trans>;
+const confirm = <Trans>Delete {" "}<strong>{selectedProjectName}</strong> ? This action cannot be undone.</Trans>;
+`
+    const result = transformPalamedesMacros(code, "test.tsx")
+
+    expect(result.code).toContain('message={"Reach out to your <0>advisor</0> for help."}')
+    expect(result.code).toContain(
+      'message={"Delete <0>{selectedProjectName}</0>? This action cannot be undone."}'
+    )
+  })
+
   it("strips the message field when requested", () => {
     const code = `
 import { t } from "@palamedes/core/macro";


### PR DESCRIPTION
Fixes #226.

## What changed

- Normalize JSX message assembly so adjacent whitespace from source text and `{" "}` expression boundaries collapses to one word boundary.
- Remove incidental whitespace before punctuation after generated rich-text placeholders such as `</0>`.
- Add Rust core and `@palamedes/transform` regression coverage for rich-text placeholder boundary whitespace.

## Why

Palamedes was normalizing each JSX text chunk independently and then joining chunks directly. When a rich-text placeholder had source whitespace plus explicit `{" "}` around it, the derived message could gain double spaces and therefore a different catalog ID from visually equivalent Lingui messages.

## Validation

- `cargo test -p palamedes --locked`
- `pnpm --filter @palamedes/transform test`
- `cargo fmt --all --check`
- `pnpm format:check`
