### PR TITLE
chore(deps): update napi-rs bindings

### DIFF
--- a/crates/palamedes-node/Cargo.toml
+++ b/crates/palamedes-node/Cargo.toml
@@ -13,8 +13,8 @@ path = "src/lib.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-napi = { version = "3.9.0", default-features = false, features = ["napi9"] }
-napi-derive = "3.5.6"
+napi = { version = "3.9.4", default-features = false, features = ["napi9"] }
+napi-derive = "3.5.7"
 palamedes = { path = "../palamedes" }
 
 [build-dependencies]


### PR DESCRIPTION
## Summary
- raise the direct `napi` manifest version from 3.9.0 to 3.9.4
- raise the direct `napi-derive` manifest version from 3.5.6 to 3.5.7
- leave `napi-build` unchanged at 2.3.2

## Upstream
- napi v3.9.4: https://github.com/napi-rs/napi-rs/releases/tag/napi-v3.9.4
- napi-derive v3.5.7: https://github.com/napi-rs/napi-rs/releases/tag/napi-derive-v3.5.7

## Validation
- `cargo fmt --all --check`
- `cargo test -p palamedes-node --locked`
- `cargo clippy -p palamedes-node --all-targets --locked -- -D warnings`