### PR TITLE
docs: surface live example deployments across README, examples, and demo note

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ The current proof:
 - Benchmark commands and fixtures are checked in so the numbers can be rerun
   locally.
 
+**Try it live.** The full framework matrix is deployed at `*.examples.palamedes.dev`. Open [Next.js (cookie)](https://nextjs-cookie.examples.palamedes.dev) and [SolidStart (route)](https://solidstart-route.examples.palamedes.dev), switch language, and watch copy, plural seat counts, currency, and dates change together — the same design across every framework. Full list in [examples/README](examples/README.md).
+
 Under the hood, a Rust core, OXC-powered transforms, and `ferrocat` catalog
 semantics handle the careful work: parsing, extraction, updates, audits,
 diagnostics, and runtime artifact compilation.
@@ -244,7 +246,7 @@ The same foundation also matters for future translation workflows:
 - [Troubleshooting common setup failures](https://github.com/sebastian-software/palamedes/blob/main/docs/troubleshooting.md)
 - [Pseudo-localization and fallback locale config](https://github.com/sebastian-software/palamedes/blob/main/docs/pseudo-localization.md)
 - [Versioned example screenshots](https://github.com/sebastian-software/palamedes/blob/main/docs/example-screenshots/README.md)
-- [Optional demo deployment note](https://github.com/sebastian-software/palamedes/blob/main/docs/demo-deployments.md)
+- [Live demo deployments](https://github.com/sebastian-software/palamedes/blob/main/docs/demo-deployments.md)
 - [Benchmarking against Lingui v6 Preview](https://github.com/sebastian-software/palamedes/blob/main/docs/benchmark-lingui-v6-preview.md)
 - [Approach comparison across Lingui, next-intl, and GT](https://github.com/sebastian-software/palamedes/blob/main/docs/approach-comparison.md)
 - [Palamedes principles](https://github.com/sebastian-software/palamedes/blob/main/docs/principles.md)

--- a/docs/demo-deployments.md
+++ b/docs/demo-deployments.md
@@ -1,14 +1,34 @@
-# Optional Demo Deployments
+# Demo Deployments
 
 The Palamedes example matrix is verified primarily through local runs and CI.
-Public hosting is optional and is not part of the default merge or release path.
+Automatic deployments are not part of the default merge or release path. All ten
+examples are publicly accessible as a live reference — see the Live Reference
+Deployment section below.
 
 ## Current Policy
 
 - the canonical verification path is `pnpm build:examples` plus `pnpm verify:examples`
 - example deployments do not run automatically on `main`
-- `nextjs-cookie` and `nextjs-route` are CI-only in the standard workflow
-- the remaining examples can still be deployed manually if a hosted URL is useful for debugging or ad hoc sharing
+- `nextjs-cookie` and `nextjs-route` are excluded from `deploy-examples.yml`; both are accessible via the live reference deployment
+- the `deploy-examples.yml` workflow supports manual deployment of the eight non-Next.js examples if an additional hosted URL is needed
+
+## Live Reference Deployment
+
+All ten examples are publicly accessible. Switch language in any of them and
+watch copy, plural seat counts, currency, and dates change together.
+
+| Framework | Locale strategy | Live demo |
+| -------------- | --------------- | --------- |
+| Next.js | cookie | [nextjs-cookie.examples.palamedes.dev](https://nextjs-cookie.examples.palamedes.dev) |
+| Next.js | route | [nextjs-route.examples.palamedes.dev](https://nextjs-route.examples.palamedes.dev) |
+| TanStack Start | cookie | [tanstack-cookie.examples.palamedes.dev](https://tanstack-cookie.examples.palamedes.dev) |
+| TanStack Start | route | [tanstack-route.examples.palamedes.dev](https://tanstack-route.examples.palamedes.dev) |
+| Waku | cookie | [waku-cookie.examples.palamedes.dev](https://waku-cookie.examples.palamedes.dev) |
+| Waku | route | [waku-route.examples.palamedes.dev](https://waku-route.examples.palamedes.dev) |
+| React Router | cookie | [react-router-cookie.examples.palamedes.dev](https://react-router-cookie.examples.palamedes.dev) |
+| React Router | route | [react-router-route.examples.palamedes.dev](https://react-router-route.examples.palamedes.dev) |
+| SolidStart | cookie | [solidstart-cookie.examples.palamedes.dev](https://solidstart-cookie.examples.palamedes.dev) |
+| SolidStart | route | [solidstart-route.examples.palamedes.dev](https://solidstart-route.examples.palamedes.dev) |
 
 ## Optional Manual Deployments
 
@@ -32,17 +52,18 @@ Supported deployment targets:
 - `react-router-cookie`
 - `react-router-route`
 
-## Why Next.js Is Not In The Deploy Path
+## Why Next.js Is Not In `deploy-examples.yml`
 
-The Next.js examples are part of the verified matrix, but they are not part of
-the standard Vercel deployment workflow for this repository.
+The Next.js examples are part of the verified matrix, but they are excluded from
+the `deploy-examples.yml` workflow. That workflow targets the eight non-Next.js
+examples specifically.
 
-For this OSS setup, the useful guarantee is:
+For this OSS setup, the guaranteed baseline is:
 
 - the examples build
 - the examples run locally
 - SSR, locale routing, cookie handling, and localized server actions are covered in browser tests
 
-If hosted Next.js demos become important later, they should be treated as a
-separate operational track using Vercel's normal remote-build path rather than
-the current CI-first example baseline.
+Both `nextjs-cookie` and `nextjs-route` are nonetheless publicly accessible — see
+the Live Reference Deployment section above. The hosting mechanism for the Next.js
+examples is separate from `deploy-examples.yml` and is not further documented here.

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,8 +7,9 @@ They prove the current Palamedes story across five framework families and two
 locale strategies while preserving the same underlying runtime and identity
 model.
 
-The matrix is intended to be run locally and validated in CI. Public hosting is
-optional and not part of the default example story.
+The matrix is intended to be run locally and validated in CI — that remains the
+canonical verification path. All ten examples are also publicly accessible as a
+live reference at `*.examples.palamedes.dev`.
 
 ## What This Matrix Proves
 
@@ -19,6 +20,25 @@ optional and not part of the default example story.
 
 That is the real point of the matrix. It is not a pile of demos. It is the
 evidence behind the claim that Palamedes stays coherent across frameworks.
+
+## Live Demos
+
+All ten matrix examples are publicly deployed as a live reference. Switch
+language in any of them and watch copy, plural seat counts, currency, and dates
+change together — the same design across every framework.
+
+| Framework | Locale strategy | Live demo |
+| -------------- | --------------- | --------- |
+| Next.js | cookie | [nextjs-cookie.examples.palamedes.dev](https://nextjs-cookie.examples.palamedes.dev) |
+| Next.js | route | [nextjs-route.examples.palamedes.dev](https://nextjs-route.examples.palamedes.dev) |
+| TanStack Start | cookie | [tanstack-cookie.examples.palamedes.dev](https://tanstack-cookie.examples.palamedes.dev) |
+| TanStack Start | route | [tanstack-route.examples.palamedes.dev](https://tanstack-route.examples.palamedes.dev) |
+| Waku | cookie | [waku-cookie.examples.palamedes.dev](https://waku-cookie.examples.palamedes.dev) |
+| Waku | route | [waku-route.examples.palamedes.dev](https://waku-route.examples.palamedes.dev) |
+| React Router | cookie | [react-router-cookie.examples.palamedes.dev](https://react-router-cookie.examples.palamedes.dev) |
+| React Router | route | [react-router-route.examples.palamedes.dev](https://react-router-route.examples.palamedes.dev) |
+| SolidStart | cookie | [solidstart-cookie.examples.palamedes.dev](https://solidstart-cookie.examples.palamedes.dev) |
+| SolidStart | route | [solidstart-route.examples.palamedes.dev](https://solidstart-route.examples.palamedes.dev) |
 
 ## Locale Strategy Matrix
 


### PR DESCRIPTION
## Summary

Surfaces the newly deployed live example matrix in the docs. All ten example apps (five framework families × cookie/route locale strategy) are now publicly reachable at `*.examples.palamedes.dev`.

- **README.md** — adds a compact **"Try it live"** callout in the top proof block with two representative demo links (Next.js cookie, SolidStart route) and a pointer to the full list; renames the doc-list label "Optional demo deployment note" → "Live demo deployments".
- **examples/README.md** — adds a `## Live Demos` section with a table of all ten public demo domains; adjusts the intro so local + CI stays the canonical verification path while noting the public live reference.
- **docs/demo-deployments.md** — reconciles the previously outdated "not hosted / Next.js excluded" wording with reality: adds a `## Live Reference Deployment` table for all ten domains, separates *automatic deploys* (still not part of the release path) from *public reachability*, and scopes the Next.js exclusion specifically to the `deploy-examples.yml` workflow. Title tightened to "Demo Deployments".

## Constraints honored

- Only public domain names are documented — **no backend hosts or ports** (`127.0.0.1:40xx`). The existing local "Default Dev Ports" section is untouched.
- No product/code behavior changed; documentation only.

## Verification

HTTP reachability checked for all ten domains:

- `200`: nextjs-cookie, waku-cookie, react-router-cookie, solidstart-cookie
- `302`/`307` (expected locale redirect, route strategy): nextjs-route, waku-route, react-router-route, solidstart-route
- ⚠️ `403 Forbidden`: **tanstack-cookie, tanstack-route** — app-side host/origin rejection (related to #276 "allow deployed preview host for tanstack examples"). Known deployment issue, tracked separately; documented anyway per explicit decision.

Plan: `docs/plan/0001-add-live-example-deployments-to-docs.md` (kept local; `docs/plan/` is gitignored).