### PR TITLE
fix(extractor): normalize rich-text placeholder whitespace

### DIFF
--- a/crates/palamedes/src/extract.rs
+++ b/crates/palamedes/src/extract.rs
@@ -827,7 +827,7 @@ fn extract_jsx_children_as_message_with_state(
         }
     }
 
-    Ok(parts.join("").trim().to_string())
+    Ok(join_jsx_message_parts(&parts))
 }
 
 fn clean_jsx_text(text: &str) -> String {
@@ -847,6 +847,69 @@ fn clean_jsx_text(text: &str) -> String {
     }
 
     decode_jsx_entities(&result)
+}
+
+fn join_jsx_message_parts(parts: &[String]) -> String {
+    let mut message = String::new();
+
+    for part in parts {
+        push_jsx_message_part(&mut message, part);
+    }
+
+    message.trim().to_string()
+}
+
+fn push_jsx_message_part(message: &mut String, part: &str) {
+    if part.is_empty() {
+        return;
+    }
+
+    let mut next = part;
+
+    if !message.is_empty() {
+        if message.ends_with(char::is_whitespace) && next.starts_with(char::is_whitespace) {
+            next = next.trim_start_matches(char::is_whitespace);
+        }
+
+        if ends_with_component_placeholder(message) && starts_with_whitespace_then_punctuation(next)
+        {
+            next = next.trim_start_matches(char::is_whitespace);
+        }
+    }
+
+    message.push_str(next);
+}
+
+fn ends_with_component_placeholder(value: &str) -> bool {
+    let Some(before_closing_angle) = value.strip_suffix('>') else {
+        return false;
+    };
+    let Some(tag_start) = before_closing_angle.rfind("</") else {
+        return false;
+    };
+
+    before_closing_angle[tag_start + 2..]
+        .chars()
+        .all(|ch| ch.is_ascii_digit())
+}
+
+fn starts_with_whitespace_then_punctuation(value: &str) -> bool {
+    let mut chars = value.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+
+    if !first.is_whitespace() {
+        return false;
+    }
+
+    chars
+        .find(|ch| !ch.is_whitespace())
+        .is_some_and(is_message_punctuation)
+}
+
+fn is_message_punctuation(ch: char) -> bool {
+    matches!(ch, '.' | ',' | ';' | ':' | '!' | '?' | ')' | ']' | '}')
 }
 
 fn extract_choice_options_from_jsx(opening_element: &JSXOpeningElement<'_>) -> ChoiceOptions {
@@ -1282,6 +1345,49 @@ mod tests {
         .expect("messages should extract");
 
         assert_eq!(messages[0].message, "<0>A</0> and <1>B</1>");
+    }
+
+    #[test]
+    fn normalizes_jsx_component_placeholder_boundary_whitespace() {
+        let messages = extract_messages(
+            r#"
+              import { Trans } from "@palamedes/react/macro"
+              const helper = <Trans>Reach out to your {" "}<a href="/advisor">advisor</a>{" "} for help.</Trans>
+              const target = <Trans><strong>100%</strong> Clean Energy by {" "}<strong>{targetYear}</strong></Trans>
+              const details = <Trans><strong>Dates & Capacity:</strong> {" "}commercial_operation_date, project_capacity_mw, buyer_capacity_mw</Trans>
+            "#,
+            "test.tsx",
+        )
+        .expect("messages should extract");
+
+        assert_eq!(
+            messages
+                .iter()
+                .map(|message| message.message.as_str())
+                .collect::<Vec<_>>(),
+            vec![
+                "Reach out to your <0>advisor</0> for help.",
+                "<0>100%</0> Clean Energy by <1>{targetYear}</1>",
+                "<0>Dates & Capacity:</0> commercial_operation_date, project_capacity_mw, buyer_capacity_mw",
+            ]
+        );
+    }
+
+    #[test]
+    fn normalizes_jsx_component_placeholder_before_punctuation() {
+        let messages = extract_messages(
+            r#"
+              import { Trans } from "@palamedes/react/macro"
+              const message = <Trans>Delete {" "}<strong>{selectedProjectName}</strong> ? This action cannot be undone.</Trans>
+            "#,
+            "test.tsx",
+        )
+        .expect("messages should extract");
+
+        assert_eq!(
+            messages[0].message,
+            "Delete <0>{selectedProjectName}</0>? This action cannot be undone."
+        );
     }
 
     #[test]

--- a/crates/palamedes/src/extract.rs
+++ b/crates/palamedes/src/extract.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use crate::catalog_update::{CatalogUpdateMessage, CatalogUpdateOrigin};
 use crate::error::{PalamedesError, PalamedesResult};
 use crate::jsx_entities::decode_jsx_entities;
+use crate::jsx_message::{clean_jsx_text, join_jsx_message_parts};
 use oxc_allocator::Allocator;
 use oxc_ast::ast::{
     Argument, CallExpression, Expression, ImportDeclaration, ImportDeclarationSpecifier,
@@ -828,88 +829,6 @@ fn extract_jsx_children_as_message_with_state(
     }
 
     Ok(join_jsx_message_parts(&parts))
-}
-
-fn clean_jsx_text(text: &str) -> String {
-    let mut result = String::with_capacity(text.len());
-    let mut last_was_whitespace = false;
-
-    for ch in text.chars() {
-        if ch.is_whitespace() {
-            if !last_was_whitespace {
-                result.push(' ');
-                last_was_whitespace = true;
-            }
-        } else {
-            result.push(ch);
-            last_was_whitespace = false;
-        }
-    }
-
-    decode_jsx_entities(&result)
-}
-
-fn join_jsx_message_parts(parts: &[String]) -> String {
-    let mut message = String::new();
-
-    for part in parts {
-        push_jsx_message_part(&mut message, part);
-    }
-
-    message.trim().to_string()
-}
-
-fn push_jsx_message_part(message: &mut String, part: &str) {
-    if part.is_empty() {
-        return;
-    }
-
-    let mut next = part;
-
-    if !message.is_empty() {
-        if message.ends_with(char::is_whitespace) && next.starts_with(char::is_whitespace) {
-            next = next.trim_start_matches(char::is_whitespace);
-        }
-
-        if ends_with_component_placeholder(message) && starts_with_whitespace_then_punctuation(next)
-        {
-            next = next.trim_start_matches(char::is_whitespace);
-        }
-    }
-
-    message.push_str(next);
-}
-
-fn ends_with_component_placeholder(value: &str) -> bool {
-    let Some(before_closing_angle) = value.strip_suffix('>') else {
-        return false;
-    };
-    let Some(tag_start) = before_closing_angle.rfind("</") else {
-        return false;
-    };
-
-    before_closing_angle[tag_start + 2..]
-        .chars()
-        .all(|ch| ch.is_ascii_digit())
-}
-
-fn starts_with_whitespace_then_punctuation(value: &str) -> bool {
-    let mut chars = value.chars();
-    let Some(first) = chars.next() else {
-        return false;
-    };
-
-    if !first.is_whitespace() {
-        return false;
-    }
-
-    chars
-        .find(|ch| !ch.is_whitespace())
-        .is_some_and(is_message_punctuation)
-}
-
-fn is_message_punctuation(ch: char) -> bool {
-    matches!(ch, '.' | ',' | ';' | ':' | '!' | '?' | ')' | ']' | '}')
 }
 
 fn extract_choice_options_from_jsx(opening_element: &JSXOpeningElement<'_>) -> ChoiceOptions {

--- a/crates/palamedes/src/jsx_message.rs
+++ b/crates/palamedes/src/jsx_message.rs
@@ -1,0 +1,83 @@
+use crate::jsx_entities::decode_jsx_entities;
+
+pub(crate) fn clean_jsx_text(text: &str) -> String {
+    let mut result = String::with_capacity(text.len());
+    let mut last_was_whitespace = false;
+
+    for ch in text.chars() {
+        if ch.is_whitespace() {
+            if !last_was_whitespace {
+                result.push(' ');
+                last_was_whitespace = true;
+            }
+        } else {
+            result.push(ch);
+            last_was_whitespace = false;
+        }
+    }
+
+    decode_jsx_entities(&result)
+}
+
+pub(crate) fn join_jsx_message_parts(parts: &[String]) -> String {
+    let mut message = String::new();
+
+    for part in parts {
+        push_jsx_message_part(&mut message, part);
+    }
+
+    message.trim().to_string()
+}
+
+fn push_jsx_message_part(message: &mut String, part: &str) {
+    if part.is_empty() {
+        return;
+    }
+
+    let mut next = part;
+
+    if !message.is_empty() {
+        if message.ends_with(char::is_whitespace) && next.starts_with(char::is_whitespace) {
+            next = next.trim_start_matches(char::is_whitespace);
+        }
+
+        if ends_with_component_placeholder(message) && starts_with_whitespace_then_punctuation(next)
+        {
+            next = next.trim_start_matches(char::is_whitespace);
+        }
+    }
+
+    message.push_str(next);
+}
+
+fn ends_with_component_placeholder(value: &str) -> bool {
+    let Some(before_closing_angle) = value.strip_suffix('>') else {
+        return false;
+    };
+    let Some(tag_start) = before_closing_angle.rfind("</") else {
+        return false;
+    };
+
+    before_closing_angle[tag_start + 2..]
+        .chars()
+        .all(|ch| ch.is_ascii_digit())
+}
+
+fn starts_with_whitespace_then_punctuation(value: &str) -> bool {
+    let mut chars = value.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+
+    if !first.is_whitespace() {
+        return false;
+    }
+
+    chars
+        .find(|ch| !ch.is_whitespace())
+        .is_some_and(is_message_punctuation)
+}
+
+fn is_message_punctuation(ch: char) -> bool {
+    matches!(ch, '.' | ',' | ';' | ':' | '!' | '?' | ')' | ']' | '}')
+}

--- a/crates/palamedes/src/lib.rs
+++ b/crates/palamedes/src/lib.rs
@@ -26,6 +26,7 @@ mod diagnostic;
 mod error;
 mod extract;
 mod jsx_entities;
+mod jsx_message;
 mod message_metadata;
 mod transform;
 

--- a/crates/palamedes/src/transform/messages.rs
+++ b/crates/palamedes/src/transform/messages.rs
@@ -8,6 +8,7 @@ use oxc_span::GetSpan;
 
 use crate::error::{PalamedesError, PalamedesResult};
 use crate::jsx_entities::decode_jsx_entities;
+use crate::jsx_message::{clean_jsx_text, join_jsx_message_parts};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct ValueBinding {
@@ -183,88 +184,6 @@ pub(super) fn extract_choice_options_from_jsx(
     }
 
     options
-}
-
-pub(super) fn clean_jsx_text(text: &str) -> String {
-    let mut result = String::with_capacity(text.len());
-    let mut last_was_whitespace = false;
-
-    for ch in text.chars() {
-        if ch.is_whitespace() {
-            if !last_was_whitespace {
-                result.push(' ');
-                last_was_whitespace = true;
-            }
-        } else {
-            result.push(ch);
-            last_was_whitespace = false;
-        }
-    }
-
-    decode_jsx_entities(&result)
-}
-
-fn join_jsx_message_parts(parts: &[String]) -> String {
-    let mut message = String::new();
-
-    for part in parts {
-        push_jsx_message_part(&mut message, part);
-    }
-
-    message.trim().to_string()
-}
-
-fn push_jsx_message_part(message: &mut String, part: &str) {
-    if part.is_empty() {
-        return;
-    }
-
-    let mut next = part;
-
-    if !message.is_empty() {
-        if message.ends_with(char::is_whitespace) && next.starts_with(char::is_whitespace) {
-            next = next.trim_start_matches(char::is_whitespace);
-        }
-
-        if ends_with_component_placeholder(message) && starts_with_whitespace_then_punctuation(next)
-        {
-            next = next.trim_start_matches(char::is_whitespace);
-        }
-    }
-
-    message.push_str(next);
-}
-
-fn ends_with_component_placeholder(value: &str) -> bool {
-    let Some(before_closing_angle) = value.strip_suffix('>') else {
-        return false;
-    };
-    let Some(tag_start) = before_closing_angle.rfind("</") else {
-        return false;
-    };
-
-    before_closing_angle[tag_start + 2..]
-        .chars()
-        .all(|ch| ch.is_ascii_digit())
-}
-
-fn starts_with_whitespace_then_punctuation(value: &str) -> bool {
-    let mut chars = value.chars();
-    let Some(first) = chars.next() else {
-        return false;
-    };
-
-    if !first.is_whitespace() {
-        return false;
-    }
-
-    chars
-        .find(|ch| !ch.is_whitespace())
-        .is_some_and(is_message_punctuation)
-}
-
-fn is_message_punctuation(ch: char) -> bool {
-    matches!(ch, '.' | ',' | ';' | ':' | '!' | '?' | ')' | ']' | '}')
 }
 
 pub(super) fn opening_element_to_component(

--- a/packages/extractor/src/extractMessages.test.ts
+++ b/packages/extractor/src/extractMessages.test.ts
@@ -71,6 +71,24 @@ describe("extractMessages", () => {
       expect(messages[2].message).toBe("A &amp; B")
       expect(messages[3].message).toBe("Literal &amp; Value")
     })
+
+    it("normalizes rich-text placeholder boundary whitespace", () => {
+      const code = `
+        import { Trans } from "@palamedes/react/macro"
+        const helper = <Trans>Reach out to your {" "}<a href="/advisor">advisor</a>{" "} for help.</Trans>
+        const target = <Trans><strong>100%</strong> Clean Energy by {" "}<strong>{targetYear}</strong></Trans>
+        const details = <Trans><strong>Dates & Capacity:</strong> {" "}commercial_operation_date, project_capacity_mw, buyer_capacity_mw</Trans>
+        const confirm = <Trans>Delete {" "}<strong>{selectedProjectName}</strong> ? This action cannot be undone.</Trans>
+      `
+      const messages = extract(code)
+
+      expect(messages.map((message) => message.message)).toStrictEqual([
+        "Reach out to your <0>advisor</0> for help.",
+        "<0>100%</0> Clean Energy by <1>{targetYear}</1>",
+        "<0>Dates & Capacity:</0> commercial_operation_date, project_capacity_mw, buyer_capacity_mw",
+        "Delete <0>{selectedProjectName}</0>? This action cannot be undone.",
+      ])
+    })
   })
 
   describe("macro calls", () => {


### PR DESCRIPTION
Follow-up for #226.

## What changed

- Apply the rich-text placeholder whitespace normalization to the extractor JSX message assembly path.
- Cover the EACManagement retest examples that still produced extra spaces after `0.7.5`.
- Keep the existing transform-path coverage from #227 unchanged.

## Root cause

#227 fixed `<Trans>` macro transform output, but catalog extraction uses `crates/palamedes/src/extract.rs`. That extractor path still joined JSX message parts with `parts.join("").trim()`, so `pnpm i18n:validate` continued to derive catalog IDs with doubled whitespace around generated rich-text placeholders.

## Validation

- `cargo test -p palamedes --locked`
- `pnpm --filter @palamedes/extractor test`
- `pnpm --filter @palamedes/core-node-darwin-arm64 build`
- `pnpm --filter @palamedes/core-node --filter @palamedes/extractor build`
- `cargo fmt --all --check`
- `pnpm format:check`
