### PR TITLE
chore(release): revert pre-1.0 minor-bump override

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -60,7 +60,6 @@
   "packages": {
     ".": {
       "release-type": "simple",
-      "bump-minor-pre-major": true,
       "package-name": "palamedes",
       "component": "palamedes",
       "changelog-path": "CHANGELOG.md",


### PR DESCRIPTION
Reverts the `bump-minor-pre-major` setting added in #294.

After investigation, the `1.0.0` bump on the release-please PR (#287) is **intended**: it is forced by an explicit `Release-As: 1.0.0` footer in the `docs!: prepare Palamedes 1.0 migration` commit, not by the default breaking-change bump behavior. `bump-minor-pre-major` had no effect on the current release (`Release-As` overrides it) and is not the desired policy, so this removes it again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)