### PR TITLE
feat(examples): map the .com tld to en for the tld demos

### DIFF
--- a/docs/demo-deployments.md
+++ b/docs/demo-deployments.md
@@ -30,8 +30,8 @@ How each strategy encodes the locale:
 - **subdomain** — the leftmost DNS label is the locale
   (`de.<app>-subdomain.examples.palamedes.dev`).
 - **tld** — the top-level domain is the locale
-  (`<app>.examples.palamedes-i18n.de`); `.com` is the non-authoritative `en`
-  entry point and falls back to `Accept-Language`/default.
+  (`<app>.examples.palamedes-i18n.de`); `.com` maps to `en` via an explicit
+  override.
 
 ### Next.js
 
@@ -127,9 +127,10 @@ Each framework example is reachable under four TLDs:
 All four TLD variants of a given framework point to the same backend. The
 reverse proxy must pass the original `Host` header through unchanged — the app
 reads the TLD to select the locale, so it is authoritative. `.de`, `.es`, and
-`.fr` are authoritative (country code equals language code); `.com` is
-non-authoritative and falls back to `Accept-Language` or the default locale (en).
-A multi-lingual country TLD such as `.ch` would intentionally be non-authoritative.
+`.fr` are authoritative automatically (country code equals language code); the
+generic `.com` is mapped to `en` through an explicit `tld` override. A
+multi-lingual country TLD such as `.ch` would intentionally be left unmapped
+(non-authoritative), falling back to `Accept-Language` or the default locale.
 
 Because locale and switch links are derived from the request host, responses must
 not be cached host-agnostically. Any cache in front of a tld example must include

--- a/docs/locale-strategies.md
+++ b/docs/locale-strategies.md
@@ -83,7 +83,7 @@ for the locale:
 
 - `<app>.examples.palamedes-i18n.de` -> `de`
 - `<app>.examples.palamedes-i18n.fr` -> `fr`
-- `<app>.examples.palamedes-i18n.com` -> fallback (not authoritative)
+- `<app>.examples.palamedes-i18n.com` -> `en` (explicit override)
 
 TLD examples follow this rule set:
 
@@ -91,30 +91,34 @@ TLD examples follow this rule set:
   1. a tld label that already _is_ a supported locale is authoritative
      automatically (`.de` -> `de`, `.es` -> `es`, `.fr` -> `fr`), because the
      country code equals the language code
-  2. a tld whose label is not a language code is authoritative only when listed
-     in the `tld` map (`hosts: { mode: "tld", tld: { at: "de", uk: "en" } }`)
+  2. a tld whose label is not a language code is authoritative when listed in the
+     `tld` map. These demos map the generic `.com` to `en`
+     (`hosts: { mode: "tld", tld: { com: "en" } }`); real deployments might add
+     entries such as `{ at: "de", uk: "en" }`
   3. anything else is deliberately not authoritative and falls back to the best
      `Accept-Language` match (region tags expand, so `de-CH` yields `de`), then
      the default locale
 - there is no `/:locale/...` path prefix; the locale lives in the domain
 - switching locale swaps the top-level domain (the control swaps the rightmost
   label via `canonicalUrl`), so it is always a full document load. The default
-  locale has no authoritative tld of its own and switches to `defaultTld`
-  (`hosts: { mode: "tld", defaultTld: "com" }`, so `en` -> `.com`), which then
-  renders `en` through the fallback above
+  locale `en` switches to `defaultTld`
+  (`hosts: { mode: "tld", defaultTld: "com" }`, so `en` -> `.com`), which the
+  `.com` -> `en` override above also serves authoritatively
 
-### Why `.com` and `.ch` are not authoritative
+### Why real TLDs need an explicit policy
 
 Unlike the subdomain label — which the operator fully controls, so the label can
 simply _be_ the locale — real top-level domains carry meaning the app does not
