### PR TITLE
fix(ci): unblock native package publish on Windows and musl

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -176,7 +176,10 @@ jobs:
       - name: Configure musl Node addon linker
         if: matrix.package_name == '@palamedes/core-node-linux-x64-musl'
         run: |
-          echo 'RUSTFLAGS=-C target-feature=-crt-static -C panic=abort' >> "$GITHUB_ENV"
+          # The cdylib N-API addon must disable crt-static, which makes rustc link
+          # `-lgcc_s` dynamically. musl-tools ships no musl `libgcc_s.so.1`, so force
+          # musl-gcc to resolve libgcc statically instead of the missing shared lib.
+          echo 'RUSTFLAGS=-C target-feature=-crt-static -C panic=abort -C link-arg=-static-libgcc' >> "$GITHUB_ENV"
           echo 'CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc' >> "$GITHUB_ENV"
 
       - name: Build native package

--- a/scripts/publish-package-if-needed.mjs
+++ b/scripts/publish-package-if-needed.mjs
@@ -3,6 +3,10 @@ import { existsSync, readFileSync, readdirSync } from "node:fs"
 import path from "node:path"
 
 const root = process.cwd()
+// On Windows the package manager binaries resolve to `pnpm.cmd`/`npm.cmd`.
+// Node refuses to spawn `.cmd`/`.bat` files without a shell (CVE-2024-27980),
+// so run through the shell there; POSIX keeps the direct, unquoted spawn.
+const useShell = process.platform === "win32"
 const args = process.argv.slice(2)
 const dryRun = args.includes("--dry-run")
 const packageName = args.find((arg) => !arg.startsWith("--"))
@@ -18,6 +22,7 @@ const packageSpec = `${packageName}@${packageJson.version}`
 const viewResult = spawnSync(command("pnpm"), ["view", packageSpec, "version"], {
   cwd: root,
   encoding: "utf8",
+  shell: useShell,
 })
 
 if (viewResult.error) {
@@ -46,6 +51,7 @@ const publishResult = isNativeArtifactPackage(packageJson)
   ? spawnSync(command("npm"), ["publish", workspacePackage.directory, "--access", "public"], {
       cwd: root,
       stdio: "inherit",
+      shell: useShell,
     })
   : spawnSync(
       command("pnpm"),
@@ -53,6 +59,7 @@ const publishResult = isNativeArtifactPackage(packageJson)
       {
         cwd: root,
         stdio: "inherit",
+        shell: useShell,
       }
     )
 


### PR DESCRIPTION
## Kontext

Der Release-Run [28625375952](https://github.com/sebastian-software/palamedes/actions/runs/28625375952) (Publish, Release #277) hatte 3 rote `publish-native`-Jobs – zwei unabhängige Ursachen.

## A) Windows-Publish (2 Jobs: `cli-win32-x64-msvc`, `core-node-win32-x64-msvc`)

Step *Publish native package* → `scripts/publish-package-if-needed.mjs`. `command()` hängt auf Windows `.cmd` an (`pnpm.cmd`/`npm.cmd`). Node 24 verweigert seit dem CVE-2024-27980-Fix `spawnSync` von `.cmd`/`.bat` ohne `shell: true` → `errno -4071 EINVAL` bereits bei `pnpm view <spec> version`.

**Fix:** `shell`-Flag nur auf win32 (`const useShell = process.platform === \"win32\"`) an allen drei `spawnSync`-Aufrufen. POSIX-Pfad bleibt unverändert (direkter, unquoted Spawn). Args sind space-frei → kein Quoting-Risiko.

## B) musl-Build (1 Job: `core-node-linux-x64-musl`)

Step *Build native package* → `cargo build --target x86_64-unknown-linux-musl` exit 101: `/usr/bin/ld: cannot find libgcc_s.so.1`. `palamedes-node` ist `crate-type = [\"cdylib\"]`; der Workflow deaktiviert `crt-static` (nötig für cdylib) → rustc linkt `-lgcc_s` dynamisch, aber `musl-tools` liefert kein musl-natives `libgcc_s.so.1`.

**Fix:** `-C link-arg=-static-libgcc` in `RUSTFLAGS` des Steps *Configure musl Node addon linker* → `musl-gcc` löst libgcc statisch auf.

## Verifikation

- `publish-package-if-needed.mjs`: `node --check` ok, funktionaler `--dry-run` ok, oxfmt/oxlint/eslint grün.
- `publish.yml`: valides YAML, alle Jobs intakt.
- **Restrisiko:** Beide Fixes sind CI-only und nicht lokal auf macOS reproduzierbar. Endgültige Bestätigung erst durch einen grünen Re-Run der 3 Jobs (Merge auf `main` mit Release-Commit oder `workflow_dispatch` mit `force_publish`). Der `-static-libgcc`-Ansatz für musl ist der minimal-invasive; falls der Link weiterhin scheitert, sind Alpine-Container-Build oder cargo-zigbuild die Fallbacks.