### PR TITLE
fix(release): build musl node addon with the default self-contained linker

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -173,14 +173,6 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Configure musl Node addon linker
-        if: matrix.package_name == '@palamedes/core-node-linux-x64-musl'
-        run: |
-          # build-native.mjs scopes the cdylib-only musl flags to the final
-          # palamedes-node target so dependency cdylibs keep Rust's default
-          # static musl linkage.
-          echo 'CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc' >> "$GITHUB_ENV"
-
       - name: Build native package
         run: pnpm --filter "${{ matrix.package_name }}" build
 

--- a/packages/core-node/scripts/build-native.mjs
+++ b/packages/core-node/scripts/build-native.mjs
@@ -104,24 +104,23 @@ if (muslNodeAddon) {
   // only reach the final crate too late for that check.
   //
   // The override is scoped to the musl *target* (not the global RUSTFLAGS), so
-  // host build scripts and proc-macros stay untouched. `link-self-contained=+unwind`
-  // supplies the unwinder in-tree for every cdylib built for this target —
-  // including the `oxc_sourcemap` cdylib — so musl-gcc never looks for a shared
-  // `libgcc_s` that the Ubuntu musl toolchain does not ship.
+  // host build scripts and proc-macros stay untouched. With crt-static off, the
+  // musl target's default self-contained linking (rust-lld plus the bundled musl
+  // objects and unwinder) links the cdylib on its own — the same path the
+  // static-musl CLI addon already uses — so no external `musl-gcc` linker and no
+  // `link-self-contained` component flag are needed. (The unstable
+  // `link-self-contained=+unwind` form is rejected on stable Rust anyway.)
   //
   // `panic=abort` is intentionally not forced here. napi-rs (`#[napi]`) wraps
   // every `extern "C"` entry point in a panic guard, so panics are converted to
-  // JS errors and never unwind across the FFI boundary. The gnu, darwin, and
-  // win32 addons already build with the default unwind strategy for the same
-  // reason; scoping abort to musl only would diverge from them and force the
-  // whole musl dependency graph off the prebuilt unwind std.
+  // JS errors and never unwind across the FFI boundary — matching the gnu,
+  // darwin, and win32 addons, which all build with the default unwind strategy.
   //
   // Prepend any inherited target rustflags so an externally provided value
   // (e.g. CI optimisation overrides) is preserved rather than dropped.
   cargoEnv.CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_RUSTFLAGS = [
     process.env.CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_RUSTFLAGS ?? "",
     "-C target-feature=-crt-static",
-    "-C link-self-contained=+unwind",
   ]
     .filter(Boolean)
     .join(" ")


### PR DESCRIPTION
## Problem

The 1.1.0 release Publish failed on `publish-native (@palamedes/core-node-linux-x64-musl)`:

```
error: only `-C link-self-contained` values y/yes/on/n/no/off/-linker are stable,
the -Z unstable-options flag must also be passed to use the unstable values
```

The prior musl fix (#296) correctly moved `-crt-static` into `CARGO_TARGET_..._RUSTFLAGS` so cargo's cdylib crate-type check passes — but it kept `-C link-self-contained=+unwind`, whose **component-specific form is unstable** and is rejected on the stable toolchain the workflow uses.

## Fix

Drop `link-self-contained` and the external `musl-gcc` linker entirely; use the musl target's **default self-contained linking** (rust-lld + bundled musl objects and unwinder):

- `build-native.mjs`: musl `RUSTFLAGS` is now just `-C target-feature=-crt-static`.
- `publish.yml`: removed the core-node-only `CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc` step.

**Why this is the right path:** the `@palamedes/cli-linux-x64-musl` addon already builds green with the default linker (no `musl-gcc`, no extra flags). With `crt-static` disabled, the core-node cdylib links the same way — Rust ships the unwinder in-tree, so there is no external `libgcc_s` lookup and no unstable flag. The `musl-gcc` + `link-self-contained` combination was a pre-#296 workaround that is now both broken and unnecessary.

## Verification

- `node --check` + `pnpm lint` + `oxfmt --check` on the changed files — green; workflow step removed cleanly (indentation intact).
- The musl cross-build cannot be exercised on macOS; it verifies in CI on the next Publish (or a manual run). `musl-tools` install is left in place (harmless if unused).

🤖 Generated with [Claude Code](https://claude.com/claude-code)