### PR TITLE
feat(config): default PO origins to git root

### DIFF
--- a/crates/palamedes/src/extract.rs
+++ b/crates/palamedes/src/extract.rs
@@ -1,4 +1,5 @@
 use std::collections::{BTreeMap, HashMap};
+use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 
 use crate::catalog_update::{CatalogUpdateMessage, CatalogUpdateOrigin};
@@ -1162,9 +1163,76 @@ pub fn extract_catalog_messages_from_files(
 fn relative_origin_file(root_dir: &Path, file: &str) -> String {
     let path = Path::new(file);
     path.strip_prefix(root_dir)
-        .unwrap_or(path)
+        .map(Path::to_path_buf)
+        .or_else(|_| relative_path_from(root_dir, path).ok_or(()))
+        .unwrap_or_else(|_| path.to_path_buf())
         .to_string_lossy()
         .replace('\\', "/")
+}
+
+fn relative_path_from(root_dir: &Path, path: &Path) -> Option<PathBuf> {
+    if root_dir.is_absolute() != path.is_absolute() {
+        return None;
+    }
+
+    if path_prefix(root_dir) != path_prefix(path) {
+        return None;
+    }
+
+    let root_components = normalized_path_components(root_dir);
+    let path_components = normalized_path_components(path);
+    let common_len = root_components
+        .iter()
+        .zip(path_components.iter())
+        .take_while(|(root, path)| root == path)
+        .count();
+
+    let mut relative = PathBuf::new();
+    for _ in common_len..root_components.len() {
+        relative.push("..");
+    }
+    for component in &path_components[common_len..] {
+        relative.push(component);
+    }
+
+    if relative.as_os_str().is_empty() {
+        relative.push(".");
+    }
+
+    Some(relative)
+}
+
+fn path_prefix(path: &Path) -> Option<OsString> {
+    path.components().find_map(|component| match component {
+        std::path::Component::Prefix(prefix) => Some(prefix.as_os_str().to_os_string()),
+        _ => None,
+    })
+}
+
+fn normalized_path_components(path: &Path) -> Vec<OsString> {
+    let mut normalized: Vec<OsString> = Vec::new();
+
+    for component in path.components() {
+        match component {
+            std::path::Component::Prefix(_) | std::path::Component::RootDir => {}
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => {
+                if normalized
+                    .last()
+                    .is_some_and(|previous| previous.as_os_str() != "..")
+                {
+                    normalized.pop();
+                } else {
+                    normalized.push(component.as_os_str().to_os_string());
+                }
+            }
+            std::path::Component::Normal(_) => {
+                normalized.push(component.as_os_str().to_os_string());
+            }
+        }
+    }
+
+    normalized
 }
 
 fn add_extracted_message(
@@ -1717,6 +1785,44 @@ mod tests {
                 .expect("placeholder expression"),
             &vec!["user.name".to_string()]
         );
+
+        fs::remove_dir_all(root).expect("cleanup");
+    }
+
+    #[test]
+    fn batch_extracts_parent_include_origins_relative_to_root_dir() {
+        let root = temp_root("batch-parent-relative");
+        let app = root.join("apps").join("web");
+        let shared_src = root.join("packages").join("ui").join("src");
+        fs::create_dir_all(&app).expect("app dir");
+        fs::create_dir_all(&shared_src).expect("shared src dir");
+        let shared = shared_src.join("shared-card.tsx");
+        fs::write(
+            &shared,
+            r#"
+              import { t } from "@palamedes/core/macro"
+              export const label = t`Shared action`
+            "#,
+        )
+        .expect("shared source");
+
+        let result = extract_catalog_messages_from_files(ExtractCatalogMessagesRequest {
+            root_dir: app.to_string_lossy().into_owned(),
+            files: vec![shared.to_string_lossy().into_owned()],
+        })
+        .expect("batch extraction");
+
+        let shared_action = result
+            .messages
+            .iter()
+            .find(|message| message.message == "Shared action")
+            .expect("shared message");
+        assert_eq!(shared_action.origins.len(), 1);
+        assert_eq!(
+            shared_action.origins[0].file,
+            "../../packages/ui/src/shared-card.tsx"
+        );
+        assert!(!shared_action.origins[0].file.starts_with('/'));
 
         fs::remove_dir_all(root).expect("cleanup");
     }

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -117,6 +117,7 @@ import { defineConfig } from "@palamedes/config"
 export default defineConfig({
   locales: ["en", "de"],
   sourceLocale: "en",
+  sourceReferenceRoot: "git",
   catalogs: [
     {
       path: "src/locales/{locale}",
@@ -125,6 +126,11 @@ export default defineConfig({
   ],
 })
 ```
+
+`sourceReferenceRoot` controls PO `#:` references written by `pmds extract`.
+The default is `"git"`, so monorepo references are emitted relative to the
+nearest Git repository root. Use `"lingui"` or `"config"` to keep references
+relative to the config directory, matching Lingui's default behavior.
 
 ## Related Packages
 

--- a/packages/cli/src/commands/extract.test.ts
+++ b/packages/cli/src/commands/extract.test.ts
@@ -101,6 +101,25 @@ describe("extract", () => {
     const enCatalog = normalizePo(
       await readFile(path.join(appDir, "locales", "en", "messages.po"), "utf8")
     )
+    expect(findItem(enCatalog.items, "Dashboard")?.references).toStrictEqual([
+      "apps/web/app/page.tsx:3",
+    ])
+    expect(findItem(enCatalog.items, "Shared action")?.references).toStrictEqual([
+      "packages/ui/src/shared-card.tsx:3",
+    ])
+  })
+
+  it("supports Lingui-compatible config-root PO references", async () => {
+    const appDir = await createMonorepoFixture({ sourceReferenceRoot: "lingui" })
+
+    await extract({
+      config: path.join(appDir, "palamedes.config.ts"),
+      clean: true,
+    })
+
+    const enCatalog = normalizePo(
+      await readFile(path.join(appDir, "locales", "en", "messages.po"), "utf8")
+    )
     expect(findItem(enCatalog.items, "Dashboard")?.references).toStrictEqual(["app/page.tsx:3"])
     expect(findItem(enCatalog.items, "Shared action")?.references).toStrictEqual([
       "../../packages/ui/src/shared-card.tsx:3",
@@ -143,12 +162,16 @@ async function copyFixture(): Promise<string> {
   return targetDir
 }
 
-async function createMonorepoFixture(): Promise<string> {
+async function createMonorepoFixture(
+  options: { sourceReferenceRoot?: "lingui" } = {}
+): Promise<string> {
   const dir = await mkdtemp(path.join(os.tmpdir(), "palamedes-cli-monorepo-"))
   tempDirs.push(dir)
 
-  const appDir = path.join(dir, "repo", "apps", "web")
-  const sharedDir = path.join(dir, "repo", "packages", "ui", "src")
+  const repoDir = path.join(dir, "repo")
+  const appDir = path.join(repoDir, "apps", "web")
+  const sharedDir = path.join(repoDir, "packages", "ui", "src")
+  await mkdir(path.join(repoDir, ".git"), { recursive: true })
   await mkdir(path.join(appDir, "app"), { recursive: true })
   await mkdir(sharedDir, { recursive: true })
 
@@ -159,6 +182,7 @@ async function createMonorepoFixture(): Promise<string> {
 export default defineConfig({
   sourceLocale: "en",
   locales: ["en", "de"],
+  ${options.sourceReferenceRoot ? `sourceReferenceRoot: "${options.sourceReferenceRoot}",` : ""}
   catalogs: [
     {
       path: "locales/{locale}/messages",

--- a/packages/cli/src/commands/extract.test.ts
+++ b/packages/cli/src/commands/extract.test.ts
@@ -1,4 +1,4 @@
-import { cp, mkdtemp, readFile, rm } from "node:fs/promises"
+import { cp, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
 import { fileURLToPath } from "node:url"
@@ -90,6 +90,23 @@ describe("extract", () => {
     expect(await readCatalog(fixtureDir, "de")).toBe(firstDeCatalog)
   })
 
+  it("emits relative PO references for parent-directory monorepo includes", async () => {
+    const appDir = await createMonorepoFixture()
+
+    await extract({
+      config: path.join(appDir, "palamedes.config.ts"),
+      clean: true,
+    })
+
+    const enCatalog = normalizePo(
+      await readFile(path.join(appDir, "locales", "en", "messages.po"), "utf8")
+    )
+    expect(findItem(enCatalog.items, "Dashboard")?.references).toStrictEqual(["app/page.tsx:3"])
+    expect(findItem(enCatalog.items, "Shared action")?.references).toStrictEqual([
+      "../../packages/ui/src/shared-card.tsx:3",
+    ])
+  })
+
   it("emits timing JSON with glob and extract buckets", async () => {
     const fixtureDir = await copyFixture()
     process.env.PALAMEDES_TIMING_JSON = "1"
@@ -124,6 +141,54 @@ async function copyFixture(): Promise<string> {
   tempDirs.push(dir)
   await cp(FIXTURE_DIR, targetDir, { recursive: true })
   return targetDir
+}
+
+async function createMonorepoFixture(): Promise<string> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "palamedes-cli-monorepo-"))
+  tempDirs.push(dir)
+
+  const appDir = path.join(dir, "repo", "apps", "web")
+  const sharedDir = path.join(dir, "repo", "packages", "ui", "src")
+  await mkdir(path.join(appDir, "app"), { recursive: true })
+  await mkdir(sharedDir, { recursive: true })
+
+  await writeFile(
+    path.join(appDir, "palamedes.config.ts"),
+    `import { defineConfig } from "@palamedes/config";
+
+export default defineConfig({
+  sourceLocale: "en",
+  locales: ["en", "de"],
+  catalogs: [
+    {
+      path: "locales/{locale}/messages",
+      include: ["app", "../../packages/ui/src"],
+    },
+  ],
+});
+`,
+    "utf8"
+  )
+  await writeFile(
+    path.join(appDir, "app", "page.tsx"),
+    `import { t } from "@palamedes/core/macro";
+export function Page() {
+  return t\`Dashboard\`;
+}
+`,
+    "utf8"
+  )
+  await writeFile(
+    path.join(sharedDir, "shared-card.tsx"),
+    `import { t } from "@palamedes/core/macro";
+export function SharedCard() {
+  return t\`Shared action\`;
+}
+`,
+    "utf8"
+  )
+
+  return appDir
 }
 
 async function readCatalog(fixtureDir: string, locale: string): Promise<string> {

--- a/packages/cli/src/commands/extract.ts
+++ b/packages/cli/src/commands/extract.ts
@@ -131,7 +131,7 @@ async function extractFromCatalog(
 
   const extractStartedAt = Date.now()
   const result = extractCatalogMessagesFromFiles({
-    rootDir,
+    rootDir: config.sourceReferenceRoot,
     files,
   })
   const extractMs = Date.now() - extractStartedAt

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -19,6 +19,8 @@ import { defineConfig } from "@palamedes/config"
 export default defineConfig({
   locales: ["en", "de"],
   sourceLocale: "en",
+  // Optional: use "lingui" for config-root source references.
+  sourceReferenceRoot: "git",
   catalogs: [
     {
       path: "src/locales/{locale}",
@@ -42,6 +44,11 @@ export default defineConfig({
 - `pseudoLocale` marks a generated pseudo-locale used for layout and hardcoded
   string checks. Plugin integrations skip `failOnMissing` failures for that
   locale while keeping strict checks for real locales.
+- `sourceReferenceRoot` controls the root used for PO `#:` source references.
+  The default is `"git"`, which emits paths relative to the nearest Git
+  repository root and falls back to the config directory when no Git root is
+  available. Use `"lingui"` or `"config"` for Lingui-compatible references
+  relative to the config directory, or pass a custom path.
 
 See [Pseudo-localization and fallback locales](https://github.com/sebastian-software/palamedes/blob/main/docs/pseudo-localization.md)
 for examples and the recommended development workflow.

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -11,6 +11,7 @@ export const CONFIG_FILENAMES = [
 ] as const
 
 export type PalamedesFallbackLocales = string[] | Record<string, string[]>
+export type PalamedesSourceReferenceRoot = "git" | "lingui" | "config" | (string & {})
 
 export type PalamedesCatalogConfig = {
   path: string
@@ -23,13 +24,15 @@ export type PalamedesConfig = {
   sourceLocale: string
   fallbackLocales?: PalamedesFallbackLocales
   pseudoLocale?: string
+  sourceReferenceRoot?: PalamedesSourceReferenceRoot
   catalogs: PalamedesCatalogConfig[]
 }
 
 export type LoadedPalamedesConfig = {
   configPath: string
   rootDir: string
-} & PalamedesConfig
+  sourceReferenceRoot: string
+} & Omit<PalamedesConfig, "sourceReferenceRoot">
 
 export type LoadPalamedesConfigOptions = {
   cwd?: string
@@ -142,17 +145,55 @@ function unwrapModule(loaded: unknown): unknown {
   return loaded
 }
 
-function normalizeConfig(config: PalamedesConfig, configPath: string): LoadedPalamedesConfig {
+async function normalizeConfig(
+  config: PalamedesConfig,
+  configPath: string
+): Promise<LoadedPalamedesConfig> {
+  const rootDir = path.dirname(configPath)
   return {
-    ...config,
     configPath,
-    rootDir: path.dirname(configPath),
+    rootDir,
     locales: [...config.locales],
+    sourceLocale: config.sourceLocale,
+    ...(config.fallbackLocales !== undefined ? { fallbackLocales: config.fallbackLocales } : {}),
+    ...(config.pseudoLocale !== undefined ? { pseudoLocale: config.pseudoLocale } : {}),
+    sourceReferenceRoot: await resolveSourceReferenceRoot(config.sourceReferenceRoot, rootDir),
     catalogs: config.catalogs.map((catalog) => ({
       path: catalog.path,
       include: [...catalog.include],
       ...(catalog.exclude ? { exclude: [...catalog.exclude] } : {}),
     })),
+  }
+}
+
+async function resolveSourceReferenceRoot(
+  value: PalamedesSourceReferenceRoot | undefined,
+  rootDir: string
+): Promise<string> {
+  if (value === undefined || value === "git") {
+    return (await findGitRoot(rootDir)) ?? rootDir
+  }
+
+  if (value === "lingui" || value === "config") {
+    return rootDir
+  }
+
+  return path.resolve(rootDir, value)
+}
+
+async function findGitRoot(startDir: string): Promise<string | undefined> {
+  let current = path.resolve(startDir)
+
+  while (true) {
+    if (await fileExists(path.join(current, ".git"))) {
+      return current
+    }
+
+    const parent = path.dirname(current)
+    if (parent === current) {
+      return undefined
+    }
+    current = parent
   }
 }
 
@@ -191,6 +232,15 @@ function validateConfig(config: unknown, configPath: string): asserts config is 
   if (record.pseudoLocale !== undefined && typeof record.pseudoLocale !== "string") {
     throw new TypeError(
       `Invalid Palamedes config in ${configPath}: "pseudoLocale" must be a string when provided.`
+    )
+  }
+
+  if (
+    record.sourceReferenceRoot !== undefined &&
+    (typeof record.sourceReferenceRoot !== "string" || record.sourceReferenceRoot.length === 0)
+  ) {
+    throw new TypeError(
+      `Invalid Palamedes config in ${configPath}: "sourceReferenceRoot" must be a non-empty string when provided.`
     )
   }
 

--- a/packages/config/src/loadConfig.test.ts
+++ b/packages/config/src/loadConfig.test.ts
@@ -77,6 +77,63 @@ describe("loadPalamedesConfig", () => {
     expect(config.catalogs[0]?.exclude).toStrictEqual(["src/ignore"])
   })
 
+  it("uses the nearest git root as the default source reference root", async () => {
+    const fixtureDir = await createTempDir()
+    const appDir = path.join(fixtureDir, "apps", "web")
+
+    await mkdir(path.join(fixtureDir, ".git"), { recursive: true })
+    await mkdir(appDir, { recursive: true })
+    await writeFile(
+      path.join(appDir, "palamedes.config.ts"),
+      `
+        export default {
+          locales: ["en"],
+          sourceLocale: "en",
+          catalogs: [
+            {
+              path: "locales/{locale}/messages",
+              include: ["app"],
+            },
+          ],
+        }
+      `
+    )
+
+    const config = await loadPalamedesConfig({ cwd: appDir })
+
+    expect(config.rootDir).toBe(appDir)
+    expect(config.sourceReferenceRoot).toBe(fixtureDir)
+  })
+
+  it("supports Lingui-compatible config-root source references", async () => {
+    const fixtureDir = await createTempDir()
+    const appDir = path.join(fixtureDir, "apps", "web")
+
+    await mkdir(path.join(fixtureDir, ".git"), { recursive: true })
+    await mkdir(appDir, { recursive: true })
+    await writeFile(
+      path.join(appDir, "palamedes.config.ts"),
+      `
+        export default {
+          locales: ["en"],
+          sourceLocale: "en",
+          sourceReferenceRoot: "lingui",
+          catalogs: [
+            {
+              path: "locales/{locale}/messages",
+              include: ["src"],
+            },
+          ],
+        }
+      `
+    )
+
+    const config = await loadPalamedesConfig({ cwd: appDir })
+
+    expect(config.rootDir).toBe(appDir)
+    expect(config.sourceReferenceRoot).toBe(appDir)
+  })
+
   it("fails validation for invalid config shapes", async () => {
     const fixtureDir = await createTempDir()
     await writeFile(


### PR DESCRIPTION
## Summary

- Defaults PO `#:` source references to the nearest Git repository root, so monorepo catalogs emit stable paths like `apps/web/app/page.tsx` and `packages/ui/src/shared-card.tsx`.
- Adds `sourceReferenceRoot` config support:
  - `"git"` default: nearest Git root, falling back to the config directory outside Git.
  - `"lingui"` / `"config"`: config-root references matching Lingui's default behavior.
  - custom path: references relative to that path.
- Keeps the Rust extractor able to render files outside the chosen root as deterministic relative paths, avoiding absolute checkout or CI workspace paths.
- Adds Rust core, config, and CLI regression coverage for parent-directory includes and Lingui-compatible references.

## Issue

Closes #257

## Validation

- cargo test -p palamedes extract --locked
- CI=true pnpm install --frozen-lockfile
- CI=true pnpm build
- CI=true pnpm --filter @palamedes/cli test
- CI=true pnpm --filter @palamedes/config test
- cargo fmt --all --check
- CI=true pnpm format:check
- cargo clippy -p palamedes --all-targets --locked -- -D warnings
- CI=true pnpm check-types

## Notes

Lingui 6.4.0 computes origins with `path.relative(config.rootDir, originFile)`, where `config.rootDir` defaults to the config file directory. Palamedes now intentionally defaults to repository-root references for new projects, while `sourceReferenceRoot: "lingui"` preserves that Lingui-compatible config-root behavior.
