### PR TITLE
fix(release): handle follow-up native publish failures

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -176,7 +176,7 @@ jobs:
       - name: Configure musl Node addon linker
         if: matrix.package_name == '@palamedes/core-node-linux-x64-musl'
         run: |
-          echo 'RUSTFLAGS=-C target-feature=-crt-static' >> "$GITHUB_ENV"
+          echo 'RUSTFLAGS=-C target-feature=-crt-static -C panic=abort' >> "$GITHUB_ENV"
           echo 'CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc' >> "$GITHUB_ENV"
 
       - name: Build native package

--- a/scripts/publish-package-if-needed.mjs
+++ b/scripts/publish-package-if-needed.mjs
@@ -15,10 +15,15 @@ if (!packageName) {
 const workspacePackage = findWorkspacePackage(packageName)
 const packageJson = workspacePackage.packageJson
 const packageSpec = `${packageName}@${packageJson.version}`
-const viewResult = spawnSync("pnpm", ["view", packageSpec, "version"], {
+const viewResult = spawnSync(command("pnpm"), ["view", packageSpec, "version"], {
   cwd: root,
   encoding: "utf8",
 })
+
+if (viewResult.error) {
+  console.error(viewResult.error)
+  process.exit(1)
+}
 
 if (viewResult.status === 0) {
   console.log(`${packageSpec} is already published; skipping.`)
@@ -38,19 +43,29 @@ if (dryRun) {
 }
 
 const publishResult = isNativeArtifactPackage(packageJson)
-  ? spawnSync("npm", ["publish", workspacePackage.directory, "--access", "public"], {
+  ? spawnSync(command("npm"), ["publish", workspacePackage.directory, "--access", "public"], {
       cwd: root,
       stdio: "inherit",
     })
   : spawnSync(
-      "pnpm",
+      command("pnpm"),
       ["--filter", packageName, "publish", "--access", "public", "--no-git-checks"],
       {
         cwd: root,
         stdio: "inherit",
       }
     )
+
+if (publishResult.error) {
+  console.error(publishResult.error)
+  process.exit(1)
+}
+
 process.exit(publishResult.status ?? 1)
+
+function command(name) {
+  return process.platform === "win32" ? `${name}.cmd` : name
+}
 
 function findWorkspacePackage(name) {
   for (const directory of readdirSync(path.join(root, "packages"))) {


### PR DESCRIPTION
## Summary
- resolve Windows publish wrapper execution by using .cmd shims for pnpm/npm and logging spawn failures
- build the musl Node addon with panic=abort so the shared object does not require the missing libgcc_s link path

## Verification
- node --check scripts/publish-package-if-needed.mjs
- pnpm check:release-set
- pnpm format:check
- git diff --check
- node scripts/publish-package-if-needed.mjs @palamedes/cli-linux-x64-musl --dry-run
- node scripts/publish-package-if-needed.mjs @palamedes/core-node-linux-x64-musl --dry-run