### PR TITLE
fix(extractor): reject nested message macros

### DIFF
--- a/crates/palamedes/src/error.rs
+++ b/crates/palamedes/src/error.rs
@@ -157,4 +157,12 @@ pub enum PalamedesError {
         /// Value names provided by values but not referenced by the message.
         extra: String,
     },
+    /// A JSX message macro was nested inside another JSX message macro.
+    #[error(
+        "Nested i18n macro is not extractable as a single message at {location}. Move the full sentence into <Plural> branches or use plural() so translators receive the complete sentence."
+    )]
+    NestedMessageMacro {
+        /// Source location of the nested macro.
+        location: String,
+    },
 }

--- a/crates/palamedes/src/extract.rs
+++ b/crates/palamedes/src/extract.rs
@@ -10,9 +10,8 @@ use crate::jsx_message::{
 use oxc_allocator::Allocator;
 use oxc_ast::ast::{
     Argument, CallExpression, Expression, ImportDeclaration, ImportDeclarationSpecifier,
-    JSXAttributeValue, JSXChild, JSXElement, JSXExpression, JSXFragment, JSXOpeningElement,
-    MemberExpression, ObjectExpression, ObjectPropertyKind, TaggedTemplateExpression,
-    TemplateLiteral,
+    JSXAttributeValue, JSXChild, JSXElement, JSXExpression, JSXOpeningElement, MemberExpression,
+    ObjectExpression, ObjectPropertyKind, TaggedTemplateExpression, TemplateLiteral,
 };
 use oxc_ast_visit::{walk, Visit};
 use oxc_parser::Parser;
@@ -231,11 +230,11 @@ impl<'a> Visit<'a> for ExtractionVisitor<'a> {
             tag_name.as_str(),
             &["Trans", "Plural", "Select", "SelectOrdinal"],
         ) {
-            if let Some(nested) =
+            if let Some(nested_start) =
                 nested_message_macro_in_children(&it.children, self.imported_macros)
             {
                 self.fail(PalamedesError::NestedMessageMacro {
-                    location: self.location(nested.span.start as usize),
+                    location: self.location(nested_start),
                 });
                 return;
             }
@@ -362,61 +361,48 @@ impl<'a> Visit<'a> for ExtractionVisitor<'a> {
 fn nested_message_macro_in_children<'a>(
     children: &'a [JSXChild<'a>],
     imported_macros: &HashMap<String, ImportedMacro>,
