### PR TITLE
fix(examples): allow deployed preview host for tanstack examples

### DIFF
--- a/.sf-plugin/config.json
+++ b/.sf-plugin/config.json
@@ -1,0 +1,28 @@
+{
+  "review": {
+    "profile": "focused",
+    "autoConfirmScope": false,
+    "designDecisionSources": "standard",
+    "validation": "full"
+  },
+  "applyReview": {
+    "defaultCommitStrategy": null,
+    "finalValidation": "full",
+    "stashPolicy": "interactive",
+    "worktree": {
+      "baseDir": ".sf-plugin/.worktrees",
+      "setup": "auto"
+    }
+  },
+  "plan": {
+    "markerLanguage": "en"
+  },
+  "worktree": {
+    "enabled": true,
+    "baseBranch": "origin/main",
+    "branchPrefix": "sf",
+    "completion": "pr",
+    "setup": "auto",
+    "baseDir": ".sf-plugin/.worktrees"
+  }
+}

--- a/examples/tanstack-cookie/vite.config.ts
+++ b/examples/tanstack-cookie/vite.config.ts
@@ -5,4 +5,7 @@ import { palamedes } from "@palamedes/vite-plugin"
 
 export default defineConfig({
   plugins: [tanstackStart(), palamedes(), react()],
+  preview: {
+    allowedHosts: [".examples.palamedes.dev"],
+  },
 })

--- a/examples/tanstack-route/vite.config.ts
+++ b/examples/tanstack-route/vite.config.ts
@@ -6,7 +6,7 @@ import { palamedes } from "@palamedes/vite-plugin"
 export default defineConfig({
   plugins: [tanstackStart(), palamedes(), react()],
   preview: {
-    allowedHosts: ["de.lvh.me", "en.lvh.me", "es.lvh.me"],
+    allowedHosts: [".examples.palamedes.dev", "de.lvh.me", "en.lvh.me", "es.lvh.me"],
   },
   server: {
     allowedHosts: ["de.lvh.me", "en.lvh.me", "es.lvh.me"],


### PR DESCRIPTION
## Problem

Die Beispiele `tanstack-cookie` und `tanstack-route` liefern ihren Production-Build über `vite preview` aus. Vite blockiert dabei alle Hosts, die nicht in `preview.allowedHosts` stehen (DNS-Rebinding-Schutz). Dadurch schlugen die Deploys unter `*.examples.palamedes.dev` fehl:

> Blocked request. This host ("tanstack-cookie.examples.palamedes.dev") is not allowed. To allow this host, add … to `preview.allowedHosts` in vite.config.js.

- `tanstack-cookie` hatte gar kein `preview.allowedHosts`.
- `tanstack-route` listete nur lokale `*.lvh.me`-Dev-Hosts.

Nur diese beiden Beispiele sind betroffen – die übrigen liefern Production über eigene Node-Server aus (`next start`, `react-router-serve`, `vinxi start`, `waku start`) und kennen die Vite-Host-Allowlist nicht.

## Fix

`preview.allowedHosts` in beiden Configs um das Subdomain-Wildcard `.examples.palamedes.dev` ergänzt. Das deckt beide Deploys sowie künftige Beispiel-Deploys ab und hält die Allowlist restriktiv (kein `allowedHosts: true`). Bestehende `lvh.me`-Dev-Hosts bleiben erhalten.

## Validierung

- `oxfmt --check`, `oxlint`, `eslint` auf beiden Dateien grün
- Keine neuen Typfehler auf den geänderten Dateien
- Kein Regressionstest möglich (Vite-internes Middleware-Verhalten, kein Projektcode)