### PR TITLE
fix: make release publishing retryable

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,13 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      force_publish:
+        description: "Publish the current release version even without a release commit"
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: publish-${{ github.ref }}
@@ -28,17 +35,24 @@ jobs:
       - name: Detect release commit
         id: release
         shell: bash
+        env:
+          FORCE_PUBLISH: ${{ github.event_name == 'workflow_dispatch' && inputs.force_publish && 'true' || 'false' }}
         run: |
           set -euo pipefail
 
-          base_ref="${{ github.event.before }}"
-          if [ "$base_ref" = "0000000000000000000000000000000000000000" ]; then
-            base_ref="$(git rev-parse HEAD^)"
-          fi
-
           has_release_commit=false
-          if git log --format=%s "$base_ref..${{ github.sha }}" | grep -Eq '^chore: release '; then
+
+          if [ "$FORCE_PUBLISH" = "true" ]; then
             has_release_commit=true
+          elif [ "$GITHUB_EVENT_NAME" = "push" ]; then
+            base_ref="${{ github.event.before }}"
+            if [ "$base_ref" = "0000000000000000000000000000000000000000" ]; then
+              base_ref="$(git rev-parse HEAD^)"
+            fi
+
+            if git log --format=%s "$base_ref..${{ github.sha }}" | grep -Eq '^chore: release '; then
+              has_release_commit=true
+            fi
           fi
 
           if [ "$has_release_commit" = true ]; then
@@ -153,7 +167,7 @@ jobs:
           if (!out.includes('pmds (Palamedes)')) process.exit(1)"
 
       - name: Publish native package
-        run: pnpm --filter "${{ matrix.package_name }}" publish --access public --no-git-checks
+        run: node ./scripts/publish-package-if-needed.mjs "${{ matrix.package_name }}"
 
   publish-js:
     needs:
@@ -202,19 +216,17 @@ jobs:
           build
 
       - name: Publish JavaScript packages
-        run: >
-          pnpm -r
-          --filter @palamedes/core
-          --filter @palamedes/config
-          --filter @palamedes/runtime
-          --filter @palamedes/core-node
-          --filter @palamedes/transform
-          --filter @palamedes/extractor
-          --filter @palamedes/react
-          --filter @palamedes/solid
-          --filter @palamedes/cli
-          --filter @palamedes/vite-plugin
-          --filter @palamedes/next-plugin
-          --filter palamedes
-          --filter create-palamedes
-          publish --no-git-checks
+        run: |
+          node ./scripts/publish-package-if-needed.mjs @palamedes/core
+          node ./scripts/publish-package-if-needed.mjs @palamedes/config
+          node ./scripts/publish-package-if-needed.mjs @palamedes/runtime
+          node ./scripts/publish-package-if-needed.mjs @palamedes/core-node
+          node ./scripts/publish-package-if-needed.mjs @palamedes/transform
+          node ./scripts/publish-package-if-needed.mjs @palamedes/extractor
+          node ./scripts/publish-package-if-needed.mjs @palamedes/react
+          node ./scripts/publish-package-if-needed.mjs @palamedes/solid
+          node ./scripts/publish-package-if-needed.mjs @palamedes/cli
+          node ./scripts/publish-package-if-needed.mjs @palamedes/vite-plugin
+          node ./scripts/publish-package-if-needed.mjs @palamedes/next-plugin
+          node ./scripts/publish-package-if-needed.mjs palamedes
+          node ./scripts/publish-package-if-needed.mjs create-palamedes

--- a/scripts/publish-package-if-needed.mjs
+++ b/scripts/publish-package-if-needed.mjs
@@ -1,0 +1,73 @@
+import { spawnSync } from "node:child_process"
+import { existsSync, readFileSync, readdirSync } from "node:fs"
+import path from "node:path"
+
+const root = process.cwd()
+const args = process.argv.slice(2)
+const dryRun = args.includes("--dry-run")
+const packageName = args.find((arg) => !arg.startsWith("--"))
+
+if (!packageName) {
+  console.error("Usage: node ./scripts/publish-package-if-needed.mjs <package-name> [--dry-run]")
+  process.exit(1)
+}
+
+const packageJson = findWorkspacePackage(packageName)
+const packageSpec = `${packageName}@${packageJson.version}`
+const viewResult = spawnSync("pnpm", ["view", packageSpec, "version"], {
+  cwd: root,
+  encoding: "utf8",
+})
+
+if (viewResult.status === 0) {
+  console.log(`${packageSpec} is already published; skipping.`)
+  process.exit(0)
+}
+
+const viewOutput = `${viewResult.stdout ?? ""}\n${viewResult.stderr ?? ""}`
+if (!isMissingPackageVersion(viewOutput)) {
+  process.stdout.write(viewResult.stdout ?? "")
+  process.stderr.write(viewResult.stderr ?? "")
+  process.exit(viewResult.status ?? 1)
+}
+
+if (dryRun) {
+  console.log(`${packageSpec} is not published yet; dry-run stops before publishing.`)
+  process.exit(0)
+}
+
+const publishResult = spawnSync(
+  "pnpm",
+  ["--filter", packageName, "publish", "--access", "public", "--no-git-checks"],
+  {
+    cwd: root,
+    stdio: "inherit",
+  }
+)
+process.exit(publishResult.status ?? 1)
+
+function findWorkspacePackage(name) {
+  for (const directory of readdirSync(path.join(root, "packages"))) {
+    const packageJsonPath = path.join(root, "packages", directory, "package.json")
+    if (!existsSync(packageJsonPath)) {
+      continue
+    }
+
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"))
+    if (packageJson.name === name) {
+      return packageJson
+    }
+  }
+
+  console.error(`${name} is not a workspace package.`)
+  process.exit(1)
+}
+
+function isMissingPackageVersion(output) {
+  return (
+    output.includes("404 Not Found") ||
+    output.includes("[ERR_PNPM_FETCH_404]") ||
+    output.includes("[E404]") ||
+    output.includes("is not in the npm registry")
+  )
+}


### PR DESCRIPTION
## Summary
- add a publish helper that skips workspace packages when the current name@version is already on npm
- use that helper for native and JavaScript release publishing so partial publishes can be retried safely
- add a manual Publish workflow dispatch with force_publish for retrying the current release after registry setup

## Validation
- node --check scripts/publish-package-if-needed.mjs
- node ./scripts/check-release-set.mjs
- git diff --check
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/publish.yml"); puts "publish.yml parses"'
- node ./scripts/publish-package-if-needed.mjs palamedes-scope/core-node-darwin-arm64 --dry-run
- node ./scripts/publish-package-if-needed.mjs palamedes-scope/cli-darwin-arm64 --dry-run

## Release recovery note
The failed Publish run already published some native core-node packages in the palamedes npm scope at 0.9.0, but the new native CLI packages in that scope do not exist in npm yet. The CI token currently receives 404 on creating those packages.

After this lands, publish recovery should be:
1. Give CI an npm token that can create new packages under the palamedes npm scope, or initially create the four native CLI packages with real platform builds.
2. Enable npm Trusted Publishing for:
   - palamedes scope: cli-darwin-arm64
   - palamedes scope: cli-linux-arm64-gnu
   - palamedes scope: cli-linux-x64-gnu
   - palamedes scope: cli-win32-x64-msvc
3. Manually run the Publish workflow on main with force_publish=true. Already published 0.9.0 packages will be skipped.