### PR TITLE
Complete Ferrocat 2 migration release readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ easier to review, and easier to carry from one framework to the next.
 - Verified today across Next.js, TanStack Start, SolidStart, Waku, and React Router on Node.js `>=22.22`
 - Source-string-first catalogs are stable and powered by `ferrocat`, including structured audits and ICU authoring diagnostics
 - Placeholder top-level packages exist, but there is no `palamedes` or `create-palamedes` first-run entry yet
-- Pre-1.0 stability tiers and public API expectations are documented in [Stability and versioning](https://github.com/sebastian-software/palamedes/blob/main/docs/stability.md)
+- 1.0 stability tiers and public API expectations are documented in [Stability and versioning](https://github.com/sebastian-software/palamedes/blob/main/docs/stability.md)
 
 ## What Exists Today
 
@@ -243,6 +243,7 @@ The same foundation also matters for future translation workflows:
 
 - [MDX-ready messaging source for homepage/docs](https://github.com/sebastian-software/palamedes/blob/main/docs/site/index.mdx)
 - [Catalog formats: PO and FCL](https://github.com/sebastian-software/palamedes/blob/main/docs/catalog-formats.md)
+- [Migrating to Palamedes 1.0](https://github.com/sebastian-software/palamedes/blob/main/docs/migrations/1.0.0.md)
 - [Proof, benchmarks, and current maturity](https://github.com/sebastian-software/palamedes/blob/main/docs/proof-and-benchmarks.md)
 - [Stability and versioning](https://github.com/sebastian-software/palamedes/blob/main/docs/stability.md)
 - [Example matrix and local/CI verification story](https://github.com/sebastian-software/palamedes/blob/main/examples/README.md)

--- a/crates/palamedes-node/src/extract.rs
+++ b/crates/palamedes-node/src/extract.rs
@@ -11,6 +11,7 @@ pub struct ExtractedMessageOrigin {
     pub filename: String,
     pub line: u32,
     pub column: Option<u32>,
+    pub scope: Option<String>,
 }
 
 #[napi(object)]
@@ -56,6 +57,7 @@ impl TryFrom<palamedes::ExtractedMessageRecord> for NativeExtractedMessage {
                 filename: value.origin.0,
                 line: checked_u32(value.origin.1, "origin.line")?,
                 column: checked_optional_u32(value.origin.2, "origin.column")?,
+                scope: value.scope,
             },
         })
     }

--- a/crates/palamedes/src/extract.rs
+++ b/crates/palamedes/src/extract.rs
@@ -10,9 +10,10 @@ use crate::jsx_message::{
 };
 use oxc_allocator::Allocator;
 use oxc_ast::ast::{
-    Argument, CallExpression, Expression, ImportDeclaration, ImportDeclarationSpecifier,
-    JSXAttributeValue, JSXChild, JSXElement, JSXExpression, JSXOpeningElement, MemberExpression,
-    ObjectExpression, ObjectPropertyKind, TaggedTemplateExpression, TemplateLiteral,
+    Argument, BindingPattern, CallExpression, Declaration, Expression, ImportDeclaration,
+    ImportDeclarationSpecifier, JSXAttributeValue, JSXChild, JSXElement, JSXExpression,
+    JSXOpeningElement, MemberExpression, ObjectExpression, ObjectPropertyKind,
+    TaggedTemplateExpression, TemplateLiteral, VariableDeclarator,
 };
 use oxc_ast_visit::{walk, Visit};
 use oxc_parser::Parser;
@@ -48,6 +49,9 @@ pub struct ExtractedMessageRecord {
     pub placeholders: Option<BTreeMap<String, String>>,
     /// Source origin as `(filename, line, column)`.
     pub origin: (String, usize, Option<usize>),
+    /// Optional stable source container name.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scope: Option<String>,
 }
 
 /// Request for extracting and aggregating catalog messages from source files.
@@ -165,6 +169,7 @@ struct ExtractionVisitor<'a> {
     imported_macros: &'a HashMap<String, ImportedMacro>,
     messages: Vec<ExtractedMessageRecord>,
     error: Option<PalamedesError>,
+    scope_stack: Vec<String>,
 }
 
 impl<'a> ExtractionVisitor<'a> {
@@ -181,6 +186,7 @@ impl<'a> ExtractionVisitor<'a> {
             imported_macros,
             messages: Vec::new(),
             error: None,
+            scope_stack: Vec::new(),
         }
     }
 
@@ -202,6 +208,18 @@ impl<'a> ExtractionVisitor<'a> {
         )
     }
 
+    fn current_scope(&self) -> Option<String> {
+        self.scope_stack.last().cloned()
+    }
+
+    fn push_scope(&mut self, scope: &str) {
+        self.scope_stack.push(scope.to_string());
+    }
+
+    fn pop_scope(&mut self) {
+        self.scope_stack.pop();
+    }
+
     fn location(&self, span_start: usize) -> String {
         let (line, column) = self.line_locator.get_location(span_start);
 
@@ -218,6 +236,35 @@ impl<'a> ExtractionVisitor<'a> {
 }
 
 impl<'a> Visit<'a> for ExtractionVisitor<'a> {
+    fn visit_declaration(&mut self, it: &Declaration<'a>) {
+        let scope = match it {
+            Declaration::FunctionDeclaration(function) => {
+                function.id.as_ref().map(|id| id.name.as_str().to_string())
+            }
+            _ => None,
+        };
+
+        if let Some(scope) = scope {
+            self.push_scope(&scope);
+            walk::walk_declaration(self, it);
+            self.pop_scope();
+        } else {
+            walk::walk_declaration(self, it);
+        }
+    }
+
+    fn visit_variable_declarator(&mut self, it: &VariableDeclarator<'a>) {
+        let scope = function_like_initializer_name(it);
+
+        if let Some(scope) = scope {
+            self.push_scope(&scope);
+            walk::walk_variable_declarator(self, it);
+            self.pop_scope();
+        } else {
+            walk::walk_variable_declarator(self, it);
+        }
+    }
+
     fn visit_jsx_element(&mut self, it: &JSXElement<'a>) {
         if self.error.is_some() {
             return;
@@ -245,6 +292,7 @@ impl<'a> Visit<'a> for ExtractionVisitor<'a> {
                 it,
                 macro_name,
                 self.origin(it.span.start as usize),
+                self.current_scope(),
                 self.source,
             ) {
                 Ok(Some(message)) => self.push(message),
@@ -272,6 +320,7 @@ impl<'a> Visit<'a> for ExtractionVisitor<'a> {
                 match extract_from_tagged_template(
                     &it.quasi,
                     self.origin(it.span.start as usize),
+                    self.current_scope(),
                     self.source,
                     false,
                 ) {
@@ -289,6 +338,7 @@ impl<'a> Visit<'a> for ExtractionVisitor<'a> {
             match extract_from_tagged_template(
                 &it.quasi,
                 self.origin(it.span.start as usize),
+                self.current_scope(),
                 self.source,
                 true,
             ) {
@@ -326,11 +376,13 @@ impl<'a> Visit<'a> for ExtractionVisitor<'a> {
                         it,
                         macro_name,
                         self.origin(it.span.start as usize),
+                        self.current_scope(),
                     ),
                     _ => extract_from_descriptor_call(
                         it,
                         macro_name,
                         self.origin(it.span.start as usize),
+                        self.current_scope(),
                     ),
                 };
 
@@ -346,7 +398,11 @@ impl<'a> Visit<'a> for ExtractionVisitor<'a> {
         }
 
         if is_i18n_runtime_call(&it.callee, false) {
-            match extract_from_runtime_call(it, self.origin(it.span.start as usize)) {
+            match extract_from_runtime_call(
+                it,
+                self.origin(it.span.start as usize),
+                self.current_scope(),
+            ) {
                 Ok(Some(message)) => self.push(message),
                 Ok(None) => {}
                 Err(error) => {
@@ -506,6 +562,7 @@ fn extract_from_jsx_element(
     element: &JSXElement<'_>,
     macro_name: &str,
     origin: (String, usize, Option<usize>),
+    scope: Option<String>,
     source: &str,
 ) -> PalamedesResult<Option<ExtractedMessageRecord>> {
     let attrs = jsx_attributes(&element.opening_element);
@@ -534,6 +591,7 @@ fn extract_from_jsx_element(
             context,
             placeholders: None,
             origin,
+            scope,
         }));
     }
 
@@ -570,6 +628,7 @@ fn extract_from_jsx_element(
             context,
             placeholders: None,
             origin,
+            scope,
         }));
     }
 
@@ -579,6 +638,7 @@ fn extract_from_jsx_element(
 fn extract_from_tagged_template(
     template: &TemplateLiteral<'_>,
     origin: (String, usize, Option<usize>),
+    scope: Option<String>,
     source: &str,
     _runtime: bool,
 ) -> PalamedesResult<Option<ExtractedMessageRecord>> {
@@ -593,6 +653,7 @@ fn extract_from_tagged_template(
         context: None,
         placeholders: (!placeholders.is_empty()).then_some(placeholders),
         origin,
+        scope,
     }))
 }
 
@@ -600,6 +661,7 @@ fn extract_from_descriptor_call(
     call: &CallExpression<'_>,
     macro_name: &str,
     origin: (String, usize, Option<usize>),
+    scope: Option<String>,
 ) -> PalamedesResult<Option<ExtractedMessageRecord>> {
     let Some(first_arg) = call.arguments.first() else {
         return Ok(None);
@@ -632,6 +694,7 @@ fn extract_from_descriptor_call(
         context,
         placeholders: None,
         origin,
+        scope,
     }))
 }
 
@@ -639,6 +702,7 @@ fn extract_from_choice_call(
     call: &CallExpression<'_>,
     macro_name: &str,
     origin: (String, usize, Option<usize>),
+    scope: Option<String>,
 ) -> PalamedesResult<Option<ExtractedMessageRecord>> {
     let Some(value_arg) = call.arguments.first() else {
         return Ok(None);
@@ -672,6 +736,7 @@ fn extract_from_choice_call(
         context: None,
         placeholders: None,
         origin,
+        scope,
     }))
 }
 
@@ -703,6 +768,7 @@ fn is_i18n_runtime_call(expr: &Expression<'_>, allow_t: bool) -> bool {
 fn extract_from_runtime_call(
     call: &CallExpression<'_>,
     origin: (String, usize, Option<usize>),
+    scope: Option<String>,
 ) -> PalamedesResult<Option<ExtractedMessageRecord>> {
     let Some(first_arg) = call.arguments.first() else {
         return Ok(None);
@@ -722,6 +788,7 @@ fn extract_from_runtime_call(
             context: props.get("context").cloned(),
             placeholders: None,
             origin,
+            scope,
         }));
     }
 
@@ -745,7 +812,42 @@ fn extract_from_runtime_call(
         context,
         placeholders: None,
         origin,
+        scope,
     }))