-own. `.com` is generic and maps to no single language, so it is left unmapped and
-serves the default locale through the `Accept-Language` fallback. `.ch`
-(Switzerland) has four official languages, so it _cannot_ be authoritative for one
-of them; it too stays unmapped and follows the browser's regional preference
-(`de-CH` -> `de`). Country codes whose language is unambiguous but differs from
-the code (`.at` -> German, `.uk` -> English) are opt-in through the `tld` map.
-This is why the tld strategy resolves through an explicit, three-tiered policy
-rather than the subdomain strategy's pure label-is-locale rule.
+own. `.de`, `.es`, and `.fr` happen to match a language code and resolve
+automatically. `.com` is generic and matches no language, so these demos map it
+explicitly to `en` (`{ com: "en" }`), the natural default for a generic TLD.
+`.ch` (Switzerland) has four official languages, so it _cannot_ be authoritative
+for one of them; left unmapped, it follows the browser's regional preference
+(`de-CH` -> `de`) and then the default locale. Country codes whose language is
+unambiguous but differs from the code (`.at` -> German, `.uk` -> English) are
+opt-in through the same `tld` map. This is why the tld strategy resolves through
+an explicit, three-tiered policy rather than the subdomain strategy's pure
+label-is-locale rule.
 
 ## Switching Mechanism: Reload vs. Live
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -39,8 +39,8 @@ How each strategy encodes the locale:
 - **subdomain** — the leftmost DNS label is the locale
   (`de.<app>-subdomain.examples.palamedes.dev`).
 - **tld** — the top-level domain is the locale
-  (`<app>.examples.palamedes-i18n.de`); `.com` is the non-authoritative `en`
-  entry point and falls back to `Accept-Language`/default.
+  (`<app>.examples.palamedes-i18n.de`); `.com` maps to `en` via an explicit
+  override.
 
 ### Next.js
 
@@ -149,8 +149,8 @@ These examples prove:
 
 - the rightmost DNS label (TLD) as the authoritative locale (`.de` → de), no `/:locale/...` prefix
 - three-level resolution: automatic when country code equals language code, explicit tld map for others, otherwise `Accept-Language` or default
-- `.com` is non-authoritative — falls back to `Accept-Language` or the default locale (en)
-- `resolve({ strategy: "tld", requestHost })` with `hosts: { mode: "tld", defaultTld: "com" }`
+- the generic `.com` mapped to `en` via an explicit `tld` override (authoritative)
+- `resolve({ strategy: "tld", requestHost })` with `hosts: { mode: "tld", tld: { com: "en" }, defaultTld: "com" }`
 - locale switching as a full document reload with the TLD swapped
 - SSR with localized server actions or server functions
 

--- a/examples/nextjs-tld/src/lib/i18n.ts
+++ b/examples/nextjs-tld/src/lib/i18n.ts
@@ -10,13 +10,13 @@ export type Locale = (typeof LOCALES)[number]
  * Headless locale controls for this demo (TLD strategy). The locale comes from
  * the top-level domain (rightmost label): `.de` → de, `.es` → es, `.fr` → fr
  * are automatically authoritative because the country code matches the language
- * code. `.com` is not authoritative and falls back to Accept-Language / default
- * (en). `defaultTld: "com"` is the switch target for the default locale en.
+ * code. `.com` maps to `en` via an explicit `tld` override (its label is not a
+ * locale code); `defaultTld: "com"` also routes the `en` switch back to `.com`.
  */
 export const locales = defineLocaleControls<Locale>({
   locales: LOCALES,
   defaultLocale: DEFAULT_LOCALE,
-  hosts: { mode: "tld", defaultTld: "com" },
+  hosts: { mode: "tld", tld: { com: "en" }, defaultTld: "com" },
 })
 
 export const LOCALE_LABELS = locales.labels

--- a/examples/react-router-tld/app/lib/i18n.ts
+++ b/examples/react-router-tld/app/lib/i18n.ts
@@ -14,15 +14,15 @@ export type Locale = (typeof LOCALES)[number]
 /**
  * Headless locale controls for this demo (TLD strategy). The rightmost DNS
  * label (Top-Level-Domain) is authoritative for locale: `.de` → `de`,
- * `.es` → `es`, `.fr` → `fr`. `.com` is not authoritative — the locale
- * falls back to Accept-Language or the default (`en`). `defaultTld: "com"`
+ * `.es` → `es`, `.fr` → `fr`. `.com` maps to `en` via an explicit `tld`
+ * override (its label is not a locale code). `defaultTld: "com"`
  * is the switch target for the English locale, so locale switcher links for
  * `en` point at the `.com` host.
  */
 export const locales = defineLocaleControls<Locale>({
   locales: LOCALES,
   defaultLocale: DEFAULT_LOCALE,
-  hosts: { mode: "tld", defaultTld: "com" },
+  hosts: { mode: "tld", tld: { com: "en" }, defaultTld: "com" },
 })
 
 export const LOCALE_LABELS = locales.labels
