### PR TITLE
fix(extract): match Lingui JSX whitespace at expression boundaries

### DIFF
--- a/crates/palamedes/src/extract.rs
+++ b/crates/palamedes/src/extract.rs
@@ -1410,6 +1410,32 @@ mod tests {
     }
 
     #[test]
+    fn preserves_lingui_inline_expression_spacing_across_line_breaks() {
+        let messages = extract_messages(
+            "
+              import { Trans } from \"@palamedes/react/macro\"
+              const paren = <Trans>\n  Allocate energy usage to business units for {locationName} (\n  {periodLabel}). Total: {totalMwh} MWh\n</Trans>
+              const percent = <Trans>\n  Match Score: {matchPercentage}\n  %\n</Trans>
+              const possessive = <Trans>\n  We just need a few details to connect you with {clientCompanyName}\n  's sustainability program.\n</Trans>
+            ",
+            "test.tsx",
+        )
+        .expect("messages should extract");
+
+        assert_eq!(
+            messages
+                .iter()
+                .map(|message| message.message.as_str())
+                .collect::<Vec<_>>(),
+            vec![
+                "Allocate energy usage to business units for {locationName} ({periodLabel}). Total: {totalMwh} MWh",
+                "Match Score: {matchPercentage}%",
+                "We just need a few details to connect you with {clientCompanyName}'s sustainability program.",
+            ]
+        );
+    }
+
+    #[test]
     fn normalizes_jsx_component_placeholder_boundary_whitespace() {
         let messages = extract_messages(
             r#"

--- a/crates/palamedes/src/jsx_message.rs
+++ b/crates/palamedes/src/jsx_message.rs
@@ -47,18 +47,39 @@ pub(crate) struct JoinedJsxMessage {
 }
 
 pub(crate) fn clean_jsx_text(text: &str) -> String {
-    let mut result = String::with_capacity(text.len());
-    let mut last_was_whitespace = false;
+    // Mirror Babel's `cleanJSXElementLiteralChild`, which Lingui relies on:
+    // whitespace touching a line break is dropped, lines are trimmed, and the
+    // remaining lines are joined with a single space. This keeps message ids
+    // stable across transformers and avoids stray spaces around expression
+    // boundaries (e.g. `{value}` followed by `%` on the next line).
+    let normalized = text.replace("\r\n", "\n").replace('\r', "\n");
+    let lines: Vec<&str> = normalized.split('\n').collect();
+    let last_non_empty_line = lines
+        .iter()
+        .rposition(|line| line.contains(|ch: char| ch != ' ' && ch != '\t'))
+        .unwrap_or(0);
 
-    for ch in text.chars() {
-        if ch.is_whitespace() {
-            if !last_was_whitespace {
-                result.push(' ');
-                last_was_whitespace = true;
-            }
-        } else {
-            result.push(ch);
-            last_was_whitespace = false;
+    let mut result = String::with_capacity(text.len());
+
+    for (index, line) in lines.iter().enumerate() {
+        let is_first_line = index == 0;
+        let is_last_line = index == lines.len() - 1;
+
+        let mut trimmed = line.replace('\t', " ");
+        if !is_first_line {
+            trimmed = trimmed.trim_start_matches(' ').to_string();
+        }
+        if !is_last_line {
+            trimmed = trimmed.trim_end_matches(' ').to_string();
+        }
+
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        result.push_str(&trimmed);
+        if index != last_non_empty_line {
+            result.push(' ');
         }
     }
 
@@ -256,5 +277,31 @@ mod tests {
     #[test]
     fn decodes_jsx_entities_after_collapsing_whitespace() {
         assert_eq!(clean_jsx_text("Green-e&reg;\n applies"), "Green-e® applies");
+    }
+
+    #[test]
+    fn drops_line_break_whitespace_before_trailing_text() {
+        // `{value}` then a newline before `%` must not introduce a space.
+        assert_eq!(clean_jsx_text("\n  %\n"), "%");
+        assert_eq!(
+            clean_jsx_text("\n  's sustainability program.\n"),
+            "'s sustainability program."
+        );
+    }
+
+    #[test]
+    fn keeps_trailing_space_on_text_line() {
+        assert_eq!(clean_jsx_text("\n  Match Score: "), "Match Score: ");
+    }
+
+    #[test]
+    fn drops_trailing_indent_after_open_paren() {
+        // `{location} (` newline `{period}` must collapse to `{location} ({period}`.
+        assert_eq!(clean_jsx_text(" (\n  "), " (");
+    }
+
+    #[test]
+    fn joins_multiline_text_with_single_space() {
+        assert_eq!(clean_jsx_text("\n  Hello\n  world\n"), "Hello world");
     }
 }


### PR DESCRIPTION
## Summary

Fixes the inline JSX expression spacing parity gaps from #246. Palamedes 0.7.8 collapsed every whitespace run — including line breaks — into a single space, which introduced spurious spaces around inline JSX expression boundaries that Lingui (via Babel) trims. This caused avoidable `msgid` drift during Lingui migrations even when the source message was semantically identical.

### Before / after

| Source (line break between expr and text) | Lingui / now | Palamedes 0.7.8 |
| --- | --- | --- |
| `{locationName} (`⏎`{periodLabel})` | `{locationName} ({periodLabel})` | `{locationName} ( {periodLabel})` |
| `{matchPercentage}`⏎`%` | `{matchPercentage}%` | `{matchPercentage} %` |
| `{clientCompanyName}`⏎`'s …` | `{clientCompanyName}'s …` | `{clientCompanyName} 's …` |

## Approach

Reimplement `clean_jsx_text` to mirror Babel's [`cleanJSXElementLiteralChild`](https://github.com/babel/babel/blob/main/packages/babel-types/src/utils/react/cleanJSXElementLiteralChild.ts) — the exact routine Lingui relies on: whitespace touching a line break is dropped, each line is trimmed, and the remaining lines are joined with a single space. This is the compile-time JSX semantic shared by all transformers, so it is the principled fix rather than a punctuation-specific patch.

Extraction and transform share this helper, so compiled runtime message ids stay in sync with extracted catalog ids.

## Scope

Intentionally limited to the **inline expression spacing** half of #246. The standalone `<Plural>` placeholder identity (`{0, plural, …}` vs `{length, plural, …}`) is left as a deliberate, separate decision: Palamedes' name-derived form is the better default for newly-authored catalogs, and migration parity there is better solved via an opt-in option or update-time id mapping if real reuse pain shows up.

## Tests

- New unit tests in `jsx_message.rs` covering line-break trimming at expression boundaries.
- New integration test `preserves_lingui_inline_expression_spacing_across_line_breaks` exercising all three cases from the issue end to end.
- Full workspace test suite, `cargo fmt --check`, and `clippy` all green.

Refs #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)