### PR TITLE
fix(transform): accept fallback choice values

### DIFF
--- a/crates/palamedes/src/extract.rs
+++ b/crates/palamedes/src/extract.rs
@@ -24,6 +24,7 @@ const PALAMEDES_MACRO_PACKAGES: [&str; 3] = [
     "@palamedes/solid/macro",
 ];
 type ChoiceOptions = Vec<(String, String)>;
+const CHOICE_VALUE_FALLBACK_NAME: &str = "value";
 
 #[derive(Debug, Clone)]
 struct ImportedMacro {
@@ -652,11 +653,8 @@ fn extract_from_choice_call(
     if options.is_empty() {
         return Ok(None);
     }
-    let Some(value_name) = argument_expression_name(value_arg) else {
-        return Err(PalamedesError::UnnamedPlaceholder {
-            syntax: "choice value expression",
-        });
-    };
+    let value_name = argument_expression_name(value_arg)
+        .unwrap_or_else(|| CHOICE_VALUE_FALLBACK_NAME.to_string());
 
     let format = match macro_name {
         "plural" => "plural",
@@ -842,11 +840,10 @@ fn extract_jsx_value_name(
             continue;
         };
 
-        return jsx_expression_name(&container.expression).map(Some).ok_or(
-            PalamedesError::UnnamedPlaceholder {
-                syntax: "JSX choice value expression",
-            },
-        );
+        return Ok(Some(
+            jsx_expression_name(&container.expression)
+                .unwrap_or_else(|| CHOICE_VALUE_FALLBACK_NAME.to_string()),
+        ));
     }
 
     Ok(None)
@@ -856,10 +853,17 @@ fn jsx_expression_name(expr: &JSXExpression<'_>) -> Option<String> {
     match expr {
         JSXExpression::Identifier(identifier) => Some(identifier.name.to_string()),
         JSXExpression::StaticMemberExpression(member) => Some(member.property.name.to_string()),
-        JSXExpression::ComputedMemberExpression(member) => {
-            member.static_property_name().map(|name| name.to_string())
-        }
+        JSXExpression::ComputedMemberExpression(member) => member
+            .static_property_name()
+            .map(|name| name.to_string())
+            .or_else(|| expression_name(&member.expression)),
         JSXExpression::CallExpression(call) => getter_name(call.callee_name()?),
+        JSXExpression::LogicalExpression(logical) if logical.operator.is_coalesce() => {
+            expression_name(&logical.left).or_else(|| expression_name(&logical.right))
+        }
+        JSXExpression::LogicalExpression(logical) if logical.operator.is_or() => {
+            expression_name(&logical.left).or_else(|| expression_name(&logical.right))
+        }
         JSXExpression::ParenthesizedExpression(expr) => expression_name(&expr.expression),
         _ => None,
     }
@@ -989,10 +993,17 @@ fn argument_expression_name(arg: &Argument<'_>) -> Option<String> {
     match arg {
         Argument::Identifier(identifier) => Some(identifier.name.to_string()),
         Argument::StaticMemberExpression(member) => Some(member.property.name.to_string()),
-        Argument::ComputedMemberExpression(member) => {
-            member.static_property_name().map(|name| name.to_string())
-        }
+        Argument::ComputedMemberExpression(member) => member
+            .static_property_name()
+            .map(|name| name.to_string())
+            .or_else(|| expression_name(&member.expression)),
         Argument::CallExpression(call) => getter_name(call.callee_name()?),
+        Argument::LogicalExpression(logical) if logical.operator.is_coalesce() => {
+            expression_name(&logical.left).or_else(|| expression_name(&logical.right))
+        }
+        Argument::LogicalExpression(logical) if logical.operator.is_or() => {
+            expression_name(&logical.left).or_else(|| expression_name(&logical.right))
+        }
         Argument::ParenthesizedExpression(expr) => expression_name(&expr.expression),
         _ => None,
     }
@@ -1006,11 +1017,26 @@ fn expression_name(expr: &Expression<'_>) -> Option<String> {
     }
 
     if let Some(member) = expr.as_member_expression() {
-        return member.static_property_name().map(ToString::to_string);
+        return match member {
+            MemberExpression::ComputedMemberExpression(member) => member
+                .static_property_name()
+                .map(|name| name.to_string())
+                .or_else(|| expression_name(&member.expression)),
+            MemberExpression::StaticMemberExpression(member) => {
+                Some(member.property.name.to_string())
+            }
+            MemberExpression::PrivateFieldExpression(_) => None,
+        };
     }
 
     if let Expression::CallExpression(call) = expr {
         return getter_name(call.callee_name()?);
+    }
+
+    if let Expression::LogicalExpression(logical) = expr {
+        if logical.operator.is_coalesce() || logical.operator.is_or() {
+            return expression_name(&logical.left).or_else(|| expression_name(&logical.right));
+        }
     }
 
     None
@@ -1347,6 +1373,47 @@ mod tests {
         assert_eq!(
             messages[0].message,
             "{count, plural, one {# item & fee} other {# items & fees}}"
+        );
+    }
+
+    #[test]
+    fn extracts_computed_defaulted_and_literal_choice_values() {
+        let messages = extract_messages(
+            r##"
+              import { plural } from "@palamedes/core/macro"
+              const computed = plural(periodCounts[period] ?? 0, { one: "# entry", other: "# entries" })
+              const literal = plural(21, { one: "# month", other: "# months" })
+            "##,
+            "test.tsx",
+        )
+        .expect("messages should extract");
+
+        assert_eq!(
+            messages
+                .iter()
+                .map(|message| message.message.as_str())
+                .collect::<Vec<_>>(),
+            vec![
+                "{period, plural, one {# entry} other {# entries}}",
+                "{value, plural, one {# month} other {# months}}",
+            ]
+        );
+    }
+
+    #[test]
+    fn extracts_defaulted_jsx_choice_values() {
+        let messages = extract_messages(
+            r##"
+              import { Plural } from "@palamedes/react/macro"
+              const message = <Plural value={node.locationCount ?? 0} one="# location" other="# locations" />
+            "##,
+            "test.tsx",
+        )
+        .expect("messages should extract");
+
+        assert_eq!(
+            messages[0].message,
+            "{locationCount, plural, one {# location} other {# locations}}"
         );
     }
 

--- a/crates/palamedes/src/transform/messages.rs
+++ b/crates/palamedes/src/transform/messages.rs
@@ -18,6 +18,8 @@ pub(super) struct ValueBinding {
     pub name: String,
 }
 
+const CHOICE_VALUE_FALLBACK_NAME: &str = "value";
+
 pub(super) fn identifier_name<'a>(expr: &'a Expression<'a>) -> Option<&'a str> {
     match expr.without_parentheses() {
         Expression::Identifier(identifier) => Some(identifier.name.as_str()),
@@ -134,13 +136,11 @@ pub(super) fn extract_jsx_value_binding(
         };
 
         let mut used_value_names = HashMap::<String, String>::new();
-        return jsx_value_binding(
+        return Ok(Some(choice_jsx_value_binding(
             &container.expression,
             source,
-            "JSX choice value expression",
             &mut used_value_names,
-        )
-        .map(Some);
+        )));
     }
 
     Ok(None)
@@ -150,10 +150,17 @@ pub(super) fn jsx_expression_name(expr: &JSXExpression<'_>) -> Option<String> {
     match expr {
         JSXExpression::Identifier(identifier) => Some(identifier.name.to_string()),
         JSXExpression::StaticMemberExpression(member) => Some(member.property.name.to_string()),
-        JSXExpression::ComputedMemberExpression(member) => {
-            member.static_property_name().map(|name| name.to_string())
-        }
+        JSXExpression::ComputedMemberExpression(member) => member
+            .static_property_name()
+            .map(|name| name.to_string())
+            .or_else(|| expression_name(&member.expression)),
         JSXExpression::CallExpression(call) => getter_name(call.callee_name()?),
+        JSXExpression::LogicalExpression(logical) if logical.operator.is_coalesce() => {
+            expression_name(&logical.left).or_else(|| expression_name(&logical.right))
+        }
+        JSXExpression::LogicalExpression(logical) if logical.operator.is_or() => {
+            expression_name(&logical.left).or_else(|| expression_name(&logical.right))
+        }
         JSXExpression::ParenthesizedExpression(expr) => expression_name(&expr.expression),
         _ => None,
     }
@@ -377,15 +384,22 @@ fn append_unique_bindings(bindings: &mut Vec<ValueBinding>, incoming: Vec<ValueB
 pub(super) fn expression_name(expr: &Expression<'_>) -> Option<String> {
     let expr = expr.without_parentheses();
 
-    if let Expression::Identifier(identifier) = expr {
-        return Some(identifier.name.to_string());
+    match expr {
+        Expression::Identifier(identifier) => Some(identifier.name.to_string()),
+        Expression::StaticMemberExpression(member) => Some(member.property.name.to_string()),
+        Expression::ComputedMemberExpression(member) => member
+            .static_property_name()
+            .map(|name| name.to_string())
+            .or_else(|| expression_name(&member.expression)),
+        Expression::CallExpression(call) => getter_name(call.callee_name()?),
+        Expression::LogicalExpression(logical) if logical.operator.is_coalesce() => {
+            expression_name(&logical.left).or_else(|| expression_name(&logical.right))
+        }
+        Expression::LogicalExpression(logical) if logical.operator.is_or() => {
+            expression_name(&logical.left).or_else(|| expression_name(&logical.right))
+        }
+        _ => None,
     }
-
-    if let Some(member) = expr.as_member_expression() {
-        return member.static_property_name().map(ToString::to_string);
-    }
-
-    None
 }
 
 pub(super) fn expression_source(expr: &Expression<'_>, source: &str) -> String {
@@ -437,6 +451,19 @@ pub(super) fn expression_binding(
     Ok(ValueBinding { expression, name })
 }
 
+pub(super) fn choice_expression_binding(
+    expr: &Expression<'_>,
+    source: &str,
+    used_value_names: &mut HashMap<String, String>,
+) -> ValueBinding {
+    let expression = expression_source(expr, source);
+    let preferred_name =
+        expression_name(expr).unwrap_or_else(|| CHOICE_VALUE_FALLBACK_NAME.to_string());
+    let name = make_unique_binding_name(preferred_name, &expression, used_value_names);
+
+    ValueBinding { expression, name }
+}
+
 fn jsx_expression_source(expr: &JSXExpression<'_>, source: &str) -> Option<String> {
     match expr {
         JSXExpression::EmptyExpression(_) => None,
@@ -460,6 +487,19 @@ pub(super) fn jsx_value_binding(
     let name = make_unique_binding_name(preferred_name, &expression, used_value_names);
 
     Ok(ValueBinding { expression, name })
+}
+
+pub(super) fn choice_jsx_value_binding(
+    expr: &JSXExpression<'_>,
+    source: &str,
+    used_value_names: &mut HashMap<String, String>,
+) -> ValueBinding {
+    let expression = jsx_expression_source(expr, source).unwrap_or_default();
+    let preferred_name =
+        jsx_expression_name(expr).unwrap_or_else(|| CHOICE_VALUE_FALLBACK_NAME.to_string());
+    let name = make_unique_binding_name(preferred_name, &expression, used_value_names);
+
+    ValueBinding { expression, name }
 }
 
 pub(super) fn template_to_message(

--- a/crates/palamedes/src/transform/runtime.rs
+++ b/crates/palamedes/src/transform/runtime.rs
@@ -9,7 +9,7 @@ use oxc_span::GetSpan;
 use crate::error::{PalamedesError, PalamedesResult};
 
 use super::messages::{
-    build_icu_message, escape_string, expression_binding, expression_source,
+    build_icu_message, choice_expression_binding, escape_string, expression_source,
     extract_choice_options, extract_choice_options_from_jsx, extract_jsx_children_parts,
     extract_jsx_value_binding, extract_object_properties, first_argument_object, jsx_attributes,
     template_to_message, ValueBinding,
@@ -255,12 +255,7 @@ pub(super) fn transform_choice_call(
     };
 
     let mut used_value_names = std::collections::HashMap::new();
-    let value_binding = expression_binding(
-        value_expr,
-        source,
-        "choice value expression",
-        &mut used_value_names,
-    )?;
+    let value_binding = choice_expression_binding(value_expr, source, &mut used_value_names);
     let value_name = value_binding.name.clone();
     let choice_options = extract_choice_options(choice_object);
 

--- a/crates/palamedes/src/transform/tests.rs
+++ b/crates/palamedes/src/transform/tests.rs
@@ -662,13 +662,39 @@ fn rejects_unnamed_jsx_placeholders() {
 }
 
 #[test]
-fn rejects_unnamed_choice_value_placeholders() {
-    let error = transform_macros(
-        "import { plural } from \"@palamedes/core/macro\";\nconst msg = plural(count + 1, { one: \"# item\", other: \"# items\" });\n",
+fn accepts_computed_defaulted_and_literal_choice_values() {
+    let result = transform_macros(
+        "import { plural } from \"@palamedes/core/macro\";\nconst computed = plural(periodCounts[period] ?? 0, { one: \"# entry\", other: \"# entries\" });\nconst literal = plural(21, { one: \"# month\", other: \"# months\" });\n",
         "test.ts",
         None,
     )
-    .expect_err("unnamed choice value should fail");
+    .expect("choice values should support fallback placeholder names");
 
-    assert!(error.to_string().contains("stable placeholder name"));
+    assert!(result
+        .code
+        .contains("message: \"{period, plural, one {# entry} other {# entries}}\""));
+    assert!(result
+        .code
+        .contains("{ period: periodCounts[period] ?? 0 }"));
+    assert!(result
+        .code
+        .contains("message: \"{value, plural, one {# month} other {# months}}\""));
+    assert!(result.code.contains("{ value: 21 }"));
+}
+
+#[test]
+fn accepts_defaulted_jsx_choice_values() {
+    let result = transform_macros(
+        "import { Plural } from \"@palamedes/react/macro\";\nconst el = <Plural value={node.locationCount ?? 0} one=\"# location\" other=\"# locations\" />;\n",
+        "test.tsx",
+        None,
+    )
+    .expect("JSX choice values should support fallback placeholder names");
+
+    assert!(result
+        .code
+        .contains("message: \"{locationCount, plural, one {# location} other {# locations}}\""));
+    assert!(result
+        .code
+        .contains("{ locationCount: node.locationCount ?? 0 }"));
 }

--- a/packages/extractor/src/extractMessages.test.ts
+++ b/packages/extractor/src/extractMessages.test.ts
@@ -317,13 +317,21 @@ describe("extractMessages", () => {
       expect(messages[0].message).toBe("<0/>")
     })
 
-    it("rejects unnamed choice value placeholders", () => {
+    it("accepts computed, defaulted, and literal choice values", () => {
       const code = `
         import { plural } from "@palamedes/core/macro"
-        const x = plural(count + 1, { one: "# item", other: "# items" })
+        import { Plural } from "@palamedes/react/macro"
+        const computed = plural(periodCounts[period] ?? 0, { one: "# entry", other: "# entries" })
+        const literal = plural(21, { one: "# month", other: "# months" })
+        const jsx = <Plural value={node.locationCount ?? 0} one="# location" other="# locations" />
       `
+      const messages = extract(code)
 
-      expect(() => extract(code)).toThrow(/stable placeholder name/)
+      expect(messages.map((message) => message.message)).toEqual([
+        "{period, plural, one {# entry} other {# entries}}",
+        "{value, plural, one {# month} other {# months}}",
+        "{locationCount, plural, one {# location} other {# locations}}",
+      ])
     })
   })
 })

--- a/packages/transform/src/transform.test.ts
+++ b/packages/transform/src/transform.test.ts
@@ -430,13 +430,31 @@ const el = <Trans><List renderItem={() => <Plural value={count} one="one" other=
     expect(result.code).toContain("renderItem={() => <Plural")
   })
 
-  it("rejects unnamed choice value placeholders", () => {
+  it("accepts computed, defaulted, and literal choice values", () => {
     const code = `
 import { plural } from "@palamedes/core/macro";
-const msg = plural(count + 1, { one: "# item", other: "# items" });
+const computed = plural(periodCounts[period] ?? 0, { one: "# entry", other: "# entries" });
+const literal = plural(21, { one: "# month", other: "# months" });
 `
+    const result = transformPalamedesMacros(code, "test.ts")
 
-    expect(() => transformPalamedesMacros(code, "test.ts")).toThrow(/stable placeholder name/)
+    expect(result.code).toContain('message: "{period, plural, one {# entry} other {# entries}}"')
+    expect(result.code).toContain("{ period: periodCounts[period] ?? 0 }")
+    expect(result.code).toContain('message: "{value, plural, one {# month} other {# months}}"')
+    expect(result.code).toContain("{ value: 21 }")
+  })
+
+  it("accepts defaulted JSX choice values", () => {
+    const code = `
+import { Plural } from "@palamedes/react/macro";
+const el = <Plural value={node.locationCount ?? 0} one="# location" other="# locations" />;
+`
+    const result = transformPalamedesMacros(code, "test.tsx")
+
+    expect(result.code).toContain(
+      'message: "{locationCount, plural, one {# location} other {# locations}}"'
+    )
+    expect(result.code).toContain("{ locationCount: node.locationCount ?? 0 }")
   })
 
   it("leaves legacy Lingui macro imports untouched", () => {


### PR DESCRIPTION
## Summary

- Allows choice macro values to use computed, defaulted, and literal expressions instead of failing stable-placeholder inference.
- Keeps extraction and transform aligned for plural(...) and JSX Plural value expressions.
- Adds Rust and package-level regression coverage for the issue 252 repro shapes.

## Issue

Closes #252

## Validation

- cargo fmt --all --check
- cargo test -p palamedes transform --locked
- cargo test -p palamedes extract --locked
- pnpm build
- pnpm --filter @palamedes/transform test
- pnpm --filter @palamedes/extractor test
- cargo test --workspace --locked
- cargo clippy --workspace --all-targets --locked -- -D warnings
- pnpm test
- pnpm format:check
- pnpm lint
- pnpm check-types
- pnpm check:release-set
- CI=true pnpm benchmark:proof

## Benchmark

`CI=true pnpm benchmark:proof` on 2026-06-27, darwin/arm64, Node v24.16.0, Palamedes core 0.7.10, Ferrocat 1.3.1. Fixture set: 5 files, 1,628 source bytes, 7 catalog messages, 3 warmup runs, 7 measured runs.

- transform: median 0.44 ms; sampled peak RSS 52.9 MiB
- extract: median 0.28 ms; sampled peak RSS 53.0 MiB
- catalog-update: median 0.33 ms; sampled peak RSS 53.5 MiB
- catalog-artifact-compile: median 3.43 ms; sampled peak RSS 55.3 MiB

## Follow-up

None.