@@ -74,8 +74,8 @@ export function syncClientI18n(locale: Locale) {
 /**
  * Resolve the authoritative locale from the request `Host` header. The TLD
  * strategy reads the rightmost DNS label (Top-Level-Domain): `.de` → `de`,
- * `.es` → `es`, `.fr` → `fr`. `.com` is not authoritative, so requests on
- * `.com` fall back to the Accept-Language header or the default locale (`en`).
+ * `.es` → `es`, `.fr` → `fr`. `.com` maps to `en` via an explicit `tld`
+ * override, so requests on `.com` resolve authoritatively to English.
  * The banner surfaces an Accept-Language hint when the visitor's preferred
  * locale differs from the one the TLD is currently serving.
  */

--- a/examples/solidstart-tld/src/lib/i18n.ts
+++ b/examples/solidstart-tld/src/lib/i18n.ts
@@ -15,8 +15,8 @@ export type Locale = (typeof LOCALES)[number]
 /**
  * Headless locale controls for this demo (TLD strategy). The rightmost DNS
  * label (Top-Level-Domain) is authoritative for locale: `.de` → `de`,
- * `.es` → `es`, `.fr` → `fr`. `.com` is not authoritative — the locale
- * falls back to Accept-Language or the default (`en`). `defaultTld: "com"`
+ * `.es` → `es`, `.fr` → `fr`. `.com` maps to `en` via an explicit `tld`
+ * override (its label is not a locale code). `defaultTld: "com"`
  * is the switch target for the English locale, so locale switcher links for
  * `en` point at the `.com` host.
  */
@@ -24,7 +24,7 @@ export const locales = defineLocaleControls<Locale>({
   locales: LOCALES,
   defaultLocale: DEFAULT_LOCALE,
   cookies: { locale: LOCALE_COOKIE },
-  hosts: { mode: "tld", defaultTld: "com" },
+  hosts: { mode: "tld", tld: { com: "en" }, defaultTld: "com" },
 })
 
 export const LOCALE_LABELS = locales.labels

--- a/examples/tanstack-tld/src/lib/i18n.ts
+++ b/examples/tanstack-tld/src/lib/i18n.ts
@@ -15,15 +15,15 @@ export type Locale = (typeof LOCALES)[number]
 /**
  * Headless locale controls for this demo (TLD strategy). The rightmost DNS
  * label (top-level domain) is authoritative for the locale: `.de` → `de`,
- * `.es` → `es`, `.fr` → `fr`. `.com` is not authoritative — Accept-Language
- * / default (`en`) acts as the fallback. `defaultTld: "com"` is the switch
+ * `.es` → `es`, `.fr` → `fr`. `.com` maps to `en` via an explicit `tld`
+ * override (its label is not a locale code). `defaultTld: "com"` is the switch
  * target for the `en` locale so the switcher can build the correct URL.
  */
 export const locales = defineLocaleControls<Locale>({
   locales: LOCALES,
   defaultLocale: DEFAULT_LOCALE,
   cookies: { locale: LOCALE_COOKIE },
-  hosts: { mode: "tld", defaultTld: "com" },
+  hosts: { mode: "tld", tld: { com: "en" }, defaultTld: "com" },
 })
 
 export const LOCALE_LABELS = locales.labels

--- a/examples/waku-tld/src/lib/i18n.ts
+++ b/examples/waku-tld/src/lib/i18n.ts
@@ -13,14 +13,14 @@ export type Locale = (typeof LOCALES)[number]
 /**
  * Headless locale controls for this demo (TLD strategy). The rightmost DNS
  * label is authoritative for the locale (`.de` -> `de`, `.es` -> `es`,
- * `.fr` -> `fr`). The default TLD `.com` is not authoritative — there
- * Accept-Language is consulted and falls back to `en`. Set `defaultTld:"com"`
- * so the locale switcher navigates to the `.com` domain when switching to `en`.
+ * `.fr` -> `fr`). `.com` maps to `en` via an explicit `tld` override (its
+ * label is not a locale code). Set `defaultTld:"com"` so the locale switcher
+ * navigates to the `.com` domain when switching to `en`.
  */
 export const locales = defineLocaleControls<Locale>({
   locales: LOCALES,
   defaultLocale: DEFAULT_LOCALE,
-  hosts: { mode: "tld", defaultTld: "com" },
+  hosts: { mode: "tld", tld: { com: "en" }, defaultTld: "com" },
 })
 
 export const LOCALE_LABELS = locales.labels

--- a/scripts/example-matrix.mjs
+++ b/scripts/example-matrix.mjs
@@ -355,11 +355,11 @@ export const EXAMPLE_MATRIX = [
         substrings: ["français", "places restantes"],
       },
       {
-        // `.com` is not an authoritative TLD: the locale falls back to the browser
-        // preference (Accept-Language `de` -> German).
+        // `.com` maps to `en` (explicit tld override), so it is authoritative and
+        // wins over the browser preference (Accept-Language `de`).
         headers: { host: "palamedes-i18n.com:4013", "accept-language": "de" },
         path: "/",
-        substrings: ["Deutsch", "Plätze frei"],
+        substrings: ["English", "seats left"],
       },
     ],
   },
