### PR TITLE
fix(ci): build examples container for amd64 (x86_64 target host)

### DIFF
--- a/.github/workflows/publish-examples-container.yml
+++ b/.github/workflows/publish-examples-container.yml
@@ -65,8 +65,9 @@ jobs:
   build-and-push:
     needs: determine-release
     if: needs.determine-release.outputs.should_publish == 'true'
-    # Native arm64 runner so the Containerfile's Rust addon builds without emulation.
-    runs-on: ubuntu-24.04-arm
+    # Native x86_64 runner (the target host arch) so the Containerfile's Rust addon
+    # builds without emulation.
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     permissions:
       contents: read
@@ -94,15 +95,15 @@ jobs:
             type=raw,value=latest
             type=sha,format=long
 
-      # linux/arm64 only, built natively on the arm64 runner: the Containerfile
-      # compiles the native Rust addon at build time, so an emulated build would
-      # be prohibitively slow.
+      # linux/amd64 only (the target host arch), built natively on the x86_64
+      # runner: the Containerfile compiles the native Rust addon at build time, so
+      # an emulated build would be prohibitively slow.
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Containerfile
-          platforms: linux/arm64
+          platforms: linux/amd64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/docs/operations/run-examples-container.md
+++ b/docs/operations/run-examples-container.md
@@ -29,7 +29,7 @@ Container Registry, so you can pull instead of build:
 podman pull ghcr.io/sebastian-software/palamedes-examples:latest
 ```
 
-The image is built for `linux/arm64`. To build it yourself (e.g. on amd64), use
+The image is built for `linux/amd64`. To build it yourself (e.g. on arm64), use
 the next section.
 
 ## Build the image


### PR DESCRIPTION
## Problem

The examples container publish workflow was building for **arm64**, but the target deployment host is **x86_64 (amd64)**. A published arm64 image would not run natively there.

## Fix

Switch `Publish Examples Container` back to amd64:

- runner `ubuntu-24.04-arm` → `ubuntu-24.04` (native x86_64, so the Containerfile's Rust addon builds without emulation)
- `platforms: linux/arm64` → `linux/amd64`
- operations guide updated (`The image is built for linux/amd64`)

No Containerfile change needed — it builds `@palamedes/core-node-linux-x64-gnu` natively on the x86_64 runner.

## Verification

- `pnpm format:check` passes over all files.
- Workflow YAML validates.