### PR TITLE
fix(core): align JSX separator whitespace

### DIFF
--- a/crates/palamedes/src/extract.rs
+++ b/crates/palamedes/src/extract.rs
@@ -4,7 +4,9 @@ use std::path::{Path, PathBuf};
 use crate::catalog_update::{CatalogUpdateMessage, CatalogUpdateOrigin};
 use crate::error::{PalamedesError, PalamedesResult};
 use crate::jsx_entities::decode_jsx_entities;
-use crate::jsx_message::{clean_jsx_text, join_jsx_message_parts};
+use crate::jsx_message::{
+    clean_jsx_text, join_jsx_message_parts, JoinedJsxMessage, JsxMessagePart,
+};
 use oxc_allocator::Allocator;
 use oxc_ast::ast::{
     Argument, CallExpression, Expression, ImportDeclaration, ImportDeclarationSpecifier,
@@ -772,13 +774,13 @@ fn extract_jsx_children_as_message(
 ) -> PalamedesResult<String> {
     let mut next_component_index = 0usize;
 
-    extract_jsx_children_as_message_with_state(children, &mut next_component_index)
+    Ok(extract_jsx_children_as_message_with_state(children, &mut next_component_index)?.message)
 }
 
 fn extract_jsx_children_as_message_with_state(
     children: &[JSXChild<'_>],
     next_component_index: &mut usize,
-) -> PalamedesResult<String> {
+) -> PalamedesResult<JoinedJsxMessage> {
     let mut parts = Vec::new();
 
     for child in children {
@@ -786,12 +788,12 @@ fn extract_jsx_children_as_message_with_state(
             JSXChild::Text(text) => {
                 let value = clean_jsx_text(text.value.as_str());
                 if !value.is_empty() {
-                    parts.push(value);
+                    parts.push(JsxMessagePart::Text(value));
                 }
             }
             JSXChild::ExpressionContainer(container) => match &container.expression {
                 JSXExpression::StringLiteral(literal) => {
-                    parts.push(literal.value.to_string());
+                    parts.push(JsxMessagePart::Text(literal.value.to_string()));
                 }
                 expr => {
                     let Some(name) = jsx_expression_name(expr) else {
@@ -799,7 +801,7 @@ fn extract_jsx_children_as_message_with_state(
                             syntax: "JSX expression",
                         });
                     };
-                    parts.push(format!("{{{name}}}"));
+                    parts.push(JsxMessagePart::ValuePlaceholder(format!("{{{name}}}")));
                 }
             },
             JSXChild::Element(element) => {
@@ -809,15 +811,21 @@ fn extract_jsx_children_as_message_with_state(
                     &element.children,
                     next_component_index,
                 )?;
-                parts.push(format!("<{name}>{inner}</{name}>"));
+                parts.push(JsxMessagePart::ComponentPlaceholder(format!(
+                    "<{name}>{}</{name}>",
+                    inner.message
+                )));
             }
             JSXChild::Fragment(fragment) => {
                 let inner = extract_jsx_children_as_message_with_state(
                     &fragment.children,
                     next_component_index,
                 )?;
-                if !inner.is_empty() {
-                    parts.push(inner);
+                if !inner.message.is_empty() {
+                    parts.push(JsxMessagePart::Message {
+                        value: inner.message,
+                        ends_with_placeholder: inner.ends_with_placeholder,
+                    });
                 }
             }
             JSXChild::Spread(_) => {
@@ -1302,6 +1310,7 @@ mod tests {
                 Tailored to your {volume} MWh of annual electricity use in {countryName}
                 .
               </Trans>
+              const literalBraces = <Trans>{"{name}"} .</Trans>
             "#,
             "test.tsx",
         )
@@ -1315,6 +1324,7 @@ mod tests {
             messages[1].message,
             "Tailored to your {volume} MWh of annual electricity use in {countryName}."
         );
+        assert_eq!(messages[2].message, "{name} .");
     }
 
     #[test]

--- a/crates/palamedes/src/extract.rs
+++ b/crates/palamedes/src/extract.rs
@@ -1298,6 +1298,10 @@ mod tests {
             r#"
               import { Trans } from "@palamedes/react/macro"
               const message = <Trans>Delete {" "}<strong>{selectedProjectName}</strong> ? This action cannot be undone.</Trans>
+              const tailored = <Trans>
+                Tailored to your {volume} MWh of annual electricity use in {countryName}
+                .
+              </Trans>
             "#,
             "test.tsx",
         )
@@ -1306,6 +1310,31 @@ mod tests {
         assert_eq!(
             messages[0].message,
             "Delete <0>{selectedProjectName}</0>? This action cannot be undone."
+        );
+        assert_eq!(
+            messages[1].message,
+            "Tailored to your {volume} MWh of annual electricity use in {countryName}."
+        );
+    }
+
+    #[test]
+    fn preserves_leading_jsx_separator_spacing() {
+        let messages = extract_messages(
+            r#"
+              import { Trans } from "@palamedes/react/macro"
+              const price = <Trans> · ${priceFormatted}/MWh</Trans>
+              const manager = <Trans> — no manager</Trans>
+            "#,
+            "test.tsx",
+        )
+        .expect("messages should extract");
+
+        assert_eq!(
+            messages
+                .iter()
+                .map(|message| message.message.as_str())
+                .collect::<Vec<_>>(),
+            vec![" · ${priceFormatted}/MWh", " — no manager"]
         );
     }
 

--- a/crates/palamedes/src/jsx_message.rs
+++ b/crates/palamedes/src/jsx_message.rs
@@ -26,7 +26,7 @@ pub(crate) fn join_jsx_message_parts(parts: &[String]) -> String {
         push_jsx_message_part(&mut message, part);
     }
 
-    message.trim().to_string()
+    trim_message_edges(&message)
 }
 
 fn push_jsx_message_part(message: &mut String, part: &str) {
@@ -41,13 +41,27 @@ fn push_jsx_message_part(message: &mut String, part: &str) {
             next = next.trim_start_matches(char::is_whitespace);
         }
 
-        if ends_with_component_placeholder(message) && starts_with_whitespace_then_punctuation(next)
-        {
+        if ends_with_message_placeholder(message) && starts_with_whitespace_then_punctuation(next) {
             next = next.trim_start_matches(char::is_whitespace);
         }
     }
 
     message.push_str(next);
+}
+
+fn trim_message_edges(message: &str) -> String {
+    let trimmed_end = message.trim_end_matches(char::is_whitespace);
+    let trimmed = trimmed_end.trim_start_matches(char::is_whitespace);
+
+    if starts_with_leading_separator(trimmed) && trimmed_end.starts_with(char::is_whitespace) {
+        return format!(" {trimmed}");
+    }
+
+    trimmed.to_string()
+}
+
+fn ends_with_message_placeholder(value: &str) -> bool {
+    ends_with_component_placeholder(value) || ends_with_value_placeholder(value)
 }
 
 fn ends_with_component_placeholder(value: &str) -> bool {
@@ -61,6 +75,17 @@ fn ends_with_component_placeholder(value: &str) -> bool {
     before_closing_angle[tag_start + 2..]
         .chars()
         .all(|ch| ch.is_ascii_digit())
+}
+
+fn ends_with_value_placeholder(value: &str) -> bool {
+    let Some(before_closing_brace) = value.strip_suffix('}') else {
+        return false;
+    };
+    let Some(placeholder_start) = before_closing_brace.rfind('{') else {
+        return false;
+    };
+
+    is_placeholder_name(&before_closing_brace[placeholder_start + 1..])
 }
 
 fn starts_with_whitespace_then_punctuation(value: &str) -> bool {
@@ -80,4 +105,66 @@ fn starts_with_whitespace_then_punctuation(value: &str) -> bool {
 
 fn is_message_punctuation(ch: char) -> bool {
     matches!(ch, '.' | ',' | ';' | ':' | '!' | '?' | ')' | ']' | '}')
+}
+
+fn starts_with_leading_separator(value: &str) -> bool {
+    value
+        .chars()
+        .next()
+        .is_some_and(|ch| matches!(ch, '·' | '—'))
+}
+
+fn is_placeholder_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !(first == '_' || first == '$' || first.is_ascii_alphabetic()) {
+        return false;
+    }
+
+    chars.all(|ch| ch == '_' || ch == '$' || ch.is_ascii_alphanumeric())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{clean_jsx_text, join_jsx_message_parts};
+
+    #[test]
+    fn trims_whitespace_before_punctuation_after_value_placeholders() {
+        let parts = vec![
+            "Tailored to your ".to_string(),
+            "{volume}".to_string(),
+            " MWh in ".to_string(),
+            "{countryName}".to_string(),
+            " .".to_string(),
+        ];
+
+        assert_eq!(
+            join_jsx_message_parts(&parts),
+            "Tailored to your {volume} MWh in {countryName}."
+        );
+    }
+
+    #[test]
+    fn preserves_leading_separator_spacing() {
+        assert_eq!(
+            join_jsx_message_parts(&[" · $".to_string(), "{priceFormatted}/MWh".to_string()]),
+            " · ${priceFormatted}/MWh"
+        );
+        assert_eq!(
+            join_jsx_message_parts(&[" — no manager".to_string()]),
+            " — no manager"
+        );
+    }
+
+    #[test]
+    fn still_trims_indentation_before_normal_text() {
+        assert_eq!(join_jsx_message_parts(&[" Hello".to_string()]), "Hello");
+    }
+
+    #[test]
+    fn decodes_jsx_entities_after_collapsing_whitespace() {
+        assert_eq!(clean_jsx_text("Green-e&reg;\n applies"), "Green-e® applies");
+    }
 }

--- a/crates/palamedes/src/jsx_message.rs
+++ b/crates/palamedes/src/jsx_message.rs
@@ -1,5 +1,44 @@
 use crate::jsx_entities::decode_jsx_entities;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum JsxMessagePart {
+    Text(String),
+    ValuePlaceholder(String),
+    ComponentPlaceholder(String),
+    Message {
+        value: String,
+        ends_with_placeholder: bool,
+    },
+}
+
+impl JsxMessagePart {
+    fn as_str(&self) -> &str {
+        match self {
+            Self::Text(value)
+            | Self::ValuePlaceholder(value)
+            | Self::ComponentPlaceholder(value)
+            | Self::Message { value, .. } => value,
+        }
+    }
+
+    fn ends_with_placeholder(&self) -> bool {
+        match self {
+            Self::Text(_) => false,
+            Self::ValuePlaceholder(_) | Self::ComponentPlaceholder(_) => true,
+            Self::Message {
+                ends_with_placeholder,
+                ..
+            } => *ends_with_placeholder,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct JoinedJsxMessage {
+    pub(crate) message: String,
+    pub(crate) ends_with_placeholder: bool,
+}
+
 pub(crate) fn clean_jsx_text(text: &str) -> String {
     let mut result = String::with_capacity(text.len());
     let mut last_was_whitespace = false;
@@ -19,34 +58,48 @@ pub(crate) fn clean_jsx_text(text: &str) -> String {
     decode_jsx_entities(&result)
 }
 
-pub(crate) fn join_jsx_message_parts(parts: &[String]) -> String {
+pub(crate) fn join_jsx_message_parts(parts: &[JsxMessagePart]) -> JoinedJsxMessage {
     let mut message = String::new();
+    let mut ends_with_placeholder = false;
 
     for part in parts {
-        push_jsx_message_part(&mut message, part);
+        push_jsx_message_part(&mut message, &mut ends_with_placeholder, part);
     }
 
-    trim_message_edges(&message)
+    JoinedJsxMessage {
+        message: trim_message_edges(&message),
+        ends_with_placeholder,
+    }
 }
 
-fn push_jsx_message_part(message: &mut String, part: &str) {
-    if part.is_empty() {
+fn push_jsx_message_part(
+    message: &mut String,
+    ends_with_placeholder: &mut bool,
+    part: &JsxMessagePart,
+) {
+    let part_value = part.as_str();
+
+    if part_value.is_empty() {
         return;
     }
 
-    let mut next = part;
+    let mut next = part_value;
 
     if !message.is_empty() {
         if message.ends_with(char::is_whitespace) && next.starts_with(char::is_whitespace) {
             next = next.trim_start_matches(char::is_whitespace);
         }
 
-        if ends_with_message_placeholder(message) && starts_with_whitespace_then_punctuation(next) {
+        if *ends_with_placeholder && starts_with_whitespace_then_punctuation(next) {
             next = next.trim_start_matches(char::is_whitespace);
         }
     }
 
     message.push_str(next);
+
+    if !next.trim_end_matches(char::is_whitespace).is_empty() {
+        *ends_with_placeholder = part.ends_with_placeholder();
+    }
 }
 
 fn trim_message_edges(message: &str) -> String {
@@ -58,34 +111,6 @@ fn trim_message_edges(message: &str) -> String {
     }
 
     trimmed.to_string()
-}
-
-fn ends_with_message_placeholder(value: &str) -> bool {
-    ends_with_component_placeholder(value) || ends_with_value_placeholder(value)
-}
-
-fn ends_with_component_placeholder(value: &str) -> bool {
-    let Some(before_closing_angle) = value.strip_suffix('>') else {
-        return false;
-    };
-    let Some(tag_start) = before_closing_angle.rfind("</") else {
-        return false;
-    };
-
-    before_closing_angle[tag_start + 2..]
-        .chars()
-        .all(|ch| ch.is_ascii_digit())
-}
-
-fn ends_with_value_placeholder(value: &str) -> bool {
-    let Some(before_closing_brace) = value.strip_suffix('}') else {
-        return false;
-    };
-    let Some(placeholder_start) = before_closing_brace.rfind('{') else {
-        return false;
-    };
-
-    is_placeholder_name(&before_closing_brace[placeholder_start + 1..])
 }
 
 fn starts_with_whitespace_then_punctuation(value: &str) -> bool {
@@ -114,53 +139,59 @@ fn starts_with_leading_separator(value: &str) -> bool {
         .is_some_and(|ch| matches!(ch, '·' | '—'))
 }
 
-fn is_placeholder_name(name: &str) -> bool {
-    let mut chars = name.chars();
-    let Some(first) = chars.next() else {
-        return false;
-    };
-    if !(first == '_' || first == '$' || first.is_ascii_alphabetic()) {
-        return false;
-    }
-
-    chars.all(|ch| ch == '_' || ch == '$' || ch.is_ascii_alphanumeric())
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{clean_jsx_text, join_jsx_message_parts};
+    use super::{clean_jsx_text, join_jsx_message_parts, JsxMessagePart};
 
     #[test]
     fn trims_whitespace_before_punctuation_after_value_placeholders() {
         let parts = vec![
-            "Tailored to your ".to_string(),
-            "{volume}".to_string(),
-            " MWh in ".to_string(),
-            "{countryName}".to_string(),
-            " .".to_string(),
+            JsxMessagePart::Text("Tailored to your ".to_string()),
+            JsxMessagePart::ValuePlaceholder("{volume}".to_string()),
+            JsxMessagePart::Text(" MWh in ".to_string()),
+            JsxMessagePart::ValuePlaceholder("{countryName}".to_string()),
+            JsxMessagePart::Text(" .".to_string()),
         ];
 
         assert_eq!(
-            join_jsx_message_parts(&parts),
+            join_jsx_message_parts(&parts).message,
             "Tailored to your {volume} MWh in {countryName}."
         );
     }
 
     #[test]
+    fn preserves_whitespace_before_punctuation_after_literal_brace_text() {
+        let parts = vec![
+            JsxMessagePart::Text("{name}".to_string()),
+            JsxMessagePart::Text(" .".to_string()),
+        ];
+
+        assert_eq!(join_jsx_message_parts(&parts).message, "{name} .");
+    }
+
+    #[test]
     fn preserves_leading_separator_spacing() {
         assert_eq!(
-            join_jsx_message_parts(&[" · $".to_string(), "{priceFormatted}/MWh".to_string()]),
+            join_jsx_message_parts(&[
+                JsxMessagePart::Text(" · $".to_string()),
+                JsxMessagePart::ValuePlaceholder("{priceFormatted}".to_string()),
+                JsxMessagePart::Text("/MWh".to_string())
+            ])
+            .message,
             " · ${priceFormatted}/MWh"
         );
         assert_eq!(
-            join_jsx_message_parts(&[" — no manager".to_string()]),
+            join_jsx_message_parts(&[JsxMessagePart::Text(" — no manager".to_string())]).message,
             " — no manager"
         );
     }
 
     #[test]
     fn still_trims_indentation_before_normal_text() {
-        assert_eq!(join_jsx_message_parts(&[" Hello".to_string()]), "Hello");
+        assert_eq!(
+            join_jsx_message_parts(&[JsxMessagePart::Text(" Hello".to_string())]).message,
+            "Hello"
+        );
     }
 
     #[test]

--- a/crates/palamedes/src/transform/messages.rs
+++ b/crates/palamedes/src/transform/messages.rs
@@ -8,7 +8,9 @@ use oxc_span::GetSpan;
 
 use crate::error::{PalamedesError, PalamedesResult};
 use crate::jsx_entities::decode_jsx_entities;
-use crate::jsx_message::{clean_jsx_text, join_jsx_message_parts};
+use crate::jsx_message::{
+    clean_jsx_text, join_jsx_message_parts, JoinedJsxMessage, JsxMessagePart,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct ValueBinding {
@@ -234,13 +236,15 @@ pub(super) fn extract_jsx_children_parts(
     let mut used_value_names = HashMap::<String, String>::new();
     let mut next_component_index = 0usize;
 
-    extract_jsx_children_parts_with_state(
+    let (joined_message, values, components) = extract_jsx_children_parts_with_state(
         children,
         source,
         solid_wrappers,
         &mut used_value_names,
         &mut next_component_index,
-    )
+    )?;
+
+    Ok((joined_message.message, values, components))
 }
 
 fn extract_jsx_children_parts_with_state(
@@ -249,7 +253,7 @@ fn extract_jsx_children_parts_with_state(
     solid_wrappers: bool,
     used_value_names: &mut HashMap<String, String>,
     next_component_index: &mut usize,
-) -> PalamedesResult<(String, Vec<ValueBinding>, Vec<ValueBinding>)> {
+) -> PalamedesResult<(JoinedJsxMessage, Vec<ValueBinding>, Vec<ValueBinding>)> {
     let mut parts = Vec::new();
     let mut values = Vec::new();
     let mut components = Vec::new();
@@ -259,17 +263,20 @@ fn extract_jsx_children_parts_with_state(
             JSXChild::Text(text) => {
                 let value = clean_jsx_text(text.value.as_str());
                 if !value.is_empty() {
-                    parts.push(value);
+                    parts.push(JsxMessagePart::Text(value));
                 }
             }
             JSXChild::ExpressionContainer(container) => match &container.expression {
                 JSXExpression::StringLiteral(literal) => {
-                    parts.push(literal.value.to_string());
+                    parts.push(JsxMessagePart::Text(literal.value.to_string()));
                 }
                 expr => {
                     let binding =
                         jsx_value_binding(expr, source, "JSX expression", used_value_names)?;
-                    parts.push(format!("{{{}}}", binding.name));
+                    parts.push(JsxMessagePart::ValuePlaceholder(format!(
+                        "{{{}}}",
+                        binding.name
+                    )));
                     push_unique_binding(&mut values, binding);
                 }
             },
@@ -290,9 +297,10 @@ fn extract_jsx_children_parts_with_state(
                         used_value_names,
                         next_component_index,
                     )?;
-                parts.push(format!(
-                    "<{component_name}>{inner_message}</{component_name}>"
-                ));
+                parts.push(JsxMessagePart::ComponentPlaceholder(format!(
+                    "<{component_name}>{}</{component_name}>",
+                    inner_message.message
+                )));
                 append_unique_bindings(&mut values, inner_values);
                 components.push(ValueBinding {
                     expression: component_expression,
@@ -309,8 +317,11 @@ fn extract_jsx_children_parts_with_state(
                         used_value_names,
                         next_component_index,
                     )?;
-                if !inner_message.is_empty() {
-                    parts.push(inner_message);
+                if !inner_message.message.is_empty() {
+                    parts.push(JsxMessagePart::Message {
+                        value: inner_message.message,
+                        ends_with_placeholder: inner_message.ends_with_placeholder,
+                    });
                 }
                 append_unique_bindings(&mut values, inner_values);
                 components.extend(inner_components);

--- a/crates/palamedes/src/transform/tests.rs
+++ b/crates/palamedes/src/transform/tests.rs
@@ -210,7 +210,7 @@ fn normalizes_trans_jsx_placeholder_boundary_whitespace() {
 #[test]
 fn normalizes_trans_jsx_placeholder_before_punctuation() {
     let result = transform_macros(
-        "import { Trans } from \"@palamedes/react/macro\";\nconst el = <Trans>Delete {\" \"}<strong>{selectedProjectName}</strong> ? This action cannot be undone.</Trans>;\n",
+        "import { Trans } from \"@palamedes/react/macro\";\nconst el = <Trans>Delete {\" \"}<strong>{selectedProjectName}</strong> ? This action cannot be undone.</Trans>;\nconst tailored = <Trans>\n  Tailored to your {volume} MWh of annual electricity use in {countryName}\n  .\n</Trans>;\n",
         "test.tsx",
         None,
     )
@@ -219,6 +219,24 @@ fn normalizes_trans_jsx_placeholder_before_punctuation() {
     assert!(result.code.contains(
         "message={\"Delete <0>{selectedProjectName}</0>? This action cannot be undone.\"}"
     ));
+    assert!(result.code.contains(
+        "message={\"Tailored to your {volume} MWh of annual electricity use in {countryName}.\"}"
+    ));
+}
+
+#[test]
+fn preserves_trans_jsx_leading_separator_spacing() {
+    let result = transform_macros(
+        "import { Trans } from \"@palamedes/react/macro\";\nconst price = <Trans> · ${priceFormatted}/MWh</Trans>;\nconst manager = <Trans> — no manager</Trans>;\n",
+        "test.tsx",
+        None,
+    )
+    .expect("transform should succeed");
+
+    assert!(result
+        .code
+        .contains("message={\" · ${priceFormatted}/MWh\"}"));
+    assert!(result.code.contains("message={\" — no manager\"}"));
 }
 
 #[test]

--- a/crates/palamedes/src/transform/tests.rs
+++ b/crates/palamedes/src/transform/tests.rs
@@ -210,7 +210,7 @@ fn normalizes_trans_jsx_placeholder_boundary_whitespace() {
 #[test]
 fn normalizes_trans_jsx_placeholder_before_punctuation() {
     let result = transform_macros(
-        "import { Trans } from \"@palamedes/react/macro\";\nconst el = <Trans>Delete {\" \"}<strong>{selectedProjectName}</strong> ? This action cannot be undone.</Trans>;\nconst tailored = <Trans>\n  Tailored to your {volume} MWh of annual electricity use in {countryName}\n  .\n</Trans>;\n",
+        "import { Trans } from \"@palamedes/react/macro\";\nconst el = <Trans>Delete {\" \"}<strong>{selectedProjectName}</strong> ? This action cannot be undone.</Trans>;\nconst tailored = <Trans>\n  Tailored to your {volume} MWh of annual electricity use in {countryName}\n  .\n</Trans>;\nconst literalBraces = <Trans>{\"{name}\"} .</Trans>;\n",
         "test.tsx",
         None,
     )
@@ -222,6 +222,7 @@ fn normalizes_trans_jsx_placeholder_before_punctuation() {
     assert!(result.code.contains(
         "message={\"Tailored to your {volume} MWh of annual electricity use in {countryName}.\"}"
     ));
+    assert!(result.code.contains("message={\"{name} .\"}"));
 }
 
 #[test]

--- a/packages/extractor/src/extractMessages.test.ts
+++ b/packages/extractor/src/extractMessages.test.ts
@@ -83,6 +83,7 @@ describe("extractMessages", () => {
           Tailored to your {volume} MWh of annual electricity use in {countryName}
           .
         </Trans>
+        const literalBraces = <Trans>{"{name}"} .</Trans>
       `
       const messages = extract(code)
 
@@ -92,6 +93,7 @@ describe("extractMessages", () => {
         "<0>Dates & Capacity:</0> commercial_operation_date, project_capacity_mw, buyer_capacity_mw",
         "Delete <0>{selectedProjectName}</0>? This action cannot be undone.",
         "Tailored to your {volume} MWh of annual electricity use in {countryName}.",
+        "{name} .",
       ])
     })
 

--- a/packages/extractor/src/extractMessages.test.ts
+++ b/packages/extractor/src/extractMessages.test.ts
@@ -79,6 +79,10 @@ describe("extractMessages", () => {
         const target = <Trans><strong>100%</strong> Clean Energy by {" "}<strong>{targetYear}</strong></Trans>
         const details = <Trans><strong>Dates & Capacity:</strong> {" "}commercial_operation_date, project_capacity_mw, buyer_capacity_mw</Trans>
         const confirm = <Trans>Delete {" "}<strong>{selectedProjectName}</strong> ? This action cannot be undone.</Trans>
+        const tailored = <Trans>
+          Tailored to your {volume} MWh of annual electricity use in {countryName}
+          .
+        </Trans>
       `
       const messages = extract(code)
 
@@ -87,6 +91,21 @@ describe("extractMessages", () => {
         "<0>100%</0> Clean Energy by <1>{targetYear}</1>",
         "<0>Dates & Capacity:</0> commercial_operation_date, project_capacity_mw, buyer_capacity_mw",
         "Delete <0>{selectedProjectName}</0>? This action cannot be undone.",
+        "Tailored to your {volume} MWh of annual electricity use in {countryName}.",
+      ])
+    })
+
+    it("preserves leading separator spacing", () => {
+      const code = `
+        import { Trans } from "@palamedes/react/macro"
+        const price = <Trans> · \${priceFormatted}/MWh</Trans>
+        const manager = <Trans> — no manager</Trans>
+      `
+      const messages = extract(code)
+
+      expect(messages.map((message) => message.message)).toStrictEqual([
+        " · ${priceFormatted}/MWh",
+        " — no manager",
       ])
     })
   })

--- a/packages/transform/src/transform.test.ts
+++ b/packages/transform/src/transform.test.ts
@@ -186,6 +186,10 @@ const el = <Trans><strong>A</strong> and <strong>B</strong></Trans>;
 import { Trans } from "@palamedes/react/macro";
 const helper = <Trans>Reach out to your {" "}<a href="/advisor">advisor</a>{" "} for help.</Trans>;
 const confirm = <Trans>Delete {" "}<strong>{selectedProjectName}</strong> ? This action cannot be undone.</Trans>;
+const tailored = <Trans>
+  Tailored to your {volume} MWh of annual electricity use in {countryName}
+  .
+</Trans>;
 `
     const result = transformPalamedesMacros(code, "test.tsx")
 
@@ -193,6 +197,21 @@ const confirm = <Trans>Delete {" "}<strong>{selectedProjectName}</strong> ? This
     expect(result.code).toContain(
       'message={"Delete <0>{selectedProjectName}</0>? This action cannot be undone."}'
     )
+    expect(result.code).toContain(
+      'message={"Tailored to your {volume} MWh of annual electricity use in {countryName}."}'
+    )
+  })
+
+  it("preserves leading separator spacing", () => {
+    const code = `
+import { Trans } from "@palamedes/react/macro";
+const price = <Trans> · \${priceFormatted}/MWh</Trans>;
+const manager = <Trans> — no manager</Trans>;
+`
+    const result = transformPalamedesMacros(code, "test.tsx")
+
+    expect(result.code).toContain('message={" · ${priceFormatted}/MWh"}')
+    expect(result.code).toContain('message={" — no manager"}')
   })
 
   it("strips the message field when requested", () => {

--- a/packages/transform/src/transform.test.ts
+++ b/packages/transform/src/transform.test.ts
@@ -190,6 +190,7 @@ const tailored = <Trans>
   Tailored to your {volume} MWh of annual electricity use in {countryName}
   .
 </Trans>;
+const literalBraces = <Trans>{"{name}"} .</Trans>;
 `
     const result = transformPalamedesMacros(code, "test.tsx")
 
@@ -200,6 +201,7 @@ const tailored = <Trans>
     expect(result.code).toContain(
       'message={"Tailored to your {volume} MWh of annual electricity use in {countryName}."}'
     )
+    expect(result.code).toContain('message={"{name} ."}')
   })
 
   it("preserves leading separator spacing", () => {


### PR DESCRIPTION
Refs #226.

## Summary
- trims whitespace before punctuation after JSX value placeholders such as `{countryName} .`
- preserves one leading space for inline separator messages starting with `·` or `—`
- keeps the behavior shared between extractor and transform through the existing JSX message assembly helper

## Validation
- `cargo test -p palamedes --locked`
- `cargo clippy -p palamedes --all-targets --locked`
- `node_modules/.bin/oxfmt --check --ignore-path .gitignore --ignore-path .oxfmtignore .`
- `node ../core-node/scripts/build-native.mjs` from `packages/core-node-darwin-arm64`
- `unbuild` in `packages/core-node`, `packages/extractor`, `packages/transform`
- `vitest run --globals src/extractMessages.test.ts` from `packages/extractor`
- `vitest run --globals src/*.test.ts` from `packages/transform`

Note: `pnpm` script invocation was not used for the final Node checks because the local pnpm dependency-status check attempted an interactive `node_modules` purge after switching branches; the equivalent direct repo-local binaries/scripts were used instead.