+}
+
+fn function_like_initializer_name(declarator: &VariableDeclarator<'_>) -> Option<String> {
+    let init = declarator.init.as_ref()?.without_parentheses();
+
+    is_function_like_expression(init)
+        .then(|| binding_identifier_name(&declarator.id))
+        .flatten()
+}
+
+fn is_function_like_expression(expr: &Expression<'_>) -> bool {
+    match expr.without_parentheses() {
+        Expression::ArrowFunctionExpression(_) | Expression::FunctionExpression(_) => true,
+        Expression::CallExpression(call) => call
+            .arguments
+            .first()
+            .and_then(argument_expression)
+            .is_some_and(is_function_like_expression),
+        _ => false,
+    }
+}
+
+fn argument_expression<'a>(argument: &'a Argument<'a>) -> Option<&'a Expression<'a>> {
+    match argument {
+        Argument::SpreadElement(_) => None,
+        _ => argument.as_expression(),
+    }
+}
+
+fn binding_identifier_name(pattern: &BindingPattern<'_>) -> Option<String> {
+    match pattern {
+        BindingPattern::BindingIdentifier(identifier) => Some(identifier.name.to_string()),
+        _ => None,
+    }
 }
 
 fn template_to_message(
@@ -1273,7 +1375,7 @@ fn add_extracted_message(
     let origin = CatalogUpdateOrigin {
         file: relative_file.to_string(),
         line: u32::try_from(message.origin.1).unwrap_or(u32::MAX),
-        scope: None,
+        scope: message.scope.clone(),
     };
     if !entry.origins.contains(&origin) {
         entry.origins.push(origin);
@@ -1293,7 +1395,12 @@ impl From<AggregatedCatalogEntry> for CatalogUpdateMessage {
             extracted_comments,
             mut origins,
         } = value;
-        origins.sort_by(|a, b| a.file.cmp(&b.file).then(a.line.cmp(&b.line)));
+        origins.sort_by(|a, b| {
+            a.file
+                .cmp(&b.file)
+                .then(a.line.cmp(&b.line))
+                .then(a.scope.cmp(&b.scope))
+        });
 
         Self {
             message,
@@ -1824,6 +1931,80 @@ mod tests {
             "../../packages/ui/src/shared-card.tsx"
         );
         assert!(!shared_action.origins[0].file.starts_with('/'));
+
+        fs::remove_dir_all(root).expect("cleanup");
+    }
+
+    #[test]
+    fn batch_extracts_stable_origin_scopes_from_named_containers() {
+        let root = temp_root("batch-origin-scopes");
+        let src = root.join("src");
+        fs::create_dir_all(&src).expect("src dir");
+        let app = src.join("App.tsx");
+        fs::write(
+            &app,
+            r#"
+              import { t } from "@palamedes/core/macro"
+              import { Trans } from "@palamedes/react/macro"
+
+              export function CheckoutButton() {
+                return <Trans>Start checkout</Trans>
+              }
+
+              export const GET = () => {
+                return t`Route response`
+              }
+
+              export const WrappedButton = memo(() => {
+                return <Trans>Wrapped checkout</Trans>
+              })
+
+              export const topLevelLabel = t`Top level label`
+            "#,
+        )
+        .expect("source");
+
+        let result = extract_catalog_messages_from_files(ExtractCatalogMessagesRequest {
+            root_dir: root.to_string_lossy().into_owned(),
+            files: vec![app.to_string_lossy().into_owned()],
+        })
+        .expect("batch extraction");
+
+        let checkout = result
+            .messages
+            .iter()
+            .find(|message| message.message == "Start checkout")
+            .expect("checkout message");
+        assert_eq!(checkout.origins.len(), 1);
+        assert_eq!(checkout.origins[0].file, "src/App.tsx");
+        assert_eq!(checkout.origins[0].scope.as_deref(), Some("CheckoutButton"));
+
+        let route = result
+            .messages
+            .iter()
+            .find(|message| message.message == "Route response")
+            .expect("route message");
+        assert_eq!(route.origins.len(), 1);
+        assert_eq!(route.origins[0].file, "src/App.tsx");
+        assert_eq!(route.origins[0].scope.as_deref(), Some("GET"));
+
+        let wrapped = result
+            .messages
+            .iter()
+            .find(|message| message.message == "Wrapped checkout")
+            .expect("wrapped message");
+        assert_eq!(wrapped.origins.len(), 1);
+        assert_eq!(wrapped.origins[0].file, "src/App.tsx");
+        assert_eq!(wrapped.origins[0].scope.as_deref(), Some("WrappedButton"));
+
+        let top_level = result
+            .messages
+            .iter()
+            .find(|message| message.message == "Top level label")
+            .expect("top-level message");
+        assert_eq!(top_level.origins.len(), 1);
+        assert_eq!(top_level.origins[0].file, "src/App.tsx");
+        assert_eq!(top_level.origins[0].scope, None);
 
         fs::remove_dir_all(root).expect("cleanup");
     }

--- a/docs/api/core-node.md
+++ b/docs/api/core-node.md
@@ -30,8 +30,8 @@ warnings because the runtime falls back to default `Intl` formatting.
 ## Stability
 
 This package is useful for integration tests and custom tooling, but it is a
-preview surface before 1.0. Generated type details may change as the native
-boundary evolves.
+preview surface. Generated type details may change as the native boundary
+evolves.
 
 Use `@palamedes/cli`, `@palamedes/vite-plugin`, or `@palamedes/next-plugin`
 when you do not need direct native access.

--- a/docs/catalog-formats.md
+++ b/docs/catalog-formats.md
@@ -49,6 +49,9 @@ That writes `src/locales/en.fcl` and `src/locales/de.fcl`.
 FCL is not NDJSON. The older `ndjson` config value is intentionally rejected;
 use `format: fcl` instead.
 
+For existing projects moving from old NDJSON catalog settings, see
+[Migrating to Palamedes 1.0](./migrations/1.0.0.md).
+
 ## Runtime Loading
 
 Catalog storage and framework module loading are related but separate:
@@ -76,3 +79,6 @@ pmds catalog convert --config palamedes.yaml --to fcl
 ```
 
 After conversion, update the matching catalog config to `format: fcl`.
+
+The full 1.0 migration checklist, including merge-driver cleanup and metadata
+shape changes, lives in [Migrating to Palamedes 1.0](./migrations/1.0.0.md).

--- a/docs/migrations/1.0.0.md
+++ b/docs/migrations/1.0.0.md
@@ -1,0 +1,155 @@
+# Migrating To Palamedes 1.0
+
+Palamedes 1.0 ships the Ferrocat 2.x catalog migration as the stabilization
+release for the public app-facing surface. The runtime authoring model stays
+source-string-first, but catalog storage, metadata, and cleanup semantics now
+follow Ferrocat 2.x.
+
+## Summary
+
+- PO remains the default catalog storage format.
+- FCL is the new opt-in generated storage format for canonical, merge-friendly
+  catalogs.
+- NDJSON catalog surfaces have been removed instead of kept as a compatibility
+  shim.
+- Catalog origins no longer serialize source line numbers; stable scope anchors
+  are stored separately when extraction can infer them.
+- Machine-translation metadata now uses Ferrocat's `machine` shape.
+- Fuzzy report semantics have been removed.
+- Obsolete cleanup is age-aware by default.
+
+## Config
+
+Keep PO storage by omitting `format`:
+
+```yaml
+catalogs:
+  - path: src/locales/{locale}
+    include: [src]
+```
+
+Opt into FCL storage:
+
+```yaml
+catalogs:
+  - path: src/locales/{locale}
+    format: fcl
+    include: [src]
+```
+
+Replace any old NDJSON config:
+
+```diff
+ catalogs:
+   - path: src/locales/{locale}
+-    format: ndjson
++    format: fcl
+     include: [src]
+```
+
+Existing `format: ndjson` configs now fail with a diagnostic that points to
+`format: fcl`.
+
+## Catalog Files And Merge Drivers
+
+Remove old NDJSON gitattributes and merge-driver entries such as:
+
+```gitattributes
+*.ndjson merge=palamedes-catalog
+*.fcat.ndjson merge=palamedes-catalog
+```
+
+Use PO and FCL drivers instead:
+
+```gitattributes
+*.po merge=palamedes-catalog
+*.fcl merge=palamedes-catalog-fcl
+```
+
+```bash
+git config merge.palamedes-catalog.name "Palamedes catalog merge"
+git config merge.palamedes-catalog.driver \
+  'pmds catalog merge --format=po --conflict-strategy=use-first --base %O --output %A %A %B'
+
+git config merge.palamedes-catalog-fcl.name "Palamedes FCL catalog merge"
+git config merge.palamedes-catalog-fcl.driver \
+  'pmds catalog merge --format=fcl --conflict-strategy=use-first --base %O --output %A %A %B'
+```
+
+## Converting PO To FCL
+
+Convert one catalog:
+
+```bash
+pmds catalog convert src/locales/de.po --to fcl --output src/locales/de.fcl
+```
+
+Convert every configured PO catalog:
+
+```bash
+pmds catalog convert --config palamedes.yaml --to fcl
+```
+
+Conversion fails before writing output when a PO source contains raw `fuzzy`
+flags. Reverse FCL-to-PO conversion is not part of 1.0.
+
+## Metadata Shape
+
+Machine metadata is exposed as:
+
+```ts
+type MachineMetadata = {
+  lock: string
+  ai?: {
+    model: string
+    confidence?: number
+  }
+}
+```
+
+Replace old `machineTranslation` consumers with `machine`. AI confidence is a
+number in `0..1`.
+
+Parsed origins now use:
+
+```ts
+type CatalogOrigin = {
+  file: string
+  scope?: string
+}
+```
+
+Catalog update inputs still carry extraction line data for deterministic writes:
+
+```ts
+type CatalogUpdateOrigin = {
+  file: string
+  line: number
+  scope?: string
+}
+```
+
+Line numbers remain extraction-internal for diagnostics and deterministic
+sorting. They are not serialized into catalogs.
+
+## CLI Cleanup Semantics
+
+`pmds extract --clean` now removes only obsolete entries whose
+`obsolete-since` date is at least 30 days old. Undated obsolete entries are kept.
+
+`pmds extract --force-clean` removes obsolete entries immediately, including
+undated entries.
+
+## API Removals
+
+- `CatalogFileFormat` no longer accepts `ndjson`.
+- Native catalog format enums expose `Po | Fcl`.
+- TypeScript wrapper APIs expose `"po" | "fcl"`.
+- `fuzzyFlags` and fuzzy report columns are removed.
+
+## More Detail
+
+- [Catalog formats](../catalog-formats.md)
+- [CLI reference](../cli.md)
+- [Configuration reference](../configuration.md)
+- [Stability and versioning](../stability.md)

--- a/docs/plans/2026-06-30-ferrocat-2-migration-rfc.md
+++ b/docs/plans/2026-06-30-ferrocat-2-migration-rfc.md
@@ -43,6 +43,11 @@ options-embedded ICU helpers used for the 2.2-proofing landed in the available
 `2.1.1` patch release. The migration therefore pins the Ferrocat crates to
 `2.1.1` instead of carrying the older cross-product entry points.
 
+Release-decision update: the migration is shipping as Palamedes `1.0.0`, with
+SemVer-stable app-facing surfaces documented in
+[`docs/stability.md`](../stability.md) and migration notes in
+[`docs/migrations/1.0.0.md`](../migrations/1.0.0.md).
+
 Compatibility probe:
 
 - A scratch migration against `origin/main` found that, after the mechanical
@@ -77,14 +82,10 @@ Compatibility probe:
   machine metadata.
 - Preserve source extraction locations for diagnostics without serializing
   synthetic line numbers into catalogs.
-- Decide the Palamedes release signal before implementation lands. Current
-  Palamedes packages are `0.11.4`. The recommended vehicle is Palamedes
-  `1.0.0` in lockstep: the public surface breaks either way, Ferrocat 2.x is
-  the catalog foundation Palamedes wants to stabilize on, and the 2.2-proofing
-  in this migration removes the last anticipated breaking change to the stable
-  surfaces. A breaking pre-1.0 minor (`0.12.0`) remains the documented
-  fallback if review rejects the 1.0 promise; see
-  [palamedes#285](https://github.com/sebastian-software/palamedes/issues/285).
+- Ship the migration as Palamedes `1.0.0` in lockstep: the public surface
+  breaks either way, Ferrocat 2.x is the catalog foundation Palamedes wants to
+  stabilize on, and the 2.2-proofing in this migration removes the last
+  anticipated breaking change to the stable app-facing surfaces.
 
 ## Non-Goals
 
@@ -237,7 +238,7 @@ through Palamedes config, CLI, N-API, or TypeScript surfaces in this migration.
 | Options construction (2.1)             | struct literals / functional record update                                                                             | options structs are `#[non_exhaustive]` with `new()` + `with_*()` builders                                                        | Build all Ferrocat options through the builder chains.                                                                                                             |
 | ICU options entry points (2.2 preview) | `audit_catalogs_with_icu_options`, `compile_catalog_artifact*_with_icu_options`, `pseudolocalize_*_with_syntax_policy` | cross-product call variants are removed in 2.2; ICU config moves onto the options values                                          | Adopt `with_icu_options(...)` / `with_syntax_policy(...)` on the options structs now.                                                                              |
 | Diagnostic codes (2.2 preview)         | plain `String` comparisons                                                                                             | `DiagnosticCode` newtype with exported `diagnostic_codes` constants; JSON output unchanged                                        | Compare against the constants; keep report JSON consumers untouched.                                                                                               |
-| Palamedes release                      | all packages currently publish as `0.11.4`                                                                             | public config, CLI, N-API, and TypeScript surfaces change                                                                         | Recommended vehicle is `1.0.0` in lockstep with migration notes; breaking `0.12.0` is the fallback. Decide before implementation lands.                            |
+| Palamedes release                      | all packages currently publish as `0.11.4`                                                                             | public config, CLI, N-API, and TypeScript surfaces change                                                                         | Ship `1.0.0` in lockstep with migration notes and a breaking conventional commit.                                                                                  |
 
 ## Public API Shape
 
@@ -697,7 +698,7 @@ config-aware test coverage.
 | Fuzzy removal looks like a regression                          | Document that fuzzy is not high-level catalog semantics anymore, while conversion still rejects raw PO fuzzy flags before writing.                                              |
 | Obsolete cleanup policy becomes implicit                       | Make `--clean` fixed 30-day cleanup for dated obsolete entries, document that undated obsolete entries are kept, and reserve `--force-clean` for deleting all obsolete entries. |
 | TypeScript generated and wrapper types drift                   | Regenerate native types and keep wrapper conversion tests for `po` / `fcl`.                                                                                                     |
-| Breaking changes are under-communicated                        | Follow `docs/stability.md`: publish migration notes and release notes even during pre-1.0.                                                                                      |
+| Breaking changes are under-communicated                        | Follow `docs/stability.md`: publish migration notes and release notes for the 1.0 stabilization release.                                                                        |
 | Ferrocat 2.2 cleanup breaks Palamedes again                    | Adopt options-embedded ICU configuration and `DiagnosticCode` constants now, per the published upgrade guide.                                                                   |
 
 ## Resolved Follow-Up Decisions
@@ -719,12 +720,9 @@ config-aware test coverage.
 - PO-to-FCL conversion is in scope as an explicit adoption workflow.
 - FCL-to-PO conversion is out of scope for the initial migration.
 - Pseudo-locale generation must work the same way for PO and FCL catalogs.
-- Palamedes does not automatically mirror Ferrocat's version. The recommended
-  release vehicle is Palamedes `1.0.0` with an updated `docs/stability.md`
-  and migration notes; a breaking `0.12.0` per the pre-1.0 stability policy is
-  the fallback. The final call is made in
-  [palamedes#285](https://github.com/sebastian-software/palamedes/issues/285)
-  before implementation lands.
+- Palamedes does not automatically mirror Ferrocat's version. The release
+  vehicle is Palamedes `1.0.0` with an updated `docs/stability.md` and
+  migration notes in `docs/migrations/1.0.0.md`.
 
 ## Acceptance Criteria
 

--- a/docs/proof-and-benchmarks.md
+++ b/docs/proof-and-benchmarks.md
@@ -196,6 +196,11 @@ Ferrocat `2.1.1`; rerun the command above when you need fresh numbers for the
 current release line. The benchmark script also prints the raw sample series and
 sampled peak RSS so the checked median and memory shape are easy to verify.
 
+For the Ferrocat 2.x / Palamedes 1.0 migration PR, record a fresh
+`pnpm benchmark:proof` run in the PR description so reviewers can compare it
+with this historical baseline without turning machine-local numbers into a
+portable performance claim.
+
 ## What This Page Does Not Claim
 
 - It does not claim universal results across every machine or every codebase.
@@ -208,6 +213,7 @@ The goal is simpler: show the work and make local verification easy.
 
 - [First working translation in 5 minutes](https://github.com/sebastian-software/palamedes/blob/main/docs/first-working-translation.md)
 - [Catalog formats: PO and FCL](https://github.com/sebastian-software/palamedes/blob/main/docs/catalog-formats.md)
+- [Migrating to Palamedes 1.0](https://github.com/sebastian-software/palamedes/blob/main/docs/migrations/1.0.0.md)
 - [Examples](https://github.com/sebastian-software/palamedes/blob/main/examples/README.md)
 - [Example screenshots](https://github.com/sebastian-software/palamedes/blob/main/docs/example-screenshots/README.md)
 - [Framework example notes](https://github.com/sebastian-software/palamedes/blob/main/docs/framework-example-notes.md)

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -1,24 +1,26 @@
 # Stability And Versioning
 
-Palamedes is pre-1.0 software, but not every surface has the same stability
-level. This page defines what app teams can depend on today and where changes
-may still happen between minor releases.
+Palamedes 1.0 makes the app-facing surfaces below SemVer-stable. This page
+defines what app teams can depend on and where changes may still happen between
+minor releases.
 
-## Versioning During 0.x
+## Versioning From 1.0
 
-All publishable Palamedes packages ship in lockstep. A 0.x minor release may
-include breaking changes, but Palamedes treats the app-facing surfaces below as
-stable enough to require migration notes and release notes before they change.
+All publishable Palamedes packages ship in lockstep.
 
-Patch releases should be compatible bug fixes.
+From 1.0 onward:
 
-The 1.0 target is to make the stable surfaces below SemVer-stable in the usual
-major/minor/patch sense.
+- major releases may include breaking changes to Stable surfaces
+- minor releases add compatible behavior to Stable surfaces
+- patch releases are compatible bug fixes
+
+Preview, Internal, and Reserved surfaces are not SemVer-stable adoption
+contracts. They should still receive migration notes when practical, but they
+may change faster than Stable surfaces.
 
 ## Stability Tiers
 
-- **Stable**: app-facing surface that should only change with migration notes
-  and release notes during 0.x.
+- **Stable**: app-facing surface covered by SemVer.
 - **Preview**: usable, but still allowed to change as real adoption clarifies
   the API shape.
 - **Internal**: implementation detail. Apps should not import or depend on it
@@ -26,22 +28,22 @@ major/minor/patch sense.
 - **Reserved**: package name or surface intentionally held for future work, with
   no supported adoption path yet.
 
-| Surface                                               | Tier     | Notes                                                                                                                          |
-| ----------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| `@palamedes/core` runtime API                         | Stable   | `createI18n`, message descriptors, locale activation, and source-message fallback behavior are app-facing.                     |
-| `@palamedes/runtime`                                  | Stable   | `getI18n`, `setClientI18n`, and the server runtime contract are the public transform target.                                   |
-| `@palamedes/react` and `@palamedes/solid`             | Stable   | Runtime components and macro entry points are public app APIs.                                                                 |
-| `@palamedes/vite-plugin` and `@palamedes/next-plugin` | Stable   | Plugin options and `.po` loading behavior are public integration APIs.                                                         |
-| `@palamedes/config`                                   | Stable   | Config file names, `defineConfig`, and the config schema are public.                                                           |
-| `@palamedes/cli`                                      | Stable   | Documented commands and flags are public. New commands may appear in minors.                                                   |
-| Source-string-first PO catalogs                       | Stable   | Message identity is `message + context`. Catalog files remain user-owned.                                                      |
-| FCL catalog storage                                   | Preview  | Supported through config, CLI, and native catalog APIs; app-facing framework imports remain PO-loader based for now.           |
-| Macro syntax                                          | Stable   | Supported macros remain the authoring model. Unsupported explicit IDs are not a compatibility target.                          |
-| `@palamedes/core-node`                                | Preview  | It is usable directly, but primarily exists as the JS boundary to the Rust core. Generated type details may change before 1.0. |
-| Platform native packages                              | Internal | `@palamedes/core-node-*` packages are optional dependency carriers for native binaries. Apps should not import them directly.  |
-| `palamedes` and `create-palamedes`                    | Reserved | Placeholder top-level packages exist, but there is no supported first-run entry yet.                                           |
-| Compiled catalog artifact internals                   | Preview  | Public loaders can consume them; the internal representation may evolve before 1.0.                                            |
-| `crates/*` Rust APIs                                  | Preview  | The Rust crates support the Node toolchain today. They are not yet a separately promised public Rust SDK.                      |
+| Surface                                               | Tier     | Notes                                                                                                                         |
+| ----------------------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `@palamedes/core` runtime API                         | Stable   | `createI18n`, message descriptors, locale activation, and source-message fallback behavior are app-facing.                    |
+| `@palamedes/runtime`                                  | Stable   | `getI18n`, `setClientI18n`, and the server runtime contract are the public transform target.                                  |
+| `@palamedes/react` and `@palamedes/solid`             | Stable   | Runtime components and macro entry points are public app APIs.                                                                |
+| `@palamedes/vite-plugin` and `@palamedes/next-plugin` | Stable   | Plugin options and `.po` loading behavior are public integration APIs.                                                        |
+| `@palamedes/config`                                   | Stable   | Config file names, `defineConfig`, and the config schema are public.                                                          |
+| `@palamedes/cli`                                      | Stable   | Documented commands and flags are public. New commands may appear in minors.                                                  |
+| Source-string-first PO catalogs                       | Stable   | Message identity is `message + context`. Catalog files remain user-owned.                                                     |
+| FCL catalog storage                                   | Preview  | Supported through config, CLI, and native catalog APIs; app-facing framework imports remain PO-loader based for now.          |
+| Macro syntax                                          | Stable   | Supported macros remain the authoring model. Unsupported explicit IDs are not a compatibility target.                         |
+| `@palamedes/core-node`                                | Preview  | It is usable directly, but primarily exists as the JS boundary to the Rust core. Generated type details may change in minors. |
+| Platform native packages                              | Internal | `@palamedes/core-node-*` packages are optional dependency carriers for native binaries. Apps should not import them directly. |
+| `palamedes` and `create-palamedes`                    | Reserved | Placeholder top-level packages exist, but there is no supported first-run entry yet.                                          |
+| Compiled catalog artifact internals                   | Preview  | Public loaders can consume them; the internal representation may evolve in minors.                                            |
+| `crates/*` Rust APIs                                  | Preview  | The Rust crates support the Node toolchain today. They are not yet a separately promised public Rust SDK.                     |
 
 ## Stable Surfaces
 
@@ -56,7 +58,7 @@ Palamedes treats these as stable adoption surfaces:
 - `createI18n()` and descriptor-based lookup behavior
 - React and Solid runtime components and macro package names
 
-If one of these must change before 1.0, the release should include:
+If one of these must change after 1.0, the release should include:
 
 - a changelog entry calling out the break
 - a migration note or replacement path
@@ -83,7 +85,7 @@ When a stable surface needs to change, prefer this path:
 2. Document the replacement in the release notes.
 3. Keep the old path working for at least one minor release when practical.
 4. Emit a clear diagnostic or runtime warning if the old path can be detected.
-5. Remove it in a later minor or the 1.0 cleanup window.
+5. Remove it in a later major release.
 
 Security fixes, broken behavior, and unsupported preview/internal surfaces may
 skip the full deprecation window when keeping compatibility would be misleading
@@ -91,9 +93,13 @@ or unsafe.
 
 ## What 1.0 Means
 
-The 1.0 release should mean:
+The 1.0 release means:
 
 - app-facing packages follow standard SemVer
 - config, CLI, macro syntax, catalog identity, and runtime APIs are stable
 - platform support is documented in one place
 - preview/internal surfaces are clearly labeled or promoted with tests and docs
+
+See [Migrating to Palamedes 1.0](./migrations/1.0.0.md) for the breaking
+catalog-format and metadata changes that were handled in the stabilization
+release.

--- a/packages/core-node/src/generated/palamedes-node-types.ts
+++ b/packages/core-node/src/generated/palamedes-node-types.ts
@@ -282,6 +282,7 @@ export interface ExtractedMessageOrigin {
   filename: string;
   line: number;
   column?: number;
+  scope?: string;
 }
 export interface NativeExtractedMessage {
   message: string;

--- a/packages/core-node/src/index.ts
+++ b/packages/core-node/src/index.ts
@@ -149,8 +149,12 @@ export type MessageMetadataValidationReport = Omit<
   diagnostics: MessageMetadataDiagnostic[]
 }
 
+export type NativeExtractedMessageOrigin = [filename: string, line: number, column?: number] & {
+  scope?: string
+}
+
 export type NativeExtractedMessage = Omit<GeneratedNativeExtractedMessage, "origin"> & {
-  origin: [filename: string, line: number, column?: number]
+  origin: NativeExtractedMessageOrigin
 }
 
 export type NativeTransformOptions = GeneratedNativeTransformOptions
@@ -568,10 +572,19 @@ export function compileCatalogModule(
 }
 
 export function extractMessagesNative(source: string, filename: string): NativeExtractedMessage[] {
-  return native.extractMessages(source, filename).map((message) => ({
-    ...message,
-    origin: [message.origin.filename, message.origin.line, message.origin.column],
-  }))
+  return native.extractMessages(source, filename).map((message) => {
+    const origin: NativeExtractedMessageOrigin = [
+      message.origin.filename,
+      message.origin.line,
+      message.origin.column,
+    ]
+    origin.scope = message.origin.scope
+
+    return {
+      ...message,
+      origin,
+    }
+  })
 }
 
 export function extractCatalogMessagesFromFiles(

--- a/packages/extractor/src/extractMessages.test.ts
+++ b/packages/extractor/src/extractMessages.test.ts
@@ -227,6 +227,24 @@ describe("extractMessages", () => {
       expect(messages[0].origin[0]).toBe("test.ts")
     })
 
+    it("exposes stable origin scope when extraction finds a named container", async () => {
+      const code = `
+        import { Trans } from "@palamedes/react/macro"
+        export function CheckoutButton() {
+          return <Trans>Start checkout</Trans>
+        }
+      `
+      const messages: ExtractedMessageInfo[] = []
+
+      await extractor.extract("test.tsx", code, (message) => {
+        messages.push(message)
+      })
+
+      expect(messages).toHaveLength(1)
+      expect(messages[0].origin[0]).toBe("test.tsx")
+      expect(messages[0].origin.scope).toBe("CheckoutButton")
+    })
+
     it("does not hide fatal native extraction errors", async () => {
       const code = `
         import { t } from "@palamedes/core/macro"


### PR DESCRIPTION
Closes #285

## Summary

- emit stable origin scopes from named extraction containers and pass them through native and TypeScript extraction surfaces
- add the Palamedes 1.0 migration guide and wire it from the README, format docs, benchmark docs, stability docs, and RFC
- record the release decision as a breaking 1.0 migration; the release commit includes `Release-As: 1.0.0`

## Benchmark

Command: `pnpm benchmark:proof`

Current local run on Node v24.18.0, darwin/arm64, Ferrocat 2.1.1:

- transform: median 0.56 ms; sampled peak RSS 53.1 MiB
- extract: median 0.38 ms; sampled peak RSS 53.2 MiB
- catalog-update: median 0.48 ms; sampled peak RSS 53.8 MiB
- catalog-artifact-compile: median 5.56 ms; sampled peak RSS 55.5 MiB

Historical docs baseline from March 18, 2026 on Node v24.14.0, darwin/arm64, core 0.1.0, Ferrocat 0.8.0:

- transform: 0.97 ms
- extract: 0.89 ms
- catalog update: 0.64 ms
- catalog artifact compile: 4.04 ms

## Validation

- `cargo fmt --all --check`
- `cargo check --workspace --locked`
- `cargo test --workspace --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `pnpm build`
- `pnpm test`
- `pnpm check-types`
- `pnpm lint`
- `pnpm format:check`
- `pnpm check:release-set`
- `pnpm verify:examples`
- `pnpm benchmark:proof`

Note: the first `pnpm check-types` attempt in the fresh worktree failed during dependency setup because registry requests were blocked by sandbox DNS. Re-running with network access installed dependencies, then the actual type-check failure was fixed and the command passed.
