### PR TITLE
fix(release): build musl cdylib addon via target-scoped RUSTFLAGS

### DIFF
--- a/packages/core-node/scripts/build-native.mjs
+++ b/packages/core-node/scripts/build-native.mjs
@@ -108,10 +108,23 @@ if (muslNodeAddon) {
   // supplies the unwinder in-tree for every cdylib built for this target —
   // including the `oxc_sourcemap` cdylib — so musl-gcc never looks for a shared
   // `libgcc_s` that the Ubuntu musl toolchain does not ship.
+  //
+  // `panic=abort` is intentionally not forced here. napi-rs (`#[napi]`) wraps
+  // every `extern "C"` entry point in a panic guard, so panics are converted to
+  // JS errors and never unwind across the FFI boundary. The gnu, darwin, and
+  // win32 addons already build with the default unwind strategy for the same
+  // reason; scoping abort to musl only would diverge from them and force the
+  // whole musl dependency graph off the prebuilt unwind std.
+  //
+  // Prepend any inherited target rustflags so an externally provided value
+  // (e.g. CI optimisation overrides) is preserved rather than dropped.
   cargoEnv.CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_RUSTFLAGS = [
+    process.env.CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_RUSTFLAGS ?? "",
     "-C target-feature=-crt-static",
     "-C link-self-contained=+unwind",
-  ].join(" ")
+  ]
+    .filter(Boolean)
+    .join(" ")
 }
 
 execFileSync("cargo", cargoArgs, {

--- a/packages/core-node/scripts/build-native.mjs
+++ b/packages/core-node/scripts/build-native.mjs
@@ -84,7 +84,7 @@ if (!extension) {
 }
 
 const muslNodeAddon = packageJson.name === "@palamedes/core-node-linux-x64-musl"
-const cargoArgs = [muslNodeAddon ? "rustc" : "build", "--package", "palamedes-node"]
+const cargoArgs = ["build", "--package", "palamedes-node"]
 
 if (profile === "release") {
   cargoArgs.push("--release")
@@ -94,25 +94,29 @@ if (target.rustTarget) {
   cargoArgs.push("--target", target.rustTarget)
 }
 
+const cargoEnv = { ...process.env }
+
 if (muslNodeAddon) {
-  // Keep the crt-static override scoped to the final N-API cdylib. Applying it
-  // through RUSTFLAGS also changes dependency cdylib builds such as
-  // oxc_sourcemap, which makes musl-gcc look for a shared libgcc_s that the
-  // Ubuntu musl toolchain does not provide.
-  cargoArgs.push(
-    "--lib",
-    "--",
-    "-C",
-    "target-feature=-crt-static",
-    "-C",
-    "panic=abort",
-    "-C",
-    "link-self-contained=+unwind"
-  )
+  // musl defaults to `+crt-static`, and cargo refuses to produce a `cdylib` for a
+  // statically linked target ("does not support these crate types"). Disabling
+  // crt-static has to reach cargo's crate-type check in the build *plan*, so it
+  // must go through RUSTFLAGS rather than trailing `cargo rustc -- <flags>`, which
+  // only reach the final crate too late for that check.
+  //
+  // The override is scoped to the musl *target* (not the global RUSTFLAGS), so
+  // host build scripts and proc-macros stay untouched. `link-self-contained=+unwind`
+  // supplies the unwinder in-tree for every cdylib built for this target —
+  // including the `oxc_sourcemap` cdylib — so musl-gcc never looks for a shared
+  // `libgcc_s` that the Ubuntu musl toolchain does not ship.
+  cargoEnv.CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_RUSTFLAGS = [
+    "-C target-feature=-crt-static",
+    "-C link-self-contained=+unwind",
+  ].join(" ")
 }
 
 execFileSync("cargo", cargoArgs, {
   cwd: repoRoot,
+  env: cargoEnv,
   stdio: "inherit",
 })
 


### PR DESCRIPTION
## Problem

The 1.0.0 release Publish run failed on `publish-native (@palamedes/core-node-linux-x64-musl)`:

```
error: cannot produce cdylib for `palamedes-node v1.0.0` as the target
`x86_64-unknown-linux-musl` does not support these crate types
```

(The parallel `win32-x64-msvc` failure in the same run was an unrelated **transient** network error — `SocketError: other side closed` during a download step — and just needs a re-run.)

## Cause

`build-native.mjs` disabled `crt-static` only through trailing `cargo rustc --lib -- -C target-feature=-crt-static …`. Those flags reach the final crate too late for cargo's crate-type check, which runs in the build plan using the musl default `+crt-static` — under which cargo refuses to emit a `cdylib`.

## Fix

Move `-crt-static` (and `link-self-contained=+unwind`) into `CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_RUSTFLAGS` so the build plan sees crt-static disabled and allows the cdylib. Scoping to the musl **target** (not global `RUSTFLAGS`) keeps host build scripts and proc-macros untouched, and applying `link-self-contained=+unwind` target-wide supplies the in-tree unwinder for **every** cdylib built for musl — including `oxc_sourcemap` (confirmed to have a `cdylib` crate-type) — so musl-gcc never needs a shared `libgcc_s` the Ubuntu musl toolchain lacks.

## Verification

- The refactor keeps the non-musl path byte-identical; verified locally by building the darwin-arm64 addon successfully with the updated script.
- The musl cross-build cannot be exercised on macOS; it verifies in CI on the next Publish (or a manual run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)