@@ -386,9 +386,11 @@ export const EXAMPLE_MATRIX = [
         substrings: ["français", "places restantes"],
       },
       {
+        // `.com` maps to `en` (explicit tld override), so it is authoritative and
+        // wins over the browser preference (Accept-Language `de`).
         headers: { host: "palamedes-i18n.com:4023", "accept-language": "de" },
         path: "/",
-        substrings: ["Deutsch", "Plätze frei"],
+        substrings: ["English", "seats left"],
       },
     ],
   },
@@ -430,9 +432,11 @@ export const EXAMPLE_MATRIX = [
         substrings: ["français", "places restantes"],
       },
       {
+        // `.com` maps to `en` (explicit tld override), so it is authoritative and
+        // wins over the browser preference (Accept-Language `de`).
         headers: { host: "palamedes-i18n.com:4043", "accept-language": "de" },
         path: "/",
-        substrings: ["Deutsch", "Plätze frei"],
+        substrings: ["English", "seats left"],
       },
     ],
   },
@@ -463,9 +467,11 @@ export const EXAMPLE_MATRIX = [
         substrings: ["français", "places restantes"],
       },
       {
+        // `.com` maps to `en` (explicit tld override), so it is authoritative and
+        // wins over the browser preference (Accept-Language `de`).
         headers: { host: "palamedes-i18n.com:4053", "accept-language": "de" },
         path: "/",
-        substrings: ["Deutsch", "Plätze frei"],
+        substrings: ["English", "seats left"],
       },
     ],
   },


### PR DESCRIPTION
## Motivation

The tld demos left `.com` unmapped, so it resolved via the `Accept-Language`/default fallback. Per request, `.com` should now point authoritatively to **`en`**.

## Change

Add an explicit tld override in all five `-tld` example apps:

```ts
hosts: { mode: "tld", tld: { com: "en" }, defaultTld: "com" }
```

`.com` now resolves authoritatively to `en` (`source: "tld"`) and wins over `Accept-Language`. `.de`/`.es`/`.fr` stay automatically authoritative; `.ch` remains the documented non-authoritative (multilingual) fallback example.

**No core change** — `@palamedes/core` already supports the explicit `tld` map (the same mechanism as `{ at: "de" }`).

Also updated:
- the `.com` **smoke checks** (`scripts/example-matrix.mjs`) now assert English output (`.com` + `Accept-Language: de` → English, proving it is authoritative);
- the in-code `i18n.ts` doc comments;
- docs: `locale-strategies.md` (TLD section), `demo-deployments.md` and `examples/README.md` legends.

## Verification

- `node scripts/verify-examples.mjs --strategy tld` — smoke green for all five (`.com` → English authoritative, `.de` → German, `.fr` → French).
- `pnpm test` (core 42), `pnpm check-types`, `pnpm lint`, `pnpm format:check` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)