### PR TITLE
chore: add agent:check script mirroring the full CI gate

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "format:check": "oxfmt --check --ignore-path .gitignore --ignore-path .oxfmtignore .",
     "build:native": "cargo build --workspace",
     "check:rust": "cargo check --workspace",
-    "test:rust": "cargo test --workspace"
+    "test:rust": "cargo test --workspace",
+    "agent:check": "pnpm check:release-set && pnpm format:check && pnpm lint && pnpm build && pnpm test && pnpm check-types && cargo fmt --all --check && cargo clippy --workspace --all-targets --locked -- -D warnings && cargo test --workspace --locked"
   },
   "devDependencies": {
     "@playwright/test": "^1.61.1",

--- a/package.json
+++ b/package.json
@@ -43,10 +43,11 @@
     "build:native": "cargo build --workspace",
     "check:rust": "cargo check --workspace",
     "test:rust": "cargo test --workspace",
-    "agent:check": "pnpm check:release-set && pnpm format:check && pnpm lint && pnpm build && pnpm test && pnpm check-types && cargo fmt --all --check && cargo clippy --workspace --all-targets --locked -- -D warnings && cargo test --workspace --locked"
+    "agent:check": "pnpm build && concurrently --kill-others-on-fail --group --names release,format,lint,test,types,rustfmt,rust \"pnpm check:release-set\" \"pnpm format:check\" \"pnpm lint\" \"pnpm test\" \"pnpm check-types\" \"cargo fmt --all --check\" \"cargo clippy --workspace --all-targets --locked -- -D warnings && cargo test --workspace --locked\""
   },
   "devDependencies": {
     "@playwright/test": "^1.61.1",
+    "concurrently": "^10.0.3",
     "eslint": "^10.5.0",
     "eslint-config-setup": "^0.4.0",
     "oxfmt": "^0.56.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,9 @@ importers:
       '@playwright/test':
         specifier: ^1.61.1
         version: 1.61.1
+      concurrently:
+        specifier: ^10.0.3
+        version: 10.0.3
       eslint:
         specifier: ^10.5.0
         version: 10.5.0(jiti@2.7.0)
@@ -96,7 +99,7 @@ importers:
         version: link:../../packages/runtime
       next:
         specifier: ^16.2.9
-        version: 16.2.9(@babel/core@8.0.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.2.9(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -145,7 +148,7 @@ importers:
         version: link:../../packages/runtime
       next:
         specifier: ^16.2.9
-        version: 16.2.9(@babel/core@8.0.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.2.9(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -194,7 +197,7 @@ importers:
         version: link:../../packages/runtime
       next:
         specifier: ^16.2.9
-        version: 16.2.9(@babel/core@8.0.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.2.9(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -1038,7 +1041,7 @@ importers:
     devDependencies:
       next:
         specifier: ^16.2.9
-        version: 16.2.9(@babel/core@8.0.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.2.9(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -5697,6 +5700,11 @@ packages:
     resolution: {integrity: sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==}
     engines: {'0': node >= 6.0}
 
+  concurrently@10.0.3:
+    resolution: {integrity: sha512-hc3LH4UaKWd/bbyDK/IGVa4RB6PtQ3CUYwtrkzqHn+wIG3Hr5fhpRlk0L/gCa8ZE1L/Ufj50Zho69cI5w8SQBA==}
+    engines: {node: '>=22'}
+    hasBin: true
+
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
 
@@ -9032,6 +9040,9 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
+  rxjs@7.8.2:
+    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
+
   safe-array-concat@1.1.4:
     resolution: {integrity: sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==}
     engines: {node: '>=0.4'}
@@ -9171,6 +9182,10 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  shell-quote@1.8.4:
+    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
+    engines: {node: '>= 0.4'}
 
   shiki@1.29.2:
     resolution: {integrity: sha512-njXuliz/cP+67jU2hukkxCNuH1yUi4QfdZZY+sMr5PPrIyXSu5iTb/qYC4BiWWB0vZ+7TbdvYUCeL23zpwCfbg==}
@@ -14785,6 +14800,15 @@ snapshots:
       readable-stream: 3.6.2
       typedarray: 0.0.6
 
+  concurrently@10.0.3:
+    dependencies:
+      chalk: 5.6.2
+      rxjs: 7.8.2
+      shell-quote: 1.8.4
+      supports-color: 10.2.2
+      tree-kill: 1.2.2
+      yargs: 18.0.0
+
   confbox@0.1.8: {}
 
   confbox@0.2.4: {}
@@ -17613,7 +17637,7 @@ snapshots:
 
   netmask@2.0.2: {}
 
-  next@16.2.9(@babel/core@8.0.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  next@16.2.9(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       '@next/env': 16.2.9
       '@swc/helpers': 0.5.15
@@ -17622,7 +17646,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      styled-jsx: 5.1.6(@babel/core@8.0.1)(react@19.2.7)
+      styled-jsx: 5.1.6(react@19.2.7)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.2.9
       '@next/swc-darwin-x64': 16.2.9
@@ -18852,6 +18876,10 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
+  rxjs@7.8.2:
+    dependencies:
+      tslib: 2.8.1
+
   safe-array-concat@1.1.4:
     dependencies:
       call-bind: 1.0.9
@@ -19058,6 +19086,8 @@ snapshots:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  shell-quote@1.8.4: {}
 
   shiki@1.29.2:
     dependencies:
@@ -19376,12 +19406,10 @@ snapshots:
     dependencies:
       js-tokens: 9.0.1
 
-  styled-jsx@5.1.6(@babel/core@8.0.1)(react@19.2.7):
+  styled-jsx@5.1.6(react@19.2.7):
     dependencies:
       client-only: 0.0.1
       react: 19.2.7
-    optionalDependencies:
-      '@babel/core': 8.0.1
 
   stylehacks@7.0.8(postcss@8.5.15):
     dependencies:


### PR DESCRIPTION
## Summary

Adds a single `agent:check` npm script that runs **every check the CI `validate` and `validate-rust` jobs run**, so a green `pnpm agent:check` locally corresponds to a green CI run — agents and contributors can self-verify before pushing.

It is **parallelized with `concurrently`** for speed while keeping the exact same check set and fail-fast semantics.

## What it runs

`pnpm build` runs first (the native napi build holds the cargo target lock), then every remaining check fans out in parallel via `concurrently --kill-others-on-fail`:

```
pnpm build                 # build packages incl. native types (serial, holds cargo lock)
# then, in parallel:
pnpm check:release-set     # Check release package set
pnpm format:check          # oxfmt --check (JS/TS + Markdown)
pnpm lint                  # oxlint + eslint
pnpm test                  # package vitest suites
pnpm check-types           # tsc --noEmit across packages
cargo fmt --all --check
cargo clippy --workspace --all-targets --locked -- -D warnings && cargo test --workspace --locked
```

The cargo-compiling steps stay serialized relative to `build` because they share the same cargo target lock, so nothing new contends for it. The light JS/lint/format checks now overlap with the long, inherently serial Rust compile+test lane instead of adding on top.

## Notes

- **Check-only:** uses `format:check` (not `format`) and clippy `-D warnings`; never mutates files. Fails fast on the first error (`--kill-others-on-fail`).
- **Scope:** intentionally excludes `verify:examples` (example smoke/browser verification), which is not part of the gating CI workflow.
- **Speed:** warm-cache wall time drops from ~16s to ~10s (~1.6x) on this machine; the Rust clippy+test lane is the long pole and can't be parallelized further (cargo target lock).
- **Verified:** `pnpm agent:check` runs green on `main` (all JS/TS steps plus cargo fmt/clippy/test). Adds `concurrently` as a root devDependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)