### PR TITLE
fix(transform): align JSX choice value handling

### DIFF
--- a/crates/palamedes/src/transform/messages.rs
+++ b/crates/palamedes/src/transform/messages.rs
@@ -153,9 +153,23 @@ pub(super) fn jsx_expression_name(expr: &JSXExpression<'_>) -> Option<String> {
         JSXExpression::ComputedMemberExpression(member) => {
             member.static_property_name().map(|name| name.to_string())
         }
+        JSXExpression::CallExpression(call) => getter_name(call.callee_name()?),
         JSXExpression::ParenthesizedExpression(expr) => expression_name(&expr.expression),
         _ => None,
     }
+}
+
+fn getter_name(name: &str) -> Option<String> {
+    if !name.starts_with("get") || name.len() <= 3 {
+        return None;
+    }
+    let suffix = &name[3..];
+    let first = suffix.chars().next()?;
+    first.is_ascii_uppercase().then(|| {
+        let mut result = first.to_ascii_lowercase().to_string();
+        result.push_str(&suffix[first.len_utf8()..]);
+        result
+    })
 }
 
 pub(super) fn extract_choice_options_from_jsx(

--- a/crates/palamedes/src/transform/tests.rs
+++ b/crates/palamedes/src/transform/tests.rs
@@ -524,6 +524,35 @@ fn keeps_choice_jsx_macro_as_expression_in_jsx_child_expression_container() {
 }
 
 #[test]
+fn keeps_choice_jsx_macro_as_expression_in_jsx_ternary_branch() {
+    let result = transform_macros(
+        "import { Plural, Trans } from \"@palamedes/react/macro\";\nfunction ResultCount({ filtered, total }: { filtered: number; total: number }) {\n  return <p>{filtered !== total ? (<Trans>Showing {filtered} of {total} items</Trans>) : (<Plural one=\"# item\" other=\"# items\" value={total} />)}</p>;\n}\n",
+        "test.tsx",
+        None,
+    )
+    .expect("transform should succeed");
+
+    assert!(result.code.contains(": (getI18n()._(\""));
+    assert!(!result.code.contains(": ({getI18n()._(\""));
+    assert!(!result.code.contains(": ({{getI18n()._(\""));
+}
+
+#[test]
+fn accepts_getter_call_choice_jsx_value_names() {
+    let result = transform_macros(
+        "import { Plural } from \"@palamedes/react/macro\";\nconst el = <Plural value={getDemand()} one=\"# unit\" other=\"# units\" />;\n",
+        "test.tsx",
+        None,
+    )
+    .expect("transform should accept the same getter value names as extraction");
+
+    assert!(result
+        .code
+        .contains("message: \"{demand, plural, one {# unit} other {# units}}\""));
+    assert!(result.code.contains("{ demand: getDemand() }"));
+}
+
+#[test]
 fn rejects_explicit_ids() {
     let error = transform_macros(
         "import { t } from \"@palamedes/core/macro\";\nconst msg = t({ id: \"greeting\", message: \"Hello\" });\n",

--- a/packages/transform/src/transform.test.ts
+++ b/packages/transform/src/transform.test.ts
@@ -327,6 +327,40 @@ const text = <Plural one="# row" other="# rows" value={totalRows} />;
     expect(result.code).not.toContain("const text = {getI18n()._")
   })
 
+  it("keeps JSX choice macro replacements as expressions in ternary branches", () => {
+    const code = `
+import { Plural, Trans } from "@palamedes/react/macro";
+export function ResultCount({ filtered, total }: { filtered: number; total: number }) {
+  return (
+    <p>
+      {filtered !== total ? (
+        <Trans>
+          Showing {filtered} of {total} items
+        </Trans>
+      ) : (
+        <Plural one="# item" other="# items" value={total} />
+      )}
+    </p>
+  );
+}
+`
+    const result = transformPalamedesMacros(code, "test.tsx")
+
+    expect(result.code).toContain(': (\n        getI18n()._("')
+    expect(result.code).not.toContain(': (\n        {getI18n()._("')
+  })
+
+  it("accepts getter call value names for JSX choice macros", () => {
+    const code = `
+import { Plural } from "@palamedes/react/macro";
+const text = <Plural one="# unit" other="# units" value={getDemand()} />;
+`
+    const result = transformPalamedesMacros(code, "test.tsx")
+
+    expect(result.code).toContain('message: "{demand, plural, one {# unit} other {# units}}"')
+    expect(result.code).toContain("{ demand: getDemand() }")
+  })
+
   it("rejects explicit ids in macro authoring", () => {
     const code = `
 import { t } from "@palamedes/core/macro";


### PR DESCRIPTION
## Summary

- Keeps JSX choice macro replacements valid when Plural is used in JSX ternary branches.
- Aligns JSX choice value handling with extraction by accepting stable getter call names such as getDemand().
- Adds Rust and package-level regression coverage for the reported Next plugin transform shapes.

## Issue

Closes #249

## Validation

- cargo fmt --all --check
- cargo test -p palamedes transform --locked
- pnpm --filter @palamedes/transform test
- pnpm build
- cargo test --workspace --locked
- cargo clippy --workspace --all-targets --locked -- -D warnings
- pnpm test
- pnpm format:check
- pnpm lint
- pnpm check-types
- pnpm check:release-set

## Follow-up

None.