### PR TITLE
fix(release): bump minor instead of major for pre-1.0 breaking changes

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -60,6 +60,7 @@
   "packages": {
     ".": {
       "release-type": "simple",
+      "bump-minor-pre-major": true,
       "package-name": "palamedes",
       "component": "palamedes",
       "changelog-path": "CHANGELOG.md",


### PR DESCRIPTION
## Problem

The release-please PR (#287) bumps the version to `1.0.0` because of the breaking-change commit `docs!: prepare Palamedes 1.0 migration`. While the project is still on `0.x` (`0.11.4`), a breaking change should bump the **minor**, not jump to `1.0.0`.

## Cause

`.release-please-config.json` does not set `bump-minor-pre-major`. By default release-please treats a breaking change (`!` / `BREAKING CHANGE`) as a **major** bump even below 1.0.0, so `0.11.4` → `1.0.0`.

## Fix

Set `"bump-minor-pre-major": true` on the `.` package. While under 1.0.0:

- breaking change → **minor** bump (`0.11.4` → `0.12.0`)
- `feat` → minor (unchanged)
- `fix` → patch (unchanged)

After this merges to `main`, release-please regenerates #287 targeting `0.12.0` instead of `1.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)