### PR TITLE
fix(transform): keep nested choice branches as expressions

### DIFF
--- a/crates/palamedes/src/transform/tests.rs
+++ b/crates/palamedes/src/transform/tests.rs
@@ -538,6 +538,20 @@ fn keeps_choice_jsx_macro_as_expression_in_jsx_ternary_branch() {
 }
 
 #[test]
+fn keeps_choice_jsx_macro_as_expression_in_nested_jsx_ternary_branch() {
+    let result = transform_macros(
+        "import { Plural, Trans } from \"@palamedes/react/macro\";\nfunction ResultCount({ shownCount, totalCount, quickSearch }) {\n  return (\n    <section>\n      <header>\n        <Trans>Marketplace</Trans>\n      </header>\n      <button>\n        <Trans>Buy now</Trans>\n      </button>\n      <p>\n        {quickSearch.trim() && shownCount !== totalCount ? (\n          <Trans>\n            Showing {shownCount} of {totalCount} products\n          </Trans>\n        ) : (\n          <Plural one=\"# product\" other=\"# products\" value={shownCount} />\n        )}\n      </p>\n    </section>\n  );\n}\n",
+        "test.tsx",
+        None,
+    )
+    .expect("transform should succeed");
+
+    assert!(result.code.contains("<Trans id=\""));
+    assert!(result.code.contains(") : (\n          getI18n()._(\""));
+    assert!(!result.code.contains(") : (\n          {getI18n()._(\""));
+}
+
+#[test]
 fn accepts_getter_call_choice_jsx_value_names() {
     let result = transform_macros(
         "import { Plural } from \"@palamedes/react/macro\";\nconst el = <Plural value={getDemand()} one=\"# unit\" other=\"# units\" />;\n",

--- a/crates/palamedes/src/transform/visitor.rs
+++ b/crates/palamedes/src/transform/visitor.rs
@@ -32,7 +32,7 @@ pub(super) struct TransformVisitor<'a> {
     pub needs_runtime_import: bool,
     pub trans_import_modules: HashSet<String>,
     pub error: Option<PalamedesError>,
-    jsx_child_element_depth: usize,
+    jsx_child_element_spans: Vec<(usize, usize)>,
 }
 
 impl<'a> TransformVisitor<'a> {
@@ -52,7 +52,7 @@ impl<'a> TransformVisitor<'a> {
             needs_runtime_import: false,
             trans_import_modules: HashSet::new(),
             error: None,
-            jsx_child_element_depth: 0,
+            jsx_child_element_spans: Vec::new(),
         }
     }
 
@@ -70,6 +70,14 @@ impl<'a> TransformVisitor<'a> {
         {
             self.compiled_ids.push(compiled_id.to_owned());
         }
+    }
+
+    fn is_current_jsx_child_element(&self, element: &JSXElement<'_>) -> bool {
+        self.jsx_child_element_spans
+            .last()
+            .is_some_and(|(start, end)| {
+                *start == element.span.start as usize && *end == element.span.end as usize
+            })
     }
 }
 
@@ -123,12 +131,13 @@ impl<'a> Visit<'a> for TransformVisitor<'a> {
 
         match replacement {
             Ok(Some((text, compiled_id))) => {
-                let text =
-                    if macro_info.imported_name != "Trans" && self.jsx_child_element_depth > 0 {
-                        format!("{{{text}}}")
-                    } else {
-                        text
-                    };
+                let text = if macro_info.imported_name != "Trans"
+                    && self.is_current_jsx_child_element(it)
+                {
+                    format!("{{{text}}}")
+                } else {
+                    text
+                };
                 self.replacements.push(Replacement {
                     start: it.span.start as usize,
                     end: it.span.end as usize,
@@ -156,10 +165,11 @@ impl<'a> Visit<'a> for TransformVisitor<'a> {
     }
 
     fn visit_jsx_child(&mut self, it: &JSXChild<'a>) {
-        if matches!(it, JSXChild::Element(_)) {
-            self.jsx_child_element_depth += 1;
+        if let JSXChild::Element(element) = it {
+            self.jsx_child_element_spans
+                .push((element.span.start as usize, element.span.end as usize));
             walk::walk_jsx_child(self, it);
-            self.jsx_child_element_depth -= 1;
+            self.jsx_child_element_spans.pop();
         } else {
             walk::walk_jsx_child(self, it);
         }

--- a/packages/transform/src/transform.test.ts
+++ b/packages/transform/src/transform.test.ts
@@ -350,6 +350,38 @@ export function ResultCount({ filtered, total }: { filtered: number; total: numb
     expect(result.code).not.toContain(': (\n        {getI18n()._("')
   })
 
+  it("keeps JSX choice macro replacements as expressions in nested JSX ternary branches", () => {
+    const code = `
+import { Plural, Trans } from "@palamedes/react/macro";
+
+function ResultCount({ shownCount, totalCount, quickSearch }) {
+  return (
+    <section>
+      <header>
+        <Trans>Marketplace</Trans>
+      </header>
+      <button>
+        <Trans>Buy now</Trans>
+      </button>
+      <p>
+        {quickSearch.trim() && shownCount !== totalCount ? (
+          <Trans>
+            Showing {shownCount} of {totalCount} products
+          </Trans>
+        ) : (
+          <Plural one="# product" other="# products" value={shownCount} />
+        )}
+      </p>
+    </section>
+  );
+}
+`
+    const result = transformPalamedesMacros(code, "test.tsx")
+
+    expect(result.code).toContain(') : (\n          getI18n()._("')
+    expect(result.code).not.toContain(') : (\n          {getI18n()._("')
+  })
+
   it("accepts getter call value names for JSX choice macros", () => {
     const code = `
 import { Plural } from "@palamedes/react/macro";


### PR DESCRIPTION
## Summary

- Fixes the remaining issue 249 JSX output shape when a choice macro appears inside a JSX expression branch under a nested JSX tree.
- Replaces ancestor-depth based JSX child detection with span-based detection for the currently visited direct JSX child element.
- Adds Rust and `@palamedes/transform` regression coverage for the 0.7.11 repro with earlier `<Trans>` macros in the same JSX tree.

## Issue

Closes #249

## Validation

- cargo test -p palamedes transform --locked
- CI=true pnpm install --frozen-lockfile
- CI=true pnpm build
- CI=true pnpm --filter @palamedes/transform test
- cargo fmt --all --check
- CI=true pnpm format:check
- cargo clippy -p palamedes --all-targets --locked -- -D warnings
- CI=true pnpm check-types

## Notes

The first `pnpm build` attempt in the isolated worktree was interrupted because the worktree needed dependencies and sandboxed Registry access caused pnpm retry waits. After installing dependencies with network access, the build and package tests passed.