-) -> Option<&'a JSXElement<'a>> {
-    for child in children {
-        match child {
-            JSXChild::Element(element) => {
-                if is_jsx_message_macro(element, imported_macros) {
-                    return Some(element);
-                }
-                if let Some(nested) =
-                    nested_message_macro_in_children(&element.children, imported_macros)
-                {
-                    return Some(nested);
-                }
+) -> Option<usize> {
+    NestedMessageMacroFinder::find_in_children(children, imported_macros)
+}
+
+struct NestedMessageMacroFinder<'a> {
+    imported_macros: &'a HashMap<String, ImportedMacro>,
+    nested_start: Option<usize>,
+}
+
+impl<'a> NestedMessageMacroFinder<'a> {
+    fn find_in_children(
+        children: &[JSXChild<'a>],
+        imported_macros: &'a HashMap<String, ImportedMacro>,
+    ) -> Option<usize> {
+        let mut finder = Self {
+            imported_macros,
+            nested_start: None,
+        };
+
+        for child in children {
+            finder.visit_jsx_child(child);
+            if finder.nested_start.is_some() {
+                break;
             }
-            JSXChild::Fragment(fragment) => {
-                if let Some(nested) = nested_message_macro_in_fragment(fragment, imported_macros) {
-                    return Some(nested);
-                }
-            }
-            JSXChild::ExpressionContainer(container) => {
-                if let Some(nested) =
-                    nested_message_macro_in_jsx_expression(&container.expression, imported_macros)
-                {
-                    return Some(nested);
-                }
-            }
-            JSXChild::Text(_) | JSXChild::Spread(_) => {}
         }
+
+        finder.nested_start
     }
-
-    None
 }
 
-fn nested_message_macro_in_fragment<'a>(
-    fragment: &'a JSXFragment<'a>,
-    imported_macros: &HashMap<String, ImportedMacro>,
-) -> Option<&'a JSXElement<'a>> {
-    nested_message_macro_in_children(&fragment.children, imported_macros)
-}
+impl<'a> Visit<'a> for NestedMessageMacroFinder<'a> {
+    fn visit_jsx_element(&mut self, it: &JSXElement<'a>) {
+        if self.nested_start.is_some() {
+            return;
+        }
 
-fn nested_message_macro_in_jsx_expression<'a>(
-    expr: &'a JSXExpression<'a>,
-    imported_macros: &HashMap<String, ImportedMacro>,
-) -> Option<&'a JSXElement<'a>> {
-    match expr {
-        JSXExpression::JSXElement(element) => {
-            if is_jsx_message_macro(element, imported_macros) {
-                Some(element)
-            } else {
-                nested_message_macro_in_children(&element.children, imported_macros)
-            }
+        if is_jsx_message_macro(it, self.imported_macros) {
+            self.nested_start = Some(it.span.start as usize);
+            return;
         }
-        JSXExpression::JSXFragment(fragment) => {
-            nested_message_macro_in_fragment(fragment, imported_macros)
-        }
-        _ => None,
+
+        walk::walk_jsx_element(self, it);
     }
 }
 
@@ -1487,6 +1473,43 @@ mod tests {
         assert!(message.contains("Nested i18n macro is not extractable as a single message"));
         assert!(message.contains("test.tsx:3:"));
         assert!(message.contains("Move the full sentence into <Plural> branches"));
+    }
+
+    #[test]
+    fn rejects_nested_jsx_message_macros_inside_conditional_and_logical_expressions() {
+        for source in [
+            r#"
+              import { Plural, Trans } from "@palamedes/react/macro"
+              const message = <Trans>{showCount ? <Plural value={count} one="one" other="other" /> : null}</Trans>
+            "#,
+            r#"
+              import { Plural, Trans } from "@palamedes/react/macro"
+              const message = <Trans>{showCount && <Plural value={count} one="one" other="other" />}</Trans>
+            "#,
+        ] {
+            let error = extract_messages(source, "test.tsx")
+                .expect_err("nested message macros in JSX expressions should fail");
+            let message = error.to_string();
+
+            assert!(message.contains("Nested i18n macro is not extractable as a single message"));
+            assert!(!message.contains("stable placeholder name"));
+        }
+    }
+
+    #[test]
+    fn rejects_nested_jsx_message_macros_inside_map_callbacks() {
+        let error = extract_messages(
+            r#"
+              import { Plural, Trans } from "@palamedes/react/macro"
+              const message = <Trans>{items.map((item) => <Plural value={item.count} one="one" other="other" />)}</Trans>
+            "#,
+            "test.tsx",
+        )
+        .expect_err("nested message macros in map callbacks should fail");
+        let message = error.to_string();
+
+        assert!(message.contains("Nested i18n macro is not extractable as a single message"));
+        assert!(!message.contains("stable placeholder name"));
     }
 
     #[test]

--- a/crates/palamedes/src/extract.rs
+++ b/crates/palamedes/src/extract.rs
@@ -10,8 +10,9 @@ use crate::jsx_message::{
 use oxc_allocator::Allocator;
 use oxc_ast::ast::{
     Argument, CallExpression, Expression, ImportDeclaration, ImportDeclarationSpecifier,
-    JSXAttributeValue, JSXChild, JSXElement, JSXExpression, JSXOpeningElement, MemberExpression,
-    ObjectExpression, ObjectPropertyKind, TaggedTemplateExpression, TemplateLiteral,
+    JSXAttributeValue, JSXChild, JSXElement, JSXExpression, JSXFragment, JSXOpeningElement,
+    MemberExpression, ObjectExpression, ObjectPropertyKind, TaggedTemplateExpression,
+    TemplateLiteral,
 };
 use oxc_ast_visit::{walk, Visit};
 use oxc_parser::Parser;
@@ -109,6 +110,17 @@ impl LineLocator {
             Err(index) => index,
         }
     }
+
+    fn get_location(&self, offset: usize) -> (usize, usize) {
+        let line = self.get_line(offset);
+        let line_start = self
+            .line_starts
+            .get(line.saturating_sub(1))
+            .copied()
+            .unwrap_or(0);
+
+        (line, offset.saturating_sub(line_start) + 1)
+    }
 }
 
 struct MacroCollector {
@@ -189,6 +201,12 @@ impl<'a> ExtractionVisitor<'a> {
         )
     }
 
+    fn location(&self, span_start: usize) -> String {
+        let (line, column) = self.line_locator.get_location(span_start);
+
+        format!("{}:{line}:{column}", self.filename)
+    }
+
     fn imported_macro_name(&self, local_name: &str, expected: &[&str]) -> Option<&str> {
         self.imported_macros.get(local_name).and_then(|macro_info| {
             expected
@@ -213,6 +231,15 @@ impl<'a> Visit<'a> for ExtractionVisitor<'a> {
             tag_name.as_str(),
             &["Trans", "Plural", "Select", "SelectOrdinal"],
         ) {
+            if let Some(nested) =
+                nested_message_macro_in_children(&it.children, self.imported_macros)
+            {
+                self.fail(PalamedesError::NestedMessageMacro {
+                    location: self.location(nested.span.start as usize),
+                });
+                return;
+            }
+
             match extract_from_jsx_element(
                 it,
                 macro_name,
@@ -330,6 +357,85 @@ impl<'a> Visit<'a> for ExtractionVisitor<'a> {
 
         walk::walk_call_expression(self, it);
     }
+}
+
+fn nested_message_macro_in_children<'a>(
+    children: &'a [JSXChild<'a>],
+    imported_macros: &HashMap<String, ImportedMacro>,
+) -> Option<&'a JSXElement<'a>> {
+    for child in children {
+        match child {
+            JSXChild::Element(element) => {
+                if is_jsx_message_macro(element, imported_macros) {
+                    return Some(element);
+                }
+                if let Some(nested) =
+                    nested_message_macro_in_children(&element.children, imported_macros)
+                {
+                    return Some(nested);
+                }
+            }
+            JSXChild::Fragment(fragment) => {
+                if let Some(nested) = nested_message_macro_in_fragment(fragment, imported_macros) {
+                    return Some(nested);
+                }
+            }
+            JSXChild::ExpressionContainer(container) => {
+                if let Some(nested) =
+                    nested_message_macro_in_jsx_expression(&container.expression, imported_macros)
+                {
+                    return Some(nested);
+                }
+            }
+            JSXChild::Text(_) | JSXChild::Spread(_) => {}
+        }
+    }
+
+    None
+}
+
+fn nested_message_macro_in_fragment<'a>(
+    fragment: &'a JSXFragment<'a>,
+    imported_macros: &HashMap<String, ImportedMacro>,
+) -> Option<&'a JSXElement<'a>> {
+    nested_message_macro_in_children(&fragment.children, imported_macros)
+}
+
+fn nested_message_macro_in_jsx_expression<'a>(
+    expr: &'a JSXExpression<'a>,
+    imported_macros: &HashMap<String, ImportedMacro>,
+) -> Option<&'a JSXElement<'a>> {
+    match expr {
+        JSXExpression::JSXElement(element) => {
+            if is_jsx_message_macro(element, imported_macros) {
+                Some(element)
+            } else {
+                nested_message_macro_in_children(&element.children, imported_macros)
+            }
+        }
+        JSXExpression::JSXFragment(fragment) => {
+            nested_message_macro_in_fragment(fragment, imported_macros)
+        }
+        _ => None,
+    }
+}
+
+fn is_jsx_message_macro(
+    element: &JSXElement<'_>,
+    imported_macros: &HashMap<String, ImportedMacro>,
+) -> bool {
+    let Some(tag_name) = element.opening_element.name.get_identifier_name() else {
+        return false;
+    };
+
+    imported_macros
+        .get(tag_name.as_str())
+        .is_some_and(|macro_info| {
+            matches!(
+                macro_info.imported_name.as_str(),
+                "Trans" | "Plural" | "Select" | "SelectOrdinal"
+            )
+        })
 }
 
 fn identifier_name<'a>(expr: &'a Expression<'a>) -> Option<&'a str> {
@@ -973,8 +1079,9 @@ pub fn extract_messages(
 /// # Errors
 ///
 /// Returns an error only for fatal authoring failures such as explicit message
-/// IDs. Read, parse, and non-fatal extraction failures are returned in
-/// `failed_files` so callers can preserve the CLI's warning-oriented behavior.
+/// IDs or nested message macros. Read, parse, and non-fatal extraction failures
+/// are returned in `failed_files` so callers can preserve the CLI's
+/// warning-oriented behavior.
 pub fn extract_catalog_messages_from_files(
     request: ExtractCatalogMessagesRequest,
 ) -> PalamedesResult<ExtractCatalogMessagesResult> {
@@ -1001,8 +1108,11 @@ pub fn extract_catalog_messages_from_files(
 
         let extracted = match extract_messages(&source, file) {
             Ok(messages) => messages,
-            Err(PalamedesError::ExplicitMessageIdsUnsupported) => {
-                return Err(PalamedesError::ExplicitMessageIdsUnsupported);
+            Err(
+                error @ (PalamedesError::ExplicitMessageIdsUnsupported
+                | PalamedesError::NestedMessageMacro { .. }),
+            ) => {
+                return Err(error);
             }
             Err(error) => {
                 failed_files.push(ExtractCatalogFileFailure {
@@ -1363,6 +1473,23 @@ mod tests {
     }
 
     #[test]
+    fn rejects_nested_jsx_message_macros() {
+        let error = extract_messages(
+            r##"
+              import { Plural, Trans } from "@palamedes/react/macro"
+              const message = <Trans><Plural value={contractCount} one="# contract" other="# contracts" /> ({capacityMW} MW)</Trans>
+            "##,
+            "test.tsx",
+        )
+        .expect_err("nested message macros should fail");
+        let message = error.to_string();
+
+        assert!(message.contains("Nested i18n macro is not extractable as a single message"));
+        assert!(message.contains("test.tsx:3:"));
+        assert!(message.contains("Move the full sentence into <Plural> branches"));
+    }
+
+    #[test]
     fn batch_extracts_deduped_catalog_messages_with_relative_origins() {
         let root = temp_root("batch-relative");
         let src = root.join("src");
@@ -1519,6 +1646,30 @@ mod tests {
         .expect_err("explicit IDs should fail");
 
         assert!(error.to_string().contains("Explicit message ids"));
+        fs::remove_dir_all(root).expect("cleanup");
+    }
+
+    #[test]
+    fn batch_keeps_nested_jsx_message_macros_fatal() {
+        let root = temp_root("batch-nested-message-macro");
+        fs::create_dir_all(&root).expect("root dir");
+        let source = root.join("bad.tsx");
+        fs::write(
+            &source,
+            r##"
+              import { Plural, Trans } from "@palamedes/react/macro"
+              const message = <Trans><Plural value={count} one="# item" other="# items" /> total</Trans>
+            "##,
+        )
+        .expect("source");
+
+        let error = extract_catalog_messages_from_files(ExtractCatalogMessagesRequest {
+            root_dir: root.to_string_lossy().into_owned(),
+            files: vec![source.to_string_lossy().into_owned()],
+        })
+        .expect_err("nested message macros should fail");
+
+        assert!(error.to_string().contains("Nested i18n macro"));
         fs::remove_dir_all(root).expect("cleanup");
     }
 

--- a/crates/palamedes/src/extract.rs
+++ b/crates/palamedes/src/extract.rs
@@ -404,6 +404,11 @@ impl<'a> Visit<'a> for NestedMessageMacroFinder<'a> {
 
         walk::walk_jsx_element(self, it);
     }
+
+    fn visit_jsx_opening_element(&mut self, _it: &JSXOpeningElement<'a>) {
+        // Attributes and render props execute in their own render context; they are not part
+        // of the enclosing <Trans> message body.
+    }
 }
 
 fn is_jsx_message_macro(
@@ -1510,6 +1515,20 @@ mod tests {
 
         assert!(message.contains("Nested i18n macro is not extractable as a single message"));
         assert!(!message.contains("stable placeholder name"));
+    }
+
+    #[test]
+    fn allows_nested_jsx_message_macros_inside_render_prop_attributes() {
+        let messages = extract_messages(
+            r#"
+              import { Plural, Trans } from "@palamedes/react/macro"
+              const message = <Trans><List renderItem={() => <Plural value={count} one="one" other="other" />} /></Trans>
+            "#,
+            "test.tsx",
+        )
+        .expect("nested message macros in render prop attributes should not fail");
+
+        assert_eq!(messages[0].message, "<0></0>");
     }
 
     #[test]

--- a/crates/palamedes/src/transform/mod.rs
+++ b/crates/palamedes/src/transform/mod.rs
@@ -136,7 +136,7 @@ pub fn transform_macros(
         return Ok(unchanged_result(source));
     }
 
-    let mut visitor = TransformVisitor::new(source, &collector.macro_imports, &options);
+    let mut visitor = TransformVisitor::new(filename, source, &collector.macro_imports, &options);
     visitor.visit_program(&parsed.program);
 
     if let Some(error) = visitor.error {

--- a/crates/palamedes/src/transform/tests.rs
+++ b/crates/palamedes/src/transform/tests.rs
@@ -443,6 +443,19 @@ fn rejects_nested_jsx_message_macros_inside_map_callbacks() {
 }
 
 #[test]
+fn allows_nested_jsx_message_macros_inside_render_prop_attributes() {
+    let result = transform_macros(
+        "import { Plural, Trans } from \"@palamedes/react/macro\";\nconst el = <Trans><List renderItem={() => <Plural value={count} one=\"one\" other=\"other\" />} /></Trans>;\n",
+        "test.tsx",
+        None,
+    )
+    .expect("nested message macros in render prop attributes should not fail");
+
+    assert!(result.code.contains("message={\"<0></0>\"}"));
+    assert!(result.code.contains("renderItem={() => <Plural"));
+}
+
+#[test]
 fn keeps_choice_jsx_macro_as_expression_outside_jsx_children() {
     let result = transform_macros(
         "import { Plural } from \"@palamedes/react/macro\";\nconst el = <Plural value={count} one=\"# item\" other=\"# items\" />;\n",

--- a/crates/palamedes/src/transform/tests.rs
+++ b/crates/palamedes/src/transform/tests.rs
@@ -414,6 +414,35 @@ fn rejects_nested_jsx_message_macros() {
 }
 
 #[test]
+fn rejects_nested_jsx_message_macros_inside_conditional_and_logical_expressions() {
+    for source in [
+        "import { Plural, Trans } from \"@palamedes/react/macro\";\nconst el = <Trans>{showCount ? <Plural value={count} one=\"one\" other=\"other\" /> : null}</Trans>;\n",
+        "import { Plural, Trans } from \"@palamedes/react/macro\";\nconst el = <Trans>{showCount && <Plural value={count} one=\"one\" other=\"other\" />}</Trans>;\n",
+    ] {
+        let error = transform_macros(source, "test.tsx", None)
+            .expect_err("nested message macros in JSX expressions should fail");
+        let message = error.to_string();
+
+        assert!(message.contains("Nested i18n macro is not extractable as a single message"));
+        assert!(!message.contains("stable placeholder name"));
+    }
+}
+
+#[test]
+fn rejects_nested_jsx_message_macros_inside_map_callbacks() {
+    let error = transform_macros(
+        "import { Plural, Trans } from \"@palamedes/react/macro\";\nconst el = <Trans>{items.map((item) => <Plural value={item.count} one=\"one\" other=\"other\" />)}</Trans>;\n",
+        "test.tsx",
+        None,
+    )
+    .expect_err("nested message macros in map callbacks should fail");
+    let message = error.to_string();
+
+    assert!(message.contains("Nested i18n macro is not extractable as a single message"));
+    assert!(!message.contains("stable placeholder name"));
+}
+
+#[test]
 fn keeps_choice_jsx_macro_as_expression_outside_jsx_children() {
     let result = transform_macros(
         "import { Plural } from \"@palamedes/react/macro\";\nconst el = <Plural value={count} one=\"# item\" other=\"# items\" />;\n",

--- a/crates/palamedes/src/transform/tests.rs
+++ b/crates/palamedes/src/transform/tests.rs
@@ -399,6 +399,21 @@ fn wraps_choice_jsx_macro_when_used_as_jsx_child() {
 }
 
 #[test]
+fn rejects_nested_jsx_message_macros() {
+    let error = transform_macros(
+        "import { Plural, Trans } from \"@palamedes/react/macro\";\nconst el = <Trans><Plural value={contractCount} one=\"# contract\" other=\"# contracts\" /> ({capacityMW} MW)</Trans>;\n",
+        "test.tsx",
+        None,
+    )
+    .expect_err("nested message macros should fail");
+    let message = error.to_string();
+
+    assert!(message.contains("Nested i18n macro is not extractable as a single message"));
+    assert!(message.contains("test.tsx:2:"));
+    assert!(message.contains("Move the full sentence into <Plural> branches"));
+}
+
+#[test]
 fn keeps_choice_jsx_macro_as_expression_outside_jsx_children() {
     let result = transform_macros(
         "import { Plural } from \"@palamedes/react/macro\";\nconst el = <Plural value={count} one=\"# item\" other=\"# items\" />;\n",

--- a/crates/palamedes/src/transform/visitor.rs
+++ b/crates/palamedes/src/transform/visitor.rs
@@ -1,6 +1,8 @@
 use std::collections::{HashMap, HashSet};
 
-use oxc_ast::ast::{CallExpression, JSXChild, JSXElement, TaggedTemplateExpression};
+use oxc_ast::ast::{
+    CallExpression, JSXChild, JSXElement, JSXOpeningElement, TaggedTemplateExpression,
+};
 use oxc_ast_visit::{walk, Visit};
 
 use crate::error::PalamedesError;
@@ -322,6 +324,11 @@ impl<'a> Visit<'a> for NestedMessageMacroFinder<'a> {
         }
 
         walk::walk_jsx_element(self, it);
+    }
+
+    fn visit_jsx_opening_element(&mut self, _it: &JSXOpeningElement<'a>) {
+        // Attributes and render props execute in their own render context; they are not part
+        // of the enclosing <Trans> message body.
     }
 }
 

--- a/crates/palamedes/src/transform/visitor.rs
+++ b/crates/palamedes/src/transform/visitor.rs
@@ -1,6 +1,8 @@
 use std::collections::{HashMap, HashSet};
 
-use oxc_ast::ast::{CallExpression, JSXChild, JSXElement, TaggedTemplateExpression};
+use oxc_ast::ast::{
+    CallExpression, JSXChild, JSXElement, JSXExpression, JSXFragment, TaggedTemplateExpression,
+};
 use oxc_ast_visit::{walk, Visit};
 
 use crate::error::PalamedesError;
@@ -21,6 +23,7 @@ pub(super) struct Replacement {
 }
 
 pub(super) struct TransformVisitor<'a> {
+    filename: &'a str,
     source: &'a str,
     macro_imports: &'a HashMap<String, ImportedMacro>,
     options: &'a NativeTransformOptions,
@@ -34,11 +37,13 @@ pub(super) struct TransformVisitor<'a> {
 
 impl<'a> TransformVisitor<'a> {
     pub(super) fn new(
+        filename: &'a str,
         source: &'a str,
         macro_imports: &'a HashMap<String, ImportedMacro>,
         options: &'a NativeTransformOptions,
     ) -> Self {
         Self {
+            filename,
             source,
             macro_imports,
             options,
@@ -83,6 +88,23 @@ impl<'a> Visit<'a> for TransformVisitor<'a> {
             walk::walk_jsx_element(self, it);
             return;
         };
+
+        if matches!(
+            macro_info.imported_name.as_str(),
+            "Trans" | "Plural" | "Select" | "SelectOrdinal"
+        ) {
+            if let Some(nested) = nested_message_macro_in_children(&it.children, self.macro_imports)
+            {
+                self.fail(PalamedesError::NestedMessageMacro {
+                    location: source_location(
+                        self.source,
+                        self.filename,
+                        nested.span.start as usize,
+                    ),
+                });
+                return;
+            }
+        }
 
         let replacement = match macro_info.imported_name.as_str() {
             "Trans" => transform_trans_element(
@@ -258,4 +280,102 @@ impl<'a> Visit<'a> for TransformVisitor<'a> {
 
         walk::walk_call_expression(self, it);
     }
+}
+
+fn nested_message_macro_in_children<'a>(
+    children: &'a [JSXChild<'a>],
+    macro_imports: &HashMap<String, ImportedMacro>,
+) -> Option<&'a JSXElement<'a>> {
+    for child in children {
+        match child {
+            JSXChild::Element(element) => {
+                if is_jsx_message_macro(element, macro_imports) {
+                    return Some(element);
+                }
+                if let Some(nested) =
+                    nested_message_macro_in_children(&element.children, macro_imports)
+                {
+                    return Some(nested);
+                }
+            }
+            JSXChild::Fragment(fragment) => {
+                if let Some(nested) = nested_message_macro_in_fragment(fragment, macro_imports) {
+                    return Some(nested);
+                }
+            }
+            JSXChild::ExpressionContainer(container) => {
+                if let Some(nested) =
+                    nested_message_macro_in_jsx_expression(&container.expression, macro_imports)
+                {
+                    return Some(nested);
+                }
+            }
+            JSXChild::Text(_) | JSXChild::Spread(_) => {}
+        }
+    }
+
+    None
+}
+
+fn nested_message_macro_in_fragment<'a>(
+    fragment: &'a JSXFragment<'a>,
+    macro_imports: &HashMap<String, ImportedMacro>,
+) -> Option<&'a JSXElement<'a>> {
+    nested_message_macro_in_children(&fragment.children, macro_imports)
+}
+
+fn nested_message_macro_in_jsx_expression<'a>(
+    expr: &'a JSXExpression<'a>,
+    macro_imports: &HashMap<String, ImportedMacro>,
+) -> Option<&'a JSXElement<'a>> {
+    match expr {
+        JSXExpression::JSXElement(element) => {
+            if is_jsx_message_macro(element, macro_imports) {
+                Some(element)
+            } else {
+                nested_message_macro_in_children(&element.children, macro_imports)
+            }
+        }
+        JSXExpression::JSXFragment(fragment) => {
+            nested_message_macro_in_fragment(fragment, macro_imports)
+        }
+        _ => None,
+    }
+}
+
+fn is_jsx_message_macro(
+    element: &JSXElement<'_>,
+    macro_imports: &HashMap<String, ImportedMacro>,
+) -> bool {
+    let Some(tag_name) = element.opening_element.name.get_identifier_name() else {
+        return false;
+    };
+
+    macro_imports
+        .get(tag_name.as_str())
+        .is_some_and(|macro_info| {
+            matches!(
+                macro_info.imported_name.as_str(),
+                "Trans" | "Plural" | "Select" | "SelectOrdinal"
+            )
+        })
+}
+
+fn source_location(source: &str, filename: &str, offset: usize) -> String {
+    let mut line = 1usize;
+    let mut line_start = 0usize;
+
+    for (index, ch) in source.char_indices() {
+        if index >= offset {
+            break;
+        }
+        if ch == '\n' {
+            line += 1;
+            line_start = index + 1;
+        }
+    }
+
+    let column = offset.saturating_sub(line_start) + 1;
+
+    format!("{filename}:{line}:{column}")
 }

--- a/crates/palamedes/src/transform/visitor.rs
+++ b/crates/palamedes/src/transform/visitor.rs
@@ -1,8 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
-use oxc_ast::ast::{
-    CallExpression, JSXChild, JSXElement, JSXExpression, JSXFragment, TaggedTemplateExpression,
-};
+use oxc_ast::ast::{CallExpression, JSXChild, JSXElement, TaggedTemplateExpression};
 use oxc_ast_visit::{walk, Visit};
 
 use crate::error::PalamedesError;
@@ -93,14 +91,11 @@ impl<'a> Visit<'a> for TransformVisitor<'a> {
             macro_info.imported_name.as_str(),
             "Trans" | "Plural" | "Select" | "SelectOrdinal"
         ) {
-            if let Some(nested) = nested_message_macro_in_children(&it.children, self.macro_imports)
+            if let Some(nested_start) =
+                nested_message_macro_in_children(&it.children, self.macro_imports)
             {
                 self.fail(PalamedesError::NestedMessageMacro {
-                    location: source_location(
-                        self.source,
-                        self.filename,
-                        nested.span.start as usize,
-                    ),
+                    location: source_location(self.source, self.filename, nested_start),
                 });
                 return;
             }
@@ -285,61 +280,48 @@ impl<'a> Visit<'a> for TransformVisitor<'a> {
 fn nested_message_macro_in_children<'a>(
     children: &'a [JSXChild<'a>],
     macro_imports: &HashMap<String, ImportedMacro>,
-) -> Option<&'a JSXElement<'a>> {
-    for child in children {
-        match child {
-            JSXChild::Element(element) => {
-                if is_jsx_message_macro(element, macro_imports) {
-                    return Some(element);
-                }
-                if let Some(nested) =
-                    nested_message_macro_in_children(&element.children, macro_imports)
-                {
-                    return Some(nested);
-                }
+) -> Option<usize> {
+    NestedMessageMacroFinder::find_in_children(children, macro_imports)
+}
+
+struct NestedMessageMacroFinder<'a> {
+    macro_imports: &'a HashMap<String, ImportedMacro>,
+    nested_start: Option<usize>,
+}
+
+impl<'a> NestedMessageMacroFinder<'a> {
+    fn find_in_children(
+        children: &[JSXChild<'a>],
+        macro_imports: &'a HashMap<String, ImportedMacro>,
+    ) -> Option<usize> {
+        let mut finder = Self {
+            macro_imports,
+            nested_start: None,
+        };
+
+        for child in children {
+            finder.visit_jsx_child(child);
+            if finder.nested_start.is_some() {
+                break;
             }
-            JSXChild::Fragment(fragment) => {
-                if let Some(nested) = nested_message_macro_in_fragment(fragment, macro_imports) {
-                    return Some(nested);
-                }
-            }
-            JSXChild::ExpressionContainer(container) => {
-                if let Some(nested) =
-                    nested_message_macro_in_jsx_expression(&container.expression, macro_imports)
-                {
-                    return Some(nested);
-                }
-            }
-            JSXChild::Text(_) | JSXChild::Spread(_) => {}
         }
+
+        finder.nested_start
     }
-
-    None
 }
 
-fn nested_message_macro_in_fragment<'a>(
-    fragment: &'a JSXFragment<'a>,
-    macro_imports: &HashMap<String, ImportedMacro>,
-) -> Option<&'a JSXElement<'a>> {
-    nested_message_macro_in_children(&fragment.children, macro_imports)
-}
+impl<'a> Visit<'a> for NestedMessageMacroFinder<'a> {
+    fn visit_jsx_element(&mut self, it: &JSXElement<'a>) {
+        if self.nested_start.is_some() {
+            return;
+        }
 
-fn nested_message_macro_in_jsx_expression<'a>(
-    expr: &'a JSXExpression<'a>,
-    macro_imports: &HashMap<String, ImportedMacro>,
-) -> Option<&'a JSXElement<'a>> {
-    match expr {
-        JSXExpression::JSXElement(element) => {
-            if is_jsx_message_macro(element, macro_imports) {
-                Some(element)
-            } else {
-                nested_message_macro_in_children(&element.children, macro_imports)
-            }
+        if is_jsx_message_macro(it, self.macro_imports) {
+            self.nested_start = Some(it.span.start as usize);
+            return;
         }
-        JSXExpression::JSXFragment(fragment) => {
-            nested_message_macro_in_fragment(fragment, macro_imports)
-        }
-        _ => None,
+
+        walk::walk_jsx_element(self, it);
     }
 }
 

--- a/packages/extractor/src/extractMessages.test.ts
+++ b/packages/extractor/src/extractMessages.test.ts
@@ -254,6 +254,17 @@ describe("extractMessages", () => {
       expect(() => extract(code)).toThrow(/stable placeholder name/)
     })
 
+    it("rejects nested JSX message macros", () => {
+      const code = `
+        import { Plural, Trans } from "@palamedes/react/macro"
+        const x = <Trans><Plural value={contractCount} one="# contract" other="# contracts" /> ({capacityMW} MW)</Trans>
+      `
+
+      expect(() => extract(code)).toThrow(
+        /Nested i18n macro is not extractable as a single message at test\.tsx:3:\d+/
+      )
+    })
+
     it("rejects unnamed choice value placeholders", () => {
       const code = `
         import { plural } from "@palamedes/core/macro"

--- a/packages/extractor/src/extractMessages.test.ts
+++ b/packages/extractor/src/extractMessages.test.ts
@@ -265,6 +265,26 @@ describe("extractMessages", () => {
       )
     })
 
+    it("rejects nested JSX message macros in expression containers", () => {
+      const cases = [
+        `<Trans>{showCount ? <Plural value={count} one="one" other="other" /> : null}</Trans>`,
+        `<Trans>{showCount && <Plural value={count} one="one" other="other" />}</Trans>`,
+        `<Trans>{items.map((item) => <Plural value={item.count} one="one" other="other" />)}</Trans>`,
+      ]
+
+      for (const jsx of cases) {
+        const code = `
+          import { Plural, Trans } from "@palamedes/react/macro"
+          const x = ${jsx}
+        `
+
+        expect(() => extract(code)).toThrow(
+          /Nested i18n macro is not extractable as a single message/
+        )
+        expect(() => extract(code)).not.toThrow(/stable placeholder name/)
+      }
+    })
+
     it("rejects unnamed choice value placeholders", () => {
       const code = `
         import { plural } from "@palamedes/core/macro"

--- a/packages/extractor/src/extractMessages.test.ts
+++ b/packages/extractor/src/extractMessages.test.ts
@@ -285,6 +285,17 @@ describe("extractMessages", () => {
       }
     })
 
+    it("allows nested JSX message macros in render prop attributes", () => {
+      const code = `
+        import { Plural, Trans } from "@palamedes/react/macro"
+        const x = <Trans><List renderItem={() => <Plural value={count} one="one" other="other" />} /></Trans>
+      `
+
+      const messages = extract(code)
+
+      expect(messages[0].message).toBe("<0></0>")
+    })
+
     it("rejects unnamed choice value placeholders", () => {
       const code = `
         import { plural } from "@palamedes/core/macro"

--- a/packages/transform/src/transform.test.ts
+++ b/packages/transform/src/transform.test.ts
@@ -362,6 +362,17 @@ const el = ${jsx};
     }
   })
 
+  it("allows nested JSX message macros in render prop attributes", () => {
+    const code = `
+import { Plural, Trans } from "@palamedes/react/macro";
+const el = <Trans><List renderItem={() => <Plural value={count} one="one" other="other" />} /></Trans>;
+`
+    const result = transformPalamedesMacros(code, "test.tsx")
+
+    expect(result.code).toContain('message={"<0></0>"}')
+    expect(result.code).toContain("renderItem={() => <Plural")
+  })
+
   it("rejects unnamed choice value placeholders", () => {
     const code = `
 import { plural } from "@palamedes/core/macro";

--- a/packages/transform/src/transform.test.ts
+++ b/packages/transform/src/transform.test.ts
@@ -282,6 +282,17 @@ export function Demo({ totalRows }: { totalRows: number }) {
     expect(result.code).toContain(")}</p>")
   })
 
+  it("rejects nested JSX message macros", () => {
+    const code = `
+import { Plural, Trans } from "@palamedes/react/macro";
+const el = <Trans><Plural value={contractCount} one="# contract" other="# contracts" /> ({capacityMW} MW)</Trans>;
+`
+
+    expect(() => transformPalamedesMacros(code, "test.tsx")).toThrow(
+      /Nested i18n macro is not extractable as a single message at test\.tsx:3:\d+/
+    )
+  })
+
   it("keeps JSX choice macro replacements as expressions outside JSX children", () => {
     const code = `
 import { Plural } from "@palamedes/react/macro";

--- a/packages/transform/src/transform.test.ts
+++ b/packages/transform/src/transform.test.ts
@@ -340,6 +340,28 @@ const el = <Trans>Hello {firstName + lastName}</Trans>;
     expect(() => transformPalamedesMacros(code, "test.tsx")).toThrow(/stable placeholder name/)
   })
 
+  it("rejects nested JSX message macros in expression containers", () => {
+    const cases = [
+      `<Trans>{showCount ? <Plural value={count} one="one" other="other" /> : null}</Trans>`,
+      `<Trans>{showCount && <Plural value={count} one="one" other="other" />}</Trans>`,
+      `<Trans>{items.map((item) => <Plural value={item.count} one="one" other="other" />)}</Trans>`,
+    ]
+
+    for (const jsx of cases) {
+      const code = `
+import { Plural, Trans } from "@palamedes/react/macro";
+const el = ${jsx};
+`
+
+      expect(() => transformPalamedesMacros(code, "test.tsx")).toThrow(
+        /Nested i18n macro is not extractable as a single message/
+      )
+      expect(() => transformPalamedesMacros(code, "test.tsx")).not.toThrow(
+        /stable placeholder name/
+      )
+    }
+  })
+
   it("rejects unnamed choice value placeholders", () => {
     const code = `
 import { plural } from "@palamedes/core/macro";


### PR DESCRIPTION
Closes #235.

## Summary
- rejects nested Palamedes JSX message macros before they can produce fragment catalog entries
- reports a fatal diagnostic with source file, line, column, and rewrite guidance
- keeps batch extraction fatal for this authoring error so `pmds extract` fails instead of silently skipping the file
- adds Rust and TypeScript coverage for the nested `<Plural>` inside `<Trans>` case

## Validation
- `cargo fmt --all --check`
- `cargo clippy -p palamedes --all-targets -- -D warnings`
- `cargo test -p palamedes`
- `pnpm --filter @palamedes/core-node-darwin-arm64 build`
- `pnpm --filter @palamedes/core-node build`
- `pnpm --filter @palamedes/transform test`
- `pnpm --filter @palamedes/extractor test`
- `pnpm format:check`