### PR TITLE
fix(ci): repair main pipeline formatting and musl addon build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -176,10 +176,9 @@ jobs:
       - name: Configure musl Node addon linker
         if: matrix.package_name == '@palamedes/core-node-linux-x64-musl'
         run: |
-          # The cdylib N-API addon must disable crt-static, which makes rustc link
-          # `-lgcc_s` dynamically. musl-tools ships no musl `libgcc_s.so.1`, so force
-          # musl-gcc to resolve libgcc statically instead of the missing shared lib.
-          echo 'RUSTFLAGS=-C target-feature=-crt-static -C panic=abort -C link-arg=-static-libgcc' >> "$GITHUB_ENV"
+          # build-native.mjs scopes the cdylib-only musl flags to the final
+          # palamedes-node target so dependency cdylibs keep Rust's default
+          # static musl linkage.
           echo 'CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc' >> "$GITHUB_ENV"
 
       - name: Build native package

--- a/docs/demo-deployments.md
+++ b/docs/demo-deployments.md
@@ -17,18 +17,18 @@ Deployment section below.
 All ten examples are publicly accessible. Switch language in any of them and
 watch copy, plural seat counts, currency, and dates change together.
 
-| Framework | Locale strategy | Live demo |
-| -------------- | --------------- | --------- |
-| Next.js | cookie | [nextjs-cookie.examples.palamedes.dev](https://nextjs-cookie.examples.palamedes.dev) |
-| Next.js | route | [nextjs-route.examples.palamedes.dev](https://nextjs-route.examples.palamedes.dev) |
-| TanStack Start | cookie | [tanstack-cookie.examples.palamedes.dev](https://tanstack-cookie.examples.palamedes.dev) |
-| TanStack Start | route | [tanstack-route.examples.palamedes.dev](https://tanstack-route.examples.palamedes.dev) |
-| Waku | cookie | [waku-cookie.examples.palamedes.dev](https://waku-cookie.examples.palamedes.dev) |
-| Waku | route | [waku-route.examples.palamedes.dev](https://waku-route.examples.palamedes.dev) |
-| React Router | cookie | [react-router-cookie.examples.palamedes.dev](https://react-router-cookie.examples.palamedes.dev) |
-| React Router | route | [react-router-route.examples.palamedes.dev](https://react-router-route.examples.palamedes.dev) |
-| SolidStart | cookie | [solidstart-cookie.examples.palamedes.dev](https://solidstart-cookie.examples.palamedes.dev) |
-| SolidStart | route | [solidstart-route.examples.palamedes.dev](https://solidstart-route.examples.palamedes.dev) |
+| Framework      | Locale strategy | Live demo                                                                                        |
+| -------------- | --------------- | ------------------------------------------------------------------------------------------------ |
+| Next.js        | cookie          | [nextjs-cookie.examples.palamedes.dev](https://nextjs-cookie.examples.palamedes.dev)             |
+| Next.js        | route           | [nextjs-route.examples.palamedes.dev](https://nextjs-route.examples.palamedes.dev)               |
+| TanStack Start | cookie          | [tanstack-cookie.examples.palamedes.dev](https://tanstack-cookie.examples.palamedes.dev)         |
+| TanStack Start | route           | [tanstack-route.examples.palamedes.dev](https://tanstack-route.examples.palamedes.dev)           |
+| Waku           | cookie          | [waku-cookie.examples.palamedes.dev](https://waku-cookie.examples.palamedes.dev)                 |
+| Waku           | route           | [waku-route.examples.palamedes.dev](https://waku-route.examples.palamedes.dev)                   |
+| React Router   | cookie          | [react-router-cookie.examples.palamedes.dev](https://react-router-cookie.examples.palamedes.dev) |
+| React Router   | route           | [react-router-route.examples.palamedes.dev](https://react-router-route.examples.palamedes.dev)   |
+| SolidStart     | cookie          | [solidstart-cookie.examples.palamedes.dev](https://solidstart-cookie.examples.palamedes.dev)     |
+| SolidStart     | route           | [solidstart-route.examples.palamedes.dev](https://solidstart-route.examples.palamedes.dev)       |
 
 ## Optional Manual Deployments
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -27,18 +27,18 @@ All ten matrix examples are publicly deployed as a live reference. Switch
 language in any of them and watch copy, plural seat counts, currency, and dates
 change together — the same design across every framework.
 
-| Framework | Locale strategy | Live demo |
-| -------------- | --------------- | --------- |
-| Next.js | cookie | [nextjs-cookie.examples.palamedes.dev](https://nextjs-cookie.examples.palamedes.dev) |
-| Next.js | route | [nextjs-route.examples.palamedes.dev](https://nextjs-route.examples.palamedes.dev) |
-| TanStack Start | cookie | [tanstack-cookie.examples.palamedes.dev](https://tanstack-cookie.examples.palamedes.dev) |
-| TanStack Start | route | [tanstack-route.examples.palamedes.dev](https://tanstack-route.examples.palamedes.dev) |
-| Waku | cookie | [waku-cookie.examples.palamedes.dev](https://waku-cookie.examples.palamedes.dev) |
-| Waku | route | [waku-route.examples.palamedes.dev](https://waku-route.examples.palamedes.dev) |
-| React Router | cookie | [react-router-cookie.examples.palamedes.dev](https://react-router-cookie.examples.palamedes.dev) |
-| React Router | route | [react-router-route.examples.palamedes.dev](https://react-router-route.examples.palamedes.dev) |
-| SolidStart | cookie | [solidstart-cookie.examples.palamedes.dev](https://solidstart-cookie.examples.palamedes.dev) |
-| SolidStart | route | [solidstart-route.examples.palamedes.dev](https://solidstart-route.examples.palamedes.dev) |
+| Framework      | Locale strategy | Live demo                                                                                        |
+| -------------- | --------------- | ------------------------------------------------------------------------------------------------ |
+| Next.js        | cookie          | [nextjs-cookie.examples.palamedes.dev](https://nextjs-cookie.examples.palamedes.dev)             |
+| Next.js        | route           | [nextjs-route.examples.palamedes.dev](https://nextjs-route.examples.palamedes.dev)               |
+| TanStack Start | cookie          | [tanstack-cookie.examples.palamedes.dev](https://tanstack-cookie.examples.palamedes.dev)         |
+| TanStack Start | route           | [tanstack-route.examples.palamedes.dev](https://tanstack-route.examples.palamedes.dev)           |
+| Waku           | cookie          | [waku-cookie.examples.palamedes.dev](https://waku-cookie.examples.palamedes.dev)                 |
+| Waku           | route           | [waku-route.examples.palamedes.dev](https://waku-route.examples.palamedes.dev)                   |
+| React Router   | cookie          | [react-router-cookie.examples.palamedes.dev](https://react-router-cookie.examples.palamedes.dev) |
+| React Router   | route           | [react-router-route.examples.palamedes.dev](https://react-router-route.examples.palamedes.dev)   |
+| SolidStart     | cookie          | [solidstart-cookie.examples.palamedes.dev](https://solidstart-cookie.examples.palamedes.dev)     |
+| SolidStart     | route           | [solidstart-route.examples.palamedes.dev](https://solidstart-route.examples.palamedes.dev)       |
 
 ## Locale Strategy Matrix
 

--- a/packages/core-node/scripts/build-native.mjs
+++ b/packages/core-node/scripts/build-native.mjs
@@ -83,7 +83,8 @@ if (!extension) {
   throw new Error(`Unsupported platform for Palamedes native build: ${process.platform}`)
 }
 
-const cargoArgs = ["build", "--package", "palamedes-node"]
+const muslNodeAddon = packageJson.name === "@palamedes/core-node-linux-x64-musl"
+const cargoArgs = [muslNodeAddon ? "rustc" : "build", "--package", "palamedes-node"]
 
 if (profile === "release") {
   cargoArgs.push("--release")
@@ -91,6 +92,23 @@ if (profile === "release") {
 
 if (target.rustTarget) {
   cargoArgs.push("--target", target.rustTarget)
+}
+
+if (muslNodeAddon) {
+  // Keep the crt-static override scoped to the final N-API cdylib. Applying it
+  // through RUSTFLAGS also changes dependency cdylib builds such as
+  // oxc_sourcemap, which makes musl-gcc look for a shared libgcc_s that the
+  // Ubuntu musl toolchain does not provide.
+  cargoArgs.push(
+    "--lib",
+    "--",
+    "-C",
+    "target-feature=-crt-static",
+    "-C",
+    "panic=abort",
+    "-C",
+    "link-self-contained=+unwind"
+  )
 }
 
 execFileSync("cargo", cargoArgs, {


### PR DESCRIPTION
## Summary
- format the two docs tables that are currently failing main CI
- scope the musl N-API addon crt-static override to the final palamedes-node cdylib build instead of exporting it through global RUSTFLAGS
- keep dependency cdylibs on Rust's default static musl linkage and preserve the explicit musl-gcc linker for the final addon

## Verification
- ./node_modules/.bin/oxfmt --check --ignore-path .gitignore --ignore-path .oxfmtignore .
- node --check packages/core-node/scripts/build-native.mjs
- git diff --check

Note: I did not dispatch Publish with force_publish because that workflow can perform real npm publication for missing release artifacts.