### PR TITLE
chore(deps): update string_wizard to 1.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1147,9 +1147,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "string_wizard"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "062809a33f90b3216e9fcadb95e0a6d41794ac5e23663ea96c47d23f13bdcea4"
+checksum = "5e854201e97dc8a03aef10096c883c950aca1a25f2435c77bbfb2a519ef8003d"
 dependencies = [
  "memchr",
  "oxc_index 5.0.0",

--- a/crates/palamedes/Cargo.toml
+++ b/crates/palamedes/Cargo.toml
@@ -17,5 +17,5 @@ oxc_parser = "0.133.0"
 oxc_span = "0.133.0"
 regex = "1.12.3"
 serde = { version = "1.0.228", features = ["derive"] }
-string_wizard = "1.1.2"
+string_wizard = "1.1.3"
 thiserror = "2.0.18"


### PR DESCRIPTION
## Summary
- update the direct `string_wizard` dependency from 1.1.2 to 1.1.3
- refresh `Cargo.lock` for the resolved crate version

## Upstream
- crates.io: https://crates.io/crates/string_wizard/1.1.3
- docs.rs: https://docs.rs/string_wizard/1.1.3

## Validation
- `cargo fmt --all --check`
- `cargo test -p palamedes --locked`
- `cargo clippy -p palamedes --all-targets --locked -- -D warnings`