### PR TITLE
Implement Ferrocat FCL catalog migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -334,9 +334,9 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ferrocat"
-version = "1.3.1"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9becff2c63214c6fa75c646b6e9563586a88191e214b245702b684b36970eb12"
+checksum = "47da07e9a7d8c9322abbc33f8a0b73ffc50c88ceb42a91b5fcd55e930245299a"
 dependencies = [
  "ferrocat-icu",
  "ferrocat-po",
@@ -344,9 +344,9 @@ dependencies = [
 
 [[package]]
 name = "ferrocat-icu"
-version = "1.3.1"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd4b4408c08d713fc3481c2021abce20de1013e6ba239b247cced67fd8e0fe5c"
+checksum = "cdf8833bc32377ed7d6bc08752da0ace1551a8882ee89c45302ae126b5a16844"
 dependencies = [
  "memchr",
  "serde",
@@ -354,17 +354,19 @@ dependencies = [
 
 [[package]]
 name = "ferrocat-po"
-version = "1.3.1"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c7fc4a25fc10199c0f025ce1e509bdc40ae39864849a724ff5ffd1df8f28806"
+checksum = "99fb40ecaa52518cac25f454043b0001781118c17f9995486f8aebf3ad6fa7a4"
 dependencies = [
  "ferrocat-icu",
  "icu_locale",
  "icu_plurals",
  "memchr",
+ "rustc-hash",
  "serde",
  "serde_json",
  "sha2",
+ "smallvec",
  "tempfile",
 ]
 
@@ -1151,6 +1153,7 @@ name = "palamedes"
 version = "0.11.4"
 dependencies = [
  "ferrocat",
+ "ferrocat-icu",
  "ferrocat-po",
  "oxc_allocator",
  "oxc_ast",
@@ -1336,9 +1339,9 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustix"
@@ -1466,6 +1469,9 @@ name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "smawk"

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -22,6 +22,10 @@ Then read the core execution model:
 5. [ADR-005: Universal `getI18n()` Runtime Model](./adr/005-universal-geti18n-runtime-model.md)
 6. [ADR-006: Ferrocat as Catalog and ICU Foundation](./adr/006-ferrocat-as-catalog-and-icu-foundation.md)
 
+ADR-006 also records the current Ferrocat integration rule: Palamedes exposes
+PO and FCL as product-shaped catalog storage formats, and uses Ferrocat builder
+options instead of struct literals at the dependency boundary.
+
 Finally read the host integration decisions:
 
 7. [ADR-007: Native Boundary and Distribution](./adr/007-native-boundary-and-distribution.md)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ The current proof:
 
 Under the hood, a Rust core, OXC-powered transforms, and `ferrocat` catalog
 semantics handle the careful work: parsing, extraction, updates, audits,
-diagnostics, and runtime artifact compilation.
+diagnostics, and runtime artifact compilation. PO remains the default catalog
+storage, and teams can opt into FCL when they want canonical, merge-friendly
+generated catalogs with cleaner machine-owned metadata.
 
 ## Why Teams Pick Palamedes
 
@@ -42,7 +44,7 @@ diagnostics, and runtime artifact compilation.
 - Familiar macro-style authoring without carrying older compatibility paths forward
 - Fast transforms, extraction, catalog updates, audits, and compile steps
 - Source-string-first catalogs that translators can inspect and teams can trust
-- Semantic catalog merging for Git merge-driver workflows without gettext
+- Semantic PO/FCL catalog merging for Git merge-driver workflows
 - A local foundation for future managed translation workflows without giving up repo ownership
 
 ## What Makes It Feel Better
@@ -221,7 +223,7 @@ Palamedes is opinionated in a few places:
 
 - `message + context` is the semantic identity
 - `getI18n()` is the public runtime model
-- catalog parsing, updates, audits, and ICU QA live in `ferrocat`
+- catalog parsing, updates, audits, PO/FCL storage, and ICU QA live in `ferrocat`
 - host adapters render modules while the core stays portable
 
 That gives teams more than a benchmark number:

--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ The same foundation also matters for future translation workflows:
 ## Proof And Adoption Docs
 
 - [MDX-ready messaging source for homepage/docs](https://github.com/sebastian-software/palamedes/blob/main/docs/site/index.mdx)
+- [Catalog formats: PO and FCL](https://github.com/sebastian-software/palamedes/blob/main/docs/catalog-formats.md)
 - [Proof, benchmarks, and current maturity](https://github.com/sebastian-software/palamedes/blob/main/docs/proof-and-benchmarks.md)
 - [Stability and versioning](https://github.com/sebastian-software/palamedes/blob/main/docs/stability.md)
 - [Example matrix and local/CI verification story](https://github.com/sebastian-software/palamedes/blob/main/examples/README.md)

--- a/adr/006-ferrocat-as-catalog-and-icu-foundation.md
+++ b/adr/006-ferrocat-as-catalog-and-icu-foundation.md
@@ -37,6 +37,7 @@ That means Palamedes needs a clean boundary, not just a dependency swap.
 - PO parsing and serialization
 - catalog update semantics
 - normalized parsed-catalog access
+- PO and FCL storage semantics
 - ICU parsing and validation
 - plural and gettext-adjacent catalog behavior
 - other reusable host-neutral catalog primitives
@@ -71,3 +72,5 @@ Rejected because it recreates the fragmentation that the Rust-first architecture
 - Remaining local catalog logic in Palamedes should be treated as candidate delegation material, not as a permanent second foundation.
 - New generic catalog or ICU helpers should default to `ferrocat` unless they are clearly product-specific.
 - Catalog compilation/export for runtime maps can now be delegated to Ferrocat's artifact APIs and compiled-key contract, while Palamedes remains responsible for host-side module rendering and config-aware orchestration.
+- Palamedes exposes PO and FCL as product-shaped storage choices; it should not expose lower-level Ferrocat modes such as gettext-compatible PO through config or host APIs without a separate product decision.
+- Ferrocat option values should be built with the upstream `new()` and `with_*()` builder style, so future Ferrocat cleanup releases stay mechanical.

--- a/adr/011-host-adapters-render-module-source-from-compiled-catalog-artifacts.md
+++ b/adr/011-host-adapters-render-module-source-from-compiled-catalog-artifacts.md
@@ -5,7 +5,9 @@
 
 ## Context
 
-Palamedes compiles `.po` catalogs into runtime lookup maps, but Vite and Next do not consume that data directly. They consume generated JavaScript modules.
+Palamedes compiles configured catalogs into runtime lookup maps, but Vite and
+Next do not consume that data directly. They consume generated JavaScript
+modules.
 
 The Rust core previously combined both responsibilities:
 
@@ -29,7 +31,7 @@ The rules are:
 
 The intended stack is:
 
-- Rust core compiles `.po` catalogs into runtime-ready message maps
+- Rust core compiles configured PO or FCL catalogs into runtime-ready message maps
 - `palamedes-node` exposes that artifact through typed N-API bindings
 - Vite and Next adapters render the final module source for their host environment
 
@@ -49,3 +51,5 @@ Rejected for now because the rendering logic is small and duplication in the hos
 - `CatalogArtifactResult` exposes `messages` instead of `code`.
 - Host adapters are responsible for rendering their own module source.
 - The core becomes more host-neutral and easier to reuse outside the current Vite/Next integrations.
+- Catalog storage can evolve from PO-only to PO/FCL without moving JavaScript
+  module rendering back into Rust.

--- a/crates/palamedes-cli/src/config.rs
+++ b/crates/palamedes-cli/src/config.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use ::config as config_rs;
-use palamedes::{CatalogArtifactConfig, CatalogConfig, FallbackLocales};
+use palamedes::{CatalogArtifactConfig, CatalogConfig, FallbackLocales, PalamedesCatalogFormat};
 use serde::Deserialize;
 use thiserror::Error;
 
@@ -46,6 +46,8 @@ pub struct LoadedConfig {
 #[serde(rename_all = "kebab-case")]
 pub struct ConfigCatalog {
     pub path: String,
+    #[serde(default)]
+    pub format: PalamedesCatalogFormat,
     pub include: Vec<String>,
     #[serde(default)]
     pub exclude: Vec<String>,
@@ -102,6 +104,7 @@ impl LoadedConfig {
                 .iter()
                 .map(|catalog| CatalogConfig {
                     path: catalog.path.clone(),
+                    format: catalog.format,
                 })
                 .collect(),
         }

--- a/crates/palamedes-cli/src/main.rs
+++ b/crates/palamedes-cli/src/main.rs
@@ -12,10 +12,10 @@ use globset::{Glob, GlobSet, GlobSetBuilder};
 use ignore::WalkBuilder;
 use notify::{RecursiveMode, Watcher};
 use palamedes::{
-    audit_catalogs, combine_catalog_files, extract_catalog_messages_from_files, parse_po,
-    update_catalog_file, CatalogAuditDiagnostic, CatalogAuditRequest, CatalogAuditResult,
-    CatalogConflictStrategy, CatalogFileCombineRequest, CatalogFileFormat, CatalogUpdateMessage,
-    CatalogUpdateRequest, JsPoItem,
+    audit_catalogs, combine_catalog_files, extract_catalog_messages_from_files, parse_catalog,
+    parse_po, update_catalog_file, CatalogAuditDiagnostic, CatalogAuditRequest, CatalogAuditResult,
+    CatalogConflictStrategy, CatalogFileCombineRequest, CatalogFileFormat, CatalogParseRequest,
+    CatalogUpdateMessage, CatalogUpdateRequest,
 };
 use serde::Serialize;
 use thiserror::Error;
@@ -55,6 +55,9 @@ struct ExtractOptions {
     /// Remove obsolete messages from catalogs.
     #[arg(long)]
     clean: bool,
+    /// Remove obsolete messages immediately, including entries without obsolete-since.
+    #[arg(long)]
+    force_clean: bool,
     /// Show verbose output.
     #[arg(short, long)]
     verbose: bool,
@@ -108,6 +111,8 @@ struct CatalogCommand {
 enum CatalogSubcommand {
     /// Merge two catalog files with semantic use-first behavior.
     Merge(MergeOptions),
+    /// Convert configured PO catalogs to another Palamedes storage format.
+    Convert(ConvertOptions),
 }
 
 #[derive(Debug, Args)]
@@ -124,6 +129,9 @@ struct MergeOptions {
     /// Catalog format.
     #[arg(long)]
     format: Option<MergeFormat>,
+    /// Ancestor catalog path supplied by Git merge drivers.
+    #[arg(long)]
+    base: Option<PathBuf>,
     /// Catalog conflict strategy.
     #[arg(long, default_value = "use-first")]
     conflict_strategy: MergeConflictStrategy,
@@ -135,10 +143,36 @@ struct MergeOptions {
     locale: Option<String>,
 }
 
+#[derive(Debug, Args)]
+struct ConvertOptions {
+    /// Input catalog file for single-file conversion.
+    input: Option<PathBuf>,
+    /// Path to a Palamedes config file for config-wide conversion.
+    #[arg(short, long)]
+    config: Option<PathBuf>,
+    /// Target catalog format.
+    #[arg(long)]
+    to: ConvertFormat,
+    /// Output catalog path for single-file conversion.
+    #[arg(long)]
+    output: Option<PathBuf>,
+    /// Source locale for single-file conversion.
+    #[arg(long, default_value = "en")]
+    source_locale: String,
+    /// Locale for single-file conversion.
+    #[arg(long)]
+    locale: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+enum ConvertFormat {
+    Fcl,
+}
+
 #[derive(Clone, Copy, Debug, ValueEnum)]
 enum MergeFormat {
     Po,
-    Ndjson,
+    Fcl,
 }
 
 #[derive(Clone, Copy, Debug, ValueEnum)]
@@ -164,6 +198,14 @@ enum CliError {
     Json(#[from] serde_json::Error),
     #[error("Catalog merge requires exactly two input files, received {0}.")]
     InvalidMergeInputCount(usize),
+    #[error("Catalog convert requires either an input file or --config.")]
+    MissingConvertInput,
+    #[error("Catalog convert --output can only be used with a single input file.")]
+    InvalidConvertOutput,
+    #[error("Catalog convert --to=fcl only supports PO source catalogs.")]
+    UnsupportedConvertSource,
+    #[error("Catalog convert refused {path} because fuzzy PO entries are not supported for FCL conversion.")]
+    FuzzyCatalogInput { path: PathBuf },
     #[error("Invalid --fail-if-below value. Expected a percent from 0 to 100.")]
     InvalidThreshold,
     #[error("Catalog audit failed with {errors} error(s).")]
@@ -213,7 +255,6 @@ struct LocaleCompletenessReport {
     total: usize,
     translated: usize,
     missing: usize,
-    fuzzy: usize,
     percent: f64,
 }
 
@@ -229,7 +270,6 @@ struct MutableLocaleStats {
     total: usize,
     translated: usize,
     missing: usize,
-    fuzzy: usize,
 }
 
 fn main() {
@@ -247,6 +287,7 @@ fn run() -> Result<(), CliError> {
         Command::Report(options) => run_report(options).map(|_| ()),
         Command::Catalog(command) => match command.command {
             CatalogSubcommand::Merge(options) => run_catalog_merge(options).map(|_| ()),
+            CatalogSubcommand::Convert(options) => run_catalog_convert(options).map(|_| ()),
         },
         Command::Version => {
             println!("pmds (Palamedes) v{}", env!("CARGO_PKG_VERSION"));
@@ -367,10 +408,10 @@ fn write_catalog(
     options: &ExtractOptions,
 ) -> Result<u128, CliError> {
     let started_at = Instant::now();
-    let po_path = config
+    let catalog_path = config
         .resolve_catalog_path(&catalog.path, locale)
-        .with_extension("po");
-    if let Some(parent) = po_path.parent() {
+        .with_extension(catalog.format.extension());
+    if let Some(parent) = catalog_path.parent() {
         fs::create_dir_all(parent).map_err(|source| CliError::Io {
             path: parent.to_path_buf(),
             source,
@@ -378,15 +419,17 @@ fn write_catalog(
     }
 
     let result = update_catalog_file(CatalogUpdateRequest {
-        target_path: po_path.to_string_lossy().into_owned(),
+        target_path: catalog_path.to_string_lossy().into_owned(),
         locale: locale.to_owned(),
         source_locale: config.source_locale.clone(),
         clean: options.clean,
+        force_clean: options.force_clean,
+        format: catalog.format,
         messages: messages.to_vec(),
     })?;
 
     if options.verbose {
-        eprintln!("  -> {}", po_path.display());
+        eprintln!("  -> {}", catalog_path.display());
         for diagnostic in result.diagnostics {
             eprintln!("Warning: {}: {}", diagnostic.code, diagnostic.message);
         }
@@ -682,7 +725,6 @@ fn build_report(config: &LoadedConfig, locales: &[String]) -> Result<Completenes
                     total: 0,
                     translated: 0,
                     missing: 0,
-                    fuzzy: 0,
                 },
             )
         })
@@ -691,13 +733,20 @@ fn build_report(config: &LoadedConfig, locales: &[String]) -> Result<Completenes
     for catalog in &config.catalogs {
         let source_path = config
             .resolve_catalog_path(&catalog.path, &config.source_locale)
-            .with_extension("po");
-        let source_catalog = read_po(&source_path)?;
+            .with_extension(catalog.format.extension());
+        let source_catalog = read_catalog_for_report(
+            &source_path,
+            &config.source_locale,
+            &config.source_locale,
+            catalog.format,
+        )?;
         let source_messages = source_catalog
-            .items
-            .iter()
-            .filter(|item| is_reportable_message(item))
-            .map(to_message_key)
+            .into_iter()
+            .filter(|message| !message.obsolete)
+            .map(|message| MessageKey {
+                message: message.message,
+                context: message.context,
+            })
             .collect::<Vec<_>>();
 
         for locale in locales {
@@ -713,27 +762,36 @@ fn build_report(config: &LoadedConfig, locales: &[String]) -> Result<Completenes
 
             let target_path = config
                 .resolve_catalog_path(&catalog.path, locale)
-                .with_extension("po");
-            let target_catalog = read_po_if_exists(&target_path)?;
-            let target_messages = target_catalog
-                .map(|catalog| {
-                    catalog
-                        .items
-                        .into_iter()
-                        .filter(is_reportable_message)
-                        .map(|item| (to_message_key(&item), item))
-                        .collect::<BTreeMap<_, _>>()
+                .with_extension(catalog.format.extension());
+            let target_messages = if target_path.exists() {
+                read_catalog_for_report(
+                    &target_path,
+                    &config.source_locale,
+                    locale,
+                    catalog.format,
+                )?
+                .into_iter()
+                .filter(|message| !message.obsolete)
+                .map(|message| {
+                    (
+                        MessageKey {
+                            message: message.message,
+                            context: message.context,
+                        },
+                        message.translated,
+                    )
                 })
-                .unwrap_or_default();
+                .collect::<BTreeMap<_, _>>()
+            } else {
+                BTreeMap::new()
+            };
 
             for source_message in &source_messages {
                 let Some(target) = target_messages.get(source_message) else {
                     locale_stats.missing += 1;
                     continue;
                 };
-                if target.flags.get("fuzzy").copied().unwrap_or(false) {
-                    locale_stats.fuzzy += 1;
-                } else if is_translated(target) {
+                if *target {
                     locale_stats.translated += 1;
                 } else {
                     locale_stats.missing += 1;
@@ -755,10 +813,24 @@ fn build_report(config: &LoadedConfig, locales: &[String]) -> Result<Completenes
                 total: locale.total,
                 translated: locale.translated,
                 missing: locale.missing,
-                fuzzy: locale.fuzzy,
             })
             .collect(),
     })
+}
+
+fn read_catalog_for_report(
+    path: &Path,
+    source_locale: &str,
+    locale: &str,
+    format: palamedes::PalamedesCatalogFormat,
+) -> Result<Vec<palamedes::ParsedCatalogMessage>, CliError> {
+    let result = parse_catalog(&CatalogParseRequest {
+        target_path: path.to_string_lossy().into_owned(),
+        locale: locale.to_owned(),
+        source_locale: source_locale.to_owned(),
+        format,
+    })?;
+    Ok(result.messages)
 }
 
 fn read_po(path: &Path) -> Result<palamedes::JsPoFile, CliError> {
@@ -767,32 +839,6 @@ fn read_po(path: &Path) -> Result<palamedes::JsPoFile, CliError> {
         source,
     })?;
     Ok(parse_po(&source)?)
-}
-
-fn read_po_if_exists(path: &Path) -> Result<Option<palamedes::JsPoFile>, CliError> {
-    match fs::read_to_string(path) {
-        Ok(source) => Ok(Some(parse_po(&source)?)),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
-        Err(source) => Err(CliError::Io {
-            path: path.to_path_buf(),
-            source,
-        }),
-    }
-}
-
-fn is_reportable_message(item: &JsPoItem) -> bool {
-    !item.obsolete && !item.msgid.is_empty()
-}
-
-fn to_message_key(item: &JsPoItem) -> MessageKey {
-    MessageKey {
-        message: item.msgid.clone(),
-        context: item.msgctxt.clone(),
-    }
-}
-
-fn is_translated(item: &JsPoItem) -> bool {
-    !item.msgstr.is_empty() && item.msgstr.iter().all(|value| !value.trim().is_empty())
 }
 
 fn resolve_report_locales(config: &LoadedConfig, selected: &[String]) -> Vec<String> {
@@ -837,17 +883,16 @@ fn print_report(result: &CompletenessReport) {
         + 2;
 
     println!(
-        "{:<locale_column_width$}Translated  Missing  Fuzzy  Complete",
+        "{:<locale_column_width$}Translated  Missing  Complete",
         "Locale"
     );
     for locale in &result.locales {
         let translated = format!("{}/{}", locale.translated, locale.total);
         println!(
-            "{:<locale_column_width$}{:<11} {:<8} {:<6} {}",
+            "{:<locale_column_width$}{:<11} {:<8} {}",
             locale.locale,
             translated,
             locale.missing,
-            locale.fuzzy,
             format_percent(locale.percent)
         );
     }
@@ -880,12 +925,17 @@ fn run_catalog_merge(
         },
     };
 
+    let mut input_paths = options.inputs;
+    if let Some(base) = options.base {
+        input_paths.push(base);
+    }
+
     Ok(combine_catalog_files(CatalogFileCombineRequest {
-        input_paths: options.inputs,
+        input_paths,
         output_path: options.output,
         format: options.format.map(|format| match format {
             MergeFormat::Po => CatalogFileFormat::Po,
-            MergeFormat::Ndjson => CatalogFileFormat::Ndjson,
+            MergeFormat::Fcl => CatalogFileFormat::Fcl,
         }),
         source_locale,
         locale: options.locale,
@@ -895,6 +945,123 @@ fn run_catalog_merge(
             MergeConflictStrategy::Error => CatalogConflictStrategy::Error,
         },
     })?)
+}
+
+fn run_catalog_convert(options: ConvertOptions) -> Result<(), CliError> {
+    match (options.input, options.config) {
+        (Some(input), config_path) => {
+            let output = options
+                .output
+                .unwrap_or_else(|| input.with_extension(convert_extension(options.to)));
+            convert_one_catalog(
+                &input,
+                &output,
+                &options.source_locale,
+                options.locale.as_deref(),
+                options.to,
+            )?;
+            println!("Converted {} -> {}", input.display(), output.display());
+            if config_path.is_some() {
+                println!(
+                    "Single-file input provided; --config was not used for catalog selection."
+                );
+            }
+            Ok(())
+        }
+        (None, Some(config_path)) => {
+            if options.output.is_some() {
+                return Err(CliError::InvalidConvertOutput);
+            }
+            let config = load_config(
+                &std::env::current_dir().expect("current dir"),
+                Some(&config_path),
+            )?;
+            let mut converted = 0usize;
+            let mut skipped = 0usize;
+            for catalog in &config.catalogs {
+                if catalog.format != palamedes::PalamedesCatalogFormat::Po {
+                    skipped += config.locales.len();
+                    continue;
+                }
+                for locale in &config.locales {
+                    let input = config
+                        .resolve_catalog_path(&catalog.path, locale)
+                        .with_extension(catalog.format.extension());
+                    if !input.exists() {
+                        skipped += 1;
+                        continue;
+                    }
+                    let output = config
+                        .resolve_catalog_path(&catalog.path, locale)
+                        .with_extension(convert_extension(options.to));
+                    convert_one_catalog(
+                        &input,
+                        &output,
+                        &config.source_locale,
+                        Some(locale),
+                        options.to,
+                    )?;
+                    converted += 1;
+                }
+            }
+            println!("Converted {converted} catalog(s), skipped {skipped}.");
+            println!(
+                "Update Palamedes config catalogs to use `format: fcl` before switching workflows."
+            );
+            Ok(())
+        }
+        (None, None) => Err(CliError::MissingConvertInput),
+    }
+}
+
+fn convert_one_catalog(
+    input: &Path,
+    output: &Path,
+    source_locale: &str,
+    locale: Option<&str>,
+    to: ConvertFormat,
+) -> Result<(), CliError> {
+    if input.extension().and_then(|ext| ext.to_str()) != Some("po") {
+        return Err(CliError::UnsupportedConvertSource);
+    }
+    reject_fuzzy_po(input)?;
+    if let Some(parent) = output.parent() {
+        fs::create_dir_all(parent).map_err(|source| CliError::Io {
+            path: parent.to_path_buf(),
+            source,
+        })?;
+    }
+    combine_catalog_files(CatalogFileCombineRequest {
+        input_paths: vec![input.to_path_buf()],
+        output_path: output.to_path_buf(),
+        format: Some(match to {
+            ConvertFormat::Fcl => CatalogFileFormat::Fcl,
+        }),
+        source_locale: source_locale.to_owned(),
+        locale: locale.map(str::to_owned),
+        conflict_strategy: CatalogConflictStrategy::UseFirst,
+    })?;
+    Ok(())
+}
+
+fn reject_fuzzy_po(path: &Path) -> Result<(), CliError> {
+    let catalog = read_po(path)?;
+    if catalog
+        .items
+        .iter()
+        .any(|item| item.flags.get("fuzzy").copied().unwrap_or(false))
+    {
+        return Err(CliError::FuzzyCatalogInput {
+            path: path.to_path_buf(),
+        });
+    }
+    Ok(())
+}
+
+const fn convert_extension(to: ConvertFormat) -> &'static str {
+    match to {
+        ConvertFormat::Fcl => "fcl",
+    }
 }
 
 #[cfg(test)]
@@ -922,7 +1089,7 @@ mod tests {
 
         let output = fs::read_to_string(app.join("locales/en/messages.po")).expect("read po");
         assert!(output.contains("msgid \"Dashboard\""));
-        assert!(output.contains("#: apps/web/app/page.tsx:2"));
+        assert!(output.contains("#: apps/web/app/page.tsx"));
     }
 
     #[test]
@@ -940,7 +1107,7 @@ mod tests {
         run_extraction(&config, &extract_options()).expect("extract");
 
         let output = fs::read_to_string(app.join("locales/en/messages.po")).expect("read po");
-        assert!(output.contains("#: app/page.tsx:2"));
+        assert!(output.contains("#: app/page.tsx"));
     }
 
     #[test]
@@ -975,7 +1142,7 @@ catalogs:
     }
 
     #[test]
-    fn report_counts_translated_missing_and_fuzzy_messages() {
+    fn report_counts_translated_and_missing_messages() {
         let app = temp_dir("report");
         write_config(&app, None);
         fs::create_dir_all(app.join("locales/en")).expect("create source locale");
@@ -995,8 +1162,7 @@ catalogs:
         let report = build_report(&config, &["de".to_owned()]).expect("build report");
 
         assert_eq!(report.locales[0].total, 2);
-        assert_eq!(report.locales[0].translated, 0);
-        assert_eq!(report.locales[0].fuzzy, 1);
+        assert_eq!(report.locales[0].translated, 1);
         assert_eq!(report.locales[0].missing, 1);
     }
 
@@ -1024,6 +1190,7 @@ source-locale: en
             config: None,
             watch: false,
             clean: false,
+            force_clean: false,
             verbose: false,
         }
     }

--- a/crates/palamedes-node/src/catalog.rs
+++ b/crates/palamedes-node/src/catalog.rs
@@ -4,13 +4,22 @@ use std::path::PathBuf;
 use napi::bindgen_prelude::{Either, Result};
 use napi_derive::napi;
 
-use crate::catalog_config::{CatalogArtifactRequest, CatalogArtifactSelectedRequest};
+use crate::catalog_config::{
+    CatalogArtifactRequest, CatalogArtifactSelectedRequest, CatalogConfigFormat,
+};
 use crate::shared::{checked_u32, to_napi_error};
 
 #[napi(object)]
 pub struct CatalogOrigin {
     pub file: String,
     pub line: u32,
+    pub scope: Option<String>,
+}
+
+#[napi(object)]
+pub struct ParsedCatalogOrigin {
+    pub file: String,
+    pub scope: Option<String>,
 }
 
 #[napi(object)]
@@ -28,6 +37,8 @@ pub struct CatalogUpdateRequest {
     pub locale: String,
     pub source_locale: String,
     pub clean: bool,
+    pub force_clean: Option<bool>,
+    pub format: Option<CatalogConfigFormat>,
     pub messages: Vec<CatalogUpdateMessage>,
 }
 
@@ -54,6 +65,7 @@ pub struct CatalogParseRequest {
     pub target_path: String,
     pub locale: String,
     pub source_locale: String,
+    pub format: Option<CatalogConfigFormat>,
 }
 
 #[napi(object)]
@@ -61,17 +73,22 @@ pub struct ParsedCatalogMessage {
     pub message: String,
     pub context: Option<String>,
     pub comments: Vec<String>,
-    pub origins: Vec<CatalogOrigin>,
+    pub origins: Vec<ParsedCatalogOrigin>,
     pub obsolete: bool,
-    pub machine_translation: Option<MachineTranslationMetadata>,
+    pub translated: bool,
+    pub machine: Option<MachineMetadata>,
 }
 
 #[napi(object)]
-pub struct MachineTranslationMetadata {
+pub struct MachineMetadata {
+    pub lock: String,
+    pub ai: Option<AiProvenance>,
+}
+
+#[napi(object)]
+pub struct AiProvenance {
     pub model: String,
-    pub modified: Option<String>,
-    pub confidence: Option<u8>,
-    pub hash: String,
+    pub confidence: Option<f64>,
 }
 
 #[napi(object)]
@@ -137,7 +154,7 @@ pub struct CatalogCombineResult {
 #[napi(string_enum)]
 pub enum CatalogFileFormat {
     Po,
-    Ndjson,
+    Fcl,
 }
 
 #[napi(object)]
@@ -186,7 +203,6 @@ pub struct CatalogAuditCheckOptions {
     pub icu_syntax: Option<bool>,
     pub icu_compatibility: Option<bool>,
     pub semantic_metadata: Option<bool>,
-    pub fuzzy_flags: Option<bool>,
     pub obsolete_entries: Option<bool>,
 }
 
@@ -396,6 +412,7 @@ impl From<CatalogOrigin> for palamedes::CatalogUpdateOrigin {
         Self {
             file: value.file,
             line: value.line,
+            scope: value.scope,
         }
     }
 }
@@ -423,6 +440,11 @@ impl From<CatalogUpdateRequest> for palamedes::CatalogUpdateRequest {
             locale: value.locale,
             source_locale: value.source_locale,
             clean: value.clean,
+            force_clean: value.force_clean.unwrap_or(false),
+            format: value
+                .format
+                .map(palamedes::PalamedesCatalogFormat::from)
+                .unwrap_or_default(),
             messages: value
                 .messages
                 .into_iter()
@@ -437,6 +459,16 @@ impl From<palamedes::CatalogUpdateOrigin> for CatalogOrigin {
         Self {
             file: value.file,
             line: value.line,
+            scope: value.scope,
+        }
+    }
+}
+
+impl From<palamedes::CatalogOriginMetadata> for ParsedCatalogOrigin {
+    fn from(value: palamedes::CatalogOriginMetadata) -> Self {
+        Self {
+            file: value.file,
+            scope: value.scope,
         }
     }
 }
@@ -479,6 +511,10 @@ impl From<CatalogParseRequest> for palamedes::CatalogParseRequest {
             target_path: value.target_path,
             locale: value.locale,
             source_locale: value.source_locale,
+            format: value
+                .format
+                .map(palamedes::PalamedesCatalogFormat::from)
+                .unwrap_or_default(),
         }
     }
 }
@@ -489,22 +525,32 @@ impl From<palamedes::ParsedCatalogMessage> for ParsedCatalogMessage {
             message: value.message,
             context: value.context,
             comments: value.comments,
-            origins: value.origins.into_iter().map(CatalogOrigin::from).collect(),
+            origins: value
+                .origins
+                .into_iter()
+                .map(ParsedCatalogOrigin::from)
+                .collect(),
             obsolete: value.obsolete,
-            machine_translation: value
-                .machine_translation
-                .map(MachineTranslationMetadata::from),
+            translated: value.translated,
+            machine: value.machine.map(MachineMetadata::from),
         }
     }
 }
 
-impl From<palamedes::MachineTranslationMetadata> for MachineTranslationMetadata {
-    fn from(value: palamedes::MachineTranslationMetadata) -> Self {
+impl From<palamedes::MachineMetadata> for MachineMetadata {
+    fn from(value: palamedes::MachineMetadata) -> Self {
+        Self {
+            lock: value.lock,
+            ai: value.ai.map(AiProvenance::from),
+        }
+    }
+}
+
+impl From<palamedes::AiProvenance> for AiProvenance {
+    fn from(value: palamedes::AiProvenance) -> Self {
         Self {
             model: value.model,
-            modified: value.modified,
-            confidence: value.confidence,
-            hash: value.hash,
+            confidence: value.confidence.map(f64::from),
         }
     }
 }
@@ -606,7 +652,7 @@ impl From<CatalogFileFormat> for palamedes::CatalogFileFormat {
     fn from(value: CatalogFileFormat) -> Self {
         match value {
             CatalogFileFormat::Po => Self::Po,
-            CatalogFileFormat::Ndjson => Self::Ndjson,
+            CatalogFileFormat::Fcl => Self::Fcl,
         }
     }
 }
@@ -617,12 +663,7 @@ impl TryFrom<palamedes::CatalogFileFormat> for CatalogFileFormat {
     fn try_from(value: palamedes::CatalogFileFormat) -> Result<Self> {
         match value {
             palamedes::CatalogFileFormat::Po => Ok(Self::Po),
-            palamedes::CatalogFileFormat::Ndjson => Ok(Self::Ndjson),
-            // Ferrocat may add formats before Palamedes exposes them through
-            // the Node API. Fail explicitly until the TypeScript surface is extended.
-            _ => Err(napi::Error::from_reason(format!(
-                "Unsupported catalog file combine format: {value:?}. Expected `po` or `ndjson`."
-            ))),
+            palamedes::CatalogFileFormat::Fcl => Ok(Self::Fcl),
         }
     }
 }
@@ -691,7 +732,6 @@ impl From<CatalogAuditCheckOptions> for palamedes::CatalogAuditCheckOptions {
             icu_syntax: value.icu_syntax,
             icu_compatibility: value.icu_compatibility,
             semantic_metadata: value.semantic_metadata,
-            fuzzy_flags: value.fuzzy_flags,
             obsolete_entries: value.obsolete_entries,
         }
     }

--- a/crates/palamedes-node/src/catalog_config.rs
+++ b/crates/palamedes-node/src/catalog_config.rs
@@ -9,8 +9,15 @@ use napi_derive::napi;
 #[napi(object)]
 pub struct CatalogArtifactCatalogConfig {
     pub path: String,
+    pub format: Option<CatalogConfigFormat>,
     pub include: Vec<String>,
     pub exclude: Option<Vec<String>>,
+}
+
+#[napi(string_enum)]
+pub enum CatalogConfigFormat {
+    Po,
+    Fcl,
 }
 
 #[napi(object)]
@@ -40,7 +47,22 @@ impl From<CatalogArtifactCatalogConfig> for palamedes::CatalogConfig {
     fn from(value: CatalogArtifactCatalogConfig) -> Self {
         let _ = value.include;
         let _ = value.exclude;
-        Self { path: value.path }
+        Self {
+            path: value.path,
+            format: value
+                .format
+                .map(palamedes::PalamedesCatalogFormat::from)
+                .unwrap_or_default(),
+        }
+    }
+}
+
+impl From<CatalogConfigFormat> for palamedes::PalamedesCatalogFormat {
+    fn from(value: CatalogConfigFormat) -> Self {
+        match value {
+            CatalogConfigFormat::Po => Self::Po,
+            CatalogConfigFormat::Fcl => Self::Fcl,
+        }
     }
 }
 

--- a/crates/palamedes/Cargo.toml
+++ b/crates/palamedes/Cargo.toml
@@ -8,8 +8,9 @@ rust-version.workspace = true
 description = "Rust core for Palamedes."
 
 [dependencies]
-ferrocat = "1.3.1"
-ferrocat-po = "1.3.1"
+ferrocat = "=2.1.1"
+ferrocat-icu = "=2.1.1"
+ferrocat-po = "=2.1.1"
 oxc_allocator = "0.133.0"
 oxc_ast = "0.133.0"
 oxc_ast_visit = "0.133.0"

--- a/crates/palamedes/src/catalog_artifact/compile.rs
+++ b/crates/palamedes/src/catalog_artifact/compile.rs
@@ -1,9 +1,9 @@
 use std::path::PathBuf;
 
 use ferrocat::{
-    pseudolocalize_compiled_catalog_artifact_with_syntax_policy, CompileCatalogArtifactIcuOptions,
-    IcuArgumentKind, IcuDiagnosticSeverity, IcuFormatter, IcuFormatterSupport,
-    IcuPseudolocalizationOptions, IcuSyntaxPolicy,
+    pseudolocalize_compiled_catalog_artifact, CompileCatalogArtifactIcuOptions,
+    CompiledCatalogPseudolocalizationOptions, IcuArgumentKind, IcuDiagnosticSeverity, IcuFormatter,
+    IcuFormatterSupport, IcuPseudolocalizationOptions, IcuSyntaxPolicy,
 };
 
 use crate::error::{PalamedesError, PalamedesResult};
@@ -26,12 +26,11 @@ pub(super) fn build_artifact_result(
     locale: &str,
 ) -> PalamedesResult<CatalogArtifactResult> {
     let artifact = if pseudo_locale == Some(locale) {
-        pseudolocalize_compiled_catalog_artifact_with_syntax_policy(
-            &artifact,
-            &IcuPseudolocalizationOptions::new(),
-            IcuSyntaxPolicy::RuntimeLiteralApostrophes,
-        )
-        .map_err(PalamedesError::PseudolocalizeCatalogArtifact)?
+        let options = CompiledCatalogPseudolocalizationOptions::new()
+            .with_icu_options(IcuPseudolocalizationOptions::new())
+            .with_syntax_policy(IcuSyntaxPolicy::RuntimeLiteralApostrophes);
+        pseudolocalize_compiled_catalog_artifact(&artifact, &options)
+            .map_err(PalamedesError::PseudolocalizeCatalogArtifact)?
     } else {
         artifact
     };

--- a/crates/palamedes/src/catalog_artifact/load.rs
+++ b/crates/palamedes/src/catalog_artifact/load.rs
@@ -2,12 +2,12 @@ use std::collections::BTreeMap;
 use std::fs;
 use std::path::Path;
 
-use ferrocat::{parse_catalog, CatalogMode, NormalizedParsedCatalog, ParseCatalogOptions};
+use ferrocat::{parse_catalog, NormalizedParsedCatalog, ParseCatalogOptions};
 
 use crate::error::{PalamedesError, PalamedesResult};
 
 use super::resolve::normalize_path;
-use super::types::CatalogArtifactConfig;
+use super::types::{CatalogArtifactConfig, CatalogConfig};
 
 pub(super) type LocaleCatalogs = BTreeMap<String, NormalizedParsedCatalog>;
 
@@ -31,9 +31,11 @@ pub(super) fn load_catalogs(
             path: file.clone(),
             source,
         })?;
-        let mut options = ParseCatalogOptions::new(&content, &config.source_locale);
-        options.locale = Some(locale.as_str());
-        options.mode = CatalogMode::IcuPo;
+        let catalog = catalog_for_path(file, config)
+            .ok_or_else(|| PalamedesError::CouldNotInferLocale { path: file.clone() })?;
+        let options = ParseCatalogOptions::new(&content, &config.source_locale)
+            .with_locale(locale.as_str())
+            .with_mode(catalog.format.ferrocat_mode());
 
         let parsed = parse_catalog(options).map_err(|source| PalamedesError::ParseCatalog {
             path: file.clone(),
@@ -59,7 +61,7 @@ fn infer_locale_from_path(path: &Path, config: &CatalogArtifactConfig) -> Option
     for catalog in &config.catalogs {
         let absolute_catalog_path = Path::new(&config.root_dir)
             .join(&catalog.path)
-            .with_extension("po");
+            .with_extension(catalog.format.extension());
         let pattern = normalize_path(&absolute_catalog_path);
         let escaped = regex::escape(&pattern);
         let regex_pattern = escaped.replace("\\{locale\\}", "([^/]+)");
@@ -69,4 +71,22 @@ fn infer_locale_from_path(path: &Path, config: &CatalogArtifactConfig) -> Option
         }
     }
     None
+}
+
+fn catalog_for_path<'a>(
+    path: &Path,
+    config: &'a CatalogArtifactConfig,
+) -> Option<&'a CatalogConfig> {
+    let normalized_resource = normalize_path(path);
+    config.catalogs.iter().find(|catalog| {
+        let absolute_catalog_path = Path::new(&config.root_dir)
+            .join(&catalog.path)
+            .with_extension(catalog.format.extension());
+        let pattern = normalize_path(&absolute_catalog_path);
+        let escaped = regex::escape(&pattern);
+        let regex_pattern = escaped.replace("\\{locale\\}", "([^/]+)");
+        regex::Regex::new(&format!("^{regex_pattern}$"))
+            .map(|matcher| matcher.is_match(&normalized_resource))
+            .unwrap_or(false)
+    })
 }

--- a/crates/palamedes/src/catalog_artifact/mod.rs
+++ b/crates/palamedes/src/catalog_artifact/mod.rs
@@ -9,8 +9,8 @@ mod tests;
 use std::path::PathBuf;
 
 use ferrocat::{
-    compile_catalog_artifact_selected_with_icu_options as ferrocat_compile_catalog_artifact_selected,
-    compile_catalog_artifact_with_icu_options as ferrocat_compile_catalog_artifact,
+    compile_catalog_artifact as ferrocat_compile_catalog_artifact,
+    compile_catalog_artifact_selected as ferrocat_compile_catalog_artifact_selected,
     CompileCatalogArtifactOptions, CompileSelectedCatalogArtifactOptions, CompiledCatalogIdIndex,
     CompiledKeyStrategy,
 };
@@ -24,6 +24,7 @@ pub use self::types::{
     CatalogArtifactConfig, CatalogArtifactDiagnostic, CatalogArtifactDiagnosticSeverity,
     CatalogArtifactMissingMessage, CatalogArtifactRequest, CatalogArtifactResult,
     CatalogArtifactSelectedRequest, CatalogArtifactSourceKey, CatalogConfig, FallbackLocales,
+    PalamedesCatalogFormat,
 };
 
 struct PreparedCompilation {
@@ -50,15 +51,20 @@ pub fn compile_catalog_artifact(
         &prepared.locale,
         &request.config.source_locale,
     );
-    let mut options =
-        CompileCatalogArtifactOptions::new(&prepared.locale, &request.config.source_locale);
-    options.fallback_chain = &ferrocat_fallback_chain;
-    options.key_strategy = CompiledKeyStrategy::FerrocatV1;
-    options.source_fallback = true;
-    options.icu_compatibility = true;
-
+    let ferrocat_fallback_chain_refs = ferrocat_fallback_chain
+        .iter()
+        .map(String::as_str)
+        .collect::<Vec<_>>();
     let icu_options = runtime_icu_options();
-    let artifact = ferrocat_compile_catalog_artifact(&catalogs, &options, &icu_options)
+    let options =
+        CompileCatalogArtifactOptions::new(&prepared.locale, &request.config.source_locale)
+            .with_fallback_chain(&ferrocat_fallback_chain_refs)
+            .with_key_strategy(CompiledKeyStrategy::FerrocatV1)
+            .with_source_fallback(true)
+            .with_icu_compatibility(true)
+            .with_icu_options(icu_options);
+
+    let artifact = ferrocat_compile_catalog_artifact(&catalogs, &options)
         .map_err(PalamedesError::CompileCatalogArtifact)?;
 
     build_artifact_result(
@@ -89,24 +95,33 @@ pub fn compile_catalog_artifact_selected(
         &prepared.locale,
         &request.config.source_locale,
     );
-    let mut options = CompileSelectedCatalogArtifactOptions::new(
+    let ferrocat_fallback_chain_refs = ferrocat_fallback_chain
+        .iter()
+        .map(String::as_str)
+        .collect::<Vec<_>>();
+    let icu_options = runtime_icu_options();
+    let artifact_options =
+        CompileCatalogArtifactOptions::new(&prepared.locale, &request.config.source_locale)
+            .with_fallback_chain(&ferrocat_fallback_chain_refs)
+            .with_key_strategy(CompiledKeyStrategy::FerrocatV1)
+            .with_source_fallback(true)
+            .with_icu_compatibility(true)
+            .with_icu_options(icu_options);
+    let compiled_id_refs = request
+        .compiled_ids
+        .iter()
+        .map(String::as_str)
+        .collect::<Vec<_>>();
+    let options = CompileSelectedCatalogArtifactOptions::new(
         &prepared.locale,
         &request.config.source_locale,
-        &request.compiled_ids,
-    );
-    options.options.fallback_chain = &ferrocat_fallback_chain;
-    options.options.key_strategy = CompiledKeyStrategy::FerrocatV1;
-    options.options.source_fallback = true;
-    options.options.icu_compatibility = true;
-
-    let icu_options = runtime_icu_options();
-    let artifact = ferrocat_compile_catalog_artifact_selected(
-        &catalogs,
-        &compiled_id_index,
-        &options,
-        &icu_options,
+        &compiled_id_refs,
     )
-    .map_err(PalamedesError::CompileSelectedCatalogArtifact)?;
+    .with_options(artifact_options);
+
+    let artifact =
+        ferrocat_compile_catalog_artifact_selected(&catalogs, &compiled_id_index, &options)
+            .map_err(PalamedesError::CompileSelectedCatalogArtifact)?;
 
     build_artifact_result(
         artifact,

--- a/crates/palamedes/src/catalog_artifact/resolve.rs
+++ b/crates/palamedes/src/catalog_artifact/resolve.rs
@@ -92,7 +92,7 @@ fn resolve_catalog_request(
 ) -> PalamedesResult<ResolvedCatalogRequest> {
     for catalog in &config.catalogs {
         let absolute_catalog_path = Path::new(&config.root_dir).join(&catalog.path);
-        let absolute_po_path = absolute_catalog_path.with_extension("po");
+        let absolute_po_path = absolute_catalog_path.with_extension(catalog.format.extension());
         let pattern = normalize_path(&absolute_po_path);
         let escaped = regex::escape(&pattern);
         let regex_pattern = escaped.replace("\\{locale\\}", "([^/]+)");
@@ -143,7 +143,8 @@ fn collect_watch_files(
 
     for catalog in &config.catalogs {
         let absolute_catalog_path = root_dir.join(&catalog.path);
-        let pattern = normalize_path(&absolute_catalog_path.with_extension("po"));
+        let pattern =
+            normalize_path(&absolute_catalog_path.with_extension(catalog.format.extension()));
         let primary_pattern = normalize_path(primary_file);
         let escaped = regex::escape(&pattern);
         let regex_pattern = escaped.replace("\\{locale\\}", "([^/]+)");
@@ -157,7 +158,7 @@ fn collect_watch_files(
             for locale in locale_chain {
                 let candidate = root_dir
                     .join(catalog.path.replace("{locale}", locale))
-                    .with_extension("po");
+                    .with_extension(catalog.format.extension());
                 if !files.contains(&candidate) {
                     files.push(candidate);
                 }

--- a/crates/palamedes/src/catalog_artifact/tests.rs
+++ b/crates/palamedes/src/catalog_artifact/tests.rs
@@ -1,7 +1,7 @@
 use super::{
     compile_catalog_artifact, compile_catalog_artifact_selected, CatalogArtifactConfig,
     CatalogArtifactDiagnosticSeverity, CatalogArtifactRequest, CatalogArtifactSelectedRequest,
-    CatalogConfig,
+    CatalogConfig, PalamedesCatalogFormat,
 };
 use ferrocat::compiled_key;
 use std::collections::BTreeSet;
@@ -51,6 +51,7 @@ msgstr "Hallo"
             pseudo_locale: None,
             catalogs: vec![CatalogConfig {
                 path: "src/locales/{locale}".to_owned(),
+                format: PalamedesCatalogFormat::Po,
             }],
         },
         resource_path: locale_dir.join("de.po").to_string_lossy().into_owned(),
@@ -115,6 +116,7 @@ msgstr "{name"
             pseudo_locale: None,
             catalogs: vec![CatalogConfig {
                 path: "src/locales/{locale}".to_owned(),
+                format: PalamedesCatalogFormat::Po,
             }],
         },
         resource_path: locale_dir.join("de.po").to_string_lossy().into_owned(),
@@ -185,6 +187,7 @@ msgstr ""
             pseudo_locale: None,
             catalogs: vec![CatalogConfig {
                 path: "src/locales/{locale}".to_owned(),
+                format: PalamedesCatalogFormat::Po,
             }],
         },
         resource_path: locale_dir.join("fr.po").to_string_lossy().into_owned(),
@@ -230,6 +233,7 @@ msgstr ""
             pseudo_locale: Some("pseudo".to_owned()),
             catalogs: vec![CatalogConfig {
                 path: "src/locales/{locale}".to_owned(),
+                format: PalamedesCatalogFormat::Po,
             }],
         },
         resource_path: locale_dir.join("pseudo.po").to_string_lossy().into_owned(),
@@ -286,6 +290,7 @@ msgstr ""
             pseudo_locale: Some("pseudo".to_owned()),
             catalogs: vec![CatalogConfig {
                 path: "src/locales/{locale}".to_owned(),
+                format: PalamedesCatalogFormat::Po,
             }],
         },
         resource_path: locale_dir.join("pseudo.po").to_string_lossy().into_owned(),
@@ -344,6 +349,7 @@ msgstr "Konnte {firstName}'s Daten nicht laden"
             pseudo_locale: None,
             catalogs: vec![CatalogConfig {
                 path: "src/locales/{locale}".to_owned(),
+                format: PalamedesCatalogFormat::Po,
             }],
         },
         resource_path: locale_dir.join("de.po").to_string_lossy().into_owned(),
@@ -405,6 +411,7 @@ msgstr "John's Daten konnten nicht geladen werden"
             pseudo_locale: None,
             catalogs: vec![CatalogConfig {
                 path: "src/locales/{locale}".to_owned(),
+                format: PalamedesCatalogFormat::Po,
             }],
         },
         resource_path: locale_dir.join("de.po").to_string_lossy().into_owned(),
@@ -457,6 +464,7 @@ msgstr "Hallo {firstName}"
             pseudo_locale: None,
             catalogs: vec![CatalogConfig {
                 path: "src/locales/{locale}".to_owned(),
+                format: PalamedesCatalogFormat::Po,
             }],
         },
         resource_path: locale_dir.join("de.po").to_string_lossy().into_owned(),
@@ -517,6 +525,7 @@ msgstr "Hallo"
             pseudo_locale: None,
             catalogs: vec![CatalogConfig {
                 path: "src/locales/{locale}".to_owned(),
+                format: PalamedesCatalogFormat::Po,
             }],
         },
         resource_path: locale_dir.join("de.po").to_string_lossy().into_owned(),
@@ -576,6 +585,7 @@ msgstr "Hallo {firstName}"
             pseudo_locale: None,
             catalogs: vec![CatalogConfig {
                 path: "src/locales/{locale}".to_owned(),
+                format: PalamedesCatalogFormat::Po,
             }],
         },
         resource_path: locale_dir.join("de.po").to_string_lossy().into_owned(),
@@ -612,6 +622,7 @@ fn compile_catalog_artifact_reports_runtime_unsupported_formatter_kinds() {
             pseudo_locale: None,
             catalogs: vec![CatalogConfig {
                 path: "src/locales/{locale}".to_owned(),
+                format: PalamedesCatalogFormat::Po,
             }],
         },
         resource_path: locale_dir.join("de.po").to_string_lossy().into_owned(),
@@ -665,6 +676,7 @@ fn compile_catalog_artifact_selected_reports_runtime_unsupported_formatter_kinds
             pseudo_locale: None,
             catalogs: vec![CatalogConfig {
                 path: "src/locales/{locale}".to_owned(),
+                format: PalamedesCatalogFormat::Po,
             }],
         },
         resource_path: locale_dir.join("de.po").to_string_lossy().into_owned(),
@@ -739,6 +751,7 @@ fn compile_catalog_artifact_reports_runtime_unsupported_formatter_styles() {
             pseudo_locale: None,
             catalogs: vec![CatalogConfig {
                 path: "src/locales/{locale}".to_owned(),
+                format: PalamedesCatalogFormat::Po,
             }],
         },
         resource_path: locale_dir.join("de.po").to_string_lossy().into_owned(),
@@ -795,6 +808,7 @@ fn compile_catalog_artifact_allows_supported_runtime_formatter_subset() {
             pseudo_locale: None,
             catalogs: vec![CatalogConfig {
                 path: "src/locales/{locale}".to_owned(),
+                format: PalamedesCatalogFormat::Po,
             }],
         },
         resource_path: locale_dir.join("de.po").to_string_lossy().into_owned(),
@@ -845,6 +859,7 @@ msgstr "Impossible d'ouvrir les regles"
             pseudo_locale: None,
             catalogs: vec![CatalogConfig {
                 path: "src/locales/{locale}".to_owned(),
+                format: PalamedesCatalogFormat::Po,
             }],
         },
         resource_path: locale_dir.join("fr.po").to_string_lossy().into_owned(),

--- a/crates/palamedes/src/catalog_artifact/types.rs
+++ b/crates/palamedes/src/catalog_artifact/types.rs
@@ -1,7 +1,9 @@
 use std::collections::BTreeMap;
 
-use ferrocat::DiagnosticSeverity as FerrocatDiagnosticSeverity;
-use serde::{Deserialize, Serialize};
+use ferrocat::{
+    CatalogMode as FerrocatCatalogMode, DiagnosticSeverity as FerrocatDiagnosticSeverity,
+};
+use serde::{Deserialize, Deserializer, Serialize};
 
 /// Request for compiling a full catalog artifact.
 #[derive(Debug, Deserialize)]
@@ -58,6 +60,57 @@ pub enum FallbackLocales {
 pub struct CatalogConfig {
     /// Catalog path pattern, usually containing `{locale}`.
     pub path: String,
+    /// Storage format for configured catalogs.
+    #[serde(default)]
+    pub format: PalamedesCatalogFormat,
+}
+
+/// Palamedes catalog storage format.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PalamedesCatalogFormat {
+    /// gettext PO catalogs.
+    #[default]
+    Po,
+    /// Ferrocat Catalog Lines catalogs.
+    Fcl,
+}
+
+impl<'de> Deserialize<'de> for PalamedesCatalogFormat {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        match value.as_str() {
+            "po" => Ok(Self::Po),
+            "fcl" => Ok(Self::Fcl),
+            "ndjson" => Err(serde::de::Error::custom(
+                "format: ndjson is no longer supported; use format: fcl for Ferrocat Catalog Lines",
+            )),
+            other => Err(serde::de::Error::custom(format!(
+                "unsupported catalog format `{other}`; expected `po` or `fcl`"
+            ))),
+        }
+    }
+}
+
+impl PalamedesCatalogFormat {
+    /// Returns the file extension used for this storage format.
+    pub const fn extension(self) -> &'static str {
+        match self {
+            Self::Po => "po",
+            Self::Fcl => "fcl",
+        }
+    }
+
+    /// Returns the Ferrocat catalog mode used by Palamedes for this format.
+    pub const fn ferrocat_mode(self) -> FerrocatCatalogMode {
+        match self {
+            Self::Po => FerrocatCatalogMode::IcuPo,
+            Self::Fcl => FerrocatCatalogMode::IcuFcl,
+        }
+    }
 }
 
 /// Host-neutral compiled catalog artifact.
@@ -167,7 +220,7 @@ impl From<ferrocat::CompiledCatalogDiagnostic> for CatalogArtifactDiagnostic {
     fn from(value: ferrocat::CompiledCatalogDiagnostic) -> Self {
         Self {
             severity: value.severity.into(),
-            code: value.code,
+            code: value.code.to_string(),
             message: value.message,
             compiled_id: value.key,
             source_key: CatalogArtifactSourceKey::new(value.msgid, value.msgctxt),

--- a/crates/palamedes/src/catalog_audit.rs
+++ b/crates/palamedes/src/catalog_audit.rs
@@ -3,12 +3,10 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use ferrocat::{
-    parse_catalog, CatalogAuditOptions, CatalogMode, IcuSyntaxPolicy, NormalizedParsedCatalog,
-    ParseCatalogOptions,
+    parse_catalog, CatalogAuditIcuOptions, CatalogAuditOptions, IcuSyntaxPolicy,
+    NormalizedParsedCatalog, ParseCatalogOptions,
 };
-use ferrocat_po::{
-    audit_catalogs_with_icu_options as ferrocat_audit_catalogs, CatalogAuditIcuOptions,
-};
+use ferrocat_po::audit_catalogs as ferrocat_audit_catalogs;
 use serde::{Deserialize, Serialize};
 
 use crate::diagnostic::{CatalogDiagnosticSeverity, CatalogDiagnosticSourceKey};
@@ -53,9 +51,6 @@ pub struct CatalogAuditCheckOptions {
     /// Validate source-side semantic message metadata.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub semantic_metadata: Option<bool>,
-    /// Report existing `fuzzy` flags.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub fuzzy_flags: Option<bool>,
     /// Report obsolete entries.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub obsolete_entries: Option<bool>,
@@ -143,15 +138,14 @@ pub fn audit_catalogs(request: CatalogAuditRequest) -> PalamedesResult<CatalogAu
             .iter()
             .map(String::as_str)
             .collect::<Vec<_>>();
-        let mut options = CatalogAuditOptions::new(&request.config.source_locale);
-        options.locales = &locale_refs;
-        options.metadata = &metadata;
-        options.checks = request.checks.to_ferrocat_checks();
-
         let icu_options = CatalogAuditIcuOptions::new()
             .with_syntax_policy(IcuSyntaxPolicy::RuntimeLiteralApostrophes);
-        let report = ferrocat_audit_catalogs(&catalogs, &options, &icu_options)
-            .map_err(PalamedesError::from)?;
+        let options = CatalogAuditOptions::new(&request.config.source_locale)
+            .with_locales(&locale_refs)
+            .with_metadata(&metadata)
+            .with_checks(request.checks.to_ferrocat_checks())
+            .with_icu_options(icu_options);
+        let report = ferrocat_audit_catalogs(&catalogs, &options).map_err(PalamedesError::from)?;
         add_summary(&mut result.summary, &report.summary);
 
         let paths_by_locale = paths_by_locale(&request.config, catalog);
@@ -161,7 +155,10 @@ pub fn audit_catalogs(request: CatalogAuditRequest) -> PalamedesResult<CatalogAu
                 .as_ref()
                 .and_then(|source_key| source_key.locale.clone())
                 .or_else(|| {
-                    diagnostic_locale_from_name(&diagnostic.code, diagnostic.name.as_deref())
+                    diagnostic_locale_from_name(
+                        diagnostic.code.as_ref(),
+                        diagnostic.name.as_deref(),
+                    )
                 });
             let catalog_path = locale
                 .as_deref()
@@ -170,7 +167,7 @@ pub fn audit_catalogs(request: CatalogAuditRequest) -> PalamedesResult<CatalogAu
                 .unwrap_or_else(|| source_catalog_path(&request.config, catalog));
             result.diagnostics.push(CatalogAuditDiagnostic {
                 severity: diagnostic.severity.into(),
-                code: diagnostic.code,
+                code: diagnostic.code.to_string(),
                 message: diagnostic.message,
                 catalog_path: catalog_path.to_string_lossy().into_owned(),
                 locale,
@@ -205,9 +202,6 @@ impl CatalogAuditCheckOptions {
         }
         if let Some(value) = self.semantic_metadata {
             checks.semantic_metadata = value;
-        }
-        if let Some(value) = self.fuzzy_flags {
-            checks.fuzzy_flags = value;
         }
         if let Some(value) = self.obsolete_entries {
             checks.obsolete_entries = value;
@@ -255,9 +249,9 @@ fn load_audit_catalogs(
             path: path.clone(),
             source,
         })?;
-        let mut options = ParseCatalogOptions::new(&content, &config.source_locale);
-        options.locale = Some(locale.as_str());
-        options.mode = CatalogMode::IcuPo;
+        let options = ParseCatalogOptions::new(&content, &config.source_locale)
+            .with_locale(locale.as_str())
+            .with_mode(catalog.format.ferrocat_mode());
 
         let parsed = parse_catalog(options).map_err(|source| PalamedesError::ParseCatalog {
             path: path.clone(),
@@ -290,7 +284,7 @@ fn paths_by_locale(
 fn catalog_path(config: &CatalogArtifactConfig, catalog: &CatalogConfig, locale: &str) -> PathBuf {
     Path::new(&config.root_dir)
         .join(catalog.path.replace("{locale}", locale))
-        .with_extension("po")
+        .with_extension(catalog.format.extension())
 }
 
 fn source_catalog_path(config: &CatalogArtifactConfig, catalog: &CatalogConfig) -> PathBuf {
@@ -319,7 +313,7 @@ mod tests {
     use std::time::{SystemTime, UNIX_EPOCH};
 
     use super::{audit_catalogs, CatalogAuditCheckOptions, CatalogAuditRequest};
-    use crate::{CatalogArtifactConfig, CatalogConfig};
+    use crate::{CatalogArtifactConfig, CatalogConfig, PalamedesCatalogFormat};
 
     #[test]
     fn reports_missing_and_invalid_catalog_entries() {
@@ -470,6 +464,7 @@ msgstr "Hallo {{name}}"
             pseudo_locale: None,
             catalogs: vec![CatalogConfig {
                 path: "src/locales/{locale}".to_owned(),
+                format: PalamedesCatalogFormat::Po,
             }],
         }
     }

--- a/crates/palamedes/src/catalog_combine.rs
+++ b/crates/palamedes/src/catalog_combine.rs
@@ -10,8 +10,38 @@ use crate::error::{PalamedesError, PalamedesResult};
 
 pub use ferrocat::{
     CatalogCombineResult, CatalogCombineSelection, CatalogCombineStats, CatalogConflictStrategy,
-    CatalogFileCombineResult, CatalogFileFormat,
 };
+
+/// Catalog file format exposed by Palamedes combine operations.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CatalogFileFormat {
+    /// gettext PO catalog files.
+    Po,
+    /// Ferrocat Catalog Lines files.
+    Fcl,
+}
+
+/// Result returned by catalog file combine operations.
+#[derive(Debug)]
+pub struct CatalogFileCombineResult {
+    /// Output path replaced by the operation.
+    pub output_path: PathBuf,
+    /// File format used for reading inputs and writing the output.
+    pub format: CatalogFileFormat,
+    /// Summary counters for the operation.
+    pub stats: CatalogCombineStats,
+    /// Non-fatal diagnostics collected during processing.
+    pub diagnostics: Vec<ferrocat::Diagnostic>,
+}
+
+impl From<CatalogFileFormat> for ferrocat::CatalogFileFormat {
+    fn from(value: CatalogFileFormat) -> Self {
+        match value {
+            CatalogFileFormat::Po => Self::Po,
+            CatalogFileFormat::Fcl => Self::Fcl,
+        }
+    }
+}
 
 /// Request for combining multiple catalog contents into one catalog.
 #[derive(Debug)]
@@ -39,7 +69,7 @@ pub struct CatalogCombineInput {
     pub label: Option<String>,
 }
 
-/// Request for combining exactly two catalog files and writing the result.
+/// Request for combining catalog files and writing the result.
 #[derive(Debug)]
 pub struct CatalogFileCombineRequest {
     /// Input catalog file paths in precedence order.
@@ -79,20 +109,21 @@ fn combine_catalog_contents(
         })
         .collect::<Vec<_>>();
 
-    let mut options = CombineCatalogOptions::new(&inputs, &request.source_locale);
-    options.locale = request.locale.as_deref();
-    options.mode = mode;
-    options.conflict_strategy = request.conflict_strategy;
-    options.selection = request.selection;
-    options.order_by = OrderBy::Msgid;
-    options.include_origins = true;
-    options.include_line_numbers = true;
-    options.include_obsolete = request.include_obsolete;
+    let mut options = CombineCatalogOptions::new(&inputs, &request.source_locale)
+        .with_mode(mode)
+        .with_conflict_strategy(request.conflict_strategy)
+        .with_selection(request.selection)
+        .with_order_by(OrderBy::Msgid)
+        .with_include_origins(true)
+        .with_include_obsolete(request.include_obsolete);
+    if let Some(locale) = request.locale.as_deref() {
+        options = options.with_locale(locale);
+    }
 
     ferrocat_combine_catalogs(options).map_err(PalamedesError::from)
 }
 
-/// Combines exactly two catalog files and atomically replaces the requested output path.
+/// Combines catalog files and atomically replaces the requested output path.
 ///
 /// # Errors
 ///
@@ -102,7 +133,7 @@ fn combine_catalog_contents(
 pub fn combine_catalog_files(
     request: CatalogFileCombineRequest,
 ) -> PalamedesResult<CatalogFileCombineResult> {
-    if request.input_paths.len() != 2 {
+    if request.input_paths.is_empty() {
         return Err(PalamedesError::InvalidCatalogFileCombineInputCount {
             count: request.input_paths.len(),
         });
@@ -112,17 +143,34 @@ pub fn combine_catalog_files(
         &request.input_paths,
         &request.output_path,
         &request.source_locale,
-    );
-    options.format = request.format;
-    options.locale = request.locale.as_deref();
-    options.conflict_strategy = request.conflict_strategy;
-    options.selection = ferrocat::CatalogCombineSelection::All;
-    options.order_by = OrderBy::Msgid;
-    options.include_origins = true;
-    options.include_line_numbers = true;
-    options.include_obsolete = false;
+    )
+    .with_conflict_strategy(request.conflict_strategy)
+    .with_selection(ferrocat::CatalogCombineSelection::All)
+    .with_order_by(OrderBy::Msgid)
+    .with_include_origins(true)
+    .with_include_obsolete(false);
+    if let Some(format) = request.format {
+        options = options.with_format(format.into());
+    }
+    if let Some(locale) = request.locale.as_deref() {
+        options = options.with_locale(locale);
+    }
 
-    ferrocat_combine_catalog_files(options).map_err(PalamedesError::from)
+    let result = ferrocat_combine_catalog_files(options).map_err(PalamedesError::from)?;
+    Ok(CatalogFileCombineResult {
+        output_path: result.output_path,
+        format: match result.format {
+            ferrocat::CatalogFileFormat::Po => CatalogFileFormat::Po,
+            ferrocat::CatalogFileFormat::Fcl => CatalogFileFormat::Fcl,
+            _ => {
+                return Err(PalamedesError::UnsupportedCatalogFileFormat {
+                    format: format!("{:?}", result.format),
+                });
+            }
+        },
+        stats: result.stats,
+        diagnostics: result.diagnostics,
+    })
 }
 
 #[cfg(test)]
@@ -309,52 +357,33 @@ mod tests {
     }
 
     #[test]
-    fn combines_ndjson_files_with_ndjson_format() {
-        let dir = temp_dir("ndjson");
-        let ours = dir.join("ours.json");
-        let theirs = dir.join("theirs.json");
-        let output = dir.join("merged.json");
-        fs::write(
-            &ours,
-            concat!(
-                "---\n",
-                "format: ferrocat.ndjson.v1\n",
-                "source_locale: en\n",
-                "locale: de\n",
-                "---\n",
-                "{\"id\":\"Hello\",\"str\":\"Hallo\"}\n",
-            ),
-        )
-        .expect("write ours");
+    fn combines_fcl_files_with_fcl_format() {
+        let dir = temp_dir("fcl");
+        let ours = dir.join("ours.fcl");
+        let theirs = dir.join("theirs.fcl");
+        let output = dir.join("merged.fcl");
+        fs::write(&ours, "%FCL1\tsource=en\tlocale=de\nHello\t\tHallo\n").expect("write ours");
         fs::write(
             &theirs,
-            concat!(
-                "---\n",
-                "format: ferrocat.ndjson.v1\n",
-                "source_locale: en\n",
-                "locale: de\n",
-                "---\n",
-                "{\"id\":\"Hello\",\"str\":\"Servus\"}\n",
-                "{\"id\":\"New\",\"str\":\"Neu\",\"ctx\":\"nav\"}\n",
-            ),
+            "%FCL1\tsource=en\tlocale=de\nHello\t\tServus\nNew\tnav\tNeu\n",
         )
         .expect("write theirs");
 
         let result = combine_catalog_files(CatalogFileCombineRequest {
             input_paths: vec![ours, theirs],
             output_path: output.clone(),
-            format: Some(CatalogFileFormat::Ndjson),
+            format: Some(CatalogFileFormat::Fcl),
             source_locale: "en".to_owned(),
             locale: Some("de".to_owned()),
             conflict_strategy: CatalogConflictStrategy::UseFirst,
         })
         .expect("merge");
 
-        assert_eq!(result.format, CatalogFileFormat::Ndjson);
+        assert_eq!(result.format, CatalogFileFormat::Fcl);
         let merged = fs::read_to_string(output).expect("read output");
-        assert!(merged.contains("format: ferrocat.ndjson.v1"));
-        assert!(merged.contains("\"id\":\"Hello\",\"str\":\"Hallo\""));
-        assert!(merged.contains("\"id\":\"New\",\"str\":\"Neu\",\"ctx\":\"nav\""));
+        assert!(merged.starts_with("%FCL1"));
+        assert!(merged.contains("Hello\t\tHallo"));
+        assert!(merged.contains("New\tnav\tNeu"));
         assert!(!merged.contains("Servus"));
     }
 
@@ -362,21 +391,10 @@ mod tests {
     fn mixed_inferred_formats_leave_output_unchanged() {
         let dir = temp_dir("mixed-format");
         let ours = dir.join("ours.po");
-        let theirs = dir.join("theirs.ndjson");
+        let theirs = dir.join("theirs.fcl");
         let output = dir.join("merged.po");
         fs::write(&ours, "msgid \"Hello\"\nmsgstr \"Hallo\"\n").expect("write ours");
-        fs::write(
-            &theirs,
-            concat!(
-                "---\n",
-                "format: ferrocat.ndjson.v1\n",
-                "source_locale: en\n",
-                "locale: de\n",
-                "---\n",
-                "{\"id\":\"New\",\"str\":\"Neu\"}\n",
-            ),
-        )
-        .expect("write theirs");
+        fs::write(&theirs, "%FCL1\tsource=en\tlocale=de\nNew\t\tNeu\n").expect("write theirs");
         fs::write(&output, "unchanged").expect("write output");
 
         let error = combine_catalog_files(CatalogFileCombineRequest {

--- a/crates/palamedes/src/catalog_update.rs
+++ b/crates/palamedes/src/catalog_update.rs
@@ -1,15 +1,16 @@
 use std::collections::BTreeMap;
 use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::diagnostic::CatalogDiagnostic;
 use crate::error::{PalamedesError, PalamedesResult};
-use ferrocat::MachineTranslationMetadata as FerrocatMachineTranslationMetadata;
 use ferrocat::{
     parse_catalog as ferrocat_parse_catalog, update_catalog_file as ferrocat_update_catalog_file,
-    CatalogMode, CatalogOrigin, CatalogStats, CatalogUpdateInput, CatalogUpdateResult,
-    ObsoleteStrategy, ParseCatalogOptions, ParsedCatalog, PlaceholderCommentMode,
-    SourceExtractedMessage, UpdateCatalogFileOptions,
+    CatalogOrigin, CatalogStats, CatalogUpdateInput, CatalogUpdateResult, EffectiveTranslationRef,
+    ObsoleteStrategy, ParseCatalogOptions, ParsedCatalog, PlaceholderCommentMode, RenderOptions,
+    SourceExtractedMessage, UpdateCatalogFileOptions, UpdateCatalogOptions,
 };
+use ferrocat::{AiProvenance as FerrocatAiProvenance, MachineMetadata as FerrocatMachineMetadata};
 use serde::{Deserialize, Serialize};
 
 /// Source origin used for catalog updates and parsed catalog messages.
@@ -20,6 +21,20 @@ pub struct CatalogUpdateOrigin {
     pub file: String,
     /// 1-based source line.
     pub line: u32,
+    /// Optional stable source scope, such as a component or function name.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scope: Option<String>,
+}
+
+/// Source origin stored in parsed catalogs.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CatalogOriginMetadata {
+    /// Source filename.
+    pub file: String,
+    /// Optional stable source scope, such as a component or function name.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scope: Option<String>,
 }
 
 /// Source-first extracted message used for catalog updates.
@@ -54,6 +69,12 @@ pub struct CatalogUpdateRequest {
     pub source_locale: String,
     /// Whether obsolete messages should be deleted instead of marked.
     pub clean: bool,
+    /// Whether obsolete messages should be deleted immediately, including undated entries.
+    #[serde(default)]
+    pub force_clean: bool,
+    /// Catalog storage format.
+    #[serde(default)]
+    pub format: super::catalog_artifact::PalamedesCatalogFormat,
     /// Extracted messages to project into the catalog.
     pub messages: Vec<CatalogUpdateMessage>,
 }
@@ -68,6 +89,9 @@ pub struct CatalogParseRequest {
     pub locale: String,
     /// Source locale used for parsing semantics.
     pub source_locale: String,
+    /// Catalog storage format.
+    #[serde(default)]
+    pub format: super::catalog_artifact::PalamedesCatalogFormat,
 }
 
 /// Result of updating a catalog file.
@@ -130,37 +154,52 @@ pub struct ParsedCatalogMessage {
     pub comments: Vec<String>,
     /// Source origins attached to the message.
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub origins: Vec<CatalogUpdateOrigin>,
+    pub origins: Vec<CatalogOriginMetadata>,
     /// Whether the message is obsolete.
     pub obsolete: bool,
+    /// Whether the effective translation is non-empty.
+    pub translated: bool,
     /// Machine-translation provenance for the current translation, when present.
-    #[serde(rename = "machineTranslation", skip_serializing_if = "Option::is_none")]
-    pub machine_translation: Option<MachineTranslationMetadata>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub machine: Option<MachineMetadata>,
 }
 
-/// Machine-translation metadata attached to one translated catalog entry.
+/// Machine metadata attached to one translated catalog entry.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct MachineTranslationMetadata {
-    /// Model identifier used to produce the translation.
-    pub model: String,
-    /// Time when the machine-generated translation was last modified.
+pub struct MachineMetadata {
+    /// Integrity lock for the current translation payload.
+    pub lock: String,
+    /// Optional AI provenance for machine-managed content.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub modified: Option<String>,
-    /// Optional model confidence from 0 to 100.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub confidence: Option<u8>,
-    /// Change-detection hash for the current translation payload.
-    pub hash: String,
+    pub ai: Option<AiProvenance>,
 }
 
-impl From<FerrocatMachineTranslationMetadata> for MachineTranslationMetadata {
-    fn from(value: FerrocatMachineTranslationMetadata) -> Self {
+/// AI provenance for machine-managed content.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AiProvenance {
+    /// Model identifier used to produce the translation.
+    pub model: String,
+    /// Optional model confidence in the 0..1 interval.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub confidence: Option<f32>,
+}
+
+impl From<FerrocatMachineMetadata> for MachineMetadata {
+    fn from(value: FerrocatMachineMetadata) -> Self {
+        Self {
+            lock: value.lock,
+            ai: value.ai.map(AiProvenance::from),
+        }
+    }
+}
+
+impl From<FerrocatAiProvenance> for AiProvenance {
+    fn from(value: FerrocatAiProvenance) -> Self {
         Self {
             model: value.model,
-            modified: value.modified,
             confidence: value.confidence,
-            hash: value.hash,
         }
     }
 }
@@ -190,9 +229,9 @@ pub fn parse_catalog(request: &CatalogParseRequest) -> PalamedesResult<CatalogPa
             path: target_path,
             source,
         })?;
-    let mut options = ParseCatalogOptions::new(&content, &request.source_locale);
-    options.locale = Some(&request.locale);
-    options.mode = CatalogMode::IcuPo;
+    let options = ParseCatalogOptions::new(&content, &request.source_locale)
+        .with_locale(&request.locale)
+        .with_mode(request.format.ferrocat_mode());
 
     let parsed = ferrocat_parse_catalog(options).map_err(PalamedesError::from)?;
 
@@ -213,20 +252,34 @@ fn update_catalog_file_source_first(
             .collect::<Result<Vec<_>, _>>()?,
     );
 
-    let mut options = UpdateCatalogFileOptions::new(&target_path, &request.source_locale, input);
-    options.options.locale = Some(&request.locale);
-    options.options.mode = CatalogMode::IcuPo;
-    options.options.obsolete_strategy = if request.clean {
+    let now = current_iso_date();
+    let obsolete_strategy = if request.force_clean {
         ObsoleteStrategy::Delete
+    } else if request.clean {
+        ObsoleteStrategy::DropObsoleteBefore(clean_cutoff_date(&now))
     } else {
         ObsoleteStrategy::Mark
     };
-    options.options.overwrite_source_translations = true;
-    options.options.render.custom_header_attributes = Some(&custom_header_attributes);
-    options.options.render.include_origins = true;
-    options.options.render.include_line_numbers = true;
-    options.options.render.print_placeholders_in_comments =
-        PlaceholderCommentMode::Enabled { limit: 3 };
+
+    let mut render = RenderOptions::default()
+        .with_include_origins(true)
+        .with_placeholder_comments(PlaceholderCommentMode::Enabled { limit: 3 });
+    if request.format == super::catalog_artifact::PalamedesCatalogFormat::Po {
+        render = render.with_custom_header_attributes(&custom_header_attributes);
+    }
+    let update_options = UpdateCatalogOptions::new(&request.source_locale, input)
+        .with_locale(&request.locale)
+        .with_mode(request.format.ferrocat_mode())
+        .with_obsolete_strategy(obsolete_strategy)
+        .with_overwrite_source_translations(true)
+        .with_render(render)
+        .with_now(&now);
+    let options = UpdateCatalogFileOptions::new(
+        &target_path,
+        &request.source_locale,
+        Vec::<SourceExtractedMessage>::new(),
+    )
+    .with_options(update_options);
 
     let result = ferrocat_update_catalog_file(options).map_err(PalamedesError::from)?;
 
@@ -243,7 +296,7 @@ fn project_message(message: CatalogUpdateMessage) -> PalamedesResult<SourceExtra
         .into_iter()
         .map(|origin| CatalogOrigin {
             file: origin.file,
-            line: Some(origin.line),
+            scope: origin.scope,
         })
         .collect::<Vec<_>>();
 
@@ -276,22 +329,24 @@ fn public_parse_result(parsed: ParsedCatalog) -> CatalogParseResult {
         messages: parsed
             .messages
             .into_iter()
-            .map(|message| ParsedCatalogMessage {
-                message: message.msgid,
-                context: message.msgctxt,
-                comments: message.comments,
-                origins: message
-                    .origin
-                    .into_iter()
-                    .map(|origin| CatalogUpdateOrigin {
-                        file: origin.file,
-                        line: origin.line.unwrap_or_default(),
-                    })
-                    .collect(),
-                obsolete: message.obsolete,
-                machine_translation: message
-                    .machine_translation
-                    .map(MachineTranslationMetadata::from),
+            .map(|message| {
+                let translated = is_effectively_translated(message.effective_translation());
+                ParsedCatalogMessage {
+                    message: message.msgid,
+                    context: message.msgctxt,
+                    comments: message.comments,
+                    origins: message
+                        .origin
+                        .into_iter()
+                        .map(|origin| CatalogOriginMetadata {
+                            file: origin.file,
+                            scope: origin.scope,
+                        })
+                        .collect(),
+                    obsolete: message.obsolete.is_some(),
+                    translated,
+                    machine: message.machine.map(MachineMetadata::from),
+                }
             })
             .collect(),
         diagnostics: parsed
@@ -300,6 +355,72 @@ fn public_parse_result(parsed: ParsedCatalog) -> CatalogParseResult {
             .map(CatalogDiagnostic::from)
             .collect(),
     }
+}
+
+fn is_effectively_translated(translation: EffectiveTranslationRef<'_>) -> bool {
+    match translation {
+        EffectiveTranslationRef::Singular(value) => !value.is_empty(),
+        EffectiveTranslationRef::Plural(values) => values.values().any(|value| !value.is_empty()),
+    }
+}
+
+fn current_iso_date() -> String {
+    let seconds = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or(0);
+    let days = i64::try_from(seconds / 86_400).unwrap_or(i64::MAX);
+    iso_date_from_unix_days(days)
+}
+
+fn clean_cutoff_date(today: &str) -> String {
+    let Some(days) = unix_days_from_iso_date(today) else {
+        return today.to_owned();
+    };
+    iso_date_from_unix_days(days - 30)
+}
+
+fn iso_date_from_unix_days(days: i64) -> String {
+    let (year, month, day) = civil_from_days(days);
+    format!("{year:04}-{month:02}-{day:02}")
+}
+
+fn unix_days_from_iso_date(value: &str) -> Option<i64> {
+    let mut parts = value.split('-');
+    let year = parts.next()?.parse::<i32>().ok()?;
+    let month = parts.next()?.parse::<u32>().ok()?;
+    let day = parts.next()?.parse::<u32>().ok()?;
+    (parts.next().is_none() && (1..=12).contains(&month) && (1..=31).contains(&day))
+        .then(|| days_from_civil(year, month, day))
+}
+
+fn civil_from_days(days: i64) -> (i32, u32, u32) {
+    let z = days + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = z - era * 146_097;
+    let yoe = (doe - doe / 1_460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let day = doy - (153 * mp + 2) / 5 + 1;
+    let month = mp + if mp < 10 { 3 } else { -9 };
+    let year = y + if month <= 2 { 1 } else { 0 };
+    (
+        i32::try_from(year).unwrap_or(i32::MAX),
+        u32::try_from(month).unwrap_or(1),
+        u32::try_from(day).unwrap_or(1),
+    )
+}
+
+fn days_from_civil(year: i32, month: u32, day: u32) -> i64 {
+    let year = i64::from(year) - i64::from(month <= 2);
+    let era = if year >= 0 { year } else { year - 399 } / 400;
+    let yoe = year - era * 400;
+    let month = i64::from(month);
+    let day = i64::from(day);
+    let doy = (153 * (month + if month > 2 { -3 } else { 9 }) + 2) / 5 + day - 1;
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    era * 146_097 + doe - 719_468
 }
 
 fn public_stats(stats: &CatalogStats) -> CatalogUpdateStats {
@@ -342,6 +463,8 @@ mod tests {
             locale: "en".to_owned(),
             source_locale: "en".to_owned(),
             clean: false,
+            force_clean: false,
+            format: crate::PalamedesCatalogFormat::Po,
             messages: vec![CatalogUpdateMessage {
                 message: "Hello".to_owned(),
                 context: None,
@@ -350,6 +473,7 @@ mod tests {
                 origins: vec![CatalogUpdateOrigin {
                     file: "src/App.tsx".to_owned(),
                     line: 3,
+                    scope: None,
                 }],
             }],
         })
@@ -381,6 +505,8 @@ mod tests {
             locale: "de".to_owned(),
             source_locale: "en".to_owned(),
             clean: false,
+            force_clean: false,
+            format: crate::PalamedesCatalogFormat::Po,
             messages: vec![CatalogUpdateMessage {
                 message: "Hello".to_owned(),
                 context: None,
@@ -397,13 +523,14 @@ mod tests {
     }
 
     #[test]
-    fn parse_catalog_exposes_machine_translation_metadata() {
+    fn parse_catalog_exposes_machine_metadata() {
         let path = temp_file("machine-translation-parse");
         let hash = machine_translation_hash(EffectiveTranslationRef::Singular("Hallo"));
         std::fs::write(
             &path,
             format!(
-                "#@ ferrocat-mt model=openai/gpt-5.5-high modified=2026-05-12T10:30:00Z confidence=95 hash={hash}\n\
+                "#@ lock: {hash}\n\
+                 #@ ai: openai/gpt-5.5-high:0.95\n\
                  msgid \"Hello\"\n\
                  msgstr \"Hallo\"\n"
             ),
@@ -414,17 +541,18 @@ mod tests {
             target_path: path,
             locale: "de".to_owned(),
             source_locale: "en".to_owned(),
+            format: crate::PalamedesCatalogFormat::Po,
         })
         .expect("parse catalog");
 
         let metadata = parsed.messages[0]
-            .machine_translation
+            .machine
             .as_ref()
-            .expect("machine translation metadata");
-        assert_eq!(metadata.model, "openai/gpt-5.5-high");
-        assert_eq!(metadata.modified.as_deref(), Some("2026-05-12T10:30:00Z"));
-        assert_eq!(metadata.confidence, Some(95));
-        assert_eq!(metadata.hash, hash);
+            .expect("machine metadata");
+        assert_eq!(metadata.lock, hash);
+        let ai = metadata.ai.as_ref().expect("ai provenance");
+        assert_eq!(ai.model, "openai/gpt-5.5-high");
+        assert_eq!(ai.confidence, Some(0.95));
     }
 
     #[test]
@@ -434,7 +562,8 @@ mod tests {
         std::fs::write(
             &path,
             format!(
-                "#@ ferrocat-mt model=openai/gpt-5.5-high confidence=95 hash={hash}\n\
+                "#@ lock: {hash}\n\
+                 #@ ai: openai/gpt-5.5-high:0.95\n\
                  msgid \"Hello\"\n\
                  msgstr \"Hallo\"\n"
             ),
@@ -446,6 +575,8 @@ mod tests {
             locale: "de".to_owned(),
             source_locale: "en".to_owned(),
             clean: false,
+            force_clean: false,
+            format: crate::PalamedesCatalogFormat::Po,
             messages: vec![CatalogUpdateMessage {
                 message: "Hello".to_owned(),
                 context: None,
@@ -457,11 +588,12 @@ mod tests {
         .expect("update");
 
         let output = std::fs::read_to_string(&path).expect("read");
-        assert!(output.contains("#@ ferrocat-mt model=openai/gpt-5.5-high confidence=95 hash="));
+        assert!(output.contains("#@ lock: "));
+        assert!(output.contains("#@ ai: openai/gpt-5.5-high:0.95"));
     }
 
     #[test]
-    fn clean_removes_obsolete_entries() {
+    fn clean_keeps_undated_obsolete_entries() {
         let path = temp_file("clean");
         std::fs::write(
             &path,
@@ -479,6 +611,43 @@ mod tests {
             locale: "en".to_owned(),
             source_locale: "en".to_owned(),
             clean: true,
+            force_clean: false,
+            format: crate::PalamedesCatalogFormat::Po,
+            messages: vec![CatalogUpdateMessage {
+                message: "Keep".to_owned(),
+                context: None,
+                placeholders: BTreeMap::new(),
+                extracted_comments: vec![],
+                origins: vec![],
+            }],
+        })
+        .expect("update");
+
+        let output = std::fs::read_to_string(&path).expect("read");
+        assert!(output.contains("Old"));
+    }
+
+    #[test]
+    fn force_clean_removes_undated_obsolete_entries() {
+        let path = temp_file("force-clean");
+        std::fs::write(
+            &path,
+            concat!(
+                "msgid \"Keep\"\n",
+                "msgstr \"\"\n\n",
+                "msgid \"Old\"\n",
+                "msgstr \"\"\n",
+            ),
+        )
+        .expect("write existing");
+
+        update_catalog_file(CatalogUpdateRequest {
+            target_path: path.clone(),
+            locale: "en".to_owned(),
+            source_locale: "en".to_owned(),
+            clean: false,
+            force_clean: true,
+            format: crate::PalamedesCatalogFormat::Po,
             messages: vec![CatalogUpdateMessage {
                 message: "Keep".to_owned(),
                 context: None,
@@ -502,6 +671,8 @@ mod tests {
             locale: "en".to_owned(),
             source_locale: "en".to_owned(),
             clean: false,
+            force_clean: false,
+            format: crate::PalamedesCatalogFormat::Po,
             messages: vec![CatalogUpdateMessage {
                 message: "{count, plural, one {# item} other {# items}}".to_owned(),
                 context: None,
@@ -525,6 +696,8 @@ mod tests {
             locale: "en".to_owned(),
             source_locale: "en".to_owned(),
             clean: false,
+            force_clean: false,
+            format: crate::PalamedesCatalogFormat::Po,
             messages: vec![CatalogUpdateMessage {
                 message: "Hello {0}".to_owned(),
                 context: None,

--- a/crates/palamedes/src/diagnostic.rs
+++ b/crates/palamedes/src/diagnostic.rs
@@ -67,7 +67,7 @@ impl From<ferrocat::Diagnostic> for CatalogDiagnostic {
 
         Self {
             severity: value.severity.into(),
-            code: value.code,
+            code: value.code.to_string(),
             message: value.message,
             source_key,
         }

--- a/crates/palamedes/src/error.rs
+++ b/crates/palamedes/src/error.rs
@@ -26,11 +26,17 @@ pub enum PalamedesError {
         /// Underlying filesystem error.
         source: std::io::Error,
     },
-    /// A catalog file-combine request must include exactly two inputs.
-    #[error("Catalog file combine requires exactly two input files, received {count}.")]
+    /// A catalog file-combine request must include at least two inputs.
+    #[error("Catalog file combine requires at least two input files, received {count}.")]
     InvalidCatalogFileCombineInputCount {
         /// Number of input files provided.
         count: usize,
+    },
+    /// Ferrocat returned a catalog file format Palamedes does not expose.
+    #[error("Unsupported catalog file combine format: {format}")]
+    UnsupportedCatalogFileFormat {
+        /// Unsupported format label.
+        format: String,
     },
     /// A configured catalog glob/path could not be compiled to a matcher.
     #[error("Invalid catalog path pattern {pattern}: {source}")]

--- a/crates/palamedes/src/extract.rs
+++ b/crates/palamedes/src/extract.rs
@@ -1273,6 +1273,7 @@ fn add_extracted_message(
     let origin = CatalogUpdateOrigin {
         file: relative_file.to_string(),
         line: u32::try_from(message.origin.1).unwrap_or(u32::MAX),
+        scope: None,
     };
     if !entry.origins.contains(&origin) {
         entry.origins.push(origin);

--- a/crates/palamedes/src/lib.rs
+++ b/crates/palamedes/src/lib.rs
@@ -37,7 +37,7 @@ pub use catalog_artifact::{
     compile_catalog_artifact, compile_catalog_artifact_selected, CatalogArtifactConfig,
     CatalogArtifactDiagnostic, CatalogArtifactDiagnosticSeverity, CatalogArtifactMissingMessage,
     CatalogArtifactRequest, CatalogArtifactResult, CatalogArtifactSelectedRequest,
-    CatalogArtifactSourceKey, CatalogConfig, FallbackLocales,
+    CatalogArtifactSourceKey, CatalogConfig, FallbackLocales, PalamedesCatalogFormat,
 };
 pub use catalog_audit::{
     audit_catalogs, CatalogAuditCheckOptions, CatalogAuditDiagnostic, CatalogAuditRequest,
@@ -49,9 +49,9 @@ pub use catalog_combine::{
     CatalogFileCombineRequest, CatalogFileCombineResult, CatalogFileFormat,
 };
 pub use catalog_update::{
-    parse_catalog, update_catalog_file, CatalogParseRequest, CatalogParseResult,
-    CatalogUpdateMessage, CatalogUpdateOrigin, CatalogUpdateRequest, CatalogUpdateResponse,
-    CatalogUpdateStats, MachineTranslationMetadata, ParsedCatalogMessage,
+    parse_catalog, update_catalog_file, AiProvenance, CatalogOriginMetadata, CatalogParseRequest,
+    CatalogParseResult, CatalogUpdateMessage, CatalogUpdateOrigin, CatalogUpdateRequest,
+    CatalogUpdateResponse, CatalogUpdateStats, MachineMetadata, ParsedCatalogMessage,
 };
 pub use diagnostic::{CatalogDiagnostic, CatalogDiagnosticSeverity, CatalogDiagnosticSourceKey};
 pub use error::{PalamedesError, PalamedesResult};
@@ -72,7 +72,7 @@ pub use transform::{
 };
 
 /// Published `ferrocat` version used by the Rust core.
-pub const FERROCAT_VERSION: &str = "1.3.1";
+pub const FERROCAT_VERSION: &str = "2.1.1";
 
 /// Version metadata for the loaded native core.
 #[derive(Debug, Serialize)]
@@ -167,11 +167,11 @@ impl From<PoItem> for JsPoItem {
         Self {
             msgid: value.msgid,
             msgctxt: value.msgctxt,
-            references: value.references,
+            references: value.references.into(),
             msgid_plural: value.msgid_plural,
             msgstr,
-            comments: value.comments,
-            extracted_comments: value.extracted_comments,
+            comments: value.comments.into(),
+            extracted_comments: value.extracted_comments.into(),
             flags,
             metadata,
             obsolete: value.obsolete,
@@ -217,7 +217,7 @@ mod tests {
         let declared = dependency_version(manifest, "ferrocat")
             .expect("ferrocat dependency should be declared");
 
-        assert_eq!(FERROCAT_VERSION, declared);
+        assert_eq!(FERROCAT_VERSION, declared.trim_start_matches('='));
     }
 
     #[test]

--- a/crates/palamedes/src/message_metadata.rs
+++ b/crates/palamedes/src/message_metadata.rs
@@ -440,7 +440,7 @@ impl From<ferrocat::MessageMetadataDiagnostic> for MessageMetadataDiagnostic {
     fn from(value: ferrocat::MessageMetadataDiagnostic) -> Self {
         Self {
             severity: value.severity.into(),
-            code: value.code,
+            code: value.code.to_string(),
             message: value.message,
             name: value.name,
         }

--- a/docs/api/config.md
+++ b/docs/api/config.md
@@ -46,6 +46,16 @@ export default defineConfig({
 })
 ```
 
+PO is the default catalog storage. Opt into FCL by adding `format: "fcl"`:
+
+```ts
+export default defineConfig({
+  locales: ["en", "de"],
+  sourceLocale: "en",
+  catalogs: [{ path: "src/locales/{locale}", format: "fcl", include: ["src"] }],
+})
+```
+
 ## `loadPalamedesConfig(options?)`
 
 Searches from `cwd` for a supported config file unless `configPath` is passed.

--- a/docs/api/next-plugin.md
+++ b/docs/api/next-plugin.md
@@ -3,6 +3,10 @@
 `@palamedes/next-plugin` wires Palamedes macro transformation and `.po` loading
 into Next.js.
 
+Catalog storage can be PO or FCL in `palamedes.yaml`, but this API is still a
+`.po` import loader. See [Catalog formats](../catalog-formats.md) for the
+storage/import boundary.
+
 ## Exports
 
 - `withPalamedes(baseConfig?, options?)`

--- a/docs/api/vite-plugin.md
+++ b/docs/api/vite-plugin.md
@@ -3,6 +3,10 @@
 `@palamedes/vite-plugin` transforms Palamedes macro imports and compiles `.po`
 imports inside Vite builds.
 
+Catalog storage can be PO or FCL in `palamedes.yaml`, but this API is still a
+`.po` import loader. See [Catalog formats](../catalog-formats.md) for the
+storage/import boundary.
+
 ## Exports
 
 - `palamedes(options?)`

--- a/docs/benchmark-lingui-v6-preview.md
+++ b/docs/benchmark-lingui-v6-preview.md
@@ -90,6 +90,10 @@ Before any timing run, the harness validates:
 - extract: normalized `message + context` keys match the generated manifest
 - compile: both toolchains compile the same `de.po` catalog without errors and with the expected message count
 
+This harness intentionally stays PO-based because Lingui's comparable catalog
+path is PO. FCL is a Palamedes storage option and is covered by the
+catalog-format workflow, not by this head-to-head Lingui benchmark.
+
 There are also smoke checks against checked-in repo sources:
 
 - transform parity for Palamedes, Lingui Babel, and Lingui SWC on the checked-in benchmark fixtures

--- a/docs/catalog-formats.md
+++ b/docs/catalog-formats.md
@@ -1,0 +1,78 @@
+# Catalog Formats
+
+Palamedes catalogs are source-string-first. The semantic message identity is
+`message + context`; compiled lookup keys remain an internal runtime detail.
+
+Palamedes currently exposes two catalog storage formats:
+
+| Format | Extension | Best fit                                                                 |
+| ------ | --------- | ------------------------------------------------------------------------ |
+| PO     | `.po`     | Default, translator-friendly gettext-style files and current app imports |
+| FCL    | `.fcl`    | Canonical Ferrocat Catalog Lines for generated, merge-friendly storage   |
+
+## PO
+
+PO is the default because it is familiar, human-editable, and supported by the
+current Vite and Next loader paths. A minimal config does not need a `format`
+field:
+
+```yaml
+locales: [en, de]
+source-locale: en
+catalogs:
+  - path: src/locales/{locale}
+    include: [src]
+```
+
+That writes `src/locales/en.po` and `src/locales/de.po`.
+
+## FCL
+
+FCL means Ferrocat Catalog Lines. It is a line-oriented Ferrocat catalog format
+that Palamedes treats as canonical generated storage. Use it when the catalog
+files are mostly maintained by `pmds extract`, merge drivers, or automation
+rather than hand-edited as gettext PO files.
+
+Opt in per catalog:
+
+```yaml
+locales: [en, de]
+source-locale: en
+catalogs:
+  - path: src/locales/{locale}
+    format: fcl
+    include: [src]
+```
+
+That writes `src/locales/en.fcl` and `src/locales/de.fcl`.
+
+FCL is not NDJSON. The older `ndjson` config value is intentionally rejected;
+use `format: fcl` instead.
+
+## Runtime Loading
+
+Catalog storage and framework module loading are related but separate:
+
+- `pmds extract`, `pmds audit`, `pmds catalog merge`, and native compile APIs
+  understand both PO and FCL through the Palamedes config.
+- The current first-party Vite and Next import loaders are still `.po` import
+  loaders. Keep app-facing imports on PO unless the host adapter explicitly
+  documents FCL imports.
+- `pmds catalog convert` can write `.fcl` files beside existing `.po` files so
+  teams can trial FCL storage before changing config.
+
+## Converting Existing Catalogs
+
+Convert one catalog:
+
+```bash
+pmds catalog convert src/locales/de.po --to fcl --output src/locales/de.fcl
+```
+
+Convert every configured PO catalog:
+
+```bash
+pmds catalog convert --config palamedes.yaml --to fcl
+```
+
+After conversion, update the matching catalog config to `format: fcl`.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -90,6 +90,9 @@ catalogs:
     include: [src]
 ```
 
+See [Catalog formats](./catalog-formats.md) for when to keep PO storage and
+when to opt into FCL.
+
 ## `pmds version`
 
 Prints the installed CLI version.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -12,18 +12,20 @@ catalogs.
 pmds extract
 pmds extract --config ./palamedes.yaml
 pmds extract --clean
+pmds extract --force-clean
 pmds extract --watch
 pmds extract --verbose
 ```
 
 Options:
 
-| Option                | Description                                                       |
-| --------------------- | ----------------------------------------------------------------- |
-| `-c, --config <path>` | Use a specific config file.                                       |
-| `-w, --watch`         | Re-run extraction on file changes.                                |
-| `--clean`             | Remove obsolete catalog entries instead of marking them obsolete. |
-| `-v, --verbose`       | Print verbose extraction details.                                 |
+| Option                | Description                                                                                        |
+| --------------------- | -------------------------------------------------------------------------------------------------- |
+| `-c, --config <path>` | Use a specific config file.                                                                        |
+| `-w, --watch`         | Re-run extraction on file changes.                                                                 |
+| `--clean`             | Remove obsolete entries with `obsolete-since` at least 30 days old; keep undated obsolete entries. |
+| `--force-clean`       | Remove all obsolete entries immediately, including undated entries.                                |
+| `-v, --verbose`       | Print verbose extraction details.                                                                  |
 
 ## `pmds audit`
 
@@ -47,12 +49,13 @@ Options:
 
 ## `pmds catalog merge`
 
-Merges two catalog files with Palamedes catalog semantics. This is suitable for
+Merges catalog files with Palamedes catalog semantics. This is suitable for
 Git merge-driver workflows.
 
 ```bash
 pmds catalog merge ours.po theirs.po --output merged.po
-pmds catalog merge %A %B --output %A --format po --conflict-strategy use-first
+pmds catalog merge %A %B --base %O --output %A --format po --conflict-strategy use-first
+pmds catalog merge ours.fcl theirs.fcl --output merged.fcl --format fcl
 ```
 
 Options:
@@ -61,10 +64,31 @@ Options:
 | -------------------------------- | ---------------------------------------------------------------- |
 | `--output <path>`                | Required output path.                                            |
 | `-c, --config <path>`            | Use a specific config file when inferring `sourceLocale`.        |
-| `--format <format>`              | `po` or `ndjson`. Inferred from paths when omitted.              |
+| `--format <format>`              | `po` or `fcl`. Inferred from paths when omitted.                 |
+| `--base <path>`                  | Optional ancestor catalog path supplied by Git merge drivers.    |
 | `--conflict-strategy <strategy>` | `use-first`, `use-last`, or `error`.                             |
 | `--source-locale <locale>`       | Source locale for catalog semantics. Defaults to config or `en`. |
 | `--locale <locale>`              | Locale of the merged catalog.                                    |
+
+## `pmds catalog convert`
+
+Converts supported PO catalogs to Ferrocat Catalog Lines (FCL). Conversion
+fails before writing output when a PO source contains raw `fuzzy` flags.
+
+```bash
+pmds catalog convert src/locales/de.po --to fcl --output src/locales/de.fcl
+pmds catalog convert --config palamedes.yaml --to fcl
+```
+
+Config mode writes `.fcl` files beside existing `.po` files and leaves the
+source catalogs untouched. Update the catalog config afterwards:
+
+```yaml
+catalogs:
+  - path: src/locales/{locale}
+    format: fcl
+    include: [src]
+```
 
 ## `pmds version`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -56,6 +56,9 @@ storage extension. Palamedes appends `.po` by default or `.fcl` when
 `format` accepts `po` and `fcl`. `ndjson` is no longer supported; use `fcl`
 for Ferrocat Catalog Lines.
 
+See [Catalog formats](./catalog-formats.md) for the product boundary between
+PO storage, FCL storage, and the current framework `.po` import loaders.
+
 `include` and `exclude` are resolved relative to the config file directory.
 When an include entry is a directory-like path, extraction scans JavaScript and
 TypeScript files below it.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,16 +19,26 @@ catalogs:
     include: [src]
 ```
 
+PO remains the default storage format. Use FCL when you want Ferrocat Catalog
+Lines as the generated, canonical, merge-friendly catalog storage:
+
+```yaml
+catalogs:
+  - path: src/locales/{locale}
+    format: fcl
+    include: [src]
+```
+
 ## Fields
 
-| Field                   | Required | Type                                   | Notes                                                                        |
-| ----------------------- | -------- | -------------------------------------- | ---------------------------------------------------------------------------- |
-| `locales`               | Yes      | `string[]`                             | All locale codes known to the project. Must include `source-locale`.         |
-| `source-locale`         | Yes      | `string`                               | Locale used by source messages.                                              |
-| `catalogs`              | Yes      | catalog array                          | Catalog locations and source scan patterns.                                  |
-| `fallback-locales`      | No       | `string[] \| Record<string, string[]>` | Shared or per-locale fallback chain.                                         |
-| `pseudo-locale`         | No       | `string`                               | Locale code used for pseudo-localized UI testing.                            |
-| `source-reference-root` | No       | `git \| config \| lingui \| path`      | Root used for PO `#:` references. Defaults to nearest Git root, then config. |
+| Field                   | Required | Type                                   | Notes                                                                               |
+| ----------------------- | -------- | -------------------------------------- | ----------------------------------------------------------------------------------- |
+| `locales`               | Yes      | `string[]`                             | All locale codes known to the project. Must include `source-locale`.                |
+| `source-locale`         | Yes      | `string`                               | Locale used by source messages.                                                     |
+| `catalogs`              | Yes      | catalog array                          | Catalog locations and source scan patterns.                                         |
+| `fallback-locales`      | No       | `string[] \| Record<string, string[]>` | Shared or per-locale fallback chain.                                                |
+| `pseudo-locale`         | No       | `string`                               | Locale code used for pseudo-localized UI testing.                                   |
+| `source-reference-root` | No       | `git \| config \| lingui \| path`      | Root used for catalog source references. Defaults to nearest Git root, then config. |
 
 ## Catalogs
 
@@ -40,7 +50,11 @@ catalogs:
 ```
 
 `path` should include `{locale}` and points to the catalog path without the
-`.po` extension.
+storage extension. Palamedes appends `.po` by default or `.fcl` when
+`format: fcl` is set.
+
+`format` accepts `po` and `fcl`. `ndjson` is no longer supported; use `fcl`
+for Ferrocat Catalog Lines.
 
 `include` and `exclude` are resolved relative to the config file directory.
 When an include entry is a directory-like path, extraction scans JavaScript and

--- a/docs/plans/2026-06-30-ferrocat-2-migration-rfc.md
+++ b/docs/plans/2026-06-30-ferrocat-2-migration-rfc.md
@@ -1,13 +1,13 @@
 # RFC: Ferrocat 2.x Migration
 
 **Status:** Active plan
-**Date:** 2026-06-30 (updated 2026-07-03 for the Ferrocat 2.1.0 baseline)
+**Date:** 2026-06-30 (updated 2026-07-03 for the Ferrocat 2.1.1 baseline)
 **Owner:** Palamedes maintainers
 **Tracking issue:** [palamedes#285](https://github.com/sebastian-software/palamedes/issues/285)
 
 ## Summary
 
-Palamedes should migrate from Ferrocat `1.3.1` to Ferrocat `2.1.0` as a
+Palamedes should migrate from Ferrocat `1.3.1` to Ferrocat `2.1.1` as a
 product migration, not as a minimal compatibility patch.
 
 The recommended direction is to make Ferrocat Catalog Lines (FCL) a public
@@ -18,13 +18,13 @@ N-API boundary, TypeScript wrapper, tests, and documentation.
 
 Primary sources:
 
-- [ferrocat 2.1.0](https://crates.io/crates/ferrocat/2.1.0)
-- [ferrocat-po 2.1.0](https://crates.io/crates/ferrocat-po/2.1.0)
-- [ferrocat-cli 2.1.0](https://crates.io/crates/ferrocat-cli/2.1.0)
-- [ferrocat v2 compare](https://github.com/sebastian-software/ferrocat/compare/ferrocat-v1.3.1...ferrocat-v2.1.0)
-- [ferrocat-po v2 compare](https://github.com/sebastian-software/ferrocat/compare/ferrocat-po-v1.3.1...ferrocat-po-v2.1.0)
+- [ferrocat 2.1.1](https://crates.io/crates/ferrocat/2.1.1)
+- [ferrocat-po 2.1.1](https://crates.io/crates/ferrocat-po/2.1.1)
+- [ferrocat-cli 2.1.1](https://crates.io/crates/ferrocat-cli/2.1.1)
+- [ferrocat v2 compare](https://github.com/sebastian-software/ferrocat/compare/ferrocat-v1.3.1...ferrocat-v2.1.1)
+- [ferrocat-po v2 compare](https://github.com/sebastian-software/ferrocat/compare/ferrocat-po-v1.3.1...ferrocat-po-v2.1.1)
 - [Releases and upgrading guide](https://ferrocat.dev/guide/upgrading), including
-  the 2.1.0 cleanup window and the announced 2.2 API cleanup
+  the 2.1.1 cleanup window and the announced 2.2 API cleanup
 - ADRs [0021](https://ferrocat.dev/architecture/adr/0021-drop-source-line-numbers),
   [0022](https://ferrocat.dev/architecture/adr/0022-machine-managed-value-integrity-and-ai-provenance),
   [0023](https://ferrocat.dev/architecture/adr/0023-drop-gettext-flags-merge-comments),
@@ -32,17 +32,22 @@ Primary sources:
   [0025](https://ferrocat.dev/architecture/adr/0025-obsolete-age-and-cleanup)
 
 Version baseline: Palamedes currently pins `ferrocat` and `ferrocat-po` at
-`1.3.1`. Upstream has since released `2.0.0` (2026-06-30) and `2.1.0`
-(2026-07-02). This migration targets `2.1.0` directly: `2.1.0` is a reviewed
+`1.3.1`. Upstream has since released `2.0.0` (2026-06-30) and `2.1.1`
+(2026-07-02). This migration targets `2.1.1` directly: `2.1.1` is a reviewed
 cleanup window for accidental public API coupling left after `2.0.0`, and
 landing on it avoids adapting to an API surface that upstream has already
 revised.
+
+Implementation note: the originally reviewed plan targeted `2.1.0`, but the
+options-embedded ICU helpers used for the 2.2-proofing landed in the available
+`2.1.1` patch release. The migration therefore pins the Ferrocat crates to
+`2.1.1` instead of carrying the older cross-product entry points.
 
 Compatibility probe:
 
 - A scratch migration against `origin/main` found that, after the mechanical
   Ferrocat 2.0 API adaptations, `cargo check --workspace --locked` passes.
-- The probe predates `2.1.0`. The 2.1 cleanups are source-level breaks, but
+- The probe predates `2.1.1`. The 2.1 cleanups are source-level breaks, but
   they are small renames and construction changes with direct replacements
   documented in the upgrade guide.
 - The main risk is therefore API and product-shape correctness, not unknown
@@ -50,9 +55,9 @@ Compatibility probe:
 
 ## Goals
 
-- Upgrade `ferrocat`, `ferrocat-po`, and `ferrocat-icu` to `2.1.0`.
+- Upgrade `ferrocat`, `ferrocat-po`, and `ferrocat-icu` to `2.1.1`.
 - Update `FERROCAT_VERSION`, `Cargo.lock`, and native type output.
-- Absorb the 2.1.0 breaking cleanups: renamed entry points, the new `MsgStr`
+- Absorb the 2.1.1 breaking cleanups: renamed entry points, the new `MsgStr`
   accessors, opaque `PoVec` construction, and `#[non_exhaustive]` options with
   builder setters.
 - Adopt the announced 2.2 API style now so the next Ferrocat cleanup is a
@@ -116,7 +121,7 @@ if they become durable product policy. For now, this document should stay under
 
 ## Relationship to ferrocat-cli
 
-`ferrocat-cli` is now available as `ferrocat-cli` `2.1.0` on crates.io and
+`ferrocat-cli` is now available as `ferrocat-cli` `2.1.1` on crates.io and
 publishes a `ferrocat` binary.
 
 The current Ferrocat CLI surface is useful, but intentionally narrower than the
@@ -142,7 +147,7 @@ This should shape the Palamedes migration in two ways:
 Example optional raw-catalog audit:
 
 ```bash
-cargo install ferrocat-cli --version 2.1.0
+cargo install ferrocat-cli --version 2.1.1
 ferrocat audit \
   --source-locale en \
   --source src/locales/en.fcl \
@@ -360,8 +365,8 @@ escape hatch for repositories that want immediate deletion.
 
 ### 1. Rust Dependency and Core API Pass
 
-- Upgrade `ferrocat`, `ferrocat-po`, and `ferrocat-icu` to `2.1.0`.
-- Update `FERROCAT_VERSION` to `2.1.0`.
+- Upgrade `ferrocat`, `ferrocat-po`, and `ferrocat-icu` to `2.1.1`.
+- Update `FERROCAT_VERSION` to `2.1.1`.
 - Run the lockfile update.
 - Replace removed imports and type names, including the 2.1 renames:
   `catalog_review` to `review_catalogs`, `catalog_coverage` to
@@ -646,7 +651,7 @@ Type generation:
 Optional cross-check:
 
 ```bash
-cargo install ferrocat-cli --version 2.1.0
+cargo install ferrocat-cli --version 2.1.1
 ferrocat audit \
   --source-locale en \
   --source <source.fcl> \
@@ -723,8 +728,8 @@ config-aware test coverage.
 
 ## Acceptance Criteria
 
-- `ferrocat`, `ferrocat-po`, and `ferrocat-icu` resolve to `2.1.0`.
-- `FERROCAT_VERSION` reports `2.1.0`.
+- `ferrocat`, `ferrocat-po`, and `ferrocat-icu` resolve to `2.1.1`.
+- `FERROCAT_VERSION` reports `2.1.1`.
 - No usage of the pre-2.1 names remains (`catalog_review`, `catalog_coverage`,
   `has_selectordinal`, `MergeExtractedMessage`, `MsgStr::first_str`).
 - Ferrocat options are constructed exclusively through `new()` + `with_*()`

--- a/docs/proof-and-benchmarks.md
+++ b/docs/proof-and-benchmarks.md
@@ -24,7 +24,7 @@ evidence easy to inspect.
 | Recommended use cases | New projects, i18n cleanup, teams already comfortable with Lingui-style authoring |
 | Supported frameworks  | Verified examples for Next.js, TanStack Start, SolidStart, Waku, and React Router |
 | Runtime model         | `@palamedes/runtime` with `getI18n()`                                             |
-| Catalog model         | Source-string-first, `.po`, `message + context` identity                          |
+| Catalog model         | Source-string-first, `message + context` identity; PO default, FCL opt-in         |
 | Native core           | Rust + `napi-rs`                                                                  |
 | Catalog semantics     | Delegated to `ferrocat`, including audit and ICU diagnostics                      |
 | Node requirement      | `>=22.22`                                                                         |
@@ -34,7 +34,7 @@ evidence easy to inspect.
 
 - first-party multi-framework example matrix with cookie and route locale strategies
 - a native core with typed bindings
-- source-string-first catalog semantics backed by `ferrocat`
+- source-string-first PO/FCL catalog semantics backed by `ferrocat`
 - structured catalog audits and ICU metadata validation
 - reproducible local benchmark commands
 - versioned browser screenshots generated from the same CI browser flows
@@ -160,8 +160,13 @@ run can measure:
 - catalog update time for the generated message set
 - catalog artifact compile time for the generated PO catalog
 
-Set `--large-messages` to enable that section. The default benchmark remains
-small and quick so it is still useful during routine local checks.
+Set `--large-messages` to enable that section. The benchmark intentionally keeps
+PO as the baseline catalog storage because PO is the default app-facing format
+and the Lingui comparison harness is PO-based. Use the catalog-format tests and
+CLI conversion workflow to validate FCL behavior separately.
+
+The default benchmark remains small and quick so it is still useful during
+routine local checks.
 
 ## Local Baseline
 
@@ -187,7 +192,7 @@ Median results from that run:
 - catalog artifact compile: `4.04 ms`
 
 This sample is a historical reference point. Current Palamedes builds use
-Ferrocat `1.3.1`; rerun the command above when you need fresh numbers for the
+Ferrocat `2.1.1`; rerun the command above when you need fresh numbers for the
 current release line. The benchmark script also prints the raw sample series and
 sampled peak RSS so the checked median and memory shape are easy to verify.
 
@@ -202,6 +207,7 @@ The goal is simpler: show the work and make local verification easy.
 ## Related Proof Assets
 
 - [First working translation in 5 minutes](https://github.com/sebastian-software/palamedes/blob/main/docs/first-working-translation.md)
+- [Catalog formats: PO and FCL](https://github.com/sebastian-software/palamedes/blob/main/docs/catalog-formats.md)
 - [Examples](https://github.com/sebastian-software/palamedes/blob/main/examples/README.md)
 - [Example screenshots](https://github.com/sebastian-software/palamedes/blob/main/docs/example-screenshots/README.md)
 - [Framework example notes](https://github.com/sebastian-software/palamedes/blob/main/docs/framework-example-notes.md)

--- a/docs/site/index.mdx
+++ b/docs/site/index.mdx
@@ -25,6 +25,7 @@ The repo backs that claim with visible evidence:
 - two locale strategies per framework: cookie and route segment
 - versioned browser screenshots generated from the same Playwright verifier used in CI
 - reproducible benchmark commands for transform, extract, catalog update, and artifact compile
+- opt-in FCL catalog storage for canonical, merge-friendly generated catalogs
 - 16 ADRs that explain the product decisions, including what Palamedes deliberately does not own
 
 Start with the [example matrix](../../examples/README.md), the
@@ -67,6 +68,7 @@ Palamedes keeps the day-to-day model simpler:
 - identify messages with `message + context`
 - resolve the active runtime through `getI18n()`
 - let `ferrocat` own catalog parsing, updates, audits, and ICU diagnostics
+- choose PO by default or opt into FCL when a repo needs canonical generated catalog storage
 - keep framework adapters small
 
 Rust matters here because the careful work has one clear home. That keeps the

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -34,7 +34,8 @@ major/minor/patch sense.
 | `@palamedes/vite-plugin` and `@palamedes/next-plugin` | Stable   | Plugin options and `.po` loading behavior are public integration APIs.                                                         |
 | `@palamedes/config`                                   | Stable   | Config file names, `defineConfig`, and the config schema are public.                                                           |
 | `@palamedes/cli`                                      | Stable   | Documented commands and flags are public. New commands may appear in minors.                                                   |
-| Source-string-first `.po` catalogs                    | Stable   | Message identity is `message + context`. Catalog files remain user-owned.                                                      |
+| Source-string-first PO catalogs                       | Stable   | Message identity is `message + context`. Catalog files remain user-owned.                                                      |
+| FCL catalog storage                                   | Preview  | Supported through config, CLI, and native catalog APIs; app-facing framework imports remain PO-loader based for now.           |
 | Macro syntax                                          | Stable   | Supported macros remain the authoring model. Unsupported explicit IDs are not a compatibility target.                          |
 | `@palamedes/core-node`                                | Preview  | It is usable directly, but primarily exists as the JS boundary to the Rust core. Generated type details may change before 1.0. |
 | Platform native packages                              | Internal | `@palamedes/core-node-*` packages are optional dependency carriers for native binaries. Apps should not import them directly.  |
@@ -48,6 +49,7 @@ Palamedes treats these as stable adoption surfaces:
 
 - `palamedes.yaml` schema and config discovery
 - source-string-first PO catalogs using `message + context` identity
+- documented FCL storage configuration and conversion workflows
 - documented `pmds` commands and flags
 - Vite and Next plugin options documented in package READMEs
 - runtime access through `getI18n()`
@@ -67,6 +69,7 @@ adoption:
 
 - generated native binding type details
 - compiled artifact internals
+- FCL import support in framework adapters
 - package layout for new native platform targets
 - benchmark fixture shape and reporting fields
 - internal package boundaries between plugins and transform/core-node helpers

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -70,6 +70,9 @@ For local performance checks, set `PALAMEDES_TIMING_JSON=1` on `pmds extract`.
 The command prints a machine-readable timing line with total, glob, extract,
 and catalog-write timings.
 
+See [Catalog formats](https://github.com/sebastian-software/palamedes/blob/main/docs/catalog-formats.md)
+for when to keep PO storage and when to opt into FCL.
+
 ### Completeness Report
 
 `pmds report` prints a per-locale translation-management view:

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -18,7 +18,7 @@ Use `@palamedes/cli` when you want:
 - a supported extraction command for Palamedes projects
 - structured catalog audits in CI
 - watch mode during development
-- a clean way to update `.po` catalogs in CI
+- a clean way to update `.po` catalogs in CI, with opt-in `.fcl` storage
 - a semantic catalog merge command for Git merge drivers
 
 If you are building your own extraction workflow inside your i18n config or custom tooling, look at [`@palamedes/extractor`](https://www.npmjs.com/package/@palamedes/extractor) instead.
@@ -49,6 +49,7 @@ The npm package currently publishes native binaries for:
 pnpm exec pmds extract
 pnpm exec pmds extract --watch
 pnpm exec pmds extract --clean
+pnpm exec pmds extract --force-clean
 pnpm exec pmds extract --config ./palamedes.yaml
 pnpm exec pmds extract --verbose
 pnpm exec pmds audit
@@ -58,10 +59,11 @@ pnpm exec pmds report
 pnpm exec pmds report --locale de,fr --fail-if-below 95
 pnpm exec pmds report --json
 pnpm exec pmds catalog merge --output src/locales/de.po src/locales/de.po other.po
+pnpm exec pmds catalog convert src/locales/de.po --to fcl --output src/locales/de.fcl
 ```
 
-`pmds audit` reports missing translations, extra catalog entries, fuzzy or
-obsolete messages, and ICU compatibility issues through the same `ferrocat`
+`pmds audit` reports missing translations, extra catalog entries, obsolete
+messages, and ICU compatibility issues through the same `ferrocat`
 catalog engine that powers Palamedes builds.
 
 For local performance checks, set `PALAMEDES_TIMING_JSON=1` on `pmds extract`.
@@ -73,9 +75,9 @@ and catalog-write timings.
 `pmds report` prints a per-locale translation-management view:
 
 ```text
-Locale  Translated  Missing  Fuzzy  Complete
-de      480/520     37       3      92.3%
-fr      510/520     10       0      98.1%
+Locale  Translated  Missing  Complete
+de      483/520     37       92.9%
+fr      510/520     10       98.1%
 ```
 
 By default, it reports configured target locales and skips the source locale
@@ -85,31 +87,31 @@ locale is below the threshold.
 
 ### Catalog Merge
 
-`pmds catalog merge` combines exactly two catalog files. When both inputs
+`pmds catalog merge` combines catalog files. When inputs
 contain the same semantic identity, `--conflict-strategy` controls how
 translator-facing conflicts are handled; messages that only exist in the second
 input are added.
 
 ```bash
-pnpm exec pmds catalog merge --format=po --conflict-strategy=use-first --output %A %A %B
+pnpm exec pmds catalog merge --format=po --conflict-strategy=use-first --base %O --output %A %A %B
+pnpm exec pmds catalog merge --format=fcl --conflict-strategy=use-first --base %O --output %A %A %B
 ```
 
 `--format` can be omitted when all input and output extensions are supported
-and match. `.po` maps to `po`; `.json`, `.ndjson`, and `.fcat.ndjson` map to
-Ferrocat's `ndjson` storage format.
+and match. `.po` maps to `po`; `.fcl` maps to `fcl`.
 
 For Git merge-driver usage:
 
 ```gitattributes
 *.po merge=palamedes-catalog
-*.fcat.ndjson merge=palamedes-catalog-ndjson
+*.fcl merge=palamedes-catalog-fcl
 ```
 
 ```bash
 git config merge.palamedes-catalog.driver \
-  'pmds catalog merge --format=po --conflict-strategy=use-first --output %A %A %B'
-git config merge.palamedes-catalog-ndjson.driver \
-  'pmds catalog merge --format=ndjson --conflict-strategy=use-first --output %A %A %B'
+  'pmds catalog merge --format=po --conflict-strategy=use-first --base %O --output %A %A %B'
+git config merge.palamedes-catalog-fcl.driver \
+  'pmds catalog merge --format=fcl --conflict-strategy=use-first --base %O --output %A %A %B'
 ```
 
 `--source-locale` is optional. The command uses an explicit value first, then

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -45,6 +45,9 @@ catalogs:
 - `catalogs[].format` defaults to `"po"`. Set it to `"fcl"` to use Ferrocat
   Catalog Lines for canonical, merge-friendly generated catalog storage.
 
+See [Catalog formats](https://github.com/sebastian-software/palamedes/blob/main/docs/catalog-formats.md)
+for the PO/FCL storage boundary.
+
 See [Pseudo-localization and fallback locales](https://github.com/sebastian-software/palamedes/blob/main/docs/pseudo-localization.md)
 for examples and the recommended development workflow.
 

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -42,6 +42,8 @@ catalogs:
   repository root and falls back to the config directory when no Git root is
   available. Use `"lingui"` or `"config"` for Lingui-compatible references
   relative to the config directory, or pass a custom path.
+- `catalogs[].format` defaults to `"po"`. Set it to `"fcl"` to use Ferrocat
+  Catalog Lines for canonical, merge-friendly generated catalog storage.
 
 See [Pseudo-localization and fallback locales](https://github.com/sebastian-software/palamedes/blob/main/docs/pseudo-localization.md)
 for examples and the recommended development workflow.

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -22,6 +22,7 @@ export type PalamedesSourceReferenceRoot = "git" | "lingui" | "config" | (string
 
 export type PalamedesCatalogConfig = {
   path: string
+  format?: "po" | "fcl"
   include: string[]
   exclude?: string[]
 }
@@ -228,6 +229,7 @@ async function normalizeConfig(
     sourceReferenceRoot: await resolveSourceReferenceRoot(config.sourceReferenceRoot, rootDir),
     catalogs: config.catalogs.map((catalog) => ({
       path: catalog.path,
+      ...(catalog.format !== undefined ? { format: catalog.format } : {}),
       include: [...catalog.include],
       ...(catalog.exclude ? { exclude: [...catalog.exclude] } : {}),
     })),
@@ -367,6 +369,17 @@ function validateCatalog(catalog: unknown, configPath: string, index: number): v
   if (!Array.isArray(record.include) || record.include.some((value) => typeof value !== "string")) {
     throw new Error(
       `Invalid Palamedes config in ${configPath}: "catalogs[${index}].include" must be an array of strings.`
+    )
+  }
+
+  if (record.format !== undefined && record.format !== "po" && record.format !== "fcl") {
+    if (record.format === "ndjson") {
+      throw new Error(
+        `Invalid Palamedes config in ${configPath}: "catalogs[${index}].format" value "ndjson" is no longer supported; use "fcl" for Ferrocat Catalog Lines.`
+      )
+    }
+    throw new Error(
+      `Invalid Palamedes config in ${configPath}: "catalogs[${index}].format" must be "po" or "fcl" when provided.`
     )
   }
 

--- a/packages/config/src/loadConfig.test.ts
+++ b/packages/config/src/loadConfig.test.ts
@@ -56,6 +56,7 @@ describe("loadPalamedesConfig", () => {
         source-reference-root: config
         catalogs:
           - path: src/locales/{locale}
+            format: fcl
             include: [src]
             exclude: [src/generated]
       `
@@ -68,9 +69,30 @@ describe("loadPalamedesConfig", () => {
     expect(config.sourceReferenceRoot).toBe(fixtureDir)
     expect(config.catalogs[0]).toStrictEqual({
       path: "src/locales/{locale}",
+      format: "fcl",
       include: ["src"],
       exclude: ["src/generated"],
     })
+  })
+
+  it("rejects the removed ndjson catalog format with an FCL migration hint", async () => {
+    const fixtureDir = await createTempDir()
+
+    await writeFile(
+      path.join(fixtureDir, "palamedes.yaml"),
+      `
+        locales: [en, de]
+        source-locale: en
+        catalogs:
+          - path: src/locales/{locale}
+            format: ndjson
+            include: [src]
+      `
+    )
+
+    await expect(loadPalamedesConfig({ cwd: fixtureDir })).rejects.toThrow(
+      /"catalogs\[0\]\.format" value "ndjson" is no longer supported; use "fcl"/
+    )
   })
 
   it("loads palamedes.toml as a secondary config format", async () => {

--- a/packages/core-node/README.md
+++ b/packages/core-node/README.md
@@ -8,8 +8,9 @@
 The Node.js wrapper around Palamedes' native core.
 
 Use this package when you are building tooling on top of Palamedes and want
-direct access to the careful parts of the system: catalog updates, audits,
-metadata validation, `.po` parsing, extraction, and macro transformation.
+direct access to the careful parts of the system: PO/FCL catalog updates,
+audits, metadata validation, `.po` parsing, extraction, and macro
+transformation.
 
 The public catalog model is source-string-first: `message + context` is the
 semantic identity, while compact lookup keys remain internal compile/runtime
@@ -75,6 +76,12 @@ combineCatalogFiles({
   format: "po",
   sourceLocale: "en",
 })
+combineCatalogFiles({
+  inputPaths: ["src/locales/de.fcl", "incoming/de.fcl"],
+  outputPath: "src/locales/de.fcl",
+  format: "fcl",
+  sourceLocale: "en",
+})
 
 console.log(info.palamedesVersion)
 console.log(po.headers.Language)
@@ -102,6 +109,9 @@ Catalog operations use Ferrocat for parsing, updates, audits, ICU authoring
 diagnostics, metadata validation, and deterministic combine workflows. That
 keeps custom tooling close to the same semantics used by the official CLI and
 framework plugins.
+
+The wrapper exposes lowercase public format values (`"po"` and `"fcl"`) while
+mapping to the native Ferrocat-backed API internally.
 
 ## Related Packages
 

--- a/packages/core-node/src/generated/palamedes-node-types.ts
+++ b/packages/core-node/src/generated/palamedes-node-types.ts
@@ -4,6 +4,11 @@
 export interface CatalogOrigin {
   file: string;
   line: number;
+  scope?: string;
+}
+export interface ParsedCatalogOrigin {
+  file: string;
+  scope?: string;
 }
 export interface CatalogUpdateMessage {
   message: string;
@@ -17,6 +22,8 @@ export interface CatalogUpdateRequest {
   locale: string;
   sourceLocale: string;
   clean: boolean;
+  forceClean?: boolean;
+  format?: CatalogConfigFormat;
   messages: Array<CatalogUpdateMessage>;
 }
 export interface CatalogUpdateStats {
@@ -37,20 +44,24 @@ export interface CatalogParseRequest {
   targetPath: string;
   locale: string;
   sourceLocale: string;
+  format?: CatalogConfigFormat;
 }
 export interface ParsedCatalogMessage {
   message: string;
   context?: string;
   comments: Array<string>;
-  origins: Array<CatalogOrigin>;
+  origins: Array<ParsedCatalogOrigin>;
   obsolete: boolean;
-  machineTranslation?: MachineTranslationMetadata;
+  translated: boolean;
+  machine?: MachineMetadata;
 }
-export interface MachineTranslationMetadata {
+export interface MachineMetadata {
+  lock: string;
+  ai?: AiProvenance;
+}
+export interface AiProvenance {
   model: string;
-  modified?: string;
   confidence?: number;
-  hash: string;
 }
 export interface CatalogParseResult {
   locale?: string;
@@ -89,7 +100,7 @@ export interface CatalogCombineResult {
   stats: CatalogCombineStats;
   diagnostics: Array<CatalogDiagnostic>;
 }
-export type CatalogFileFormat = "Po" | "Ndjson"
+export type CatalogFileFormat = "Po" | "Fcl"
 export interface CatalogFileCombineRequest {
   inputPaths: Array<string>;
   outputPath: string;
@@ -121,7 +132,6 @@ export interface CatalogAuditCheckOptions {
   icuSyntax?: boolean;
   icuCompatibility?: boolean;
   semanticMetadata?: boolean;
-  fuzzyFlags?: boolean;
   obsoleteEntries?: boolean;
 }
 export interface CatalogAuditRequest {
@@ -246,9 +256,11 @@ export interface CatalogModuleResult {
 }
 export interface CatalogArtifactCatalogConfig {
   path: string;
+  format?: CatalogConfigFormat;
   include: Array<string>;
   exclude?: Array<string>;
 }
+export type CatalogConfigFormat = "Po" | "Fcl"
 export interface CatalogArtifactConfig {
   rootDir: string;
   locales: Array<string>;

--- a/packages/core-node/src/index.ts
+++ b/packages/core-node/src/index.ts
@@ -11,6 +11,7 @@ import type {
   CatalogFileCombineResult as GeneratedCatalogFileCombineResult,
   CatalogCombineRequest as GeneratedCatalogCombineRequest,
   CatalogCombineResult as GeneratedCatalogCombineResult,
+  CatalogArtifactCatalogConfig as GeneratedCatalogArtifactCatalogConfig,
   CatalogArtifactConfig as GeneratedCatalogArtifactConfig,
   CatalogArtifactDiagnostic as GeneratedCatalogArtifactDiagnostic,
   CatalogArtifactMissingMessage as GeneratedCatalogArtifactMissingMessage,
@@ -42,7 +43,7 @@ import type {
   MessageOriginMetadata as GeneratedMessageOriginMetadata,
   MessageSelectorKind as GeneratedMessageSelectorKind,
   MessageSelectorMetadata as GeneratedMessageSelectorMetadata,
-  MachineTranslationMetadata as GeneratedMachineTranslationMetadata,
+  MachineMetadata as GeneratedMachineMetadata,
   NativeBindings as GeneratedNativeBindings,
   NativeExtractedMessage as GeneratedNativeExtractedMessage,
   NativeInfo as GeneratedNativeInfo,
@@ -60,14 +61,12 @@ export type ParsedPoItem = GeneratedParsedPoItem
 export type ParsedPoFile = GeneratedParsedPoFile
 export type CatalogOrigin = GeneratedCatalogOrigin
 export type CatalogUpdateMessage = GeneratedCatalogUpdateMessage
-export type CatalogUpdateRequest = GeneratedCatalogUpdateRequest
 export type CatalogUpdateStats = GeneratedCatalogUpdateStats
 export type ExtractCatalogFileFailure = GeneratedExtractCatalogFileFailure
 export type ExtractCatalogMessagesRequest = GeneratedExtractCatalogMessagesRequest
 export type ExtractCatalogMessagesResult = GeneratedExtractCatalogMessagesResult
-export type CatalogParseRequest = GeneratedCatalogParseRequest
 export type ParsedCatalogMessage = GeneratedParsedCatalogMessage
-export type MachineTranslationMetadata = GeneratedMachineTranslationMetadata
+export type MachineMetadata = GeneratedMachineMetadata
 export type CatalogAuditCheckOptions = GeneratedCatalogAuditCheckOptions
 export type CatalogAuditSummary = GeneratedCatalogAuditSummary
 export type CatalogDiagnosticSeverity = "info" | "warning" | "error"
@@ -103,7 +102,14 @@ export type CatalogCombineRequest = {
 export type CatalogCombineResult = Omit<GeneratedCatalogCombineResult, "diagnostics"> & {
   diagnostics: CatalogDiagnostic[]
 }
-export type CatalogFileFormat = "po" | "ndjson"
+export type CatalogFileFormat = "po" | "fcl"
+export type CatalogConfigFormat = CatalogFileFormat
+export type CatalogUpdateRequest = Omit<GeneratedCatalogUpdateRequest, "format"> & {
+  format?: CatalogConfigFormat
+}
+export type CatalogParseRequest = Omit<GeneratedCatalogParseRequest, "format"> & {
+  format?: CatalogConfigFormat
+}
 export type CatalogFileCombineRequest = {
   inputPaths: string[]
   outputPath: string
@@ -160,7 +166,12 @@ export type CatalogArtifactDiagnostic = Omit<GeneratedCatalogArtifactDiagnostic,
 export type CatalogArtifactFallbackLocales = NonNullable<
   GeneratedCatalogArtifactConfig["fallbackLocales"]
 >
-export type CatalogArtifactConfig = GeneratedCatalogArtifactConfig
+export type CatalogArtifactCatalogConfig = Omit<GeneratedCatalogArtifactCatalogConfig, "format"> & {
+  format?: CatalogConfigFormat
+}
+export type CatalogArtifactConfig = Omit<GeneratedCatalogArtifactConfig, "catalogs"> & {
+  catalogs: CatalogArtifactCatalogConfig[]
+}
 export type CatalogArtifactResult = Omit<GeneratedCatalogArtifactResult, "diagnostics"> & {
   diagnostics: CatalogArtifactDiagnostic[]
 }
@@ -182,6 +193,8 @@ type NativeCatalogFileCombineRequest = GeneratedCatalogFileCombineRequest
 type NativeCatalogArtifactRequest = GeneratedCatalogArtifactRequest
 type NativeCatalogArtifactSelectedRequest = GeneratedCatalogArtifactSelectedRequest
 type NativeCatalogModuleRequest = GeneratedCatalogModuleRequest
+type NativeCatalogUpdateRequest = GeneratedCatalogUpdateRequest
+type NativeCatalogParseRequest = GeneratedCatalogParseRequest
 
 function detectLinuxLibc(): "gnu" | "musl" | null {
   if (process.platform !== "linux") {
@@ -303,7 +316,7 @@ export function parsePo(source: string): ParsedPoFile {
 }
 
 export function updateCatalogFile(request: CatalogUpdateRequest): CatalogUpdateResult {
-  const result = native.updateCatalogFile(request)
+  const result = native.updateCatalogFile(toNativeUpdateRequest(request))
   return {
     ...result,
     diagnostics: mapCatalogDiagnostics(result.diagnostics),
@@ -311,7 +324,7 @@ export function updateCatalogFile(request: CatalogUpdateRequest): CatalogUpdateR
 }
 
 export function parseCatalog(request: CatalogParseRequest): CatalogParseResult {
-  const result = native.parseCatalog(request)
+  const result = native.parseCatalog(toNativeParseRequest(request))
   return {
     ...result,
     diagnostics: mapCatalogDiagnostics(result.diagnostics),
@@ -323,7 +336,7 @@ export function auditCatalogs(
   options: CatalogAuditOptions = {}
 ): CatalogAuditResult {
   const request: NativeCatalogAuditRequest = {
-    config,
+    config: toNativeArtifactConfig(config),
     locales: options.locales,
     checks: options.checks,
     metadata: options.metadata,
@@ -427,9 +440,39 @@ function toNativeFileFormat(
     case "po": {
       return "Po"
     }
-    case "ndjson": {
-      return "Ndjson"
+    case "fcl": {
+      return "Fcl"
     }
+  }
+}
+
+function toNativeConfigFormat(
+  format: CatalogConfigFormat
+): NonNullable<GeneratedCatalogArtifactCatalogConfig["format"]> {
+  return toNativeFileFormat(format)
+}
+
+function toNativeUpdateRequest(request: CatalogUpdateRequest): NativeCatalogUpdateRequest {
+  return {
+    ...request,
+    format: request.format ? toNativeConfigFormat(request.format) : undefined,
+  }
+}
+
+function toNativeParseRequest(request: CatalogParseRequest): NativeCatalogParseRequest {
+  return {
+    ...request,
+    format: request.format ? toNativeConfigFormat(request.format) : undefined,
+  }
+}
+
+function toNativeArtifactConfig(config: CatalogArtifactConfig): GeneratedCatalogArtifactConfig {
+  return {
+    ...config,
+    catalogs: config.catalogs.map((catalog) => ({
+      ...catalog,
+      format: catalog.format ? toNativeConfigFormat(catalog.format) : undefined,
+    })),
   }
 }
 
@@ -440,8 +483,8 @@ function fromNativeFileFormat(
     case "Po": {
       return "po"
     }
-    case "Ndjson": {
-      return "ndjson"
+    case "Fcl": {
+      return "fcl"
     }
   }
 }
@@ -470,7 +513,7 @@ export function compileCatalogArtifact(
   resourcePath: string
 ): CatalogArtifactResult {
   const request: NativeCatalogArtifactRequest = {
-    config,
+    config: toNativeArtifactConfig(config),
     resourcePath,
   }
   const result = native.compileCatalogArtifact(request)
@@ -490,7 +533,7 @@ export function compileCatalogArtifactSelected(
   compiledIds: string[]
 ): CatalogArtifactResult {
   const request: NativeCatalogArtifactSelectedRequest = {
-    config,
+    config: toNativeArtifactConfig(config),
     resourcePath,
     compiledIds,
   }
@@ -511,7 +554,7 @@ export function compileCatalogModule(
   options: CatalogModuleOptions
 ): CatalogModuleResult {
   const request: NativeCatalogModuleRequest = {
-    config,
+    config: toNativeArtifactConfig(config),
     resourcePath,
     locale: options.locale,
     pseudoLocale: options.pseudoLocale,

--- a/packages/next-plugin/README.md
+++ b/packages/next-plugin/README.md
@@ -52,6 +52,10 @@ catalogs:
 
 Transformed code expects `getI18n()` from `@palamedes/runtime`, so make sure the active i18n instance is available on both the client and the server before translated code executes.
 
+Catalog storage can be PO or FCL in `palamedes.yaml`, but the current Next
+loader is still a `.po` import loader. Keep direct app imports on `.po` unless a
+future adapter release explicitly documents `.fcl` imports.
+
 For App Router Server Components on the Node runtime, use a server-only module
 with `@palamedes/runtime/server`. This follows the official RSC shape: keep
 server code behind `server-only`, memoize request work with React `cache()`, and

--- a/packages/vite-plugin/README.md
+++ b/packages/vite-plugin/README.md
@@ -78,6 +78,10 @@ catalogs:
 
 Transformed code expects `getI18n()` from `@palamedes/runtime`, so register the active client i18n instance before translated code executes.
 
+Catalog storage can be PO or FCL in `palamedes.yaml`, but the current Vite
+loader is still a `.po` import loader. Keep direct app imports on `.po` unless a
+future adapter release explicitly documents `.fcl` imports.
+
 ## Options
 
 ```ts


### PR DESCRIPTION
## Summary
- migrate catalog storage paths to Ferrocat 2.1.1 with PO default and opt-in FCL support
- add CLI workflows for FCL merge/convert, merge bases, and force-clean extraction
- expose FCL formats and machine metadata through the Node and TypeScript surface
- update README, CLI/config/API docs, homepage copy, ADR/Decisions, and the migration RFC

Tracking: https://github.com/sebastian-software/palamedes/issues/285

## Notes
- The RFC baseline is adjusted from 2.1.0 to 2.1.1 because 2.1.1 is the first published Ferrocat version with the required builder-style APIs.
- Public TS/config format values stay lowercase: po/fcl. N-API enum values are mapped inside the wrapper.

## Validation
- cargo check --workspace --locked
- cargo test --workspace --locked
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo fmt --all
- pnpm build
- pnpm check-types
- pnpm test
- pnpm format:check