### PR TITLE
chore(deps): update root tooling

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,13 +42,13 @@
     "test:rust": "cargo test --workspace"
   },
   "devDependencies": {
-    "@playwright/test": "^1.61.0",
+    "@playwright/test": "^1.61.1",
     "eslint": "^10.5.0",
     "eslint-config-setup": "^0.4.0",
     "oxfmt": "^0.56.0",
     "oxlint": "^1.71.0",
     "typescript": "^6.0.3",
-    "vercel": "^54.15.0",
+    "vercel": "^54.17.3",
     "vitest": "^4.1.9"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,8 +14,8 @@ importers:
   .:
     devDependencies:
       '@playwright/test':
-        specifier: ^1.61.0
-        version: 1.61.0
+        specifier: ^1.61.1
+        version: 1.61.1
       eslint:
         specifier: ^10.5.0
         version: 10.5.0(jiti@2.7.0)
@@ -32,8 +32,8 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
       vercel:
-        specifier: ^54.15.0
-        version: 54.15.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(rollup@4.59.0)
+        specifier: ^54.17.3
+        version: 54.17.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(rollup@4.59.0)
       vitest:
         specifier: ^4.1.9
         version: 4.1.9(@edge-runtime/vm@3.2.0)(@types/node@26.0.0)(jsdom@29.1.1)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
@@ -81,7 +81,7 @@ importers:
         version: link:../../packages/runtime
       next:
         specifier: ^16.2.9
-        version: 16.2.9(@playwright/test@1.61.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.2.9(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -130,7 +130,7 @@ importers:
         version: link:../../packages/runtime
       next:
         specifier: ^16.2.9
-        version: 16.2.9(@playwright/test@1.61.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.2.9(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -748,7 +748,7 @@ importers:
     devDependencies:
       next:
         specifier: ^16.2.9
-        version: 16.2.9(@playwright/test@1.61.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.2.9(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -3329,8 +3329,8 @@ packages:
     resolution: {integrity: sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==}
     engines: {node: ^14.18.0 || >=16.0.0}
 
-  '@playwright/test@1.61.0':
-    resolution: {integrity: sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==}
+  '@playwright/test@1.61.1':
+    resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -4472,18 +4472,18 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@vercel/backends@0.8.15':
-    resolution: {integrity: sha512-aWF4/YJiD5kww2rlIsMVDVg91rlouLI3Aex8+cFj5Sd6+LzL6pq2kr4Mqam5uECTLZVPoaFBFj2fB7UQc5Dc6Q==}
+  '@vercel/backends@0.8.18':
+    resolution: {integrity: sha512-HMUwm923y8AxXKp1j1VqlWFmpN0gubeU4UDgskDjDeU7kHwYEfaZT9c2iOUAqhwmnrpp0mAEAM9d8PjtFJ4O/w==}
 
   '@vercel/blob@2.4.0':
     resolution: {integrity: sha512-ncQ8CRb6XoEAYJwjOTRGpACRT6h/AeY+/33gLyeVxG5BIes27OPm1jmqreF+JHjcTmGhClTP+kBpmyLfbV0xew==}
     engines: {node: '>=20.0.0'}
 
-  '@vercel/build-utils@13.31.0':
-    resolution: {integrity: sha512-48f+C+2NB1XkLfGxuNNyd4vKS7fz9RWu8HfCtTzl7093SDvGG7MVJ+SRKLWL5mRU3E4YWMh964u1RGJohroR5g==}
+  '@vercel/build-utils@13.32.1':
+    resolution: {integrity: sha512-r8H6DZ1NLi2i4mY7YGOeb5b8mtGPaTtYe5ezYbLoV7nrjCSRMqHKKsAWOjPYDRKZ2Vf48OQB0OZ4lj9Cc5Vwhw==}
 
-  '@vercel/cervel@0.1.23':
-    resolution: {integrity: sha512-LeX0SWi4gd9njZOCJ+J/y5hVPaItgAoRFFb2PqRl3lRuNTAPA3K3o7m4Ei7IAbvtHUN3a2oLDm1ZKSEJ2IEsew==}
+  '@vercel/cervel@0.1.26':
+    resolution: {integrity: sha512-n2qeyZs96XbnBfKDsQ/8QPr12Mb8ZFMcxdQJFEvciWK9+nygrWKEEuC6akH3tK3Pw7IubQY07Yn3rMUXfhdLxA==}
     hasBin: true
 
   '@vercel/cli-auth@0.3.0':
@@ -4492,21 +4492,24 @@ packages:
   '@vercel/cli-config@0.2.0':
     resolution: {integrity: sha512-fJRRRB7734BDuXZ89yBEaA2ncYhH7bWX30mk04W80J6VAfQc+4iB8lyzAdaGpFV3/vNlkt9VZt+/uoQoWX6UsQ==}
 
+  '@vercel/container@0.0.2':
+    resolution: {integrity: sha512-t7vIpTRejh7zoxxcqa9lNSwlzYqB/mOYo3cQjifnBvBPyrFI3OXdW9WCFl+y3hgOAY6cIUnNFeD3OHzAZf3cwA==}
+
   '@vercel/detect-agent@1.2.3':
     resolution: {integrity: sha512-VYNCgUc0nOmC4WJmWw9GkrKdfr8Zl4/rxhC5SvgacBgxiW9W/9NRttUoHHXV8xdII3MaRgkZZVX8Ikzc/Jmjag==}
     engines: {node: '>=14'}
 
-  '@vercel/elysia@0.1.94':
-    resolution: {integrity: sha512-+gt6laGEOlry16v5Sb3sJerxxB+REIHmk6BNuYFGnomnkRBESmmmelWKW8c26kaCUQ13TC4RK+NV0I8URPmMZw==}
+  '@vercel/elysia@0.1.97':
+    resolution: {integrity: sha512-ShEPurEH8Q+htrCBj0b8okmX5x92F8VosIKhHRpz51jb/TW5iUblgBhHkbJKMrSTXeUvV6KvzPr5nY2HrWgCAg==}
 
   '@vercel/error-utils@2.2.0':
     resolution: {integrity: sha512-WFWiRxfPzoYWYifaj4thSKvAaZZwUOqD4k5GINRIgZgCiS2E3iAJbWbIsIZmkQdTecWFHcWGA6q48CjisgpOBA==}
 
-  '@vercel/express@0.1.106':
-    resolution: {integrity: sha512-tboZD13WKaotsk9psrt+yjD8mzWZxpgl7facW8CV1D1nYtlpLb9wIt2EeOdx30dlVjKwSAVKLPdFotQnCvQZqA==}
+  '@vercel/express@0.1.109':
+    resolution: {integrity: sha512-X/NMmEPoRjgcy8jqc+Op4L/r8g2wTKB/X7aNWJ9+/3aGIHlnwVU7Fp2R+tQUH2/yW0eGyGtwZWX81M1uZK3phg==}
 
-  '@vercel/fastify@0.1.97':
-    resolution: {integrity: sha512-U9nOQMDmTtMei3AKxZZsdW4LD59GgEnfZFg9o27ID6ANcxkY0TWoi9QPD7WngKWX55X2biITZyVPxtkBQfpQBA==}
+  '@vercel/fastify@0.1.100':
+    resolution: {integrity: sha512-X2aTOnb630pi7e7a6pA4UtMbXaFXhuEwWfKMBtYmJEAwI2SxLG0DhL5byYIpd6/KENYH5M+PvsBJQOxMdGR3cg==}
 
   '@vercel/fun@1.3.0':
     resolution: {integrity: sha512-8erw9uPe0dFg45THkNxmjtvMX143SkZebmjgSVbcM3XCkXu3RIiBaJMcMNG8aaS+rnTuw8+d4De9HVT0M/r3wg==}
@@ -4515,29 +4518,29 @@ packages:
   '@vercel/gatsby-plugin-vercel-analytics@1.0.11':
     resolution: {integrity: sha512-iTEA0vY6RBPuEzkwUTVzSHDATo1aF6bdLLspI68mQ/BTbi5UQEGjpjyzdKOVcSYApDtFU6M6vypZ1t4vIEnHvw==}
 
-  '@vercel/gatsby-plugin-vercel-builder@2.2.20':
-    resolution: {integrity: sha512-2NUupYEZ8AhqueaN9rGHZEFEs4RA6XAnZXsXrndBlLOyMldcKHv6g9J2A4GYbj45vj/j/S18ZUjaaTUG8C0sGg==}
+  '@vercel/gatsby-plugin-vercel-builder@2.2.23':
+    resolution: {integrity: sha512-UxInx6QtZZQkjeoOK+fMBxavlS+GWm1PUWAvCvZpyCNO971JzdlGwW6zzSIeUsBrHB8SozPqnG1PMQisLY6TxQ==}
 
-  '@vercel/go@3.9.1':
-    resolution: {integrity: sha512-EZTyb+C6RqDi4zkicrXLaDjdAnk0eRdgOA4fAI4wziB62HRz/He9dmDxVuoRPneXn4dlb/3Cl9BoXjyjwe4JqA==}
+  '@vercel/go@3.10.1':
+    resolution: {integrity: sha512-6i37zdMUS4PX1BWRHBCUqp5Ev0NbOrfrRVCwAzKj8YKh48LNu/Ye5r5NFI3JW7g40HkAC8wBMwZ7fRQPlWgBSg==}
 
-  '@vercel/h3@0.1.103':
-    resolution: {integrity: sha512-iPUABbgC47jBkZD1+y2wKWvePq7yIrk+VlurMKbGSrwkHPm2rzyehHsR0EhZ8Ly1Rhfb1YlOQYeClFLe2vSaFA==}
+  '@vercel/h3@0.1.106':
+    resolution: {integrity: sha512-Sl9k42VQnlbPgtg0vQyUmhhQ0LmjSYhLklLKjd5pzD0GXITKbhPXa+0QwdnRtJo0Eb2kFzluZmypEF7KoNxW4g==}
 
-  '@vercel/hono@0.2.97':
-    resolution: {integrity: sha512-IYgKFqBaHtr3kvaY1wqHKEtVNOUxGRMAGzLB5njBbjyzsiT3Y1mjehHkrKT0CIalwRC6vqEdPXf+58ML+ATBWQ==}
+  '@vercel/hono@0.2.100':
+    resolution: {integrity: sha512-AIVfTN2txUEj7yLEUdbDCfBLgQOe+jbnQUgWWFAI5nH0RAn4I3OtySp6xI3FlP+TOCOAe0hdsbTF+7bpDyG52A==}
 
   '@vercel/hydrogen@1.4.0':
     resolution: {integrity: sha512-gf3ELmAjcia7WNGNHAB/rFWFU0l5fJ7mTMgGC5hvcCjSIE4kp8WWuGYiTQgQ8W6GF/1FJAxa2J3BhY/yxjY8tA==}
 
-  '@vercel/koa@0.1.77':
-    resolution: {integrity: sha512-XkExbgzpGfJyXRDwQ7C+LszLgBYhAUn28kAa40ExpVTyplBGvcf6zY943kuprBqVddIuebSScg2gLktMNM1hGg==}
+  '@vercel/koa@0.1.80':
+    resolution: {integrity: sha512-Ul9G9P7Jy/vh0M8OH4A14WId96l2FLqwtUKnuuwKF4m1Fun8NvUw+5AM/xVwT0GQUNJsRJpVlTuGX+vhmgDFhA==}
 
-  '@vercel/nestjs@0.2.98':
-    resolution: {integrity: sha512-lOj1o1QbzDpRekIQ4YYx/qCEbCMUmp+xYwcVPwsLQ5JAHxj/aIWsSw50XHWJwoWAdre9cZtTZTIuslFJzSilJg==}
+  '@vercel/nestjs@0.2.101':
+    resolution: {integrity: sha512-twHcHBLJN97bK6z9NtGOzwrd9HrR/10e6FGGMCgckz3REAS4a4Us2dyS3IQennNbAT0Nfc1zdH/+trB5WIHUaw==}
 
-  '@vercel/next@4.19.1':
-    resolution: {integrity: sha512-4no1YiY7xjcNhaFpdPNFwgMg1YvQC+7DATM3MCVntLtjTEkUFgYGpFtaPiqfEhTX3QgFg2HZNOT612z+vDATkw==}
+  '@vercel/next@4.20.1':
+    resolution: {integrity: sha512-MvZSuRQUGvd4W9rcztpbj+7cNzCFlxhjEFMF4gJbW635+ZP7tN44wEcr7bzVj1m8wi6lYlrs19qXr5vsJKlsmw==}
 
   '@vercel/nft@1.10.0':
     resolution: {integrity: sha512-iLOW4fcsgkipfOh2Bw3wB38YDfxTlxr7+j4uFeui2OswkNT28jIitS/aMce7tS0mef1YPQ8zLIDYr3a0aahNrA==}
@@ -4549,8 +4552,8 @@ packages:
     engines: {node: '>=20'}
     hasBin: true
 
-  '@vercel/node@5.8.18':
-    resolution: {integrity: sha512-RoH8dZ74NLoGXQjJc9EV0WZXfaa165cgQInJZVorKNiIS3nnLyQ7ouaIMQIDrJVGqcuUYxO0UB/CzXu2W4aJGw==}
+  '@vercel/node@5.8.21':
+    resolution: {integrity: sha512-h49+XWY9nPEu2atBkbs5izbzlOVx4RxwJQrgYUpcp6KG2Ib2WRQ81uUKCIevm4O0qwAo6w7mgNN11yp8XGWK7g==}
 
   '@vercel/oidc@3.2.0':
     resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
@@ -4562,8 +4565,8 @@ packages:
   '@vercel/python-analysis@0.11.1':
     resolution: {integrity: sha512-EPPLuXJQhIDUx08H9nG76AR2HSgBquwe3OAX5s2w20M923iaWeGGVkhX/4yZ89CJfXEZgE1Aj/mX7lVHOVIcYA==}
 
-  '@vercel/python@6.47.1':
-    resolution: {integrity: sha512-3AKnpBnZc4ClonYrpzMeWoNnoWzQF2PyAJqsfo74IhLuAh5bnOGFOnLK2NcIg60GdzF/8TjdwPR7AkyuxdrYzw==}
+  '@vercel/python@6.47.2':
+    resolution: {integrity: sha512-ayP1s8dfCtW4XmvUFDRdA7ETbkEbRWChfCv66FZNHWgMRKELxhsuO1OHPnK+7hwHwEjpxPqZyilRO64RBKlYfw==}
 
   '@vercel/redwood@2.5.0':
     resolution: {integrity: sha512-LO24CbieV57rGAqrq5n5z/B+fMYeUqbE/Ge3qMeKRuS3Q9awgcBgB6WYLCe8crHM7XJd5AZjbuyoS/6k3r0X0w==}
@@ -4571,8 +4574,8 @@ packages:
   '@vercel/remix-builder@5.9.1':
     resolution: {integrity: sha512-s0SpfV640nmQ1BsKCPMYugGrH/V+319onTo2ZILSmsy6NTBlmeN0zJU9nPcP8dBEotGqtp68NfOlOUUdrVBzkw==}
 
-  '@vercel/ruby@2.5.0':
-    resolution: {integrity: sha512-q0VUk3s+Pmh5duMLJLopcyLIXRbubhsgCKP9IkHhmrHcSSiRJbJTAdQ/9BNIAC4XxGRgPByKE6i0Lejb4Hn7IQ==}
+  '@vercel/ruby@2.5.1':
+    resolution: {integrity: sha512-e23M7pfORQyyxSUmeQ8PqEnyLJ4swhtNrnyctU5E02UCaUYFm5YAdNfdPYRP4It874H4Wyvm+LV8u7CPBrfcPA==}
 
   '@vercel/rust@1.3.0':
     resolution: {integrity: sha512-z1X0z1NM+ISunm/scgRpuENNwcKlh7DjXn0QvKE0n10DcaYqxkBQVK8iRA9X05xSK9AzPlnB9DHdGKiXZO5buw==}
@@ -4580,8 +4583,8 @@ packages:
   '@vercel/sandbox@2.1.1':
     resolution: {integrity: sha512-gKhW+YlvU15Qxya7jQKByB+sqA1dWat5zx/rvxT52E3Ryg9MAIXgqD5wd1d+CoJDbdHL26gIOcksTZY5sFpplA==}
 
-  '@vercel/static-build@2.11.0':
-    resolution: {integrity: sha512-gRLpZIsVS0oJahEAVMTTmVEplRJ1w+GU5w6ZPFiiNNilugqf6TelYbuzzXUk93mx46OVlbhZICiv0JW1ocJ+fw==}
+  '@vercel/static-build@2.11.3':
+    resolution: {integrity: sha512-7twXLgeCbG9A0uiH9hnDmmYR5pn++0i3LCRpsO9hMyLwEGzkYxjgtA9blWBQk9dkVhDa4WGo1xGlyBKXT10dOw==}
 
   '@vercel/static-config@3.4.0':
     resolution: {integrity: sha512-wCq90CMUB//ggnFh77NQO1xaLFsS4LigQIqKrH6ohnr9Br/KI1FhlErx62WfCOuueWaW+LVsbLOqNXIUjK8t6A==}
@@ -8016,13 +8019,13 @@ packages:
   pkg-types@2.3.1:
     resolution: {integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==}
 
-  playwright-core@1.61.0:
-    resolution: {integrity: sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==}
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.61.0:
-    resolution: {integrity: sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==}
+  playwright@1.61.1:
+    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -8815,13 +8818,13 @@ packages:
   spdx-license-ids@3.0.23:
     resolution: {integrity: sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==}
 
-  srvx@0.11.17:
-    resolution: {integrity: sha512-43yM4luKfCJamyCMhrUeHUPOrf8TdZe7kN8s5zayZCH5OeprYqi49Aso5ZvHXR4aB+DHaRNO/diNFgZSMNG8Xw==}
+  srvx@0.11.16:
+    resolution: {integrity: sha512-bp07zRuycfTY43IjAvvTFnmnJi8ikW0VFiHwOhhYcVW/L4xQ1XY4PAd4Nuum1rsA17C39zL7x+CDhrn5AL32Rw==}
     engines: {node: '>=20.16.0'}
     hasBin: true
 
-  srvx@0.8.9:
-    resolution: {integrity: sha512-wYc3VLZHRzwYrWJhkEqkhLb31TI0SOkfYZDkUhXdp3NoCnNS0FqajiQszZZjfow/VYEuc6Q5sZh9nM6kPy2NBQ==}
+  srvx@0.11.17:
+    resolution: {integrity: sha512-43yM4luKfCJamyCMhrUeHUPOrf8TdZe7kN8s5zayZCH5OeprYqi49Aso5ZvHXR4aB+DHaRNO/diNFgZSMNG8Xw==}
     engines: {node: '>=20.16.0'}
     hasBin: true
 
@@ -9522,8 +9525,8 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
-  vercel@54.15.0:
-    resolution: {integrity: sha512-hWet1dwImww33K+MXUVOT+7I5ADtWMwTX+vpjPNqCkccyr7KoOJsAv6r1KBiobZX/ue+MIydvATPwyz5oZIHbQ==}
+  vercel@54.17.3:
+    resolution: {integrity: sha512-HVmYSzxvG6kDp0pqKJCdzaRUsopDVx6VyuGEWIVuyRGZWs6Tw/eUZ2OVl+VRTGn5yGOLaCPpI5nVqnk1689MSg==}
     engines: {node: '>= 18'}
     hasBin: true
 
@@ -11413,13 +11416,6 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
-  '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
-    dependencies:
-      '@emnapi/core': 1.11.1
-      '@emnapi/runtime': 1.11.1
-      '@tybys/wasm-util': 0.10.3
-    optional: true
-
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)':
     dependencies:
       '@emnapi/core': 1.11.0
@@ -11729,7 +11725,7 @@ snapshots:
 
   '@oxc-transform/binding-wasm32-wasi@0.111.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -11935,9 +11931,9 @@ snapshots:
 
   '@pkgr/core@0.3.6': {}
 
-  '@playwright/test@1.61.0':
+  '@playwright/test@1.61.1':
     dependencies:
-      playwright: 1.61.0
+      playwright: 1.61.1
 
   '@poppinss/colors@4.1.6':
     dependencies:
@@ -12093,7 +12089,7 @@ snapshots:
 
   '@rolldown/binding-wasm32-wasi@1.0.0-rc.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -12756,7 +12752,7 @@ snapshots:
 
   '@types/concat-stream@2.0.3':
     dependencies:
-      '@types/node': 26.0.0
+      '@types/node': 26.0.1
 
   '@types/debug@4.1.13':
     dependencies:
@@ -13017,9 +13013,9 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.12.2':
     optional: true
 
-  '@vercel/backends@0.8.15(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(rollup@4.59.0)':
+  '@vercel/backends@0.8.18(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(rollup@4.59.0)':
     dependencies:
-      '@vercel/build-utils': 13.31.0
+      '@vercel/build-utils': 13.32.1
       '@vercel/nft': 1.10.0(rollup@4.59.0)
       execa: 3.2.0
       fs-extra: 11.1.0
@@ -13028,7 +13024,7 @@ snapshots:
       path-to-regexp: 8.3.0
       resolve.exports: 2.0.3
       rolldown: 1.0.0-rc.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
-      srvx: 0.8.9
+      srvx: 0.11.16
       tsx: 4.21.0
       zod: 3.22.4
     transitivePeerDependencies:
@@ -13046,15 +13042,15 @@ snapshots:
       throttleit: 2.1.0
       undici: 6.27.0
 
-  '@vercel/build-utils@13.31.0':
+  '@vercel/build-utils@13.32.1':
     dependencies:
       '@vercel/python-analysis': 0.11.1
       cjs-module-lexer: 1.2.3
       es-module-lexer: 1.5.0
 
-  '@vercel/cervel@0.1.23(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(rollup@4.59.0)':
+  '@vercel/cervel@0.1.26(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(rollup@4.59.0)':
     dependencies:
-      '@vercel/backends': 0.8.15(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(rollup@4.59.0)
+      '@vercel/backends': 0.8.18(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(rollup@4.59.0)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -13075,11 +13071,13 @@ snapshots:
       xdg-app-paths: 5.1.0
       zod: 4.1.11
 
+  '@vercel/container@0.0.2': {}
+
   '@vercel/detect-agent@1.2.3': {}
 
-  '@vercel/elysia@0.1.94(rollup@4.59.0)':
+  '@vercel/elysia@0.1.97(rollup@4.59.0)':
     dependencies:
-      '@vercel/node': 5.8.18(rollup@4.59.0)
+      '@vercel/node': 5.8.21(rollup@4.59.0)
       '@vercel/static-config': 3.4.0
     transitivePeerDependencies:
       - encoding
@@ -13088,11 +13086,11 @@ snapshots:
 
   '@vercel/error-utils@2.2.0': {}
 
-  '@vercel/express@0.1.106(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(rollup@4.59.0)':
+  '@vercel/express@0.1.109(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(rollup@4.59.0)':
     dependencies:
-      '@vercel/cervel': 0.1.23(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(rollup@4.59.0)
+      '@vercel/cervel': 0.1.26(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(rollup@4.59.0)
       '@vercel/nft': 1.10.0(rollup@4.59.0)
-      '@vercel/node': 5.8.18(rollup@4.59.0)
+      '@vercel/node': 5.8.21(rollup@4.59.0)
       '@vercel/static-config': 3.4.0
       fs-extra: 11.1.0
       path-to-regexp: 8.3.0
@@ -13105,9 +13103,9 @@ snapshots:
       - rollup
       - supports-color
 
-  '@vercel/fastify@0.1.97(rollup@4.59.0)':
+  '@vercel/fastify@0.1.100(rollup@4.59.0)':
     dependencies:
-      '@vercel/node': 5.8.18(rollup@4.59.0)
+      '@vercel/node': 5.8.21(rollup@4.59.0)
       '@vercel/static-config': 3.4.0
     transitivePeerDependencies:
       - encoding
@@ -13142,29 +13140,29 @@ snapshots:
     dependencies:
       web-vitals: 0.2.4
 
-  '@vercel/gatsby-plugin-vercel-builder@2.2.20':
+  '@vercel/gatsby-plugin-vercel-builder@2.2.23':
     dependencies:
       '@sinclair/typebox': 0.25.24
-      '@vercel/build-utils': 13.31.0
+      '@vercel/build-utils': 13.32.1
       esbuild: 0.27.0
       etag: 1.8.1
       fs-extra: 11.1.0
 
-  '@vercel/go@3.9.1': {}
+  '@vercel/go@3.10.1': {}
 
-  '@vercel/h3@0.1.103(rollup@4.59.0)':
+  '@vercel/h3@0.1.106(rollup@4.59.0)':
     dependencies:
-      '@vercel/node': 5.8.18(rollup@4.59.0)
+      '@vercel/node': 5.8.21(rollup@4.59.0)
       '@vercel/static-config': 3.4.0
     transitivePeerDependencies:
       - encoding
       - rollup
       - supports-color
 
-  '@vercel/hono@0.2.97(rollup@4.59.0)':
+  '@vercel/hono@0.2.100(rollup@4.59.0)':
     dependencies:
       '@vercel/nft': 1.10.0(rollup@4.59.0)
-      '@vercel/node': 5.8.18(rollup@4.59.0)
+      '@vercel/node': 5.8.21(rollup@4.59.0)
       '@vercel/static-config': 3.4.0
       fs-extra: 11.1.0
       path-to-regexp: 8.3.0
@@ -13180,25 +13178,25 @@ snapshots:
       '@vercel/static-config': 3.4.0
       ts-morph: 12.0.0
 
-  '@vercel/koa@0.1.77(rollup@4.59.0)':
+  '@vercel/koa@0.1.80(rollup@4.59.0)':
     dependencies:
-      '@vercel/node': 5.8.18(rollup@4.59.0)
+      '@vercel/node': 5.8.21(rollup@4.59.0)
       '@vercel/static-config': 3.4.0
     transitivePeerDependencies:
       - encoding
       - rollup
       - supports-color
 
-  '@vercel/nestjs@0.2.98(rollup@4.59.0)':
+  '@vercel/nestjs@0.2.101(rollup@4.59.0)':
     dependencies:
-      '@vercel/node': 5.8.18(rollup@4.59.0)
+      '@vercel/node': 5.8.21(rollup@4.59.0)
       '@vercel/static-config': 3.4.0
     transitivePeerDependencies:
       - encoding
       - rollup
       - supports-color
 
-  '@vercel/next@4.19.1(rollup@4.59.0)':
+  '@vercel/next@4.20.1(rollup@4.59.0)':
     dependencies:
       '@vercel/nft': 1.10.0(rollup@4.59.0)
     transitivePeerDependencies:
@@ -13244,13 +13242,13 @@ snapshots:
       - rollup
       - supports-color
 
-  '@vercel/node@5.8.18(rollup@4.59.0)':
+  '@vercel/node@5.8.21(rollup@4.59.0)':
     dependencies:
       '@edge-runtime/node-utils': 2.3.0
       '@edge-runtime/primitives': 4.1.0
       '@edge-runtime/vm': 3.2.0
       '@types/node': 20.11.0
-      '@vercel/build-utils': 13.31.0
+      '@vercel/build-utils': 13.32.1
       '@vercel/error-utils': 2.2.0
       '@vercel/nft': 1.10.0(rollup@4.59.0)
       '@vercel/static-config': 3.4.0
@@ -13287,7 +13285,7 @@ snapshots:
       smol-toml: 1.5.2
       zod: 3.22.4
 
-  '@vercel/python@6.47.1':
+  '@vercel/python@6.47.2':
     dependencies:
       '@vercel/python-analysis': 0.11.1
 
@@ -13315,7 +13313,7 @@ snapshots:
       - rollup
       - supports-color
 
-  '@vercel/ruby@2.5.0': {}
+  '@vercel/ruby@2.5.1': {}
 
   '@vercel/rust@1.3.0':
     dependencies:
@@ -13339,10 +13337,10 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
-  '@vercel/static-build@2.11.0':
+  '@vercel/static-build@2.11.3':
     dependencies:
       '@vercel/gatsby-plugin-vercel-analytics': 1.0.11
-      '@vercel/gatsby-plugin-vercel-builder': 2.2.20
+      '@vercel/gatsby-plugin-vercel-builder': 2.2.23
       '@vercel/static-config': 3.4.0
       ts-morph: 12.0.0
 
@@ -15844,7 +15842,7 @@ snapshots:
 
   hosted-git-info@9.0.3:
     dependencies:
-      lru-cache: 11.3.5
+      lru-cache: 11.5.1
 
   html-encoding-sniffer@6.0.0:
     dependencies:
@@ -16923,7 +16921,7 @@ snapshots:
 
   netmask@2.0.2: {}
 
-  next@16.2.9(@playwright/test@1.61.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  next@16.2.9(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       '@next/env': 16.2.9
       '@swc/helpers': 0.5.15
@@ -16942,7 +16940,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.2.9
       '@next/swc-win32-arm64-msvc': 16.2.9
       '@next/swc-win32-x64-msvc': 16.2.9
-      '@playwright/test': 1.61.0
+      '@playwright/test': 1.61.1
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -17525,11 +17523,11 @@ snapshots:
       exsolve: 1.0.8
       pathe: 2.0.3
 
-  playwright-core@1.61.0: {}
+  playwright-core@1.61.1: {}
 
-  playwright@1.61.0:
+  playwright@1.61.1:
     dependencies:
-      playwright-core: 1.61.0
+      playwright-core: 1.61.1
     optionalDependencies:
       fsevents: 2.3.2
 
@@ -18457,11 +18455,9 @@ snapshots:
 
   spdx-license-ids@3.0.23: {}
 
-  srvx@0.11.17: {}
+  srvx@0.11.16: {}
 
-  srvx@0.8.9:
-    dependencies:
-      cookie-es: 2.0.0
+  srvx@0.11.17: {}
 
   stable-hash-x@0.2.0: {}
 
@@ -19229,33 +19225,34 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vercel@54.15.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(rollup@4.59.0):
+  vercel@54.17.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(rollup@4.59.0):
     dependencies:
-      '@vercel/backends': 0.8.15(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(rollup@4.59.0)
+      '@vercel/backends': 0.8.18(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(rollup@4.59.0)
       '@vercel/blob': 2.4.0
-      '@vercel/build-utils': 13.31.0
+      '@vercel/build-utils': 13.32.1
       '@vercel/cli-auth': 0.3.0
       '@vercel/cli-config': 0.2.0
+      '@vercel/container': 0.0.2
       '@vercel/detect-agent': 1.2.3
-      '@vercel/elysia': 0.1.94(rollup@4.59.0)
-      '@vercel/express': 0.1.106(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(rollup@4.59.0)
-      '@vercel/fastify': 0.1.97(rollup@4.59.0)
+      '@vercel/elysia': 0.1.97(rollup@4.59.0)
+      '@vercel/express': 0.1.109(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(rollup@4.59.0)
+      '@vercel/fastify': 0.1.100(rollup@4.59.0)
       '@vercel/fun': 1.3.0
-      '@vercel/go': 3.9.1
-      '@vercel/h3': 0.1.103(rollup@4.59.0)
-      '@vercel/hono': 0.2.97(rollup@4.59.0)
+      '@vercel/go': 3.10.1
+      '@vercel/h3': 0.1.106(rollup@4.59.0)
+      '@vercel/hono': 0.2.100(rollup@4.59.0)
       '@vercel/hydrogen': 1.4.0
-      '@vercel/koa': 0.1.77(rollup@4.59.0)
-      '@vercel/nestjs': 0.2.98(rollup@4.59.0)
-      '@vercel/next': 4.19.1(rollup@4.59.0)
-      '@vercel/node': 5.8.18(rollup@4.59.0)
+      '@vercel/koa': 0.1.80(rollup@4.59.0)
+      '@vercel/nestjs': 0.2.101(rollup@4.59.0)
+      '@vercel/next': 4.20.1(rollup@4.59.0)
+      '@vercel/node': 5.8.21(rollup@4.59.0)
       '@vercel/prepare-flags-definitions': 0.3.0
-      '@vercel/python': 6.47.1
+      '@vercel/python': 6.47.2
       '@vercel/redwood': 2.5.0(rollup@4.59.0)
       '@vercel/remix-builder': 5.9.1(rollup@4.59.0)
-      '@vercel/ruby': 2.5.0
+      '@vercel/ruby': 2.5.1
       '@vercel/rust': 1.3.0
-      '@vercel/static-build': 2.11.0
+      '@vercel/static-build': 2.11.3
       chokidar: 4.0.0
       esbuild: 0.27.0
       form-data: 4.0.5


### PR DESCRIPTION
## Summary
- update root `@playwright/test` from 1.61.0 to 1.61.1
- update root `vercel` from 54.15.0 to 54.17.3
- keep Vercel within the package manager release-age policy; 54.18.0 exists upstream but is newer than the accepted registry window during this run

## Upstream
- Playwright v1.61.1: https://github.com/microsoft/playwright/releases/tag/v1.61.1
- Vercel CLI v54.17.3: https://github.com/vercel/vercel/releases/tag/vercel%4054.17.3

## Validation
- `pnpm exec playwright --version`
- `pnpm exec vercel --version`
- `pnpm install`
- `pnpm build`