### PR TITLE
fix(release): repair native publish reruns

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -173,6 +173,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Configure musl Node addon linker
+        if: matrix.package_name == '@palamedes/core-node-linux-x64-musl'
+        run: |
+          echo 'RUSTFLAGS=-C target-feature=-crt-static' >> "$GITHUB_ENV"
+          echo 'CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc' >> "$GITHUB_ENV"
+
       - name: Build native package
         run: pnpm --filter "${{ matrix.package_name }}" build
 

--- a/scripts/publish-package-if-needed.mjs
+++ b/scripts/publish-package-if-needed.mjs
@@ -12,7 +12,8 @@ if (!packageName) {
   process.exit(1)
 }
 
-const packageJson = findWorkspacePackage(packageName)
+const workspacePackage = findWorkspacePackage(packageName)
+const packageJson = workspacePackage.packageJson
 const packageSpec = `${packageName}@${packageJson.version}`
 const viewResult = spawnSync("pnpm", ["view", packageSpec, "version"], {
   cwd: root,
@@ -36,14 +37,19 @@ if (dryRun) {
   process.exit(0)
 }
 
-const publishResult = spawnSync(
-  "pnpm",
-  ["--filter", packageName, "publish", "--access", "public", "--no-git-checks"],
-  {
-    cwd: root,
-    stdio: "inherit",
-  }
-)
+const publishResult = isNativeArtifactPackage(packageJson)
+  ? spawnSync("npm", ["publish", workspacePackage.directory, "--access", "public"], {
+      cwd: root,
+      stdio: "inherit",
+    })
+  : spawnSync(
+      "pnpm",
+      ["--filter", packageName, "publish", "--access", "public", "--no-git-checks"],
+      {
+        cwd: root,
+        stdio: "inherit",
+      }
+    )
 process.exit(publishResult.status ?? 1)
 
 function findWorkspacePackage(name) {
@@ -55,7 +61,10 @@ function findWorkspacePackage(name) {
 
     const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"))
     if (packageJson.name === name) {
-      return packageJson
+      return {
+        directory: path.join(root, "packages", directory),
+        packageJson,
+      }
     }
   }
 
@@ -67,7 +76,19 @@ function isMissingPackageVersion(output) {
   return (
     output.includes("404 Not Found") ||
     output.includes("[ERR_PNPM_FETCH_404]") ||
+    output.includes("[ERR_PNPM_PACKAGE_NOT_FOUND]") ||
     output.includes("[E404]") ||
+    output.includes("No matching version found for") ||
     output.includes("is not in the npm registry")
+  )
+}
+
+function isNativeArtifactPackage(packageJson) {
+  return (
+    typeof packageJson.name === "string" &&
+    (packageJson.name.startsWith("@palamedes/core-node-") ||
+      packageJson.name.startsWith("@palamedes/cli-")) &&
+    Array.isArray(packageJson.os) &&
+    Array.isArray(packageJson.cpu)
   )
 }


### PR DESCRIPTION
## Summary
- treat pnpm's missing-version response as publishable in the idempotent publish wrapper
- publish native artifact packages with npm CLI so Trusted Publishing/OIDC can be used while keeping JS packages on pnpm publish
- configure the musl Node addon build to produce a dynamic cdylib with musl-gcc

## Validation
- node --check scripts/publish-package-if-needed.mjs
- CI=true pnpm install --frozen-lockfile
- CI=true pnpm check:release-set
- CI=true pnpm format:check
- git diff --check
- node scripts/publish-package-if-needed.mjs @palamedes/core-node-linux-x64-gnu --dry-run