### PR TITLE
fix(transform): preserve self-closing rich placeholders

### DIFF
--- a/crates/palamedes/src/extract.rs
+++ b/crates/palamedes/src/extract.rs
@@ -811,10 +811,13 @@ fn extract_jsx_children_as_message_with_state(
                     &element.children,
                     next_component_index,
                 )?;
-                parts.push(JsxMessagePart::ComponentPlaceholder(format!(
-                    "<{name}>{}</{name}>",
-                    inner.message
-                )));
+                let is_empty = inner.message.is_empty();
+                let value = if is_empty {
+                    format!("<{name}/>")
+                } else {
+                    format!("<{name}>{}</{name}>", inner.message)
+                };
+                parts.push(JsxMessagePart::ComponentPlaceholder { value, is_empty });
             }
             JSXChild::Fragment(fragment) => {
                 let inner = extract_jsx_children_as_message_with_state(
@@ -1272,6 +1275,23 @@ mod tests {
         .expect("messages should extract");
 
         assert_eq!(messages[0].message, "<0>A</0> and <1>B</1>");
+    }
+
+    #[test]
+    fn uses_self_closing_jsx_component_placeholders_for_empty_children() {
+        let messages = extract_messages(
+            r#"
+              import { Trans } from "@palamedes/react/macro"
+              const message = <Trans>I agree to the <a href={COMMERCIAL_TERMS_URL}>Commercial Terms <ExternalLink className="inline" /></a></Trans>
+            "#,
+            "test.tsx",
+        )
+        .expect("messages should extract");
+
+        assert_eq!(
+            messages[0].message,
+            "I agree to the <0>Commercial Terms<1/></0>"
+        );
     }
 
     #[test]

--- a/crates/palamedes/src/extract.rs
+++ b/crates/palamedes/src/extract.rs
@@ -1295,6 +1295,20 @@ mod tests {
     }
 
     #[test]
+    fn preserves_inline_whitespace_before_empty_component_placeholders_with_trailing_text() {
+        let messages = extract_messages(
+            r#"
+              import { Trans } from "@palamedes/react/macro"
+              const message = <Trans>Foo <Icon /> bar</Trans>
+            "#,
+            "test.tsx",
+        )
+        .expect("messages should extract");
+
+        assert_eq!(messages[0].message, "Foo <0/> bar");
+    }
+
+    #[test]
     fn normalizes_jsx_component_placeholder_boundary_whitespace() {
         let messages = extract_messages(
             r#"

--- a/crates/palamedes/src/jsx_message.rs
+++ b/crates/palamedes/src/jsx_message.rs
@@ -4,7 +4,10 @@ use crate::jsx_entities::decode_jsx_entities;
 pub(crate) enum JsxMessagePart {
     Text(String),
     ValuePlaceholder(String),
-    ComponentPlaceholder(String),
+    ComponentPlaceholder {
+        value: String,
+        is_empty: bool,
+    },
     Message {
         value: String,
         ends_with_placeholder: bool,
@@ -14,22 +17,26 @@ pub(crate) enum JsxMessagePart {
 impl JsxMessagePart {
     fn as_str(&self) -> &str {
         match self {
-            Self::Text(value)
-            | Self::ValuePlaceholder(value)
-            | Self::ComponentPlaceholder(value)
-            | Self::Message { value, .. } => value,
+            Self::Text(value) | Self::ValuePlaceholder(value) | Self::Message { value, .. } => {
+                value
+            }
+            Self::ComponentPlaceholder { value, .. } => value,
         }
     }
 
     fn ends_with_placeholder(&self) -> bool {
         match self {
             Self::Text(_) => false,
-            Self::ValuePlaceholder(_) | Self::ComponentPlaceholder(_) => true,
+            Self::ValuePlaceholder(_) | Self::ComponentPlaceholder { .. } => true,
             Self::Message {
                 ends_with_placeholder,
                 ..
             } => *ends_with_placeholder,
         }
+    }
+
+    fn is_empty_component_placeholder(&self) -> bool {
+        matches!(self, Self::ComponentPlaceholder { is_empty: true, .. })
     }
 }
 
@@ -84,6 +91,11 @@ fn push_jsx_message_part(
     }
 
     let mut next = part_value;
+
+    if part.is_empty_component_placeholder() {
+        let trimmed_len = message.trim_end_matches(char::is_whitespace).len();
+        message.truncate(trimmed_len);
+    }
 
     if !message.is_empty() {
         if message.ends_with(char::is_whitespace) && next.starts_with(char::is_whitespace) {
@@ -183,6 +195,21 @@ mod tests {
         assert_eq!(
             join_jsx_message_parts(&[JsxMessagePart::Text(" — no manager".to_string())]).message,
             " — no manager"
+        );
+    }
+
+    #[test]
+    fn uses_self_closing_empty_component_placeholders() {
+        assert_eq!(
+            join_jsx_message_parts(&[
+                JsxMessagePart::Text("Commercial Terms ".to_string()),
+                JsxMessagePart::ComponentPlaceholder {
+                    value: "<0/>".to_string(),
+                    is_empty: true,
+                },
+            ])
+            .message,
+            "Commercial Terms<0/>"
         );
     }
 

--- a/crates/palamedes/src/jsx_message.rs
+++ b/crates/palamedes/src/jsx_message.rs
@@ -69,8 +69,13 @@ pub(crate) fn join_jsx_message_parts(parts: &[JsxMessagePart]) -> JoinedJsxMessa
     let mut message = String::new();
     let mut ends_with_placeholder = false;
 
-    for part in parts {
-        push_jsx_message_part(&mut message, &mut ends_with_placeholder, part);
+    for (index, part) in parts.iter().enumerate() {
+        push_jsx_message_part(
+            &mut message,
+            &mut ends_with_placeholder,
+            part,
+            should_trim_before_empty_component_placeholder(part, &parts[index + 1..]),
+        );
     }
 
     JoinedJsxMessage {
@@ -83,6 +88,7 @@ fn push_jsx_message_part(
     message: &mut String,
     ends_with_placeholder: &mut bool,
     part: &JsxMessagePart,
+    trim_before_empty_component_placeholder: bool,
 ) {
     let part_value = part.as_str();
 
@@ -92,7 +98,7 @@ fn push_jsx_message_part(
 
     let mut next = part_value;
 
-    if part.is_empty_component_placeholder() {
+    if trim_before_empty_component_placeholder {
         let trimmed_len = message.trim_end_matches(char::is_whitespace).len();
         message.truncate(trimmed_len);
     }
@@ -112,6 +118,16 @@ fn push_jsx_message_part(
     if !next.trim_end_matches(char::is_whitespace).is_empty() {
         *ends_with_placeholder = part.ends_with_placeholder();
     }
+}
+
+fn should_trim_before_empty_component_placeholder(
+    part: &JsxMessagePart,
+    remaining: &[JsxMessagePart],
+) -> bool {
+    // Lingui emits terminal empty rich children compactly (`Text<0/>`), but
+    // keeping spaces before followed-by-text placeholders avoids word joins.
+    part.is_empty_component_placeholder()
+        && remaining.iter().all(|part| part.as_str().trim().is_empty())
 }
 
 fn trim_message_edges(message: &str) -> String {
@@ -210,6 +226,22 @@ mod tests {
             ])
             .message,
             "Commercial Terms<0/>"
+        );
+    }
+
+    #[test]
+    fn preserves_inline_space_around_empty_component_placeholders_with_trailing_text() {
+        assert_eq!(
+            join_jsx_message_parts(&[
+                JsxMessagePart::Text("Foo ".to_string()),
+                JsxMessagePart::ComponentPlaceholder {
+                    value: "<0/>".to_string(),
+                    is_empty: true,
+                },
+                JsxMessagePart::Text(" bar".to_string()),
+            ])
+            .message,
+            "Foo <0/> bar"
         );
     }
 

--- a/crates/palamedes/src/transform/messages.rs
+++ b/crates/palamedes/src/transform/messages.rs
@@ -297,10 +297,16 @@ fn extract_jsx_children_parts_with_state(
                         used_value_names,
                         next_component_index,
                     )?;
-                parts.push(JsxMessagePart::ComponentPlaceholder(format!(
-                    "<{component_name}>{}</{component_name}>",
-                    inner_message.message
-                )));
+                let is_empty = inner_message.message.is_empty();
+                let value = if is_empty {
+                    format!("<{component_name}/>")
+                } else {
+                    format!(
+                        "<{component_name}>{}</{component_name}>",
+                        inner_message.message
+                    )
+                };
+                parts.push(JsxMessagePart::ComponentPlaceholder { value, is_empty });
                 append_unique_bindings(&mut values, inner_values);
                 components.push(ValueBinding {
                     expression: component_expression,

--- a/crates/palamedes/src/transform/tests.rs
+++ b/crates/palamedes/src/transform/tests.rs
@@ -194,6 +194,23 @@ fn deduplicates_same_tag_component_placeholders_with_identical_markup() {
 }
 
 #[test]
+fn trans_jsx_macro_uses_self_closing_empty_component_placeholders() {
+    let result = transform_macros(
+        "import { Trans } from \"@palamedes/react/macro\";\nconst el = <Trans>I agree to the <a href={COMMERCIAL_TERMS_URL}>Commercial Terms <ExternalLink className=\"inline\" /></a></Trans>;\n",
+        "test.tsx",
+        None,
+    )
+    .expect("transform should succeed");
+
+    assert!(result
+        .code
+        .contains("message={\"I agree to the <0>Commercial Terms<1/></0>\"}"));
+    assert!(result
+        .code
+        .contains("components={{ 0: <a href={COMMERCIAL_TERMS_URL} />, 1: <ExternalLink className=\"inline\" /> }}"));
+}
+
+#[test]
 fn normalizes_trans_jsx_placeholder_boundary_whitespace() {
     let result = transform_macros(
         "import { Trans } from \"@palamedes/react/macro\";\nconst el = <Trans>Reach out to your {\" \"}<a href=\"/advisor\">advisor</a>{\" \"} for help.</Trans>;\n",

--- a/crates/palamedes/src/transform/tests.rs
+++ b/crates/palamedes/src/transform/tests.rs
@@ -211,6 +211,18 @@ fn trans_jsx_macro_uses_self_closing_empty_component_placeholders() {
 }
 
 #[test]
+fn trans_jsx_macro_preserves_inline_space_before_empty_component_placeholders_with_trailing_text() {
+    let result = transform_macros(
+        "import { Trans } from \"@palamedes/react/macro\";\nconst el = <Trans>Foo <Icon /> bar</Trans>;\n",
+        "test.tsx",
+        None,
+    )
+    .expect("transform should succeed");
+
+    assert!(result.code.contains("message={\"Foo <0/> bar\"}"));
+}
+
+#[test]
 fn normalizes_trans_jsx_placeholder_boundary_whitespace() {
     let result = transform_macros(
         "import { Trans } from \"@palamedes/react/macro\";\nconst el = <Trans>Reach out to your {\" \"}<a href=\"/advisor\">advisor</a>{\" \"} for help.</Trans>;\n",

--- a/packages/extractor/src/extractMessages.test.ts
+++ b/packages/extractor/src/extractMessages.test.ts
@@ -46,6 +46,16 @@ describe("extractMessages", () => {
       expect(messages[0].message).toBe("Accept <0>terms</0> and <1>privacy</1>")
     })
 
+    it("uses Lingui-compatible self-closing placeholders for empty rich-text children", () => {
+      const code = `
+        import { Trans } from "@palamedes/react/macro"
+        const x = <Trans>I agree to the <a href={COMMERCIAL_TERMS_URL}>Commercial Terms <ExternalLink className="inline" /></a></Trans>
+      `
+      const messages = extract(code)
+      expect(messages).toHaveLength(1)
+      expect(messages[0].message).toBe("I agree to the <0>Commercial Terms<1/></0>")
+    })
+
     it("extracts Solid Trans macros with the same semantics", () => {
       const code = `
         import { Trans } from "@palamedes/solid/macro"

--- a/packages/extractor/src/extractMessages.test.ts
+++ b/packages/extractor/src/extractMessages.test.ts
@@ -56,6 +56,17 @@ describe("extractMessages", () => {
       expect(messages[0].message).toBe("I agree to the <0>Commercial Terms<1/></0>")
     })
 
+    it("preserves inline whitespace before self-closing placeholders with trailing text", () => {
+      const code = `
+        import { Trans } from "@palamedes/react/macro"
+        const x = <Trans>Foo <Icon /> bar</Trans>
+      `
+      const messages = extract(code)
+
+      expect(messages).toHaveLength(1)
+      expect(messages[0].message).toBe("Foo <0/> bar")
+    })
+
     it("extracts Solid Trans macros with the same semantics", () => {
       const code = `
         import { Trans } from "@palamedes/solid/macro"

--- a/packages/transform/src/transform.test.ts
+++ b/packages/transform/src/transform.test.ts
@@ -194,6 +194,16 @@ const el = <Trans>I agree to the <a href={COMMERCIAL_TERMS_URL}>Commercial Terms
     )
   })
 
+  it("preserves inline whitespace before self-closing placeholders with trailing text", () => {
+    const code = `
+import { Trans } from "@palamedes/react/macro";
+const el = <Trans>Foo <Icon /> bar</Trans>;
+`
+    const result = transformPalamedesMacros(code, "test.tsx")
+
+    expect(result.code).toContain('message={"Foo <0/> bar"}')
+  })
+
   it("normalizes rich-text placeholder boundary whitespace", () => {
     const code = `
 import { Trans } from "@palamedes/react/macro";

--- a/packages/transform/src/transform.test.ts
+++ b/packages/transform/src/transform.test.ts
@@ -181,6 +181,19 @@ const el = <Trans><strong>A</strong> and <strong>B</strong></Trans>;
     expect(result.code).toContain("components={{ 0: <strong />, 1: <strong /> }}")
   })
 
+  it("uses Lingui-compatible self-closing placeholders for empty rich-text children", () => {
+    const code = `
+import { Trans } from "@palamedes/react/macro";
+const el = <Trans>I agree to the <a href={COMMERCIAL_TERMS_URL}>Commercial Terms <ExternalLink className="inline" /></a></Trans>;
+`
+    const result = transformPalamedesMacros(code, "test.tsx")
+
+    expect(result.code).toContain('message={"I agree to the <0>Commercial Terms<1/></0>"}')
+    expect(result.code).toContain(
+      'components={{ 0: <a href={COMMERCIAL_TERMS_URL} />, 1: <ExternalLink className="inline" /> }}'
+    )
+  })
+
   it("normalizes rich-text placeholder boundary whitespace", () => {
     const code = `
 import { Trans } from "@palamedes/react/macro";


### PR DESCRIPTION
Closes #236.

## Summary
- serializes empty JSX rich-text children as self-closing placeholders like `<1/>`
- trims placeholder-adjacent JSX whitespace before empty component placeholders so Lingui-style IDs stay reusable during migration
- adds Rust and TypeScript extraction/transform coverage for the Commercial Terms migration case

## Validation
- `cargo fmt --all --check`
- `cargo test -p palamedes`
- `pnpm --filter @palamedes/core-node-darwin-arm64 build`
- `pnpm --filter @palamedes/core-node build`
- `pnpm --filter @palamedes/transform test`
- `pnpm --filter @palamedes/extractor test`
- `pnpm format:check`