### PR TITLE
docs(site): pseudo-JSX homepage structure with pages, components, and copy

### DIFF
--- a/docs/site/structure/README.md
+++ b/docs/site/structure/README.md
@@ -1,0 +1,63 @@
+# Palamedes Website Structure
+
+This directory is the design source for the public Palamedes homepage. It
+describes page structure, layout, and copy using **pseudo-JSX**: the files look
+like React components, but they are a specification, not runnable code. The
+goal is that a designer or implementer can read one page file top-to-bottom and
+know exactly what sections exist, in which order, with which copy, and which
+links they carry.
+
+## How to read the pseudo-JSX
+
+- Every `pages/*.jsx` file is one route of the site.
+- Components like `<Hero>`, `<ProofStrip>`, `<CodeShowcase>` are layout
+  primitives. Their intended anatomy and props are defined once in
+  [`components.jsx`](components.jsx).
+- All visible copy is real, final-draft copy — not lorem ipsum. Copy edits
+  happen here first, then flow into the implementation.
+- `href` values use site-relative routes (`/proof`, `/frameworks`) for internal
+  pages and full URLs for repo/docs/demo links.
+- Comments (`{/* ... */}`) carry layout intent (grid columns, emphasis,
+  responsive behavior) that markup alone cannot express.
+
+## Sitemap
+
+| Route          | File                                             | Job of the page                                                        |
+| -------------- | ------------------------------------------------ | ---------------------------------------------------------------------- |
+| `/`            | [`pages/HomePage.jsx`](pages/HomePage.jsx)       | Convert: one model across frameworks, proof-first, clear next step     |
+| `/frameworks`  | [`pages/FrameworksPage.jsx`](pages/FrameworksPage.jsx) | Show the 5×4 verified matrix and live demos per framework       |
+| `/proof`       | [`pages/ProofPage.jsx`](pages/ProofPage.jsx)     | Benchmarks, verification story, screenshots — the evidence page        |
+| `/get-started` | [`pages/GetStartedPage.jsx`](pages/GetStartedPage.jsx) | The 5-minute path from install to first rendered translation    |
+| `/compare`     | [`pages/ComparisonPage.jsx`](pages/ComparisonPage.jsx) | Honest positioning vs Lingui, next-intl, and GT                  |
+| `/blog`        | [`pages/BlogIndexPage.jsx`](pages/BlogIndexPage.jsx)   | Founder-led posts; reuses `docs/site/posts/`                     |
+
+Every page shares `<SiteNav>` and `<SiteFooter>` from `components.jsx`.
+
+## Messaging rules this structure follows
+
+These come from [`docs/site/comparison.mdx`](../comparison.mdx),
+[`docs/site/proof.mdx`](../proof.mdx), and
+[`docs/principles.md`](../../principles.md):
+
+1. **Proof before promise.** Every quantitative claim links to a checked-in
+   report or a verifiable repo artifact. No benchmark number without a
+   methodology link.
+2. **No "Rust means fast" shortcut.** Rust is mentioned as the reason the
+   careful work has one home; speed claims cite the e2e benchmark only.
+3. **Competitors are framed, not trashed.** Lingui is the closest neighbor,
+   next-intl is a better fit for some teams, GT is a different category.
+4. **Current-state honesty.** The top-level `palamedes` / `create-palamedes`
+   packages are reserved names, not the install path — the site must not
+   pretend otherwise.
+
+## Facts the copy relies on (verify before shipping)
+
+- 20 browser-verified example apps: 5 framework families × 4 locale
+  strategies (cookie, route, subdomain, TLD) — see `examples/`.
+- Live demos deployed at `*.examples.palamedes.dev`.
+- E2E extract/update benchmark medians: 33.53 ms (small), 42.92 ms (medium);
+  19.59× vs Lingui, 14.24× vs i18next-parser on the checked machine-local run
+  — see `benchmarks/e2e-workflow/results/latest.md`.
+- 16 ADRs in `adr/`.
+- CLI binary is `pmds`; recommended install is the scoped `@palamedes/*`
+  packages.

--- a/docs/site/structure/README.md
+++ b/docs/site/structure/README.md
@@ -50,11 +50,31 @@ These come from [`docs/site/comparison.mdx`](../comparison.mdx),
    packages are reserved names, not the install path — the site must not
    pretend otherwise.
 
+## Relationship to the homepage-direction planning (issue #290)
+
+Issue [#290](https://github.com/sebastian-software/palamedes/issues/290)
+explores ten visual directions and the Core vs. Palamedes+ leading question.
+This structure is deliberately **visual-direction-agnostic**: it fixes the
+information architecture, section order, and copy, and can be skinned with any
+of the explored directions. Two decisions from #290 affect this structure and
+must be resolved before implementation:
+
+1. **Core-led vs. Plus-led homepage.** The current `HomePage.jsx` is Core-led
+   (open-source proof first). If Plus leads instead, the hero and one section
+   swap, but subpages stay valid.
+2. **Palamedes+ page.** If Plus positioning is confirmed, add a `/plus` route
+   (managed AI translation, glossary/protected terms, QA, writeback) — kept
+   out of this pass because the copy must not overstate what exists today.
+
 ## Facts the copy relies on (verify before shipping)
 
 - 20 browser-verified example apps: 5 framework families × 4 locale
   strategies (cookie, route, subdomain, TLD) — see `examples/`.
-- Live demos deployed at `*.examples.palamedes.dev`.
+- Live demos referenced as `*.examples.palamedes.dev` — note: the repo's
+  deploy tooling currently targets differently named `vercel.app` hosts, and
+  `docs/demo-deployments.md` marks the subdomain/tld rows as not yet
+  reachable. The demo-URL story must be reconciled before the site ships
+  (tracked in the docs-audit epic).
 - E2E extract/update benchmark medians: 33.53 ms (small), 42.92 ms (medium);
   19.59× vs Lingui, 14.24× vs i18next-parser on the checked machine-local run
   — see `benchmarks/e2e-workflow/results/latest.md`.

--- a/docs/site/structure/README.md
+++ b/docs/site/structure/README.md
@@ -13,10 +13,19 @@ links they carry.
 - Components like `<Hero>`, `<ProofStrip>`, `<CodeShowcase>` are layout
   primitives. Their intended anatomy and props are defined once in
   [`components.jsx`](components.jsx).
-- All visible copy is real, final-draft copy — not lorem ipsum. Copy edits
-  happen here first, then flow into the implementation.
-- `href` values use site-relative routes (`/proof`, `/frameworks`) for internal
-  pages and full URLs for repo/docs/demo links.
+- All visible copy is real, **review-ready draft copy** — not lorem ipsum.
+  Copy edits happen here first, then flow into the implementation. The copy
+  freezes only after the Core-led vs. Plus-led decision in
+  [#290](https://github.com/sebastian-software/palamedes/issues/290) is made;
+  until then implementers must treat it as draft, not locked.
+- **Link contract.** `href` values come in exactly three forms:
+  1. site-relative routes for internal pages (`/proof`, `/frameworks`),
+  2. `repoHref("docs/...")` for anything living in the repository — a
+     placeholder function defined in [`components.jsx`](components.jsx) that
+     resolves a repo path to its canonical public URL (GitHub `blob/main`
+     today, docs-site route later, one place to change),
+  3. literal full URLs for genuinely external targets (demos, npm, company).
+     No other placeholder syntax is allowed in page specs.
 - Comments (`{/* ... */}`) carry layout intent (grid columns, emphasis,
   responsive behavior) that markup alone cannot express.
 
@@ -60,21 +69,26 @@ of the explored directions. Two decisions from #290 affect this structure and
 must be resolved before implementation:
 
 1. **Core-led vs. Plus-led homepage.** The current `HomePage.jsx` is Core-led
-   (open-source proof first). If Plus leads instead, the hero and one section
-   swap, but subpages stay valid.
-2. **Palamedes+ page.** If Plus positioning is confirmed, add a `/plus` route
-   (managed AI translation, glossary/protected terms, QA, writeback) — kept
-   out of this pass because the copy must not overstate what exists today.
+   (open-source proof first) — per maintainer review this is the safer public
+   default today. If Plus leads instead, the hero and one section swap, but
+   subpages stay valid.
+2. **Palamedes+ page.** Plus is expected to enter later as a bridge/route or
+   waitlist CTA (e.g. a `/plus` route: managed AI translation,
+   glossary/protected terms, QA, writeback) rather than being folded into the
+   OSS homepage claims — kept out of this pass because the copy must not
+   overstate what exists today.
 
 ## Facts the copy relies on (verify before shipping)
 
 - 20 browser-verified example apps: 5 framework families × 4 locale
   strategies (cookie, route, subdomain, TLD) — see `examples/`.
-- Live demos referenced as `*.examples.palamedes.dev` — note: the repo's
-  deploy tooling currently targets differently named `vercel.app` hosts, and
-  `docs/demo-deployments.md` marks the subdomain/tld rows as not yet
-  reachable. The demo-URL story must be reconciled before the site ships
-  (tracked in the docs-audit epic).
+- Demo links are **explicit per matrix cell with a hosting status**
+  (`FRAMEWORK_MATRIX_CELLS` in `components.jsx`), mirroring the per-strategy
+  URL shapes in `examples/README.md`: cookie (one host), route (locale path),
+  subdomain (locale host label), tld (`palamedes-i18n.{com,de,es,fr}`).
+  Subdomain/tld cells carry status `provisioning` and render no demo link
+  until the hosting story is reconciled (#306). Never derive demo URLs from
+  a single naming pattern.
 - E2E extract/update benchmark medians: 33.53 ms (small), 42.92 ms (medium);
   19.59× vs Lingui, 14.24× vs i18next-parser on the checked machine-local run
   — see `benchmarks/e2e-workflow/results/latest.md`.

--- a/docs/site/structure/README.md
+++ b/docs/site/structure/README.md
@@ -22,14 +22,14 @@ links they carry.
 
 ## Sitemap
 
-| Route          | File                                             | Job of the page                                                        |
-| -------------- | ------------------------------------------------ | ---------------------------------------------------------------------- |
-| `/`            | [`pages/HomePage.jsx`](pages/HomePage.jsx)       | Convert: one model across frameworks, proof-first, clear next step     |
-| `/frameworks`  | [`pages/FrameworksPage.jsx`](pages/FrameworksPage.jsx) | Show the 5×4 verified matrix and live demos per framework       |
-| `/proof`       | [`pages/ProofPage.jsx`](pages/ProofPage.jsx)     | Benchmarks, verification story, screenshots — the evidence page        |
-| `/get-started` | [`pages/GetStartedPage.jsx`](pages/GetStartedPage.jsx) | The 5-minute path from install to first rendered translation    |
-| `/compare`     | [`pages/ComparisonPage.jsx`](pages/ComparisonPage.jsx) | Honest positioning vs Lingui, next-intl, and GT                  |
-| `/blog`        | [`pages/BlogIndexPage.jsx`](pages/BlogIndexPage.jsx)   | Founder-led posts; reuses `docs/site/posts/`                     |
+| Route          | File                                                   | Job of the page                                                    |
+| -------------- | ------------------------------------------------------ | ------------------------------------------------------------------ |
+| `/`            | [`pages/HomePage.jsx`](pages/HomePage.jsx)             | Convert: one model across frameworks, proof-first, clear next step |
+| `/frameworks`  | [`pages/FrameworksPage.jsx`](pages/FrameworksPage.jsx) | Show the 5×4 verified matrix and live demos per framework          |
+| `/proof`       | [`pages/ProofPage.jsx`](pages/ProofPage.jsx)           | Benchmarks, verification story, screenshots — the evidence page    |
+| `/get-started` | [`pages/GetStartedPage.jsx`](pages/GetStartedPage.jsx) | The 5-minute path from install to first rendered translation       |
+| `/compare`     | [`pages/ComparisonPage.jsx`](pages/ComparisonPage.jsx) | Honest positioning vs Lingui, next-intl, and GT                    |
+| `/blog`        | [`pages/BlogIndexPage.jsx`](pages/BlogIndexPage.jsx)   | Founder-led posts; reuses `docs/site/posts/`                       |
 
 Every page shares `<SiteNav>` and `<SiteFooter>` from `components.jsx`.
 

--- a/docs/site/structure/components.jsx
+++ b/docs/site/structure/components.jsx
@@ -32,7 +32,9 @@ export function SiteNav() {
       </NavLinks>
       <NavActions>
         <GitHubStarsButton repo="sebastian-software/palamedes" />
-        <Button variant="primary" href="/get-started">Get started</Button>
+        <Button variant="primary" href="/get-started">
+          Get started
+        </Button>
       </NavActions>
     </nav>
   )

--- a/docs/site/structure/components.jsx
+++ b/docs/site/structure/components.jsx
@@ -1,0 +1,189 @@
+/**
+ * Pseudo-JSX component inventory for the Palamedes site.
+ *
+ * This file is a SPECIFICATION, not runnable code. Each component defines the
+ * layout anatomy and the props that page files (pages/*.jsx) are allowed to
+ * use. Implementation stacks (Astro, Next.js, plain SSG) map these 1:1.
+ *
+ * Layout system assumptions:
+ * - max content width 1120px, centered, 24px gutters
+ * - type scale: display / h1 / h2 / body / small
+ * - one accent color used for CTAs and inline highlights only
+ * - dark and light theme; code blocks always dark
+ */
+
+/* ---------------------------------------------------------------- chrome -- */
+
+/**
+ * Sticky top navigation, identical on every page.
+ * Left: wordmark. Center: primary routes. Right: GitHub link + primary CTA.
+ * Collapses to a burger menu below 720px.
+ */
+export function SiteNav() {
+  return (
+    <nav>
+      <Wordmark href="/" label="Palamedes" />
+      <NavLinks>
+        <a href="/frameworks">Frameworks</a>
+        <a href="/proof">Proof</a>
+        <a href="/compare">Compare</a>
+        <a href="/blog">Blog</a>
+        <a href="https://github.com/sebastian-software/palamedes/tree/main/docs">Docs</a>
+      </NavLinks>
+      <NavActions>
+        <GitHubStarsButton repo="sebastian-software/palamedes" />
+        <Button variant="primary" href="/get-started">Get started</Button>
+      </NavActions>
+    </nav>
+  )
+}
+
+/**
+ * Global footer, identical on every page.
+ * Four link columns + legal strip with Sebastian Software attribution.
+ */
+export function SiteFooter() {
+  return (
+    <footer>
+      <FooterColumn title="Product">
+        <a href="/get-started">Get started</a>
+        <a href="/frameworks">Framework matrix</a>
+        <a href="/proof">Benchmarks & proof</a>
+        <a href="/compare">Comparison</a>
+      </FooterColumn>
+      <FooterColumn title="Documentation">
+        <a href="…/docs/first-working-translation.md">5-minute quickstart</a>
+        <a href="…/docs/api/README.md">API reference</a>
+        <a href="…/docs/configuration.md">Configuration</a>
+        <a href="…/docs/cli.md">CLI</a>
+        <a href="…/docs/troubleshooting.md">Troubleshooting</a>
+      </FooterColumn>
+      <FooterColumn title="Project">
+        <a href="…/adr/">Architecture decisions</a>
+        <a href="…/docs/stability.md">Stability & versioning</a>
+        <a href="…/CHANGELOG.md">Changelog</a>
+        <a href="…/SECURITY.md">Security</a>
+        <a href="…/LICENSE">MIT license</a>
+      </FooterColumn>
+      <FooterColumn title="Company">
+        <a href="https://oss.sebastian-software.com/">Sebastian Software</a>
+        <a href="https://sebastian-software.de/werner">Sebastian Werner</a>
+        <a href="/blog">Blog</a>
+      </FooterColumn>
+      <LegalStrip>
+        MIT © 2026 Sebastian Software GmbH — built in the open, verified in CI.
+      </LegalStrip>
+    </footer>
+  )
+}
+
+/* --------------------------------------------------------------- content -- */
+
+/**
+ * Full-width hero. One headline, one subline, two CTAs, one proof visual.
+ * Two-column ≥960px (copy left, visual right), stacked below.
+ *
+ * props:
+ * - eyebrow:   small caps line above the headline (optional)
+ * - headline:  the one-sentence promise
+ * - subline:   2–3 sentences, concrete, no adjectives without evidence
+ * - primary / secondary: CTA buttons { label, href }
+ * - visual:    <Screenshot>, <LocaleMatrixAnimation>, or <CodeShowcase>
+ */
+export function Hero(props) {}
+
+/**
+ * Thin horizontal band of 3–5 hard facts directly under the hero.
+ * Each stat: big number + one-line label + link to the evidence.
+ * Never contains a number that has no checked-in source.
+ *
+ * props: stats: Array<{ value, label, href }>
+ */
+export function ProofStrip(props) {}
+
+/**
+ * Two-panel code presentation: source on the left (or top), rendered/derived
+ * result on the right (or bottom). Tabs allow multiple variants.
+ *
+ * props:
+ * - tabs: Array<{ label, code, language, caption }>
+ * - result: optional rendered-output panel { title, content }
+ */
+export function CodeShowcase(props) {}
+
+/**
+ * Grid of feature cards. 3 columns ≥960px, 1 column mobile.
+ * Card: icon, title (≤5 words), 2-sentence body, optional link.
+ *
+ * props: columns, cards: Array<{ icon, title, body, href? }>
+ */
+export function FeatureGrid(props) {}
+
+/**
+ * The 5×4 framework/strategy matrix as an interactive table.
+ * Rows: framework families. Columns: locale strategies.
+ * Each cell links to the live demo; verified cells carry a check badge.
+ *
+ * props:
+ * - frameworks: Array<{ name, slug }>
+ * - strategies: Array<{ name, slug }>
+ * - demoUrl: (frameworkSlug, strategySlug) => url
+ */
+export function FrameworkMatrix(props) {}
+
+/**
+ * Numbered horizontal step flow (vertical on mobile), 3–4 steps max.
+ * Step: number, title, one-liner, optional small code block.
+ *
+ * props: steps: Array<{ title, body, code? }>
+ */
+export function StepFlow(props) {}
+
+/**
+ * Benchmark bar chart with mandatory methodology link.
+ * Bars sorted fastest-first, values labeled in ms, log scale allowed
+ * when ratios exceed 10×. Renders a caption with machine/date context.
+ *
+ * props: title, rows: Array<{ tool, median, samples }>, methodologyHref
+ */
+export function BenchmarkChart(props) {}
+
+/**
+ * Side-by-side comparison table. First column = criteria, one column per
+ * tool. Cells are short phrases, never bare ✓/✗ without a footnote.
+ *
+ * props: criteria: string[], tools: Array<{ name, cells: string[] }>, footnotes
+ */
+export function CompareTable(props) {}
+
+/**
+ * Single large quote or statement band, used for the positioning line.
+ * props: text, attribution?
+ */
+export function StatementBand(props) {}
+
+/**
+ * Screenshot with browser chrome frame and caption.
+ * props: src, alt, caption, href?
+ */
+export function Screenshot(props) {}
+
+/**
+ * Animated (reduced-motion safe) visual cycling one UI card through
+ * en → de → es, showing copy, plurals, currency, and dates changing
+ * together. Falls back to the static localized-matrix image.
+ * props: fallbackSrc
+ */
+export function LocaleMatrixAnimation(props) {}
+
+/**
+ * Full-width closing call-to-action band before the footer.
+ * props: headline, primary: {label, href}, secondary?: {label, href}
+ */
+export function CtaBand(props) {}
+
+/**
+ * Blog post preview card: title, date, 2-line excerpt, read-time.
+ * props: post: { title, date, excerpt, href, readMinutes }
+ */
+export function PostCard(props) {}

--- a/docs/site/structure/components.jsx
+++ b/docs/site/structure/components.jsx
@@ -12,6 +12,25 @@
  * - dark and light theme; code blocks always dark
  */
 
+/* ---------------------------------------------------------- link contract -- */
+
+/**
+ * Placeholder API for links into the repository. Page specs MUST use this
+ * instead of hand-written `…/` placeholders so implementers know exactly
+ * what to resolve:
+ *
+ * - repoHref("docs/troubleshooting.md") → the canonical public URL for that
+ *   repo path — today `https://github.com/sebastian-software/palamedes/blob/main/<path>`
+ *   (or `/tree/main/<path>` for directories); later the docs-site route once
+ *   docs are published on the site itself.
+ * - Site-internal routes stay literal ("/proof", "/get-started").
+ * - Fully external URLs stay literal ("https://...").
+ *
+ * The implementation is one function; swapping GitHub URLs for docs-site
+ * routes later is a single-place change.
+ */
+export function repoHref(path) {}
+
 /* ---------------------------------------------------------------- chrome -- */
 
 /**
@@ -54,18 +73,18 @@ export function SiteFooter() {
         <a href="/compare">Comparison</a>
       </FooterColumn>
       <FooterColumn title="Documentation">
-        <a href="…/docs/first-working-translation.md">5-minute quickstart</a>
-        <a href="…/docs/api/README.md">API reference</a>
-        <a href="…/docs/configuration.md">Configuration</a>
-        <a href="…/docs/cli.md">CLI</a>
-        <a href="…/docs/troubleshooting.md">Troubleshooting</a>
+        <a href={repoHref("docs/first-working-translation.md")}>5-minute quickstart</a>
+        <a href={repoHref("docs/api/README.md")}>API reference</a>
+        <a href={repoHref("docs/configuration.md")}>Configuration</a>
+        <a href={repoHref("docs/cli.md")}>CLI</a>
+        <a href={repoHref("docs/troubleshooting.md")}>Troubleshooting</a>
       </FooterColumn>
       <FooterColumn title="Project">
-        <a href="…/adr/">Architecture decisions</a>
-        <a href="…/docs/stability.md">Stability & versioning</a>
-        <a href="…/CHANGELOG.md">Changelog</a>
-        <a href="…/SECURITY.md">Security</a>
-        <a href="…/LICENSE">MIT license</a>
+        <a href={repoHref("adr")}>Architecture decisions</a>
+        <a href={repoHref("docs/stability.md")}>Stability & versioning</a>
+        <a href={repoHref("CHANGELOG.md")}>Changelog</a>
+        <a href={repoHref("SECURITY.md")}>Security</a>
+        <a href={repoHref("LICENSE")}>MIT license</a>
       </FooterColumn>
       <FooterColumn title="Company">
         <a href="https://oss.sebastian-software.com/">Sebastian Software</a>
@@ -124,20 +143,86 @@ export function FeatureGrid(props) {}
 /**
  * The 5×4 framework/strategy matrix as an interactive table.
  * Rows: framework families. Columns: locale strategies.
- * Each cell links to the live demo; verified cells carry a check badge.
+ *
+ * Cells carry EXPLICIT links and a per-cell status — never a generated URL
+ * pattern. The real URL shapes differ per strategy (cookie: one host; route:
+ * locale path segment; subdomain: locale host label; tld: per-locale
+ * `palamedes-i18n.{com,de,es,fr}` domains), and not every cell has public
+ * hosting yet. Every cell shows its CI-verified badge; only cells with
+ * status "live" render demo links. Source of truth for cell data:
+ * examples/README.md + docs/demo-deployments.md (reconciliation tracked
+ * in #306).
  *
  * props:
  * - frameworks: Array<{ name, slug }>
  * - strategies: Array<{ name, slug }>
- * - demoUrl: (frameworkSlug, strategySlug) => url
+ * - cells: Array<{
+ *     framework, strategy,
+ *     verified: true,                      // all 20 are CI browser-verified
+ *     status: "live" | "provisioning",     // public hosting state
+ *     demoLinks?: Array<{ label, href }>,  // explicit, only when live
+ *     sourceHref,                          // example source in the repo
+ *   }>
  */
 export function FrameworkMatrix(props) {}
 
 /**
- * Numbered horizontal step flow (vertical on mobile), 3–4 steps max.
- * Step: number, title, one-liner, optional small code block.
+ * Shared cell data for <FrameworkMatrix>, used by HomePage and
+ * FrameworksPage. Mirrors the per-strategy URL shapes documented in
+ * examples/README.md ("Live Demos"). Per docs/demo-deployments.md the
+ * subdomain and tld rows are not publicly reachable yet (DNS/domains
+ * pending), so they carry status "provisioning" with no demo links until
+ * #306 lands. Cookie demos have a single URL (locale via cookie); route
+ * demos link per-locale paths.
+ */
+export const FRAMEWORK_MATRIX_CELLS = [
+  "nextjs",
+  "tanstack",
+  "solidstart",
+  "waku",
+  "react-router",
+].flatMap((framework) => [
+  {
+    framework,
+    strategy: "cookie",
+    verified: true,
+    status: "live",
+    demoLinks: [{ label: "open", href: `https://${framework}-cookie.examples.palamedes.dev` }],
+    sourceHref: repoHref(`examples/${framework}-cookie`),
+  },
+  {
+    framework,
+    strategy: "route",
+    verified: true,
+    status: "live",
+    demoLinks: ["en", "de", "es"].map((locale) => ({
+      label: locale,
+      href: `https://${framework}-route.examples.palamedes.dev/${locale}`,
+    })),
+    sourceHref: repoHref(`examples/${framework}-route`),
+  },
+  {
+    framework,
+    strategy: "subdomain",
+    verified: true,
+    status: "provisioning", // en.<framework>-subdomain.examples.palamedes.dev once DNS lands (#306)
+    sourceHref: repoHref(`examples/${framework}-subdomain`),
+  },
+  {
+    framework,
+    strategy: "tld",
+    verified: true,
+    status: "provisioning", // <framework>.examples.palamedes-i18n.{com,de,es,fr} once domains land (#306)
+    sourceHref: repoHref(`examples/${framework}-tld`),
+  },
+])
+
+/**
+ * Numbered step flow (horizontal up to 4 steps, vertical beyond and on
+ * mobile), 3–6 steps max. Step: number, title, one-liner, optional small
+ * code block, optional aside for caveats.
  *
- * props: steps: Array<{ title, body, code? }>
+ * props: steps: Array<{ title, body, code?, aside? }>
  */
 export function StepFlow(props) {}
 

--- a/docs/site/structure/drafts/README.md
+++ b/docs/site/structure/drafts/README.md
@@ -11,11 +11,11 @@ They exist to make the direction decision in
 [#290](https://github.com/sebastian-software/palamedes/issues/290) concrete:
 same content, three different personalities.
 
-| Draft | File                                                   | Direction        | Personality                                                                       |
-| ----- | ------------------------------------------------------ | ---------------- | --------------------------------------------------------------------------------- |
-| A     | [`design-a-spec-grid.html`](design-a-spec-grid.html)   | Swiss Spec Grid  | Light, strict, standards-document: hairline grid, one blue accent, spec tables    |
-| B     | [`design-b-terminal.html`](design-b-terminal.html)     | Terminal / Ops   | Dark, monospace, developer-native: terminal hero, status LEDs, CI-log proof view  |
-| C     | [`design-c-editorial.html`](design-c-editorial.html)   | Editorial Calm   | Warm paper, serif long-form essay: pull quotes, author's note, composed pacing    |
+| Draft | File                                                 | Direction       | Personality                                                                      |
+| ----- | ---------------------------------------------------- | --------------- | -------------------------------------------------------------------------------- |
+| A     | [`design-a-spec-grid.html`](design-a-spec-grid.html) | Swiss Spec Grid | Light, strict, standards-document: hairline grid, one blue accent, spec tables   |
+| B     | [`design-b-terminal.html`](design-b-terminal.html)   | Terminal / Ops  | Dark, monospace, developer-native: terminal hero, status LEDs, CI-log proof view |
+| C     | [`design-c-editorial.html`](design-c-editorial.html) | Editorial Calm  | Warm paper, serif long-form essay: pull quotes, author's note, composed pacing   |
 
 Rough mapping to the #290 exploration: A ≈ variant 03 (Swiss specification
 grid), B ≈ variants 02/07 (ops cockpit / CLI-and-repo-first), C ≈ variants

--- a/docs/site/structure/drafts/README.md
+++ b/docs/site/structure/drafts/README.md
@@ -1,0 +1,41 @@
+# Competing Visual Design Drafts
+
+Three deliberately divergent visual directions for the Palamedes site, all
+built on the same information architecture and copy from
+[`docs/site/structure/`](../README.md). These are **design mocks, not
+implementations**: single self-contained HTML files, system fonts only, no
+build step — open them directly in a browser. Each file contains four views
+(Home, Frameworks, Proof, Get started) switched by the top navigation.
+
+They exist to make the direction decision in
+[#290](https://github.com/sebastian-software/palamedes/issues/290) concrete:
+same content, three different personalities.
+
+| Draft | File                                                   | Direction        | Personality                                                                       |
+| ----- | ------------------------------------------------------ | ---------------- | --------------------------------------------------------------------------------- |
+| A     | [`design-a-spec-grid.html`](design-a-spec-grid.html)   | Swiss Spec Grid  | Light, strict, standards-document: hairline grid, one blue accent, spec tables    |
+| B     | [`design-b-terminal.html`](design-b-terminal.html)     | Terminal / Ops   | Dark, monospace, developer-native: terminal hero, status LEDs, CI-log proof view  |
+| C     | [`design-c-editorial.html`](design-c-editorial.html)   | Editorial Calm   | Warm paper, serif long-form essay: pull quotes, author's note, composed pacing    |
+
+Rough mapping to the #290 exploration: A ≈ variant 03 (Swiss specification
+grid), B ≈ variants 02/07 (ops cockpit / CLI-and-repo-first), C ≈ variants
+01/05 (editorial stack / founder-led editorial).
+
+## Shared ground rules
+
+All three drafts follow the messaging rules from the structure README:
+
+- copy comes verbatim from the page specs (review-ready draft status, see #290)
+- speed claims stay scoped to the checked machine-local benchmark
+- matrix cells carry explicit demo links + hosting status (subdomain/TLD =
+  provisioning, no demo link — see #306); all cells marked CI-verified
+- no external resources: everything renders offline
+
+## How to evaluate
+
+1. Open all three side by side and judge the first 10 seconds of the Home view.
+2. Switch to Frameworks — which matrix treatment makes the 5×4 proof most
+   credible?
+3. Check Get started — which one makes the 6-step flow feel shortest?
+4. Pick one primary + one backup, then fold the decision back into #290 and
+   the implementation issue #321.

--- a/docs/site/structure/drafts/design-a-spec-grid.html
+++ b/docs/site/structure/drafts/design-a-spec-grid.html
@@ -1,642 +1,1188 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Palamedes — Design draft A — Spec Grid</title>
-<style>
-/* ============================================================
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Palamedes — Design draft A — Spec Grid</title>
+    <style>
+      /* ============================================================
    DESIGN A — SWISS SPEC GRID
    bg #fbfbf8 · ink #101010 · hairline #d8d8d2 · accent #0038ff
    Zero radius, zero shadows, zero gradients. 8px base scale.
    ============================================================ */
 
-:root {
-  --bg: #fbfbf8;
-  --ink: #101010;
-  --hair: #d8d8d2;
-  --accent: #0038ff;
-  --gray: #8a8a84;
-  --mono: ui-monospace, "SF Mono", "SFMono-Regular", Menlo, Consolas, "Liberation Mono", monospace;
-  --sans: "Helvetica Neue", Helvetica, Arial, Inter, sans-serif;
-}
-
-* { margin: 0; padding: 0; box-sizing: border-box; }
-
-html { background: var(--bg); }
-
-body {
-  font-family: var(--sans);
-  color: var(--ink);
-  background: var(--bg);
-  font-size: 16px;
-  line-height: 1.55;
-  -webkit-font-smoothing: antialiased;
-}
-
-a { color: var(--accent); text-decoration: none; }
-a:hover { text-decoration: underline; }
-
-.mono { font-family: var(--mono); font-variant-numeric: tabular-nums; }
-
-/* ---------------------------------------------------- frame + hairlines -- */
-
-.frame {
-  max-width: 1120px;
-  margin: 0 auto;
-  border-left: 1px solid var(--hair);
-  border-right: 1px solid var(--hair);
-  min-height: 100vh;
-  background: var(--bg);
-}
-
-.sec { border-top: 1px solid var(--hair); padding: 56px 32px 64px; }
-.sec-head { display: flex; align-items: baseline; gap: 24px; margin-bottom: 32px; flex-wrap: wrap; }
-
-.sec-mark {
-  font-family: var(--mono);
-  font-size: 11px;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  color: var(--gray);
-  white-space: nowrap;
-}
-
-.eyebrow {
-  font-size: 11px;
-  letter-spacing: 0.22em;
-  text-transform: uppercase;
-  color: var(--ink);
-  margin-bottom: 24px;
-}
-.eyebrow::before { content: "§ "; color: var(--accent); }
-
-h2 {
-  font-size: clamp(24px, 3.4vw, 34px);
-  font-weight: 700;
-  letter-spacing: -0.02em;
-  line-height: 1.15;
-  max-width: 22em;
-}
-
-.lede { max-width: 44em; margin-top: 16px; font-size: 16px; }
-
-.micro {
-  font-size: 11px;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  color: var(--gray);
-}
-
-/* --------------------------------------------------------------- ribbon -- */
-
-.ribbon {
-  position: fixed;
-  left: 0;
-  bottom: 0;
-  z-index: 100;
-  background: var(--ink);
-  color: var(--bg);
-  font-family: var(--mono);
-  font-size: 10px;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  padding: 6px 12px;
-  border-top: 1px solid var(--ink);
-  border-right: 1px solid var(--ink);
-}
-.ribbon b { color: #9db2ff; font-weight: 400; }
-
-/* ------------------------------------------------------------------ nav -- */
-
-nav.site {
-  position: sticky;
-  top: 0;
-  z-index: 50;
-  background: var(--bg);
-  border-bottom: 1px solid var(--hair);
-  display: flex;
-  align-items: center;
-  gap: 24px;
-  padding: 0 32px;
-  min-height: 56px;
-  flex-wrap: wrap;
-}
-
-.wordmark {
-  font-weight: 700;
-  font-size: 17px;
-  letter-spacing: -0.02em;
-  color: var(--ink);
-}
-.wordmark:hover { text-decoration: none; }
-
-.nav-links { display: flex; gap: 20px; flex-wrap: wrap; flex: 1; }
-.nav-links a {
-  color: var(--ink);
-  font-size: 12px;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  padding: 4px 0;
-  border-bottom: 2px solid transparent;
-}
-.nav-links a:hover { text-decoration: none; border-bottom-color: var(--hair); }
-.nav-links a.active { color: var(--accent); border-bottom-color: var(--accent); }
-.nav-links a.dead { color: var(--gray); cursor: default; }
-.nav-links a.dead:hover { border-bottom-color: transparent; }
-
-.nav-actions { display: flex; gap: 12px; align-items: center; }
-
-/* -------------------------------------------------------------- buttons -- */
-
-.btn {
-  display: inline-block;
-  border: 1px solid var(--ink);
-  color: var(--ink);
-  background: transparent;
-  padding: 12px 22px;
-  font-size: 11px;
-  font-weight: 600;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
-  font-family: var(--sans);
-  cursor: pointer;
-}
-.btn:hover { text-decoration: none; background: var(--ink); color: var(--bg); }
-.btn.primary { background: var(--accent); border-color: var(--accent); color: #fff; }
-.btn.primary:hover { background: var(--ink); border-color: var(--ink); }
-.btn.small { padding: 8px 14px; font-size: 10px; }
-
-/* ----------------------------------------------------------------- hero -- */
-
-.hero { padding: 72px 32px 64px; }
-.hero-grid { display: grid; grid-template-columns: minmax(0, 7fr) minmax(0, 5fr); gap: 48px; align-items: start; }
-
-h1.display {
-  font-size: clamp(44px, 7.6vw, 88px);
-  font-weight: 700;
-  letter-spacing: -0.03em;
-  line-height: 0.98;
-  margin: 0 0 28px;
-}
-
-.subline { font-size: 16px; max-width: 38em; color: var(--ink); }
-.subline .mono { font-size: 15px; }
-
-.hero-ctas { display: flex; gap: 12px; margin-top: 32px; flex-wrap: wrap; }
-
-/* -------------------------------------------------- booking-card visual -- */
-
-.locale-stack { display: grid; gap: 1px; background: var(--hair); border: 1px solid var(--hair); }
-
-.bcard { background: var(--bg); padding: 16px 18px; }
-.bcard-loc {
-  font-family: var(--mono);
-  font-size: 10px;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  color: var(--accent);
-  margin-bottom: 8px;
-}
-.bcard-title { font-size: 17px; font-weight: 700; letter-spacing: -0.01em; }
-.bcard-row { display: flex; justify-content: space-between; align-items: baseline; gap: 12px; margin-top: 6px; flex-wrap: wrap; }
-.bcard-seats { font-size: 12.5px; border: 1px solid var(--hair); padding: 2px 8px; }
-.bcard-price { font-family: var(--mono); font-variant-numeric: tabular-nums; font-size: 15px; font-weight: 500; }
-.bcard-date { font-family: var(--mono); font-variant-numeric: tabular-nums; font-size: 12px; color: var(--gray); margin-top: 6px; }
-.locale-caption { border: 1px solid var(--hair); border-top: 0; padding: 10px 18px; font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--gray); }
-
-/* ------------------------------------------------------------ proofstrip -- */
-
-.proofstrip {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 1px;
-  background: var(--hair);
-  border-top: 1px solid var(--hair);
-}
-.proofstrip a {
-  background: var(--bg);
-  padding: 24px 32px;
-  color: var(--ink);
-  display: block;
-}
-.proofstrip a:hover { text-decoration: none; background: #f2f2ec; }
-.stat-val {
-  font-family: var(--mono);
-  font-variant-numeric: tabular-nums;
-  font-size: 34px;
-  font-weight: 500;
-  letter-spacing: -0.02em;
-  color: var(--accent);
-  display: block;
-}
-.stat-label { display: block; font-size: 12px; margin-top: 6px; max-width: 22em; }
-
-/* --------------------------------------------------------- feature grid -- */
-
-.grid { display: grid; gap: 1px; background: var(--hair); border: 1px solid var(--hair); margin-top: 32px; }
-.grid.cols-3 { grid-template-columns: repeat(3, 1fr); }
-.grid.cols-4 { grid-template-columns: repeat(4, 1fr); }
-.grid.cols-2 { grid-template-columns: repeat(2, 1fr); }
-.cell { background: var(--bg); padding: 24px; }
-.cell h3 { font-size: 15px; font-weight: 700; letter-spacing: -0.01em; margin-bottom: 8px; }
-.cell p { font-size: 13.5px; }
-.cell .cell-num { font-family: var(--mono); font-size: 10px; letter-spacing: 0.18em; color: var(--gray); display: block; margin-bottom: 12px; text-transform: uppercase; }
-.cell a.more { display: inline-block; margin-top: 12px; font-size: 12px; letter-spacing: 0.08em; text-transform: uppercase; }
-
-/* ------------------------------------------------------------ code area -- */
-
-.tabs { display: flex; gap: 0; border: 1px solid var(--hair); border-bottom: 0; width: max-content; max-width: 100%; }
-.tabs button {
-  font-family: var(--sans);
-  font-size: 11px;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  background: var(--bg);
-  border: 0;
-  border-right: 1px solid var(--hair);
-  padding: 10px 18px;
-  cursor: pointer;
-  color: var(--ink);
-}
-.tabs button:last-child { border-right: 0; }
-.tabs button.active { background: var(--ink); color: var(--bg); }
-.tabs button[disabled] { color: var(--gray); cursor: not-allowed; }
-
-pre.code {
-  background: var(--ink);
-  color: var(--bg);
-  font-family: var(--mono);
-  font-size: 12.5px;
-  line-height: 1.7;
-  padding: 20px 24px;
-  overflow-x: auto;
-  border: 1px solid var(--ink);
-}
-pre.code .cm { color: #8a8a84; }
-pre.code .kw { color: #9db2ff; }
-
-.pane-caption { font-size: 12px; color: var(--gray); padding: 8px 2px; border-bottom: 1px solid var(--hair); }
-
-.result-panel { border: 1px solid var(--hair); border-top: 0; padding: 16px 24px; display: flex; gap: 16px; align-items: baseline; flex-wrap: wrap; }
-.result-panel .micro { color: var(--accent); }
-
-/* ----------------------------------------------------------- spec table -- */
-
-.table-scroll { overflow-x: auto; border: 1px solid var(--hair); margin-top: 32px; }
-table.spec { border-collapse: collapse; width: 100%; min-width: 720px; }
-table.spec th, table.spec td {
-  border: 1px solid var(--hair);
-  padding: 12px 14px;
-  text-align: left;
-  vertical-align: top;
-  font-size: 12.5px;
-  background: var(--bg);
-}
-table.spec th {
-  font-size: 10.5px;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
-  font-weight: 600;
-  color: var(--ink);
-}
-table.spec th .mono { color: var(--gray); font-size: 10px; display: block; margin-top: 2px; letter-spacing: 0.08em; text-transform: none; }
-table.spec td .fw-name { font-weight: 700; font-size: 13.5px; white-space: nowrap; }
-table.spec td .fw-slug { font-family: var(--mono); font-size: 10.5px; color: var(--gray); display: block; }
-
-.st { font-size: 13px; margin-right: 6px; }
-.st.live { color: var(--accent); }
-.st.prov { color: var(--gray); }
-.vf { font-family: var(--mono); font-size: 10px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--ink); }
-.cell-links { display: block; margin-top: 6px; font-family: var(--mono); font-size: 11.5px; }
-.cell-links .sep { color: var(--hair); }
-.prov-label { color: var(--gray); font-family: var(--mono); font-size: 11.5px; }
-
-.legend { display: flex; gap: 24px; flex-wrap: wrap; margin-top: 12px; font-size: 11.5px; color: var(--gray); }
-.legend span b { font-weight: 400; }
-.caption { font-size: 12.5px; color: var(--gray); margin-top: 16px; max-width: 52em; }
-
-/* ------------------------------------------------------- benchmark bars -- */
-
-.bench { border: 1px solid var(--hair); margin-top: 32px; }
-.bench-title {
-  border-bottom: 1px solid var(--hair);
-  padding: 12px 16px;
-  font-size: 11px;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
-  font-weight: 600;
-}
-.bench-row {
-  display: grid;
-  grid-template-columns: minmax(120px, 170px) 1fr minmax(90px, 110px);
-  gap: 16px;
-  align-items: center;
-  padding: 12px 16px;
-  border-bottom: 1px solid var(--hair);
-}
-.bench-row:last-of-type { border-bottom: 0; }
-.bench-tool { font-size: 13px; font-weight: 600; }
-.bench-track { background: #efefe9; border: 1px solid var(--hair); height: 18px; position: relative; }
-.bench-bar { display: block; height: 100%; background: var(--gray); animation: grow 0.9s ease-out; transform-origin: left; }
-.bench-bar.accent { background: var(--accent); }
-.bench-val { font-family: var(--mono); font-variant-numeric: tabular-nums; font-size: 12.5px; text-align: right; white-space: nowrap; }
-.bench-note { border-top: 1px solid var(--hair); padding: 10px 16px; font-size: 11.5px; color: var(--gray); }
-.bench-note a { font-family: var(--mono); font-size: 11px; }
-
-@keyframes grow { from { transform: scaleX(0); } to { transform: scaleX(1); } }
-
-/* --------------------------------------------------------------- callout -- */
-
-.callout {
-  border: 1px solid var(--hair);
-  border-left: 4px solid var(--accent);
-  padding: 16px 20px;
-  font-size: 13.5px;
-  max-width: 56em;
-  margin-top: 32px;
-  background: var(--bg);
-}
-.callout .micro { display: block; margin-bottom: 6px; color: var(--accent); }
-.callout code, .aside code, p code {
-  font-family: var(--mono);
-  font-size: 12px;
-  background: #efefe9;
-  border: 1px solid var(--hair);
-  padding: 1px 5px;
-}
-
-/* --------------------------------------------------------- statement band -- */
-
-.band {
-  border-top: 1px solid var(--hair);
-  padding: 72px 32px;
-  background: var(--ink);
-  color: var(--bg);
-}
-.band p {
-  font-size: clamp(20px, 3vw, 30px);
-  font-weight: 700;
-  letter-spacing: -0.02em;
-  line-height: 1.25;
-  max-width: 32em;
-}
-.band .mark { color: #9db2ff; }
-
-/* -------------------------------------------------------------- stepflow -- */
-
-.steps { border: 1px solid var(--hair); margin-top: 32px; }
-.step { display: grid; grid-template-columns: 64px 1fr; border-bottom: 1px solid var(--hair); }
-.step:last-child { border-bottom: 0; }
-.step-num {
-  border-right: 1px solid var(--hair);
-  font-family: var(--mono);
-  font-size: 15px;
-  color: var(--accent);
-  padding: 20px 0;
-  text-align: center;
-}
-.step-body { padding: 20px 24px; min-width: 0; }
-.step-body h3 { font-size: 16px; font-weight: 700; letter-spacing: -0.01em; margin-bottom: 6px; }
-.step-body p { font-size: 13.5px; max-width: 46em; }
-.step-body pre.code { margin-top: 14px; }
-.aside {
-  border: 1px solid var(--hair);
-  border-left: 4px solid var(--gray);
-  padding: 10px 14px;
-  font-size: 12.5px;
-  color: var(--ink);
-  margin-top: 14px;
-  max-width: 46em;
-}
-.aside .micro { display: block; margin-bottom: 4px; }
-
-/* -------------------------------------------------------- framework panel -- */
-
-.fw-panel { border: 1px solid var(--hair); border-bottom: 0; padding: 20px 24px; display: grid; grid-template-columns: 180px 1fr; gap: 24px; }
-.fw-panel:last-of-type { border-bottom: 1px solid var(--hair); }
-.fw-panel h3 { font-size: 16px; font-weight: 700; }
-.fw-panel h3 .mono { display: block; font-size: 10.5px; color: var(--gray); font-weight: 400; margin-top: 2px; }
-.fw-panel p { font-size: 13.5px; max-width: 46em; }
-.fw-demos { margin-top: 10px; font-family: var(--mono); font-size: 11.5px; display: flex; gap: 14px; flex-wrap: wrap; }
-.fw-demos .prov-label { font-size: 11.5px; }
-
-/* -------------------------------------------------------------- CTA band -- */
-
-.ctaband { border-top: 1px solid var(--hair); padding: 64px 32px; text-align: left; }
-.ctaband h2 { margin-bottom: 24px; }
-.ctaband .hero-ctas { margin-top: 0; }
-
-/* ---------------------------------------------------------------- footer -- */
-
-footer.site { border-top: 1px solid var(--hair); }
-.foot-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 1px; background: var(--hair); }
-.foot-col { background: var(--bg); padding: 32px; }
-.foot-col h4 { font-size: 10.5px; letter-spacing: 0.18em; text-transform: uppercase; margin-bottom: 14px; color: var(--gray); font-weight: 600; }
-.foot-col a { display: block; color: var(--ink); font-size: 13px; padding: 3px 0; }
-.foot-col a:hover { color: var(--accent); }
-.legal {
-  border-top: 1px solid var(--hair);
-  padding: 20px 32px 40px;
-  font-family: var(--mono);
-  font-size: 11px;
-  letter-spacing: 0.06em;
-  color: var(--gray);
-}
-
-/* ------------------------------------------------------------- stack pick -- */
-
-.stackpick { display: flex; align-items: center; gap: 16px; flex-wrap: wrap; padding: 24px 32px 0; }
-.stackpick .micro { white-space: nowrap; }
-
-/* ------------------------------------------------------------- screenshot -- */
-
-.shot { border: 1px solid var(--hair); margin-top: 32px; max-width: 860px; }
-.shot-chrome { border-bottom: 1px solid var(--hair); padding: 8px 14px; display: flex; gap: 8px; align-items: center; }
-.shot-chrome i { width: 8px; height: 8px; background: var(--hair); display: inline-block; }
-.shot-chrome .mono { font-size: 10.5px; color: var(--gray); }
-.shot-body { padding: 24px; display: grid; grid-template-columns: repeat(3, 1fr); gap: 1px; background: var(--hair); border: 1px solid var(--hair); margin: 16px; }
-.shot-cap { border-top: 1px solid var(--hair); padding: 10px 16px; font-size: 12px; color: var(--gray); }
-
-/* ------------------------------------------------------------- link lists -- */
-
-.linklist { margin-top: 24px; display: flex; flex-direction: column; gap: 6px; }
-.linklist a { font-size: 13.5px; width: max-content; max-width: 100%; }
-.linklist a::before { content: "→ "; font-family: var(--mono); }
-
-/* --------------------------------------------------------------- utility -- */
-
-[hidden] { display: none !important; }
-.mt-32 { margin-top: 32px; }
-.two-col { display: grid; grid-template-columns: 1fr 1fr; gap: 48px; align-items: start; margin-top: 0; }
-
-/* ------------------------------------------------------------- responsive -- */
-
-@media (max-width: 960px) {
-  .hero-grid, .two-col { grid-template-columns: 1fr; }
-  .proofstrip, .grid.cols-3, .grid.cols-4 { grid-template-columns: repeat(2, 1fr); }
-  .fw-panel { grid-template-columns: 1fr; gap: 8px; }
-}
-
-@media (max-width: 560px) {
-  .hero { padding: 48px 20px; }
-  .sec, .ctaband { padding-left: 20px; padding-right: 20px; }
-  nav.site { padding: 8px 20px; }
-  .band { padding: 48px 20px; }
-  .proofstrip, .grid.cols-3, .grid.cols-4 { grid-template-columns: 1fr; }
-  .proofstrip a { padding: 20px; }
-  .foot-grid { grid-template-columns: 1fr; }
-  .bench-row { grid-template-columns: 1fr; gap: 6px; }
-  .bench-val { text-align: left; }
-  .shot-body { grid-template-columns: 1fr; }
-  .legal { padding-left: 20px; padding-right: 20px; }
-  .step { grid-template-columns: 44px 1fr; }
-  .step-body { padding: 16px; }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  *, *::before, *::after { animation: none !important; transition: none !important; }
-}
-</style>
-</head>
-<body>
-
-<div class="ribbon">Design draft A — <b>Spec Grid</b> · not final</div>
-
-<div class="frame">
-
-  <!-- ================================================================ NAV -->
-  <nav class="site">
-    <a class="wordmark" href="#/">Palamedes</a>
-    <div class="nav-links">
-      <a href="#/frameworks" data-nav="/frameworks">Frameworks</a>
-      <a href="#/proof" data-nav="/proof">Proof</a>
-      <a class="dead" href="#/" onclick="return false" title="Not part of this draft">Compare</a>
-      <a class="dead" href="#/" onclick="return false" title="Not part of this draft">Blog</a>
-      <a href="https://github.com/sebastian-software/palamedes/tree/main/docs">Docs</a>
-    </div>
-    <div class="nav-actions">
-      <a class="btn small" href="https://github.com/sebastian-software/palamedes">GitHub ★</a>
-      <a class="btn small primary" href="#/get-started" data-nav="/get-started">Get started</a>
-    </div>
-  </nav>
-
-  <!-- =========================================================== HOME view -->
-  <main id="view-home" data-view>
-
-    <header class="hero">
-      <div class="hero-grid">
-        <div>
-          <p class="eyebrow">Open-source i18n tooling for JavaScript &amp; TypeScript</p>
-          <h1 class="display">One translation model. Every&nbsp;framework.</h1>
-          <p class="subline">Write messages where your UI happens. Keep source-string-first
-            <code>.po</code> catalogs your translators can actually read. Ship the same
-            runtime model across Next.js, TanStack Start, SolidStart, Waku, and
-            React Router — with a Rust core that ran the checked small-corpus extract/update benchmark 19.6× faster than Lingui on the recorded machine-local run.</p>
-          <div class="hero-ctas">
-            <a class="btn primary" href="#/get-started">Get started in 5 minutes</a>
-            <a class="btn" href="https://nextjs-cookie.examples.palamedes.dev">See it live</a>
+      :root {
+        --bg: #fbfbf8;
+        --ink: #101010;
+        --hair: #d8d8d2;
+        --accent: #0038ff;
+        --gray: #8a8a84;
+        --mono:
+          ui-monospace, "SF Mono", "SFMono-Regular", Menlo, Consolas, "Liberation Mono", monospace;
+        --sans: "Helvetica Neue", Helvetica, Arial, Inter, sans-serif;
+      }
+
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+
+      html {
+        background: var(--bg);
+      }
+
+      body {
+        font-family: var(--sans);
+        color: var(--ink);
+        background: var(--bg);
+        font-size: 16px;
+        line-height: 1.55;
+        -webkit-font-smoothing: antialiased;
+      }
+
+      a {
+        color: var(--accent);
+        text-decoration: none;
+      }
+      a:hover {
+        text-decoration: underline;
+      }
+
+      .mono {
+        font-family: var(--mono);
+        font-variant-numeric: tabular-nums;
+      }
+
+      /* ---------------------------------------------------- frame + hairlines -- */
+
+      .frame {
+        max-width: 1120px;
+        margin: 0 auto;
+        border-left: 1px solid var(--hair);
+        border-right: 1px solid var(--hair);
+        min-height: 100vh;
+        background: var(--bg);
+      }
+
+      .sec {
+        border-top: 1px solid var(--hair);
+        padding: 56px 32px 64px;
+      }
+      .sec-head {
+        display: flex;
+        align-items: baseline;
+        gap: 24px;
+        margin-bottom: 32px;
+        flex-wrap: wrap;
+      }
+
+      .sec-mark {
+        font-family: var(--mono);
+        font-size: 11px;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        color: var(--gray);
+        white-space: nowrap;
+      }
+
+      .eyebrow {
+        font-size: 11px;
+        letter-spacing: 0.22em;
+        text-transform: uppercase;
+        color: var(--ink);
+        margin-bottom: 24px;
+      }
+      .eyebrow::before {
+        content: "§ ";
+        color: var(--accent);
+      }
+
+      h2 {
+        font-size: clamp(24px, 3.4vw, 34px);
+        font-weight: 700;
+        letter-spacing: -0.02em;
+        line-height: 1.15;
+        max-width: 22em;
+      }
+
+      .lede {
+        max-width: 44em;
+        margin-top: 16px;
+        font-size: 16px;
+      }
+
+      .micro {
+        font-size: 11px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        color: var(--gray);
+      }
+
+      /* --------------------------------------------------------------- ribbon -- */
+
+      .ribbon {
+        position: fixed;
+        left: 0;
+        bottom: 0;
+        z-index: 100;
+        background: var(--ink);
+        color: var(--bg);
+        font-family: var(--mono);
+        font-size: 10px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        padding: 6px 12px;
+        border-top: 1px solid var(--ink);
+        border-right: 1px solid var(--ink);
+      }
+      .ribbon b {
+        color: #9db2ff;
+        font-weight: 400;
+      }
+
+      /* ------------------------------------------------------------------ nav -- */
+
+      nav.site {
+        position: sticky;
+        top: 0;
+        z-index: 50;
+        background: var(--bg);
+        border-bottom: 1px solid var(--hair);
+        display: flex;
+        align-items: center;
+        gap: 24px;
+        padding: 0 32px;
+        min-height: 56px;
+        flex-wrap: wrap;
+      }
+
+      .wordmark {
+        font-weight: 700;
+        font-size: 17px;
+        letter-spacing: -0.02em;
+        color: var(--ink);
+      }
+      .wordmark:hover {
+        text-decoration: none;
+      }
+
+      .nav-links {
+        display: flex;
+        gap: 20px;
+        flex-wrap: wrap;
+        flex: 1;
+      }
+      .nav-links a {
+        color: var(--ink);
+        font-size: 12px;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        padding: 4px 0;
+        border-bottom: 2px solid transparent;
+      }
+      .nav-links a:hover {
+        text-decoration: none;
+        border-bottom-color: var(--hair);
+      }
+      .nav-links a.active {
+        color: var(--accent);
+        border-bottom-color: var(--accent);
+      }
+      .nav-links a.dead {
+        color: var(--gray);
+        cursor: default;
+      }
+      .nav-links a.dead:hover {
+        border-bottom-color: transparent;
+      }
+
+      .nav-actions {
+        display: flex;
+        gap: 12px;
+        align-items: center;
+      }
+
+      /* -------------------------------------------------------------- buttons -- */
+
+      .btn {
+        display: inline-block;
+        border: 1px solid var(--ink);
+        color: var(--ink);
+        background: transparent;
+        padding: 12px 22px;
+        font-size: 11px;
+        font-weight: 600;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        font-family: var(--sans);
+        cursor: pointer;
+      }
+      .btn:hover {
+        text-decoration: none;
+        background: var(--ink);
+        color: var(--bg);
+      }
+      .btn.primary {
+        background: var(--accent);
+        border-color: var(--accent);
+        color: #fff;
+      }
+      .btn.primary:hover {
+        background: var(--ink);
+        border-color: var(--ink);
+      }
+      .btn.small {
+        padding: 8px 14px;
+        font-size: 10px;
+      }
+
+      /* ----------------------------------------------------------------- hero -- */
+
+      .hero {
+        padding: 72px 32px 64px;
+      }
+      .hero-grid {
+        display: grid;
+        grid-template-columns: minmax(0, 7fr) minmax(0, 5fr);
+        gap: 48px;
+        align-items: start;
+      }
+
+      h1.display {
+        font-size: clamp(44px, 7.6vw, 88px);
+        font-weight: 700;
+        letter-spacing: -0.03em;
+        line-height: 0.98;
+        margin: 0 0 28px;
+      }
+
+      .subline {
+        font-size: 16px;
+        max-width: 38em;
+        color: var(--ink);
+      }
+      .subline .mono {
+        font-size: 15px;
+      }
+
+      .hero-ctas {
+        display: flex;
+        gap: 12px;
+        margin-top: 32px;
+        flex-wrap: wrap;
+      }
+
+      /* -------------------------------------------------- booking-card visual -- */
+
+      .locale-stack {
+        display: grid;
+        gap: 1px;
+        background: var(--hair);
+        border: 1px solid var(--hair);
+      }
+
+      .bcard {
+        background: var(--bg);
+        padding: 16px 18px;
+      }
+      .bcard-loc {
+        font-family: var(--mono);
+        font-size: 10px;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        color: var(--accent);
+        margin-bottom: 8px;
+      }
+      .bcard-title {
+        font-size: 17px;
+        font-weight: 700;
+        letter-spacing: -0.01em;
+      }
+      .bcard-row {
+        display: flex;
+        justify-content: space-between;
+        align-items: baseline;
+        gap: 12px;
+        margin-top: 6px;
+        flex-wrap: wrap;
+      }
+      .bcard-seats {
+        font-size: 12.5px;
+        border: 1px solid var(--hair);
+        padding: 2px 8px;
+      }
+      .bcard-price {
+        font-family: var(--mono);
+        font-variant-numeric: tabular-nums;
+        font-size: 15px;
+        font-weight: 500;
+      }
+      .bcard-date {
+        font-family: var(--mono);
+        font-variant-numeric: tabular-nums;
+        font-size: 12px;
+        color: var(--gray);
+        margin-top: 6px;
+      }
+      .locale-caption {
+        border: 1px solid var(--hair);
+        border-top: 0;
+        padding: 10px 18px;
+        font-size: 11px;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        color: var(--gray);
+      }
+
+      /* ------------------------------------------------------------ proofstrip -- */
+
+      .proofstrip {
+        display: grid;
+        grid-template-columns: repeat(4, 1fr);
+        gap: 1px;
+        background: var(--hair);
+        border-top: 1px solid var(--hair);
+      }
+      .proofstrip a {
+        background: var(--bg);
+        padding: 24px 32px;
+        color: var(--ink);
+        display: block;
+      }
+      .proofstrip a:hover {
+        text-decoration: none;
+        background: #f2f2ec;
+      }
+      .stat-val {
+        font-family: var(--mono);
+        font-variant-numeric: tabular-nums;
+        font-size: 34px;
+        font-weight: 500;
+        letter-spacing: -0.02em;
+        color: var(--accent);
+        display: block;
+      }
+      .stat-label {
+        display: block;
+        font-size: 12px;
+        margin-top: 6px;
+        max-width: 22em;
+      }
+
+      /* --------------------------------------------------------- feature grid -- */
+
+      .grid {
+        display: grid;
+        gap: 1px;
+        background: var(--hair);
+        border: 1px solid var(--hair);
+        margin-top: 32px;
+      }
+      .grid.cols-3 {
+        grid-template-columns: repeat(3, 1fr);
+      }
+      .grid.cols-4 {
+        grid-template-columns: repeat(4, 1fr);
+      }
+      .grid.cols-2 {
+        grid-template-columns: repeat(2, 1fr);
+      }
+      .cell {
+        background: var(--bg);
+        padding: 24px;
+      }
+      .cell h3 {
+        font-size: 15px;
+        font-weight: 700;
+        letter-spacing: -0.01em;
+        margin-bottom: 8px;
+      }
+      .cell p {
+        font-size: 13.5px;
+      }
+      .cell .cell-num {
+        font-family: var(--mono);
+        font-size: 10px;
+        letter-spacing: 0.18em;
+        color: var(--gray);
+        display: block;
+        margin-bottom: 12px;
+        text-transform: uppercase;
+      }
+      .cell a.more {
+        display: inline-block;
+        margin-top: 12px;
+        font-size: 12px;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+
+      /* ------------------------------------------------------------ code area -- */
+
+      .tabs {
+        display: flex;
+        gap: 0;
+        border: 1px solid var(--hair);
+        border-bottom: 0;
+        width: max-content;
+        max-width: 100%;
+      }
+      .tabs button {
+        font-family: var(--sans);
+        font-size: 11px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        background: var(--bg);
+        border: 0;
+        border-right: 1px solid var(--hair);
+        padding: 10px 18px;
+        cursor: pointer;
+        color: var(--ink);
+      }
+      .tabs button:last-child {
+        border-right: 0;
+      }
+      .tabs button.active {
+        background: var(--ink);
+        color: var(--bg);
+      }
+      .tabs button[disabled] {
+        color: var(--gray);
+        cursor: not-allowed;
+      }
+
+      pre.code {
+        background: var(--ink);
+        color: var(--bg);
+        font-family: var(--mono);
+        font-size: 12.5px;
+        line-height: 1.7;
+        padding: 20px 24px;
+        overflow-x: auto;
+        border: 1px solid var(--ink);
+      }
+      pre.code .cm {
+        color: #8a8a84;
+      }
+      pre.code .kw {
+        color: #9db2ff;
+      }
+
+      .pane-caption {
+        font-size: 12px;
+        color: var(--gray);
+        padding: 8px 2px;
+        border-bottom: 1px solid var(--hair);
+      }
+
+      .result-panel {
+        border: 1px solid var(--hair);
+        border-top: 0;
+        padding: 16px 24px;
+        display: flex;
+        gap: 16px;
+        align-items: baseline;
+        flex-wrap: wrap;
+      }
+      .result-panel .micro {
+        color: var(--accent);
+      }
+
+      /* ----------------------------------------------------------- spec table -- */
+
+      .table-scroll {
+        overflow-x: auto;
+        border: 1px solid var(--hair);
+        margin-top: 32px;
+      }
+      table.spec {
+        border-collapse: collapse;
+        width: 100%;
+        min-width: 720px;
+      }
+      table.spec th,
+      table.spec td {
+        border: 1px solid var(--hair);
+        padding: 12px 14px;
+        text-align: left;
+        vertical-align: top;
+        font-size: 12.5px;
+        background: var(--bg);
+      }
+      table.spec th {
+        font-size: 10.5px;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        font-weight: 600;
+        color: var(--ink);
+      }
+      table.spec th .mono {
+        color: var(--gray);
+        font-size: 10px;
+        display: block;
+        margin-top: 2px;
+        letter-spacing: 0.08em;
+        text-transform: none;
+      }
+      table.spec td .fw-name {
+        font-weight: 700;
+        font-size: 13.5px;
+        white-space: nowrap;
+      }
+      table.spec td .fw-slug {
+        font-family: var(--mono);
+        font-size: 10.5px;
+        color: var(--gray);
+        display: block;
+      }
+
+      .st {
+        font-size: 13px;
+        margin-right: 6px;
+      }
+      .st.live {
+        color: var(--accent);
+      }
+      .st.prov {
+        color: var(--gray);
+      }
+      .vf {
+        font-family: var(--mono);
+        font-size: 10px;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        color: var(--ink);
+      }
+      .cell-links {
+        display: block;
+        margin-top: 6px;
+        font-family: var(--mono);
+        font-size: 11.5px;
+      }
+      .cell-links .sep {
+        color: var(--hair);
+      }
+      .prov-label {
+        color: var(--gray);
+        font-family: var(--mono);
+        font-size: 11.5px;
+      }
+
+      .legend {
+        display: flex;
+        gap: 24px;
+        flex-wrap: wrap;
+        margin-top: 12px;
+        font-size: 11.5px;
+        color: var(--gray);
+      }
+      .legend span b {
+        font-weight: 400;
+      }
+      .caption {
+        font-size: 12.5px;
+        color: var(--gray);
+        margin-top: 16px;
+        max-width: 52em;
+      }
+
+      /* ------------------------------------------------------- benchmark bars -- */
+
+      .bench {
+        border: 1px solid var(--hair);
+        margin-top: 32px;
+      }
+      .bench-title {
+        border-bottom: 1px solid var(--hair);
+        padding: 12px 16px;
+        font-size: 11px;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        font-weight: 600;
+      }
+      .bench-row {
+        display: grid;
+        grid-template-columns: minmax(120px, 170px) 1fr minmax(90px, 110px);
+        gap: 16px;
+        align-items: center;
+        padding: 12px 16px;
+        border-bottom: 1px solid var(--hair);
+      }
+      .bench-row:last-of-type {
+        border-bottom: 0;
+      }
+      .bench-tool {
+        font-size: 13px;
+        font-weight: 600;
+      }
+      .bench-track {
+        background: #efefe9;
+        border: 1px solid var(--hair);
+        height: 18px;
+        position: relative;
+      }
+      .bench-bar {
+        display: block;
+        height: 100%;
+        background: var(--gray);
+        animation: grow 0.9s ease-out;
+        transform-origin: left;
+      }
+      .bench-bar.accent {
+        background: var(--accent);
+      }
+      .bench-val {
+        font-family: var(--mono);
+        font-variant-numeric: tabular-nums;
+        font-size: 12.5px;
+        text-align: right;
+        white-space: nowrap;
+      }
+      .bench-note {
+        border-top: 1px solid var(--hair);
+        padding: 10px 16px;
+        font-size: 11.5px;
+        color: var(--gray);
+      }
+      .bench-note a {
+        font-family: var(--mono);
+        font-size: 11px;
+      }
+
+      @keyframes grow {
+        from {
+          transform: scaleX(0);
+        }
+        to {
+          transform: scaleX(1);
+        }
+      }
+
+      /* --------------------------------------------------------------- callout -- */
+
+      .callout {
+        border: 1px solid var(--hair);
+        border-left: 4px solid var(--accent);
+        padding: 16px 20px;
+        font-size: 13.5px;
+        max-width: 56em;
+        margin-top: 32px;
+        background: var(--bg);
+      }
+      .callout .micro {
+        display: block;
+        margin-bottom: 6px;
+        color: var(--accent);
+      }
+      .callout code,
+      .aside code,
+      p code {
+        font-family: var(--mono);
+        font-size: 12px;
+        background: #efefe9;
+        border: 1px solid var(--hair);
+        padding: 1px 5px;
+      }
+
+      /* --------------------------------------------------------- statement band -- */
+
+      .band {
+        border-top: 1px solid var(--hair);
+        padding: 72px 32px;
+        background: var(--ink);
+        color: var(--bg);
+      }
+      .band p {
+        font-size: clamp(20px, 3vw, 30px);
+        font-weight: 700;
+        letter-spacing: -0.02em;
+        line-height: 1.25;
+        max-width: 32em;
+      }
+      .band .mark {
+        color: #9db2ff;
+      }
+
+      /* -------------------------------------------------------------- stepflow -- */
+
+      .steps {
+        border: 1px solid var(--hair);
+        margin-top: 32px;
+      }
+      .step {
+        display: grid;
+        grid-template-columns: 64px 1fr;
+        border-bottom: 1px solid var(--hair);
+      }
+      .step:last-child {
+        border-bottom: 0;
+      }
+      .step-num {
+        border-right: 1px solid var(--hair);
+        font-family: var(--mono);
+        font-size: 15px;
+        color: var(--accent);
+        padding: 20px 0;
+        text-align: center;
+      }
+      .step-body {
+        padding: 20px 24px;
+        min-width: 0;
+      }
+      .step-body h3 {
+        font-size: 16px;
+        font-weight: 700;
+        letter-spacing: -0.01em;
+        margin-bottom: 6px;
+      }
+      .step-body p {
+        font-size: 13.5px;
+        max-width: 46em;
+      }
+      .step-body pre.code {
+        margin-top: 14px;
+      }
+      .aside {
+        border: 1px solid var(--hair);
+        border-left: 4px solid var(--gray);
+        padding: 10px 14px;
+        font-size: 12.5px;
+        color: var(--ink);
+        margin-top: 14px;
+        max-width: 46em;
+      }
+      .aside .micro {
+        display: block;
+        margin-bottom: 4px;
+      }
+
+      /* -------------------------------------------------------- framework panel -- */
+
+      .fw-panel {
+        border: 1px solid var(--hair);
+        border-bottom: 0;
+        padding: 20px 24px;
+        display: grid;
+        grid-template-columns: 180px 1fr;
+        gap: 24px;
+      }
+      .fw-panel:last-of-type {
+        border-bottom: 1px solid var(--hair);
+      }
+      .fw-panel h3 {
+        font-size: 16px;
+        font-weight: 700;
+      }
+      .fw-panel h3 .mono {
+        display: block;
+        font-size: 10.5px;
+        color: var(--gray);
+        font-weight: 400;
+        margin-top: 2px;
+      }
+      .fw-panel p {
+        font-size: 13.5px;
+        max-width: 46em;
+      }
+      .fw-demos {
+        margin-top: 10px;
+        font-family: var(--mono);
+        font-size: 11.5px;
+        display: flex;
+        gap: 14px;
+        flex-wrap: wrap;
+      }
+      .fw-demos .prov-label {
+        font-size: 11.5px;
+      }
+
+      /* -------------------------------------------------------------- CTA band -- */
+
+      .ctaband {
+        border-top: 1px solid var(--hair);
+        padding: 64px 32px;
+        text-align: left;
+      }
+      .ctaband h2 {
+        margin-bottom: 24px;
+      }
+      .ctaband .hero-ctas {
+        margin-top: 0;
+      }
+
+      /* ---------------------------------------------------------------- footer -- */
+
+      footer.site {
+        border-top: 1px solid var(--hair);
+      }
+      .foot-grid {
+        display: grid;
+        grid-template-columns: repeat(4, 1fr);
+        gap: 1px;
+        background: var(--hair);
+      }
+      .foot-col {
+        background: var(--bg);
+        padding: 32px;
+      }
+      .foot-col h4 {
+        font-size: 10.5px;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        margin-bottom: 14px;
+        color: var(--gray);
+        font-weight: 600;
+      }
+      .foot-col a {
+        display: block;
+        color: var(--ink);
+        font-size: 13px;
+        padding: 3px 0;
+      }
+      .foot-col a:hover {
+        color: var(--accent);
+      }
+      .legal {
+        border-top: 1px solid var(--hair);
+        padding: 20px 32px 40px;
+        font-family: var(--mono);
+        font-size: 11px;
+        letter-spacing: 0.06em;
+        color: var(--gray);
+      }
+
+      /* ------------------------------------------------------------- stack pick -- */
+
+      .stackpick {
+        display: flex;
+        align-items: center;
+        gap: 16px;
+        flex-wrap: wrap;
+        padding: 24px 32px 0;
+      }
+      .stackpick .micro {
+        white-space: nowrap;
+      }
+
+      /* ------------------------------------------------------------- screenshot -- */
+
+      .shot {
+        border: 1px solid var(--hair);
+        margin-top: 32px;
+        max-width: 860px;
+      }
+      .shot-chrome {
+        border-bottom: 1px solid var(--hair);
+        padding: 8px 14px;
+        display: flex;
+        gap: 8px;
+        align-items: center;
+      }
+      .shot-chrome i {
+        width: 8px;
+        height: 8px;
+        background: var(--hair);
+        display: inline-block;
+      }
+      .shot-chrome .mono {
+        font-size: 10.5px;
+        color: var(--gray);
+      }
+      .shot-body {
+        padding: 24px;
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 1px;
+        background: var(--hair);
+        border: 1px solid var(--hair);
+        margin: 16px;
+      }
+      .shot-cap {
+        border-top: 1px solid var(--hair);
+        padding: 10px 16px;
+        font-size: 12px;
+        color: var(--gray);
+      }
+
+      /* ------------------------------------------------------------- link lists -- */
+
+      .linklist {
+        margin-top: 24px;
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+      }
+      .linklist a {
+        font-size: 13.5px;
+        width: max-content;
+        max-width: 100%;
+      }
+      .linklist a::before {
+        content: "→ ";
+        font-family: var(--mono);
+      }
+
+      /* --------------------------------------------------------------- utility -- */
+
+      [hidden] {
+        display: none !important;
+      }
+      .mt-32 {
+        margin-top: 32px;
+      }
+      .two-col {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 48px;
+        align-items: start;
+        margin-top: 0;
+      }
+
+      /* ------------------------------------------------------------- responsive -- */
+
+      @media (max-width: 960px) {
+        .hero-grid,
+        .two-col {
+          grid-template-columns: 1fr;
+        }
+        .proofstrip,
+        .grid.cols-3,
+        .grid.cols-4 {
+          grid-template-columns: repeat(2, 1fr);
+        }
+        .fw-panel {
+          grid-template-columns: 1fr;
+          gap: 8px;
+        }
+      }
+
+      @media (max-width: 560px) {
+        .hero {
+          padding: 48px 20px;
+        }
+        .sec,
+        .ctaband {
+          padding-left: 20px;
+          padding-right: 20px;
+        }
+        nav.site {
+          padding: 8px 20px;
+        }
+        .band {
+          padding: 48px 20px;
+        }
+        .proofstrip,
+        .grid.cols-3,
+        .grid.cols-4 {
+          grid-template-columns: 1fr;
+        }
+        .proofstrip a {
+          padding: 20px;
+        }
+        .foot-grid {
+          grid-template-columns: 1fr;
+        }
+        .bench-row {
+          grid-template-columns: 1fr;
+          gap: 6px;
+        }
+        .bench-val {
+          text-align: left;
+        }
+        .shot-body {
+          grid-template-columns: 1fr;
+        }
+        .legal {
+          padding-left: 20px;
+          padding-right: 20px;
+        }
+        .step {
+          grid-template-columns: 44px 1fr;
+        }
+        .step-body {
+          padding: 16px;
+        }
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        *,
+        *::before,
+        *::after {
+          animation: none !important;
+          transition: none !important;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="ribbon">Design draft A — <b>Spec Grid</b> · not final</div>
+
+    <div class="frame">
+      <!-- ================================================================ NAV -->
+      <nav class="site">
+        <a class="wordmark" href="#/">Palamedes</a>
+        <div class="nav-links">
+          <a href="#/frameworks" data-nav="/frameworks">Frameworks</a>
+          <a href="#/proof" data-nav="/proof">Proof</a>
+          <a class="dead" href="#/" onclick="return false" title="Not part of this draft"
+            >Compare</a
+          >
+          <a class="dead" href="#/" onclick="return false" title="Not part of this draft">Blog</a>
+          <a href="https://github.com/sebastian-software/palamedes/tree/main/docs">Docs</a>
+        </div>
+        <div class="nav-actions">
+          <a class="btn small" href="https://github.com/sebastian-software/palamedes">GitHub ★</a>
+          <a class="btn small primary" href="#/get-started" data-nav="/get-started">Get started</a>
+        </div>
+      </nav>
+
+      <!-- =========================================================== HOME view -->
+      <main id="view-home" data-view>
+        <header class="hero">
+          <div class="hero-grid">
+            <div>
+              <p class="eyebrow">Open-source i18n tooling for JavaScript &amp; TypeScript</p>
+              <h1 class="display">One translation model. Every&nbsp;framework.</h1>
+              <p class="subline">
+                Write messages where your UI happens. Keep source-string-first
+                <code>.po</code> catalogs your translators can actually read. Ship the same runtime
+                model across Next.js, TanStack Start, SolidStart, Waku, and React Router — with a
+                Rust core that ran the checked small-corpus extract/update benchmark 19.6× faster
+                than Lingui on the recorded machine-local run.
+              </p>
+              <div class="hero-ctas">
+                <a class="btn primary" href="#/get-started">Get started in 5 minutes</a>
+                <a class="btn" href="https://nextjs-cookie.examples.palamedes.dev">See it live</a>
+              </div>
+            </div>
+            <div>
+              <div
+                class="locale-stack"
+                role="img"
+                aria-label="The same booking card rendered in English, German, and Spanish"
+              >
+                <div class="bcard">
+                  <div class="bcard-loc">en-US</div>
+                  <div class="bcard-title">Your trip to Lisbon</div>
+                  <div class="bcard-row">
+                    <span class="bcard-seats">3 seats left</span>
+                    <span class="bcard-price">€1,234.00</span>
+                  </div>
+                  <div class="bcard-date">Jul 12, 2026</div>
+                </div>
+                <div class="bcard">
+                  <div class="bcard-loc">de-DE</div>
+                  <div class="bcard-title">Deine Reise nach Lissabon</div>
+                  <div class="bcard-row">
+                    <span class="bcard-seats">3 Plätze frei</span>
+                    <span class="bcard-price">1.234,00&nbsp;€</span>
+                  </div>
+                  <div class="bcard-date">12. Juli 2026</div>
+                </div>
+                <div class="bcard">
+                  <div class="bcard-loc">es-ES</div>
+                  <div class="bcard-title">Tu viaje a Lisboa</div>
+                  <div class="bcard-row">
+                    <span class="bcard-seats">Quedan 3 asientos</span>
+                    <span class="bcard-price">1234,00&nbsp;€</span>
+                  </div>
+                  <div class="bcard-date">12 jul 2026</div>
+                </div>
+              </div>
+              <div class="locale-caption">
+                One component · copy, plurals, currency &amp; dates change together
+              </div>
+            </div>
           </div>
+        </header>
+
+        <div class="proofstrip">
+          <a href="#/frameworks">
+            <span class="stat-val">20</span>
+            <span class="stat-label">browser-verified example apps</span>
+          </a>
+          <a href="#/frameworks">
+            <span class="stat-val">5 × 4</span>
+            <span class="stat-label">frameworks × locale strategies</span>
+          </a>
+          <a href="#/proof">
+            <span class="stat-val">19.6×</span>
+            <span class="stat-label"
+              >faster than Lingui — checked extract/update benchmark, machine-local run</span
+            >
+          </a>
+          <a href="https://github.com/sebastian-software/palamedes/tree/main/adr">
+            <span class="stat-val">16</span>
+            <span class="stat-label">ADRs documenting every tradeoff</span>
+          </a>
         </div>
-        <div>
-          <div class="locale-stack" role="img" aria-label="The same booking card rendered in English, German, and Spanish">
-            <div class="bcard">
-              <div class="bcard-loc">en-US</div>
-              <div class="bcard-title">Your trip to Lisbon</div>
-              <div class="bcard-row">
-                <span class="bcard-seats">3 seats left</span>
-                <span class="bcard-price">€1,234.00</span>
-              </div>
-              <div class="bcard-date">Jul 12, 2026</div>
+
+        <!-- 01 — Model -->
+        <section class="sec" id="model">
+          <div class="sec-head">
+            <span class="sec-mark">01 — Model</span>
+            <h2>Your i18n setup should not splinter when your framework changes.</h2>
+          </div>
+          <p class="lede">
+            Most teams relearn internationalization with every migration: new runtime, new message
+            IDs, new catalog quirks. Palamedes keeps the parts you touch every day stable — and lets
+            the framework be the only thing that changes.
+          </p>
+          <div class="grid cols-3">
+            <div class="cell">
+              <span class="cell-num">01.1 / pen</span>
+              <h3>Write messages in place</h3>
+              <p>
+                Macro-style authoring next to your JSX. No message-ID bookkeeping, no separate
+                dictionary files to keep in sync.
+              </p>
+              <a class="more" href="#/get-started">Get started</a>
             </div>
-            <div class="bcard">
-              <div class="bcard-loc">de-DE</div>
-              <div class="bcard-title">Deine Reise nach Lissabon</div>
-              <div class="bcard-row">
-                <span class="bcard-seats">3 Plätze frei</span>
-                <span class="bcard-price">1.234,00&nbsp;€</span>
-              </div>
-              <div class="bcard-date">12. Juli 2026</div>
+            <div class="cell">
+              <span class="cell-num">01.2 / fingerprint</span>
+              <h3>One identity model</h3>
+              <p>
+                Messages are identified by message + context — stable across refactors, frameworks,
+                and years of catalog history.
+              </p>
+              <a
+                class="more"
+                href="https://github.com/sebastian-software/palamedes/blob/main/adr/003-source-string-first-message-identity.md"
+                >ADR-003</a
+              >
             </div>
-            <div class="bcard">
-              <div class="bcard-loc">es-ES</div>
-              <div class="bcard-title">Tu viaje a Lisboa</div>
-              <div class="bcard-row">
-                <span class="bcard-seats">Quedan 3 asientos</span>
-                <span class="bcard-price">1234,00&nbsp;€</span>
-              </div>
-              <div class="bcard-date">12 jul 2026</div>
+            <div class="cell">
+              <span class="cell-num">01.3 / plug</span>
+              <h3>One runtime call</h3>
+              <p>
+                getI18n() resolves the active instance everywhere: server components, client
+                islands, backend request handlers.
+              </p>
+              <a
+                class="more"
+                href="https://github.com/sebastian-software/palamedes/blob/main/adr/005-universal-geti18n-runtime-model.md"
+                >ADR-005</a
+              >
             </div>
           </div>
-          <div class="locale-caption">One component · copy, plurals, currency &amp; dates change together</div>
-        </div>
-      </div>
-    </header>
+        </section>
 
-    <div class="proofstrip">
-      <a href="#/frameworks">
-        <span class="stat-val">20</span>
-        <span class="stat-label">browser-verified example apps</span>
-      </a>
-      <a href="#/frameworks">
-        <span class="stat-val">5 × 4</span>
-        <span class="stat-label">frameworks × locale strategies</span>
-      </a>
-      <a href="#/proof">
-        <span class="stat-val">19.6×</span>
-        <span class="stat-label">faster than Lingui — checked extract/update benchmark, machine-local run</span>
-      </a>
-      <a href="https://github.com/sebastian-software/palamedes/tree/main/adr">
-        <span class="stat-val">16</span>
-        <span class="stat-label">ADRs documenting every tradeoff</span>
-      </a>
-    </div>
-
-    <!-- 01 — Model -->
-    <section class="sec" id="model">
-      <div class="sec-head">
-        <span class="sec-mark">01 — Model</span>
-        <h2>Your i18n setup should not splinter when your framework changes.</h2>
-      </div>
-      <p class="lede">Most teams relearn internationalization with every migration: new runtime, new message
-        IDs, new catalog quirks. Palamedes keeps the parts you touch every day stable — and lets
-        the framework be the only thing that changes.</p>
-      <div class="grid cols-3">
-        <div class="cell">
-          <span class="cell-num">01.1 / pen</span>
-          <h3>Write messages in place</h3>
-          <p>Macro-style authoring next to your JSX. No message-ID bookkeeping, no separate dictionary files to keep in sync.</p>
-          <a class="more" href="#/get-started">Get started</a>
-        </div>
-        <div class="cell">
-          <span class="cell-num">01.2 / fingerprint</span>
-          <h3>One identity model</h3>
-          <p>Messages are identified by message + context — stable across refactors, frameworks, and years of catalog history.</p>
-          <a class="more" href="https://github.com/sebastian-software/palamedes/blob/main/adr/003-source-string-first-message-identity.md">ADR-003</a>
-        </div>
-        <div class="cell">
-          <span class="cell-num">01.3 / plug</span>
-          <h3>One runtime call</h3>
-          <p>getI18n() resolves the active instance everywhere: server components, client islands, backend request handlers.</p>
-          <a class="more" href="https://github.com/sebastian-software/palamedes/blob/main/adr/005-universal-geti18n-runtime-model.md">ADR-005</a>
-        </div>
-      </div>
-    </section>
-
-    <!-- 02 — Workflow -->
-    <section class="sec" id="code">
-      <div class="sec-head">
-        <span class="sec-mark">02 — Workflow</span>
-        <h2>The whole workflow, honestly small.</h2>
-      </div>
-      <div data-tabs class="mt-32">
-        <div class="tabs" role="tablist">
-          <button data-tab="write" class="active">Write</button>
-          <button data-tab="extract">Extract</button>
-          <button data-tab="translate">Translate</button>
-        </div>
-        <div data-pane="write">
-          <pre class="code">import { t, plural } from "@palamedes/core/macro"
+        <!-- 02 — Workflow -->
+        <section class="sec" id="code">
+          <div class="sec-head">
+            <span class="sec-mark">02 — Workflow</span>
+            <h2>The whole workflow, honestly small.</h2>
+          </div>
+          <div data-tabs class="mt-32">
+            <div class="tabs" role="tablist">
+              <button data-tab="write" class="active">Write</button>
+              <button data-tab="extract">Extract</button>
+              <button data-tab="translate">Translate</button>
+            </div>
+            <div data-pane="write">
+              <pre class="code">
+import { t, plural } from "@palamedes/core/macro"
 import { Trans } from "@palamedes/react"
 
 export function Booking({ seats }: { seats: number }) {
@@ -647,483 +1193,630 @@ export function Booking({ seats }: { seats: number }) {
       &lt;Trans&gt;Free cancellation until &lt;b&gt;24 hours&lt;/b&gt; before departure.&lt;/Trans&gt;
     &lt;/&gt;
   )
-}</pre>
-          <p class="pane-caption">Messages live where the UI happens.</p>
-        </div>
-        <div data-pane="extract" hidden>
-          <pre class="code">$ pmds extract
+}</pre
+              >
+              <p class="pane-caption">Messages live where the UI happens.</p>
+            </div>
+            <div data-pane="extract" hidden>
+              <pre class="code">
+$ pmds extract
 
   en  3 messages  (1 new)
   de  3 messages  (1 missing translation)
 
-  done in 34 ms</pre>
-          <p class="pane-caption">One native command scans, extracts, and updates catalogs.</p>
-        </div>
-        <div data-pane="translate" hidden>
-          <pre class="code"><span class="cm">#: src/Booking.tsx:7</span>
+  done in 34 ms</pre
+              >
+              <p class="pane-caption">One native command scans, extracts, and updates catalogs.</p>
+            </div>
+            <div data-pane="translate" hidden>
+              <pre class="code"><span class="cm">#: src/Booking.tsx:7</span>
 msgid "Your trip to Lisbon"
 msgstr "Deine Reise nach Lissabon"
 
 <span class="cm">#: src/Booking.tsx:8</span>
 msgid "{seats, plural, one {# seat left} other {# seats left}}"
 msgstr "{seats, plural, one {# Platz frei} other {# Plätze frei}}"</pre>
-          <p class="pane-caption">Source-string-first .po — readable by translators and every TMS.</p>
-        </div>
-        <div class="result-panel">
-          <span class="micro">Rendered</span>
-          <span style="font-size:13.5px">The same component, in every locale, in every framework.</span>
-        </div>
-      </div>
-    </section>
+              <p class="pane-caption">
+                Source-string-first .po — readable by translators and every TMS.
+              </p>
+            </div>
+            <div class="result-panel">
+              <span class="micro">Rendered</span>
+              <span style="font-size: 13.5px"
+                >The same component, in every locale, in every framework.</span
+              >
+            </div>
+          </div>
+        </section>
 
-    <!-- 03 — Proof -->
-    <section class="sec" id="proof-teaser">
-      <div class="sec-head">
-        <span class="sec-mark">03 — Proof</span>
-        <h2>We don't ask you to trust a slogan. The repo shows the work.</h2>
-      </div>
-      <p class="lede">Every framework/strategy combination is a real app, re-verified in CI through the same
-        Playwright flow — with public demos where the hosting is ready. Every benchmark number
-        links to a checked-in, re-runnable report.</p>
+        <!-- 03 — Proof -->
+        <section class="sec" id="proof-teaser">
+          <div class="sec-head">
+            <span class="sec-mark">03 — Proof</span>
+            <h2>We don't ask you to trust a slogan. The repo shows the work.</h2>
+          </div>
+          <p class="lede">
+            Every framework/strategy combination is a real app, re-verified in CI through the same
+            Playwright flow — with public demos where the hosting is ready. Every benchmark number
+            links to a checked-in, re-runnable report.
+          </p>
 
-      <div class="table-scroll">
-        <table class="spec home-matrix">
-          <!-- populated by buildMatrix() -->
-        </table>
-      </div>
-      <div class="legend">
-        <span><b style="color:var(--accent)">●</b> live — public demo hosted</span>
-        <span><b>◌</b> provisioning — hosting pending, verified source linked</span>
-        <span><b class="mono" style="font-size:10px">✓ VERIFIED</b> — CI browser-verified (Playwright), all 20 cells</span>
-      </div>
+          <div class="table-scroll">
+            <table class="spec home-matrix">
+              <!-- populated by buildMatrix() -->
+            </table>
+          </div>
+          <div class="legend">
+            <span><b style="color: var(--accent)">●</b> live — public demo hosted</span>
+            <span><b>◌</b> provisioning — hosting pending, verified source linked</span>
+            <span
+              ><b class="mono" style="font-size: 10px">✓ VERIFIED</b> — CI browser-verified
+              (Playwright), all 20 cells</span
+            >
+          </div>
 
-      <div class="bench">
-        <div class="bench-title">End-to-end extract + catalog update (small corpus, median)</div>
-        <div class="bench-row">
-          <span class="bench-tool">Palamedes</span>
-          <span class="bench-track"><span class="bench-bar accent" style="width:5.1%"></span></span>
-          <span class="bench-val">33.53 ms</span>
+          <div class="bench">
+            <div class="bench-title">
+              End-to-end extract + catalog update (small corpus, median)
+            </div>
+            <div class="bench-row">
+              <span class="bench-tool">Palamedes</span>
+              <span class="bench-track"
+                ><span class="bench-bar accent" style="width: 5.1%"></span
+              ></span>
+              <span class="bench-val">33.53 ms</span>
+            </div>
+            <div class="bench-row">
+              <span class="bench-tool">i18next-parser</span>
+              <span class="bench-track"><span class="bench-bar" style="width: 72.7%"></span></span>
+              <span class="bench-val">477.58 ms</span>
+            </div>
+            <div class="bench-row">
+              <span class="bench-tool">Lingui</span>
+              <span class="bench-track"><span class="bench-bar" style="width: 100%"></span></span>
+              <span class="bench-val">657.00 ms</span>
+            </div>
+            <div class="bench-note">
+              Linear millisecond scale, no truncation — the Palamedes bar really is that short.
+              Machine-local numbers from the checked-in report; your hardware will differ, the
+              ratios are the signal.
+              <a
+                href="https://github.com/sebastian-software/palamedes/blob/main/docs/benchmark-e2e-workflow.md"
+                >Methodology →</a
+              >
+            </div>
+          </div>
+
+          <p class="mt-32">
+            <a class="btn" href="#/proof">All benchmarks &amp; the verification story</a>
+          </p>
+        </section>
+
+        <!-- 04 — Positioning -->
+        <div class="band">
+          <span class="sec-mark" style="color: #9db2ff; display: block; margin-bottom: 24px"
+            >04 — Positioning</span
+          >
+          <p>
+            <span class="mark">Palamedes is narrower than some alternatives on purpose:</span>
+            compile-time authoring, source-string-first catalogs, and a local workflow your repo
+            owns — with a Rust core doing the careful work.
+          </p>
         </div>
-        <div class="bench-row">
-          <span class="bench-tool">i18next-parser</span>
-          <span class="bench-track"><span class="bench-bar" style="width:72.7%"></span></span>
-          <span class="bench-val">477.58 ms</span>
-        </div>
-        <div class="bench-row">
-          <span class="bench-tool">Lingui</span>
-          <span class="bench-track"><span class="bench-bar" style="width:100%"></span></span>
-          <span class="bench-val">657.00 ms</span>
-        </div>
-        <div class="bench-note">
-          Linear millisecond scale, no truncation — the Palamedes bar really is that short.
-          Machine-local numbers from the checked-in report; your hardware will differ, the ratios are the signal.
-          <a href="https://github.com/sebastian-software/palamedes/blob/main/docs/benchmark-e2e-workflow.md">Methodology →</a>
-        </div>
-      </div>
 
-      <p class="mt-32"><a class="btn" href="#/proof">All benchmarks &amp; the verification story</a></p>
-    </section>
+        <!-- 05 — Maintainer -->
+        <section class="sec" id="maintainer">
+          <div class="sec-head">
+            <span class="sec-mark">05 — Maintainer</span>
+          </div>
+          <div class="two-col">
+            <h2>Built from repeat experience, not a weekend take.</h2>
+            <div>
+              <p style="font-size: 14px; max-width: 44em">
+                Palamedes is maintained by Sebastian Software GmbH. It is the third generation of
+                source-string-first JavaScript i18n tooling from the same author — from
+                gettext-style macro systems in qooxdoo to a full enterprise Lingui migration at
+                Regrello (acquired by Salesforce in 2025). The lessons are written down as 16 ADRs
+                before you depend on the tool.
+              </p>
+              <div class="linklist">
+                <a href="https://github.com/sebastian-software/palamedes/tree/main/adr"
+                  >The decision trail (ADRs)</a
+                >
+                <a href="#/" onclick="return false" title="Blog not part of this draft"
+                  >Why this exists</a
+                >
+              </div>
+            </div>
+          </div>
+        </section>
 
-    <!-- 04 — Positioning -->
-    <div class="band">
-      <span class="sec-mark" style="color:#9db2ff; display:block; margin-bottom:24px">04 — Positioning</span>
-      <p><span class="mark">Palamedes is narrower than some alternatives on purpose:</span>
-        compile-time authoring, source-string-first catalogs, and a local
-        workflow your repo owns — with a Rust core doing the careful work.</p>
-    </div>
+        <div class="ctaband">
+          <h2>Your first working translation is 5 minutes away.</h2>
+          <div class="hero-ctas">
+            <a class="btn primary" href="#/get-started">Get started</a>
+            <a class="btn" href="https://github.com/sebastian-software/palamedes">Star on GitHub</a>
+          </div>
+        </div>
+      </main>
 
-    <!-- 05 — Maintainer -->
-    <section class="sec" id="maintainer">
-      <div class="sec-head">
-        <span class="sec-mark">05 — Maintainer</span>
-      </div>
-      <div class="two-col">
-        <h2>Built from repeat experience, not a weekend take.</h2>
-        <div>
-          <p style="font-size:14px; max-width:44em">Palamedes is maintained by Sebastian Software GmbH. It is the third generation of
-            source-string-first JavaScript i18n tooling from the same author — from gettext-style
-            macro systems in qooxdoo to a full enterprise Lingui migration at Regrello (acquired by
-            Salesforce in 2025). The lessons are written down as 16 ADRs before you depend on the
-            tool.</p>
+      <!-- ===================================================== FRAMEWORKS view -->
+      <main id="view-frameworks" data-view hidden>
+        <header class="hero">
+          <p class="eyebrow">Framework matrix</p>
+          <h1 class="display">Five frameworks. Four locale strategies. One mental&nbsp;model.</h1>
+          <p class="subline">
+            Every cell below is a real application — the same booking UI, the same catalogs, the
+            same runtime calls — browser-verified in CI. Where public hosting is ready, open the
+            demo, switch the language, and watch copy, plurals, currency, and dates change together.
+          </p>
+          <div class="hero-ctas">
+            <a class="btn primary" href="https://nextjs-cookie.examples.palamedes.dev"
+              >Open a live demo</a
+            >
+            <a class="btn" href="https://github.com/sebastian-software/palamedes/tree/main/examples"
+              >Browse the example source</a
+            >
+          </div>
+        </header>
+
+        <!-- 01 — Matrix -->
+        <section class="sec" id="matrix">
+          <div class="sec-head">
+            <span class="sec-mark">01 — Matrix</span>
+            <h2>The 5 × 4 verified matrix.</h2>
+          </div>
+          <div class="table-scroll" style="margin-top: 0">
+            <table class="spec fw-matrix" data-longnames>
+              <!-- populated by buildMatrix() -->
+            </table>
+          </div>
+          <div class="legend">
+            <span><b style="color: var(--accent)">●</b> live — public demo hosted</span>
+            <span><b>◌</b> provisioning — hosting pending, verified source linked</span>
+            <span
+              ><b class="mono" style="font-size: 10px">✓ VERIFIED</b> — CI browser-verified
+              (Playwright), all 20 cells</span
+            >
+          </div>
+          <p class="caption">
+            All 20 apps are verified in CI with the same Playwright-driven browser flow: SSR output,
+            locale switching, localized server actions. Screenshots are versioned in the repo.
+            Cookie and route demos are publicly hosted today; subdomain and TLD hosting is being
+            provisioned — until then those cells link the verified source instead.
+          </p>
+        </section>
+
+        <!-- 02 — Strategies -->
+        <section class="sec" id="strategies">
+          <div class="sec-head">
+            <span class="sec-mark">02 — Strategies</span>
+            <h2>
+              Pick the locale strategy your product needs — not the one your framework dictates.
+            </h2>
+          </div>
+          <div class="grid cols-4">
+            <div class="cell">
+              <span class="cell-num">02.1 / cookie</span>
+              <h3>Cookie</h3>
+              <p>
+                One URL for all locales. Best for apps behind login where SEO is irrelevant and
+                switching should be instant.
+              </p>
+            </div>
+            <div class="cell">
+              <span class="cell-num">02.2 / route</span>
+              <h3>Route segment</h3>
+              <p>
+                /de/checkout-style paths. The SEO-friendly default for public content with indexable
+                localized pages.
+              </p>
+            </div>
+            <div class="cell">
+              <span class="cell-num">02.3 / globe</span>
+              <h3>Subdomain</h3>
+              <p>
+                de.example.com. Clean separation per market, works well with regional CDNs and
+                analytics splits.
+              </p>
+            </div>
+            <div class="cell">
+              <span class="cell-num">02.4 / flag</span>
+              <h3>Top-level domain</h3>
+              <p>
+                example.de vs example.com. Maximum market trust; Palamedes maps each domain to its
+                locale.
+              </p>
+            </div>
+          </div>
           <div class="linklist">
-            <a href="https://github.com/sebastian-software/palamedes/tree/main/adr">The decision trail (ADRs)</a>
-            <a href="#/" onclick="return false" title="Blog not part of this draft">Why this exists</a>
+            <a
+              href="https://github.com/sebastian-software/palamedes/blob/main/docs/locale-strategies.md"
+              >Locale strategies in depth</a
+            >
+          </div>
+        </section>
+
+        <!-- 03 — Per framework -->
+        <section class="sec" id="per-framework">
+          <div class="sec-head">
+            <span class="sec-mark">03 — Per framework</span>
+            <h2>Your stack, specifically.</h2>
+          </div>
+          <div class="mt-32" id="fw-panels">
+            <!-- populated by buildPanels() -->
+          </div>
+        </section>
+
+        <!-- 04 — Backend -->
+        <section class="sec" id="backend">
+          <div class="sec-head">
+            <span class="sec-mark">04 — Backend</span>
+            <h2>And it doesn't stop at the frontend.</h2>
+          </div>
+          <p class="lede">
+            The same getI18n() model runs in Hono and Express with request-local locale resolution —
+            transactional emails, API error messages, and PDF generation speak the user's language
+            from the same catalogs.
+          </p>
+          <p class="mt-32">
+            <a
+              class="btn"
+              href="https://github.com/sebastian-software/palamedes/blob/main/docs/backend-servers.md"
+              >Backend servers guide</a
+            >
+          </p>
+        </section>
+
+        <div class="ctaband">
+          <h2>See your framework speaking three languages — right now.</h2>
+          <div class="hero-ctas">
+            <a class="btn primary" href="https://nextjs-cookie.examples.palamedes.dev"
+              >Open the live matrix</a
+            >
+            <a class="btn" href="#/get-started">Get started</a>
           </div>
         </div>
-      </div>
-    </section>
+      </main>
 
-    <div class="ctaband">
-      <h2>Your first working translation is 5 minutes away.</h2>
-      <div class="hero-ctas">
-        <a class="btn primary" href="#/get-started">Get started</a>
-        <a class="btn" href="https://github.com/sebastian-software/palamedes">Star on GitHub</a>
-      </div>
-    </div>
-
-  </main>
-
-  <!-- ===================================================== FRAMEWORKS view -->
-  <main id="view-frameworks" data-view hidden>
-
-    <header class="hero">
-      <p class="eyebrow">Framework matrix</p>
-      <h1 class="display">Five frameworks. Four locale strategies. One mental&nbsp;model.</h1>
-      <p class="subline">Every cell below is a real application — the same booking UI,
-        the same catalogs, the same runtime calls — browser-verified in CI.
-        Where public hosting is ready, open the demo, switch the language,
-        and watch copy, plurals, currency, and dates change together.</p>
-      <div class="hero-ctas">
-        <a class="btn primary" href="https://nextjs-cookie.examples.palamedes.dev">Open a live demo</a>
-        <a class="btn" href="https://github.com/sebastian-software/palamedes/tree/main/examples">Browse the example source</a>
-      </div>
-    </header>
-
-    <!-- 01 — Matrix -->
-    <section class="sec" id="matrix">
-      <div class="sec-head">
-        <span class="sec-mark">01 — Matrix</span>
-        <h2>The 5 × 4 verified matrix.</h2>
-      </div>
-      <div class="table-scroll" style="margin-top:0">
-        <table class="spec fw-matrix" data-longnames>
-          <!-- populated by buildMatrix() -->
-        </table>
-      </div>
-      <div class="legend">
-        <span><b style="color:var(--accent)">●</b> live — public demo hosted</span>
-        <span><b>◌</b> provisioning — hosting pending, verified source linked</span>
-        <span><b class="mono" style="font-size:10px">✓ VERIFIED</b> — CI browser-verified (Playwright), all 20 cells</span>
-      </div>
-      <p class="caption">All 20 apps are verified in CI with the same Playwright-driven browser flow: SSR output,
-        locale switching, localized server actions. Screenshots are versioned in the repo. Cookie
-        and route demos are publicly hosted today; subdomain and TLD hosting is being provisioned
-        — until then those cells link the verified source instead.</p>
-    </section>
-
-    <!-- 02 — Strategies -->
-    <section class="sec" id="strategies">
-      <div class="sec-head">
-        <span class="sec-mark">02 — Strategies</span>
-        <h2>Pick the locale strategy your product needs — not the one your framework dictates.</h2>
-      </div>
-      <div class="grid cols-4">
-        <div class="cell">
-          <span class="cell-num">02.1 / cookie</span>
-          <h3>Cookie</h3>
-          <p>One URL for all locales. Best for apps behind login where SEO is irrelevant and switching should be instant.</p>
-        </div>
-        <div class="cell">
-          <span class="cell-num">02.2 / route</span>
-          <h3>Route segment</h3>
-          <p>/de/checkout-style paths. The SEO-friendly default for public content with indexable localized pages.</p>
-        </div>
-        <div class="cell">
-          <span class="cell-num">02.3 / globe</span>
-          <h3>Subdomain</h3>
-          <p>de.example.com. Clean separation per market, works well with regional CDNs and analytics splits.</p>
-        </div>
-        <div class="cell">
-          <span class="cell-num">02.4 / flag</span>
-          <h3>Top-level domain</h3>
-          <p>example.de vs example.com. Maximum market trust; Palamedes maps each domain to its locale.</p>
-        </div>
-      </div>
-      <div class="linklist">
-        <a href="https://github.com/sebastian-software/palamedes/blob/main/docs/locale-strategies.md">Locale strategies in depth</a>
-      </div>
-    </section>
-
-    <!-- 03 — Per framework -->
-    <section class="sec" id="per-framework">
-      <div class="sec-head">
-        <span class="sec-mark">03 — Per framework</span>
-        <h2>Your stack, specifically.</h2>
-      </div>
-      <div class="mt-32" id="fw-panels">
-        <!-- populated by buildPanels() -->
-      </div>
-    </section>
-
-    <!-- 04 — Backend -->
-    <section class="sec" id="backend">
-      <div class="sec-head">
-        <span class="sec-mark">04 — Backend</span>
-        <h2>And it doesn't stop at the frontend.</h2>
-      </div>
-      <p class="lede">The same getI18n() model runs in Hono and Express with request-local locale resolution —
-        transactional emails, API error messages, and PDF generation speak the user's language
-        from the same catalogs.</p>
-      <p class="mt-32"><a class="btn" href="https://github.com/sebastian-software/palamedes/blob/main/docs/backend-servers.md">Backend servers guide</a></p>
-    </section>
-
-    <div class="ctaband">
-      <h2>See your framework speaking three languages — right now.</h2>
-      <div class="hero-ctas">
-        <a class="btn primary" href="https://nextjs-cookie.examples.palamedes.dev">Open the live matrix</a>
-        <a class="btn" href="#/get-started">Get started</a>
-      </div>
-    </div>
-
-  </main>
-
-  <!-- ========================================================== PROOF view -->
-  <main id="view-proof" data-view hidden>
-
-    <header class="hero">
-      <p class="eyebrow">Proof</p>
-      <h1 class="display">Claims you can re-run.</h1>
-      <p class="subline">Every number on this page comes from a checked-in,
-        machine-readable report with fixtures and commands in the repo.
-        If a claim can't be re-run, we don't make it.</p>
-      <div class="hero-ctas">
-        <a class="btn primary" href="https://github.com/sebastian-software/palamedes/blob/main/docs/benchmark-e2e-workflow.md">Re-run the benchmarks</a>
-        <a class="btn" href="https://github.com/sebastian-software/palamedes/tree/main/benchmarks/e2e-workflow/results">Browse checked-in reports</a>
-      </div>
-    </header>
-
-    <!-- 01 — Benchmarks -->
-    <section class="sec" id="benchmarks">
-      <div class="sec-head">
-        <span class="sec-mark">01 — Benchmarks</span>
-        <h2>The workflow you feel every day: extract &amp; update.</h2>
-      </div>
-      <p class="lede">The end-to-end benchmark measures what a developer actually waits for: scan sources,
-        extract messages, update catalogs, write files. Same generated message inventory, rendered
-        into each tool's idiomatic source shape, semantically validated after every run.</p>
-
-      <div class="bench">
-        <div class="bench-title">Small corpus — 80 files, 640 messages (median of 7 runs)</div>
-        <div class="bench-row">
-          <span class="bench-tool">Palamedes</span>
-          <span class="bench-track"><span class="bench-bar accent" style="width:5.1%"></span></span>
-          <span class="bench-val">33.53 ms</span>
-        </div>
-        <div class="bench-row">
-          <span class="bench-tool">i18next-parser 9.4</span>
-          <span class="bench-track"><span class="bench-bar" style="width:72.7%"></span></span>
-          <span class="bench-val">477.58 ms</span>
-        </div>
-        <div class="bench-row">
-          <span class="bench-tool">Lingui 6.4</span>
-          <span class="bench-track"><span class="bench-bar" style="width:100%"></span></span>
-          <span class="bench-val">657.00 ms</span>
-        </div>
-        <div class="bench-note">
-          Linear millisecond scale, no truncation — the ratios (19.59× vs Lingui, 14.24× vs i18next-parser)
-          are exactly as drawn. Machine-local run from the checked-in report.
-          <a href="https://github.com/sebastian-software/palamedes/blob/main/docs/benchmark-e2e-workflow.md">Methodology →</a>
-        </div>
-      </div>
-
-      <div class="bench">
-        <div class="bench-title">Medium corpus (median of 7 runs)</div>
-        <div class="bench-row">
-          <span class="bench-tool">Palamedes</span>
-          <span class="bench-track"><span class="bench-bar accent" style="width:6.5%"></span></span>
-          <span class="bench-val">42.92 ms</span>
-        </div>
-        <div class="bench-note">
-          Competitor medians for the medium corpus: see the checked-in report,
-          <a href="https://github.com/sebastian-software/palamedes/blob/main/benchmarks/e2e-workflow/results/latest.md">benchmarks/e2e-workflow/results/latest.md</a>.
-          Same linear scale as above. Machine-local run.
-          <a href="https://github.com/sebastian-software/palamedes/blob/main/docs/benchmark-e2e-workflow.md">Methodology →</a>
-        </div>
-      </div>
-
-      <div class="callout">
-        <span class="micro">Honest note</span>
-        These are machine-local numbers from the checked-in report, not a marketing average. Your
-        hardware will differ; the ratios are the signal. Commands to reproduce:
-        <code>pnpm benchmark:e2e-workflow</code>.
-      </div>
-    </section>
-
-    <!-- 02 — Verification -->
-    <section class="sec" id="verification">
-      <div class="sec-head">
-        <span class="sec-mark">02 — Verification</span>
-        <h2>20 apps, verified in a real browser, on every change.</h2>
-      </div>
-      <div class="steps">
-        <div class="step">
-          <div class="step-num mono">1</div>
-          <div class="step-body">
-            <h3>Build</h3>
-            <p>All 20 example apps build against the workspace packages — no mocked integrations.</p>
+      <!-- ========================================================== PROOF view -->
+      <main id="view-proof" data-view hidden>
+        <header class="hero">
+          <p class="eyebrow">Proof</p>
+          <h1 class="display">Claims you can re-run.</h1>
+          <p class="subline">
+            Every number on this page comes from a checked-in, machine-readable report with fixtures
+            and commands in the repo. If a claim can't be re-run, we don't make it.
+          </p>
+          <div class="hero-ctas">
+            <a
+              class="btn primary"
+              href="https://github.com/sebastian-software/palamedes/blob/main/docs/benchmark-e2e-workflow.md"
+              >Re-run the benchmarks</a
+            >
+            <a
+              class="btn"
+              href="https://github.com/sebastian-software/palamedes/tree/main/benchmarks/e2e-workflow/results"
+              >Browse checked-in reports</a
+            >
           </div>
-        </div>
-        <div class="step">
-          <div class="step-num mono">2</div>
-          <div class="step-body">
-            <h3>Drive</h3>
-            <p>A Playwright flow loads each app, checks SSR output, switches locales, and exercises localized server actions.</p>
-          </div>
-        </div>
-        <div class="step">
-          <div class="step-num mono">3</div>
-          <div class="step-body">
-            <h3>Capture</h3>
-            <p>Screenshots are versioned in the repo, so 'works across frameworks' is a diffable artifact, not a slide.</p>
-          </div>
-        </div>
-      </div>
+        </header>
 
-      <div class="shot">
-        <div class="shot-chrome">
-          <i></i><i></i><i></i>
-          <span class="mono">nextjs-cookie.examples.palamedes.dev — en · de · es</span>
-        </div>
-        <div class="shot-body">
-          <div class="bcard">
-            <div class="bcard-loc">en-US</div>
-            <div class="bcard-title">Your trip to Lisbon</div>
-            <div class="bcard-row">
-              <span class="bcard-seats">3 seats left</span>
-              <span class="bcard-price">€1,234.00</span>
+        <!-- 01 — Benchmarks -->
+        <section class="sec" id="benchmarks">
+          <div class="sec-head">
+            <span class="sec-mark">01 — Benchmarks</span>
+            <h2>The workflow you feel every day: extract &amp; update.</h2>
+          </div>
+          <p class="lede">
+            The end-to-end benchmark measures what a developer actually waits for: scan sources,
+            extract messages, update catalogs, write files. Same generated message inventory,
+            rendered into each tool's idiomatic source shape, semantically validated after every
+            run.
+          </p>
+
+          <div class="bench">
+            <div class="bench-title">Small corpus — 80 files, 640 messages (median of 7 runs)</div>
+            <div class="bench-row">
+              <span class="bench-tool">Palamedes</span>
+              <span class="bench-track"
+                ><span class="bench-bar accent" style="width: 5.1%"></span
+              ></span>
+              <span class="bench-val">33.53 ms</span>
             </div>
-            <div class="bcard-date">Jul 12, 2026</div>
-          </div>
-          <div class="bcard">
-            <div class="bcard-loc">de-DE</div>
-            <div class="bcard-title">Deine Reise nach Lissabon</div>
-            <div class="bcard-row">
-              <span class="bcard-seats">3 Plätze frei</span>
-              <span class="bcard-price">1.234,00&nbsp;€</span>
+            <div class="bench-row">
+              <span class="bench-tool">i18next-parser 9.4</span>
+              <span class="bench-track"><span class="bench-bar" style="width: 72.7%"></span></span>
+              <span class="bench-val">477.58 ms</span>
             </div>
-            <div class="bcard-date">12. Juli 2026</div>
-          </div>
-          <div class="bcard">
-            <div class="bcard-loc">es-ES</div>
-            <div class="bcard-title">Tu viaje a Lisboa</div>
-            <div class="bcard-row">
-              <span class="bcard-seats">Quedan 3 asientos</span>
-              <span class="bcard-price">1234,00&nbsp;€</span>
+            <div class="bench-row">
+              <span class="bench-tool">Lingui 6.4</span>
+              <span class="bench-track"><span class="bench-bar" style="width: 100%"></span></span>
+              <span class="bench-val">657.00 ms</span>
             </div>
-            <div class="bcard-date">12 jul 2026</div>
+            <div class="bench-note">
+              Linear millisecond scale, no truncation — the ratios (19.59× vs Lingui, 14.24× vs
+              i18next-parser) are exactly as drawn. Machine-local run from the checked-in report.
+              <a
+                href="https://github.com/sebastian-software/palamedes/blob/main/docs/benchmark-e2e-workflow.md"
+                >Methodology →</a
+              >
+            </div>
+          </div>
+
+          <div class="bench">
+            <div class="bench-title">Medium corpus (median of 7 runs)</div>
+            <div class="bench-row">
+              <span class="bench-tool">Palamedes</span>
+              <span class="bench-track"
+                ><span class="bench-bar accent" style="width: 6.5%"></span
+              ></span>
+              <span class="bench-val">42.92 ms</span>
+            </div>
+            <div class="bench-note">
+              Competitor medians for the medium corpus: see the checked-in report,
+              <a
+                href="https://github.com/sebastian-software/palamedes/blob/main/benchmarks/e2e-workflow/results/latest.md"
+                >benchmarks/e2e-workflow/results/latest.md</a
+              >. Same linear scale as above. Machine-local run.
+              <a
+                href="https://github.com/sebastian-software/palamedes/blob/main/docs/benchmark-e2e-workflow.md"
+                >Methodology →</a
+              >
+            </div>
+          </div>
+
+          <div class="callout">
+            <span class="micro">Honest note</span>
+            These are machine-local numbers from the checked-in report, not a marketing average.
+            Your hardware will differ; the ratios are the signal. Commands to reproduce:
+            <code>pnpm benchmark:e2e-workflow</code>.
+          </div>
+        </section>
+
+        <!-- 02 — Verification -->
+        <section class="sec" id="verification">
+          <div class="sec-head">
+            <span class="sec-mark">02 — Verification</span>
+            <h2>20 apps, verified in a real browser, on every change.</h2>
+          </div>
+          <div class="steps">
+            <div class="step">
+              <div class="step-num mono">1</div>
+              <div class="step-body">
+                <h3>Build</h3>
+                <p>
+                  All 20 example apps build against the workspace packages — no mocked integrations.
+                </p>
+              </div>
+            </div>
+            <div class="step">
+              <div class="step-num mono">2</div>
+              <div class="step-body">
+                <h3>Drive</h3>
+                <p>
+                  A Playwright flow loads each app, checks SSR output, switches locales, and
+                  exercises localized server actions.
+                </p>
+              </div>
+            </div>
+            <div class="step">
+              <div class="step-num mono">3</div>
+              <div class="step-body">
+                <h3>Capture</h3>
+                <p>
+                  Screenshots are versioned in the repo, so 'works across frameworks' is a diffable
+                  artifact, not a slide.
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <div class="shot">
+            <div class="shot-chrome">
+              <i></i><i></i><i></i>
+              <span class="mono">nextjs-cookie.examples.palamedes.dev — en · de · es</span>
+            </div>
+            <div class="shot-body">
+              <div class="bcard">
+                <div class="bcard-loc">en-US</div>
+                <div class="bcard-title">Your trip to Lisbon</div>
+                <div class="bcard-row">
+                  <span class="bcard-seats">3 seats left</span>
+                  <span class="bcard-price">€1,234.00</span>
+                </div>
+                <div class="bcard-date">Jul 12, 2026</div>
+              </div>
+              <div class="bcard">
+                <div class="bcard-loc">de-DE</div>
+                <div class="bcard-title">Deine Reise nach Lissabon</div>
+                <div class="bcard-row">
+                  <span class="bcard-seats">3 Plätze frei</span>
+                  <span class="bcard-price">1.234,00&nbsp;€</span>
+                </div>
+                <div class="bcard-date">12. Juli 2026</div>
+              </div>
+              <div class="bcard">
+                <div class="bcard-loc">es-ES</div>
+                <div class="bcard-title">Tu viaje a Lisboa</div>
+                <div class="bcard-row">
+                  <span class="bcard-seats">Quedan 3 asientos</span>
+                  <span class="bcard-price">1234,00&nbsp;€</span>
+                </div>
+                <div class="bcard-date">12 jul 2026</div>
+              </div>
+            </div>
+            <div class="shot-cap">
+              One demo, three locales: copy, plural seat counts, currency, and dates change
+              together.
+              <a
+                href="https://github.com/sebastian-software/palamedes/blob/main/docs/example-screenshots/README.md"
+                >Versioned screenshots →</a
+              >
+            </div>
+          </div>
+        </section>
+
+        <!-- 03 — Catalog quality -->
+        <section class="sec" id="catalog-qa">
+          <div class="sec-head">
+            <span class="sec-mark">03 — Catalog quality</span>
+            <h2>Fast would be worthless if the catalogs were wrong.</h2>
+          </div>
+          <p class="lede">
+            Catalog semantics live in one dedicated engine (ferrocat): parsing, merging, structured
+            audits, and ICU authoring diagnostics. The benchmark harness validates every tool run
+            semantically — message inventories are compared, not just timed.
+          </p>
+          <div class="grid cols-3">
+            <div class="cell">
+              <span class="cell-num">03.1 / shield</span>
+              <h3>Structured audits</h3>
+              <p>
+                Machine-readable catalog audits catch missing translations, stale entries, and
+                metadata drift in CI.
+              </p>
+            </div>
+            <div class="cell">
+              <span class="cell-num">03.2 / brackets</span>
+              <h3>ICU diagnostics</h3>
+              <p>
+                Authoring mistakes in plural/select syntax are flagged at extract time, not at
+                runtime in production.
+              </p>
+            </div>
+            <div class="cell">
+              <span class="cell-num">03.3 / merge</span>
+              <h3>Semantic merging</h3>
+              <p>
+                A Git merge driver resolves catalog conflicts by meaning, not by line — no more
+                broken .po files after rebases.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <!-- 04 — Decision trail -->
+        <section class="sec" id="adrs">
+          <div class="sec-head">
+            <span class="sec-mark">04 — Decision trail</span>
+            <h2>16 decisions, written down before you depend on them.</h2>
+          </div>
+          <p class="lede">
+            The ADRs cover message identity, the native boundary, adapter architecture — and, just
+            as deliberately, what Palamedes refuses to own. Reading them is the fastest way to know
+            if our tradeoffs match yours.
+          </p>
+          <div class="linklist">
+            <a href="https://github.com/sebastian-software/palamedes/tree/main/adr">ADR index</a>
+            <a href="https://github.com/sebastian-software/palamedes/blob/main/docs/stability.md"
+              >Stability &amp; versioning policy</a
+            >
+            <a href="https://github.com/sebastian-software/palamedes/blob/main/docs/principles.md"
+              >Palamedes principles</a
+            >
+          </div>
+        </section>
+
+        <div class="ctaband">
+          <h2>Convinced by the receipts? The quickstart takes 5 minutes.</h2>
+          <div class="hero-ctas">
+            <a class="btn primary" href="#/get-started">Get started</a>
+            <a
+              class="btn"
+              href="#/"
+              onclick="return false"
+              title="Compare page not part of this draft"
+              >Compare with your current tool</a
+            >
           </div>
         </div>
-        <div class="shot-cap">One demo, three locales: copy, plural seat counts, currency, and dates change together.
-          <a href="https://github.com/sebastian-software/palamedes/blob/main/docs/example-screenshots/README.md">Versioned screenshots →</a></div>
-      </div>
-    </section>
+      </main>
 
-    <!-- 03 — Catalog quality -->
-    <section class="sec" id="catalog-qa">
-      <div class="sec-head">
-        <span class="sec-mark">03 — Catalog quality</span>
-        <h2>Fast would be worthless if the catalogs were wrong.</h2>
-      </div>
-      <p class="lede">Catalog semantics live in one dedicated engine (ferrocat): parsing, merging, structured
-        audits, and ICU authoring diagnostics. The benchmark harness validates every tool run
-        semantically — message inventories are compared, not just timed.</p>
-      <div class="grid cols-3">
-        <div class="cell">
-          <span class="cell-num">03.1 / shield</span>
-          <h3>Structured audits</h3>
-          <p>Machine-readable catalog audits catch missing translations, stale entries, and metadata drift in CI.</p>
-        </div>
-        <div class="cell">
-          <span class="cell-num">03.2 / brackets</span>
-          <h3>ICU diagnostics</h3>
-          <p>Authoring mistakes in plural/select syntax are flagged at extract time, not at runtime in production.</p>
-        </div>
-        <div class="cell">
-          <span class="cell-num">03.3 / merge</span>
-          <h3>Semantic merging</h3>
-          <p>A Git merge driver resolves catalog conflicts by meaning, not by line — no more broken .po files after rebases.</p>
-        </div>
-      </div>
-    </section>
-
-    <!-- 04 — Decision trail -->
-    <section class="sec" id="adrs">
-      <div class="sec-head">
-        <span class="sec-mark">04 — Decision trail</span>
-        <h2>16 decisions, written down before you depend on them.</h2>
-      </div>
-      <p class="lede">The ADRs cover message identity, the native boundary, adapter architecture — and, just as
-        deliberately, what Palamedes refuses to own. Reading them is the fastest way to know if
-        our tradeoffs match yours.</p>
-      <div class="linklist">
-        <a href="https://github.com/sebastian-software/palamedes/tree/main/adr">ADR index</a>
-        <a href="https://github.com/sebastian-software/palamedes/blob/main/docs/stability.md">Stability &amp; versioning policy</a>
-        <a href="https://github.com/sebastian-software/palamedes/blob/main/docs/principles.md">Palamedes principles</a>
-      </div>
-    </section>
-
-    <div class="ctaband">
-      <h2>Convinced by the receipts? The quickstart takes 5 minutes.</h2>
-      <div class="hero-ctas">
-        <a class="btn primary" href="#/get-started">Get started</a>
-        <a class="btn" href="#/" onclick="return false" title="Compare page not part of this draft">Compare with your current tool</a>
-      </div>
-    </div>
-
-  </main>
-
-  <!-- ==================================================== GET STARTED view -->
-  <main id="view-get-started" data-view hidden>
-
-    <header class="hero">
-      <p class="eyebrow">Quickstart</p>
-      <h1 class="display">First working translation in 5&nbsp;minutes.</h1>
-      <p class="subline">One translated component, one extraction run, one .po file,
-        one runtime instance. No message IDs to invent, no dictionary files
-        to maintain.</p>
-      <div class="hero-ctas">
-        <a class="btn primary" href="#install" onclick="document.getElementById('install').scrollIntoView(); return false">Skip to step 1</a>
-        <a class="btn" href="https://github.com/sebastian-software/palamedes/blob/main/docs/first-working-translation.md">Full written guide</a>
-      </div>
-    </header>
-
-    <div class="stackpick" style="border-top:1px solid var(--hair)">
-      <span class="micro">Stack</span>
-      <div class="tabs" style="border-bottom:1px solid var(--hair)">
-        <button class="active">Vite + React</button>
-        <button disabled title="Mock: switcher is non-functional in this draft">Vite + Solid</button>
-        <button disabled title="Mock: switcher is non-functional in this draft">Next.js</button>
-      </div>
-      <span class="micro">Draft mock — flow below shows Vite + React</span>
-    </div>
-
-    <section class="sec" id="install" style="border-top:0; padding-top:32px">
-      <div class="callout" style="margin-top:0">
-        <span class="micro">Honest note</span>
-        Heads-up: install the scoped <code>@palamedes/*</code> packages. The top-level
-        <code>palamedes</code> and <code>create-palamedes</code> names are reserved for a future
-        one-command setup and are not the entry point today.
-      </div>
-
-      <div class="steps">
-        <div class="step">
-          <div class="step-num mono">1</div>
-          <div class="step-body">
-            <h3>Install</h3>
-            <p>Core, runtime, host adapter, and the build plugin — plus the CLI as a dev dependency.</p>
-            <pre class="code">pnpm add @palamedes/core @palamedes/react @palamedes/runtime @palamedes/vite-plugin
-pnpm add -D @palamedes/cli @vitejs/plugin-react</pre>
+      <!-- ==================================================== GET STARTED view -->
+      <main id="view-get-started" data-view hidden>
+        <header class="hero">
+          <p class="eyebrow">Quickstart</p>
+          <h1 class="display">First working translation in 5&nbsp;minutes.</h1>
+          <p class="subline">
+            One translated component, one extraction run, one .po file, one runtime instance. No
+            message IDs to invent, no dictionary files to maintain.
+          </p>
+          <div class="hero-ctas">
+            <a
+              class="btn primary"
+              href="#install"
+              onclick="
+                document.getElementById('install').scrollIntoView()
+                return false
+              "
+              >Skip to step 1</a
+            >
+            <a
+              class="btn"
+              href="https://github.com/sebastian-software/palamedes/blob/main/docs/first-working-translation.md"
+              >Full written guide</a
+            >
           </div>
+        </header>
+
+        <div class="stackpick" style="border-top: 1px solid var(--hair)">
+          <span class="micro">Stack</span>
+          <div class="tabs" style="border-bottom: 1px solid var(--hair)">
+            <button class="active">Vite + React</button>
+            <button disabled title="Mock: switcher is non-functional in this draft">
+              Vite + Solid
+            </button>
+            <button disabled title="Mock: switcher is non-functional in this draft">Next.js</button>
+          </div>
+          <span class="micro">Draft mock — flow below shows Vite + React</span>
         </div>
-        <div class="step">
-          <div class="step-num mono">2</div>
-          <div class="step-body">
-            <h3>Configure</h3>
-            <p>One YAML file declares your locales and where catalogs live.</p>
-            <pre class="code"><span class="cm"># palamedes.yaml</span>
+
+        <section class="sec" id="install" style="border-top: 0; padding-top: 32px">
+          <div class="callout" style="margin-top: 0">
+            <span class="micro">Honest note</span>
+            Heads-up: install the scoped <code>@palamedes/*</code> packages. The top-level
+            <code>palamedes</code> and <code>create-palamedes</code> names are reserved for a future
+            one-command setup and are not the entry point today.
+          </div>
+
+          <div class="steps">
+            <div class="step">
+              <div class="step-num mono">1</div>
+              <div class="step-body">
+                <h3>Install</h3>
+                <p>
+                  Core, runtime, host adapter, and the build plugin — plus the CLI as a dev
+                  dependency.
+                </p>
+                <pre class="code">
+pnpm add @palamedes/core @palamedes/react @palamedes/runtime @palamedes/vite-plugin
+pnpm add -D @palamedes/cli @vitejs/plugin-react</pre
+                >
+              </div>
+            </div>
+            <div class="step">
+              <div class="step-num mono">2</div>
+              <div class="step-body">
+                <h3>Configure</h3>
+                <p>One YAML file declares your locales and where catalogs live.</p>
+                <pre class="code"><span class="cm"># palamedes.yaml</span>
 locales: [en, de]
 source-locale: en
 catalogs:
   - path: src/locales/{locale}
     include: [src]</pre>
-          </div>
-        </div>
-        <div class="step">
-          <div class="step-num mono">3</div>
-          <div class="step-body">
-            <h3>Wire the plugin &amp; runtime</h3>
-            <p>The Vite plugin handles the macro transform; the runtime holds the active i18n instance.</p>
-            <pre class="code"><span class="cm">// vite.config.ts</span>
+              </div>
+            </div>
+            <div class="step">
+              <div class="step-num mono">3</div>
+              <div class="step-body">
+                <h3>Wire the plugin &amp; runtime</h3>
+                <p>
+                  The Vite plugin handles the macro transform; the runtime holds the active i18n
+                  instance.
+                </p>
+                <pre class="code"><span class="cm">// vite.config.ts</span>
 import { palamedes } from "@palamedes/vite-plugin"
 export default defineConfig({ plugins: [palamedes(), react()] })
 
@@ -1133,37 +1826,43 @@ import { setClientI18n } from "@palamedes/runtime"
 
 export const i18n = createI18n()
 setClientI18n(i18n)</pre>
-          </div>
-        </div>
-        <div class="step">
-          <div class="step-num mono">4</div>
-          <div class="step-body">
-            <h3>Write &amp; extract</h3>
-            <p>Author the message in your component, then run one command — it creates src/locales/en.po and de.po.</p>
-            <pre class="code"><span class="cm">// src/App.tsx</span>
+              </div>
+            </div>
+            <div class="step">
+              <div class="step-num mono">4</div>
+              <div class="step-body">
+                <h3>Write &amp; extract</h3>
+                <p>
+                  Author the message in your component, then run one command — it creates
+                  src/locales/en.po and de.po.
+                </p>
+                <pre class="code"><span class="cm">// src/App.tsx</span>
 import { t } from "@palamedes/core/macro"
 export const App = () =&gt; &lt;h1&gt;{t`Welcome to Palamedes`}&lt;/h1&gt;
 
 $ pmds extract</pre>
-          </div>
-        </div>
-        <div class="step">
-          <div class="step-num mono">5</div>
-          <div class="step-body">
-            <h3>Translate</h3>
-            <p>Open the German catalog and fill in the translated string.</p>
-            <pre class="code"><span class="cm"># src/locales/de.po</span>
+              </div>
+            </div>
+            <div class="step">
+              <div class="step-num mono">5</div>
+              <div class="step-body">
+                <h3>Translate</h3>
+                <p>Open the German catalog and fill in the translated string.</p>
+                <pre class="code"><span class="cm"># src/locales/de.po</span>
 msgid "Welcome to Palamedes"
 msgstr "Willkommen bei Palamedes"</pre>
-          </div>
-        </div>
-        <div class="step">
-          <div class="step-num mono">6</div>
-          <div class="step-body">
-            <h3>Load &amp; see it render</h3>
-            <p>Load the catalogs, activate a locale, and run the dev server — the page now renders
-              “Willkommen bei Palamedes”. That is the full local loop: transform, extraction, catalog, runtime.</p>
-            <pre class="code"><span class="cm">// src/main.tsx</span>
+              </div>
+            </div>
+            <div class="step">
+              <div class="step-num mono">6</div>
+              <div class="step-body">
+                <h3>Load &amp; see it render</h3>
+                <p>
+                  Load the catalogs, activate a locale, and run the dev server — the page now
+                  renders “Willkommen bei Palamedes”. That is the full local loop: transform,
+                  extraction, catalog, runtime.
+                </p>
+                <pre class="code"><span class="cm">// src/main.tsx</span>
 import { i18n } from "./i18n"
 import { messages as enMessages } from "./locales/en.po"
 import { messages as deMessages } from "./locales/de.po"
@@ -1173,278 +1872,396 @@ i18n.load("de", deMessages)
 i18n.activate("de")
 
 $ pnpm dev</pre>
-            <div class="aside">
-              <span class="micro">Aside</span>
-              TypeScript needs an ambient declaration for .po imports — add a src/po.d.ts with
-              <code>declare module "*.po"</code> (see the
-              <a href="https://github.com/sebastian-software/palamedes/blob/main/docs/troubleshooting.md">troubleshooting guide</a>).
+                <div class="aside">
+                  <span class="micro">Aside</span>
+                  TypeScript needs an ambient declaration for .po imports — add a src/po.d.ts with
+                  <code>declare module "*.po"</code> (see the
+                  <a
+                    href="https://github.com/sebastian-software/palamedes/blob/main/docs/troubleshooting.md"
+                    >troubleshooting guide</a
+                  >).
+                </div>
+              </div>
             </div>
           </div>
-        </div>
-      </div>
-    </section>
+        </section>
 
-    <!-- 02 — Next -->
-    <section class="sec" id="next">
-      <div class="sec-head">
-        <span class="sec-mark">02 — Next</span>
-        <h2>Where to go from here</h2>
-      </div>
-      <div class="grid cols-3">
-        <div class="cell">
-          <span class="cell-num">02.1 / book</span>
-          <h3>Plurals, dates &amp; currency</h3>
-          <p>ICU MessageFormat with authoring diagnostics that catch mistakes at extract time.</p>
-          <a class="more" href="https://github.com/sebastian-software/palamedes/blob/main/docs/api/core.md">Core API</a>
-        </div>
-        <div class="cell">
-          <span class="cell-num">02.2 / compass</span>
-          <h3>Pick a locale strategy</h3>
-          <p>Cookie, route, subdomain, or TLD — with a live demo for each, in your framework.</p>
-          <a class="more" href="#/frameworks">Frameworks</a>
-        </div>
-        <div class="cell">
-          <span class="cell-num">02.3 / server</span>
-          <h3>Localize your backend</h3>
-          <p>Request-local i18n for Hono and Express from the same catalogs.</p>
-          <a class="more" href="https://github.com/sebastian-software/palamedes/blob/main/docs/backend-servers.md">Backend guide</a>
-        </div>
-        <div class="cell">
-          <span class="cell-num">02.4 / arrows</span>
-          <h3>Migrating from Lingui?</h3>
-          <p>A step-by-step playbook. Source-string-first .po catalogs are often reusable after an extraction pass; explicit-ID setups need cleanup.</p>
-          <a class="more" href="https://github.com/sebastian-software/palamedes/blob/main/docs/migrate-from-lingui.md">Migration playbook</a>
-        </div>
-        <div class="cell">
-          <span class="cell-num">02.5 / wrench</span>
-          <h3>Something broke?</h3>
-          <p>The troubleshooting guide covers the common setup failures with exact error messages.</p>
-          <a class="more" href="https://github.com/sebastian-software/palamedes/blob/main/docs/troubleshooting.md">Troubleshooting</a>
-        </div>
-        <div class="cell">
-          <span class="cell-num">02.6 / robot</span>
-          <h3>Using an AI assistant?</h3>
-          <p>Point it at llms.txt — the whole API surface in one machine-readable file.</p>
-          <a class="more" href="https://github.com/sebastian-software/palamedes/blob/main/llms.txt">llms.txt</a>
-        </div>
-      </div>
-    </section>
+        <!-- 02 — Next -->
+        <section class="sec" id="next">
+          <div class="sec-head">
+            <span class="sec-mark">02 — Next</span>
+            <h2>Where to go from here</h2>
+          </div>
+          <div class="grid cols-3">
+            <div class="cell">
+              <span class="cell-num">02.1 / book</span>
+              <h3>Plurals, dates &amp; currency</h3>
+              <p>
+                ICU MessageFormat with authoring diagnostics that catch mistakes at extract time.
+              </p>
+              <a
+                class="more"
+                href="https://github.com/sebastian-software/palamedes/blob/main/docs/api/core.md"
+                >Core API</a
+              >
+            </div>
+            <div class="cell">
+              <span class="cell-num">02.2 / compass</span>
+              <h3>Pick a locale strategy</h3>
+              <p>
+                Cookie, route, subdomain, or TLD — with a live demo for each, in your framework.
+              </p>
+              <a class="more" href="#/frameworks">Frameworks</a>
+            </div>
+            <div class="cell">
+              <span class="cell-num">02.3 / server</span>
+              <h3>Localize your backend</h3>
+              <p>Request-local i18n for Hono and Express from the same catalogs.</p>
+              <a
+                class="more"
+                href="https://github.com/sebastian-software/palamedes/blob/main/docs/backend-servers.md"
+                >Backend guide</a
+              >
+            </div>
+            <div class="cell">
+              <span class="cell-num">02.4 / arrows</span>
+              <h3>Migrating from Lingui?</h3>
+              <p>
+                A step-by-step playbook. Source-string-first .po catalogs are often reusable after
+                an extraction pass; explicit-ID setups need cleanup.
+              </p>
+              <a
+                class="more"
+                href="https://github.com/sebastian-software/palamedes/blob/main/docs/migrate-from-lingui.md"
+                >Migration playbook</a
+              >
+            </div>
+            <div class="cell">
+              <span class="cell-num">02.5 / wrench</span>
+              <h3>Something broke?</h3>
+              <p>
+                The troubleshooting guide covers the common setup failures with exact error
+                messages.
+              </p>
+              <a
+                class="more"
+                href="https://github.com/sebastian-software/palamedes/blob/main/docs/troubleshooting.md"
+                >Troubleshooting</a
+              >
+            </div>
+            <div class="cell">
+              <span class="cell-num">02.6 / robot</span>
+              <h3>Using an AI assistant?</h3>
+              <p>Point it at llms.txt — the whole API surface in one machine-readable file.</p>
+              <a
+                class="more"
+                href="https://github.com/sebastian-software/palamedes/blob/main/llms.txt"
+                >llms.txt</a
+              >
+            </div>
+          </div>
+        </section>
 
-    <div class="ctaband">
-      <h2>Stuck? The maintainer reads every issue.</h2>
-      <div class="hero-ctas">
-        <a class="btn primary" href="https://github.com/sebastian-software/palamedes/issues">Open an issue</a>
-        <a class="btn" href="https://github.com/sebastian-software/palamedes/blob/main/docs/api/README.md">Read the docs</a>
-      </div>
+        <div class="ctaband">
+          <h2>Stuck? The maintainer reads every issue.</h2>
+          <div class="hero-ctas">
+            <a class="btn primary" href="https://github.com/sebastian-software/palamedes/issues"
+              >Open an issue</a
+            >
+            <a
+              class="btn"
+              href="https://github.com/sebastian-software/palamedes/blob/main/docs/api/README.md"
+              >Read the docs</a
+            >
+          </div>
+        </div>
+      </main>
+
+      <!-- ============================================================== FOOTER -->
+      <footer class="site">
+        <div class="foot-grid">
+          <div class="foot-col">
+            <h4>Product</h4>
+            <a href="#/get-started">Get started</a>
+            <a href="#/frameworks">Framework matrix</a>
+            <a href="#/proof">Benchmarks &amp; proof</a>
+            <a href="#/" onclick="return false" title="Not part of this draft">Comparison</a>
+          </div>
+          <div class="foot-col">
+            <h4>Documentation</h4>
+            <a
+              href="https://github.com/sebastian-software/palamedes/blob/main/docs/first-working-translation.md"
+              >5-minute quickstart</a
+            >
+            <a href="https://github.com/sebastian-software/palamedes/blob/main/docs/api/README.md"
+              >API reference</a
+            >
+            <a
+              href="https://github.com/sebastian-software/palamedes/blob/main/docs/configuration.md"
+              >Configuration</a
+            >
+            <a href="https://github.com/sebastian-software/palamedes/blob/main/docs/cli.md">CLI</a>
+            <a
+              href="https://github.com/sebastian-software/palamedes/blob/main/docs/troubleshooting.md"
+              >Troubleshooting</a
+            >
+          </div>
+          <div class="foot-col">
+            <h4>Project</h4>
+            <a href="https://github.com/sebastian-software/palamedes/tree/main/adr"
+              >Architecture decisions</a
+            >
+            <a href="https://github.com/sebastian-software/palamedes/blob/main/docs/stability.md"
+              >Stability &amp; versioning</a
+            >
+            <a href="https://github.com/sebastian-software/palamedes/blob/main/CHANGELOG.md"
+              >Changelog</a
+            >
+            <a href="https://github.com/sebastian-software/palamedes/blob/main/SECURITY.md"
+              >Security</a
+            >
+            <a href="https://github.com/sebastian-software/palamedes/blob/main/LICENSE"
+              >MIT license</a
+            >
+          </div>
+          <div class="foot-col">
+            <h4>Company</h4>
+            <a href="https://oss.sebastian-software.com/">Sebastian Software</a>
+            <a href="https://sebastian-software.de/werner">Sebastian Werner</a>
+            <a href="#/" onclick="return false" title="Blog not part of this draft">Blog</a>
+          </div>
+        </div>
+        <div class="legal">
+          MIT © 2026 Sebastian Software GmbH — built in the open, verified in CI.
+        </div>
+      </footer>
     </div>
+    <!-- /frame -->
 
-  </main>
+    <script>
+      /* ------------------------------------------------------------ hash router -- */
+      ;(function () {
+        var VIEWS = {
+          "/": "view-home",
+          "/frameworks": "view-frameworks",
+          "/proof": "view-proof",
+          "/get-started": "view-get-started",
+        }
+        var current = "/"
 
-  <!-- ============================================================== FOOTER -->
-  <footer class="site">
-    <div class="foot-grid">
-      <div class="foot-col">
-        <h4>Product</h4>
-        <a href="#/get-started">Get started</a>
-        <a href="#/frameworks">Framework matrix</a>
-        <a href="#/proof">Benchmarks &amp; proof</a>
-        <a href="#/" onclick="return false" title="Not part of this draft">Comparison</a>
-      </div>
-      <div class="foot-col">
-        <h4>Documentation</h4>
-        <a href="https://github.com/sebastian-software/palamedes/blob/main/docs/first-working-translation.md">5-minute quickstart</a>
-        <a href="https://github.com/sebastian-software/palamedes/blob/main/docs/api/README.md">API reference</a>
-        <a href="https://github.com/sebastian-software/palamedes/blob/main/docs/configuration.md">Configuration</a>
-        <a href="https://github.com/sebastian-software/palamedes/blob/main/docs/cli.md">CLI</a>
-        <a href="https://github.com/sebastian-software/palamedes/blob/main/docs/troubleshooting.md">Troubleshooting</a>
-      </div>
-      <div class="foot-col">
-        <h4>Project</h4>
-        <a href="https://github.com/sebastian-software/palamedes/tree/main/adr">Architecture decisions</a>
-        <a href="https://github.com/sebastian-software/palamedes/blob/main/docs/stability.md">Stability &amp; versioning</a>
-        <a href="https://github.com/sebastian-software/palamedes/blob/main/CHANGELOG.md">Changelog</a>
-        <a href="https://github.com/sebastian-software/palamedes/blob/main/SECURITY.md">Security</a>
-        <a href="https://github.com/sebastian-software/palamedes/blob/main/LICENSE">MIT license</a>
-      </div>
-      <div class="foot-col">
-        <h4>Company</h4>
-        <a href="https://oss.sebastian-software.com/">Sebastian Software</a>
-        <a href="https://sebastian-software.de/werner">Sebastian Werner</a>
-        <a href="#/" onclick="return false" title="Blog not part of this draft">Blog</a>
-      </div>
-    </div>
-    <div class="legal">MIT © 2026 Sebastian Software GmbH — built in the open, verified in CI.</div>
-  </footer>
+        function route(first) {
+          var h = location.hash.replace(/^#/, "")
+          if (h === "") h = "/"
+          if (!(h in VIEWS)) {
+            // Unknown hash (e.g. in-page anchors like #install): keep current view.
+            if (!first) return
+            h = "/"
+          }
+          current = h
+          var views = document.querySelectorAll("[data-view]")
+          for (var i = 0; i < views.length; i++) {
+            views[i].hidden = views[i].id !== VIEWS[h]
+          }
+          var links = document.querySelectorAll("[data-nav]")
+          for (var j = 0; j < links.length; j++) {
+            links[j].classList.toggle("active", links[j].getAttribute("data-nav") === h)
+          }
+          if (!first) window.scrollTo(0, 0)
+        }
 
-</div><!-- /frame -->
+        window.addEventListener("hashchange", function () {
+          route(false)
+        })
+        route(true)
+      })()
 
-<script>
-/* ------------------------------------------------------------ hash router -- */
-(function () {
-  var VIEWS = {
-    "/": "view-home",
-    "/frameworks": "view-frameworks",
-    "/proof": "view-proof",
-    "/get-started": "view-get-started"
-  };
-  var current = "/";
-
-  function route(first) {
-    var h = location.hash.replace(/^#/, "");
-    if (h === "") h = "/";
-    if (!(h in VIEWS)) {
-      // Unknown hash (e.g. in-page anchors like #install): keep current view.
-      if (!first) return;
-      h = "/";
-    }
-    current = h;
-    var views = document.querySelectorAll("[data-view]");
-    for (var i = 0; i < views.length; i++) {
-      views[i].hidden = views[i].id !== VIEWS[h];
-    }
-    var links = document.querySelectorAll("[data-nav]");
-    for (var j = 0; j < links.length; j++) {
-      links[j].classList.toggle("active", links[j].getAttribute("data-nav") === h);
-    }
-    if (!first) window.scrollTo(0, 0);
-  }
-
-  window.addEventListener("hashchange", function () { route(false); });
-  route(true);
-})();
-
-/* ----------------------------------------------------- code-showcase tabs -- */
-(function () {
-  var groups = document.querySelectorAll("[data-tabs]");
-  for (var g = 0; g < groups.length; g++) {
-    (function (group) {
-      var btns = group.querySelectorAll("[data-tab]");
-      var panes = group.querySelectorAll("[data-pane]");
-      for (var i = 0; i < btns.length; i++) {
-        (function (btn) {
-          btn.addEventListener("click", function () {
-            for (var k = 0; k < btns.length; k++) {
-              btns[k].classList.toggle("active", btns[k] === btn);
+      /* ----------------------------------------------------- code-showcase tabs -- */
+      ;(function () {
+        var groups = document.querySelectorAll("[data-tabs]")
+        for (var g = 0; g < groups.length; g++) {
+          ;(function (group) {
+            var btns = group.querySelectorAll("[data-tab]")
+            var panes = group.querySelectorAll("[data-pane]")
+            for (var i = 0; i < btns.length; i++) {
+              ;(function (btn) {
+                btn.addEventListener("click", function () {
+                  for (var k = 0; k < btns.length; k++) {
+                    btns[k].classList.toggle("active", btns[k] === btn)
+                  }
+                  for (var p = 0; p < panes.length; p++) {
+                    panes[p].hidden =
+                      panes[p].getAttribute("data-pane") !== btn.getAttribute("data-tab")
+                  }
+                })
+              })(btns[i])
             }
-            for (var p = 0; p < panes.length; p++) {
-              panes[p].hidden = panes[p].getAttribute("data-pane") !== btn.getAttribute("data-tab");
-            }
-          });
-        })(btns[i]);
-      }
-    })(groups[g]);
-  }
-})();
+          })(groups[g])
+        }
+      })()
 
-/* -------------------------------------------- framework matrix (5 × 4) ----
+      /* -------------------------------------------- framework matrix (5 × 4) ----
    Mirrors FRAMEWORK_MATRIX_CELLS in components.jsx: explicit per-cell links
    and status, never a generated URL pattern presented as such. Cookie/route
    are live; subdomain/tld are provisioning (#306) and link source only.   -- */
-(function () {
-  var GH_TREE = "https://github.com/sebastian-software/palamedes/tree/main/";
-  var FRAMEWORKS = [
-    { name: "Next.js", slug: "nextjs" },
-    { name: "TanStack Start", slug: "tanstack" },
-    { name: "SolidStart", slug: "solidstart" },
-    { name: "Waku", slug: "waku" },
-    { name: "React Router", slug: "react-router" }
-  ];
-  var STRATEGIES = [
-    { slug: "cookie", short: "Cookie", long: "Cookie" },
-    { slug: "route", short: "Route", long: "Route segment" },
-    { slug: "subdomain", short: "Subdomain", long: "Subdomain" },
-    { slug: "tld", short: "TLD", long: "Top-level domain" }
-  ];
+      ;(function () {
+        var GH_TREE = "https://github.com/sebastian-software/palamedes/tree/main/"
+        var FRAMEWORKS = [
+          { name: "Next.js", slug: "nextjs" },
+          { name: "TanStack Start", slug: "tanstack" },
+          { name: "SolidStart", slug: "solidstart" },
+          { name: "Waku", slug: "waku" },
+          { name: "React Router", slug: "react-router" },
+        ]
+        var STRATEGIES = [
+          { slug: "cookie", short: "Cookie", long: "Cookie" },
+          { slug: "route", short: "Route", long: "Route segment" },
+          { slug: "subdomain", short: "Subdomain", long: "Subdomain" },
+          { slug: "tld", short: "TLD", long: "Top-level domain" },
+        ]
 
-  function cellHtml(fw, strategy) {
-    var src = GH_TREE + "examples/" + fw.slug + "-" + strategy.slug;
-    var html = "";
-    if (strategy.slug === "cookie") {
-      html += '<span class="st live">●</span><span class="vf">✓ verified</span>';
-      html += '<span class="cell-links"><a href="https://' + fw.slug + '-cookie.examples.palamedes.dev">open</a>';
-      html += ' <span class="sep">|</span> <a href="' + src + '">source</a></span>';
-    } else if (strategy.slug === "route") {
-      html += '<span class="st live">●</span><span class="vf">✓ verified</span>';
-      var locales = ["en", "de", "es"];
-      var links = [];
-      for (var i = 0; i < locales.length; i++) {
-        links.push('<a href="https://' + fw.slug + '-route.examples.palamedes.dev/' + locales[i] + '">' + locales[i] + "</a>");
-      }
-      html += '<span class="cell-links">' + links.join(" ") + ' <span class="sep">|</span> <a href="' + src + '">source</a></span>';
-    } else {
-      html += '<span class="st prov">◌</span><span class="vf">✓ verified</span>';
-      html += '<span class="cell-links"><span class="prov-label">provisioning</span> <span class="sep">|</span> <a href="' + src + '">source</a></span>';
-    }
-    return html;
-  }
+        function cellHtml(fw, strategy) {
+          var src = GH_TREE + "examples/" + fw.slug + "-" + strategy.slug
+          var html = ""
+          if (strategy.slug === "cookie") {
+            html += '<span class="st live">●</span><span class="vf">✓ verified</span>'
+            html +=
+              '<span class="cell-links"><a href="https://' +
+              fw.slug +
+              '-cookie.examples.palamedes.dev">open</a>'
+            html += ' <span class="sep">|</span> <a href="' + src + '">source</a></span>'
+          } else if (strategy.slug === "route") {
+            html += '<span class="st live">●</span><span class="vf">✓ verified</span>'
+            var locales = ["en", "de", "es"]
+            var links = []
+            for (var i = 0; i < locales.length; i++) {
+              links.push(
+                '<a href="https://' +
+                  fw.slug +
+                  "-route.examples.palamedes.dev/" +
+                  locales[i] +
+                  '">' +
+                  locales[i] +
+                  "</a>"
+              )
+            }
+            html +=
+              '<span class="cell-links">' +
+              links.join(" ") +
+              ' <span class="sep">|</span> <a href="' +
+              src +
+              '">source</a></span>'
+          } else {
+            html += '<span class="st prov">◌</span><span class="vf">✓ verified</span>'
+            html +=
+              '<span class="cell-links"><span class="prov-label">provisioning</span> <span class="sep">|</span> <a href="' +
+              src +
+              '">source</a></span>'
+          }
+          return html
+        }
 
-  function buildMatrix(table) {
-    var longNames = table.hasAttribute("data-longnames");
-    var html = "<thead><tr><th>Framework <span class=\"mono\">5 × 4 = 20 apps</span></th>";
-    for (var s = 0; s < STRATEGIES.length; s++) {
-      var st = STRATEGIES[s];
-      html += "<th>" + (longNames ? st.long : st.short) + ' <span class="mono">' + st.slug + "</span></th>";
-    }
-    html += "</tr></thead><tbody>";
-    for (var f = 0; f < FRAMEWORKS.length; f++) {
-      var fw = FRAMEWORKS[f];
-      html += '<tr><td><span class="fw-name">' + fw.name + '</span><span class="fw-slug">' + fw.slug + "</span></td>";
-      for (var c = 0; c < STRATEGIES.length; c++) {
-        html += "<td>" + cellHtml(fw, STRATEGIES[c]) + "</td>";
-      }
-      html += "</tr>";
-    }
-    html += "</tbody>";
-    table.innerHTML = html;
-  }
+        function buildMatrix(table) {
+          var longNames = table.hasAttribute("data-longnames")
+          var html = '<thead><tr><th>Framework <span class="mono">5 × 4 = 20 apps</span></th>'
+          for (var s = 0; s < STRATEGIES.length; s++) {
+            var st = STRATEGIES[s]
+            html +=
+              "<th>" +
+              (longNames ? st.long : st.short) +
+              ' <span class="mono">' +
+              st.slug +
+              "</span></th>"
+          }
+          html += "</tr></thead><tbody>"
+          for (var f = 0; f < FRAMEWORKS.length; f++) {
+            var fw = FRAMEWORKS[f]
+            html +=
+              '<tr><td><span class="fw-name">' +
+              fw.name +
+              '</span><span class="fw-slug">' +
+              fw.slug +
+              "</span></td>"
+            for (var c = 0; c < STRATEGIES.length; c++) {
+              html += "<td>" + cellHtml(fw, STRATEGIES[c]) + "</td>"
+            }
+            html += "</tr>"
+          }
+          html += "</tbody>"
+          table.innerHTML = html
+        }
 
-  var tables = document.querySelectorAll("table.home-matrix, table.fw-matrix");
-  for (var t = 0; t < tables.length; t++) buildMatrix(tables[t]);
+        var tables = document.querySelectorAll("table.home-matrix, table.fw-matrix")
+        for (var t = 0; t < tables.length; t++) buildMatrix(tables[t])
 
-  /* -------------------------------------------- per-framework panels ---- */
-  var PANELS = [
-    {
-      name: "Next.js", slug: "nextjs",
-      body: "App Router with server components and server actions. The @palamedes/next-plugin wires the transform into the Next build; everything else is the shared model."
-    },
-    {
-      name: "TanStack Start", slug: "tanstack",
-      body: "Server functions and file-based routing, integrated through @palamedes/vite-plugin. Locale resolution runs in a server function; the client stays island-light."
-    },
-    {
-      name: "SolidStart", slug: "solidstart",
-      body: "Fine-grained reactivity with @palamedes/solid — the same macro authoring and catalogs as React, no fork of your i18n strategy for a different renderer."
-    },
-    {
-      name: "Waku", slug: "waku",
-      body: "Minimal RSC framework. If the model holds here, it holds in your custom setup too — that's why Waku is in the matrix."
-    },
-    {
-      name: "React Router", slug: "react-router",
-      body: "Framework-mode React Router with loaders and actions. The classic SPA-plus-SSR shape, same catalogs, same runtime."
-    }
-  ];
+        /* -------------------------------------------- per-framework panels ---- */
+        var PANELS = [
+          {
+            name: "Next.js",
+            slug: "nextjs",
+            body: "App Router with server components and server actions. The @palamedes/next-plugin wires the transform into the Next build; everything else is the shared model.",
+          },
+          {
+            name: "TanStack Start",
+            slug: "tanstack",
+            body: "Server functions and file-based routing, integrated through @palamedes/vite-plugin. Locale resolution runs in a server function; the client stays island-light.",
+          },
+          {
+            name: "SolidStart",
+            slug: "solidstart",
+            body: "Fine-grained reactivity with @palamedes/solid — the same macro authoring and catalogs as React, no fork of your i18n strategy for a different renderer.",
+          },
+          {
+            name: "Waku",
+            slug: "waku",
+            body: "Minimal RSC framework. If the model holds here, it holds in your custom setup too — that's why Waku is in the matrix.",
+          },
+          {
+            name: "React Router",
+            slug: "react-router",
+            body: "Framework-mode React Router with loaders and actions. The classic SPA-plus-SSR shape, same catalogs, same runtime.",
+          },
+        ]
 
-  var mount = document.getElementById("fw-panels");
-  if (mount) {
-    var out = "";
-    for (var p = 0; p < PANELS.length; p++) {
-      var pf = PANELS[p];
-      out += '<div class="fw-panel">';
-      out += "<h3>" + pf.name + '<span class="mono">examples/' + pf.slug + '-*</span></h3>';
-      out += "<div><p>" + pf.body + "</p>";
-      out += '<div class="fw-demos">';
-      out += '<span><span class="st live">●</span><a href="https://' + pf.slug + '-cookie.examples.palamedes.dev">cookie</a></span>';
-      out += '<span><span class="st live">●</span><a href="https://' + pf.slug + '-route.examples.palamedes.dev/en">route</a></span>';
-      out += '<span><span class="st prov">◌</span><span class="prov-label">subdomain · </span><a href="' + GH_TREE + "examples/" + pf.slug + '-subdomain">source</a></span>';
-      out += '<span><span class="st prov">◌</span><span class="prov-label">tld · </span><a href="' + GH_TREE + "examples/" + pf.slug + '-tld">source</a></span>';
-      out += '<span><a href="' + GH_TREE + "examples/" + pf.slug + '-route">all source →</a></span>';
-      out += "</div></div></div>";
-    }
-    mount.innerHTML = out;
-  }
-})();
-</script>
-
-</body>
+        var mount = document.getElementById("fw-panels")
+        if (mount) {
+          var out = ""
+          for (var p = 0; p < PANELS.length; p++) {
+            var pf = PANELS[p]
+            out += '<div class="fw-panel">'
+            out += "<h3>" + pf.name + '<span class="mono">examples/' + pf.slug + "-*</span></h3>"
+            out += "<div><p>" + pf.body + "</p>"
+            out += '<div class="fw-demos">'
+            out +=
+              '<span><span class="st live">●</span><a href="https://' +
+              pf.slug +
+              '-cookie.examples.palamedes.dev">cookie</a></span>'
+            out +=
+              '<span><span class="st live">●</span><a href="https://' +
+              pf.slug +
+              '-route.examples.palamedes.dev/en">route</a></span>'
+            out +=
+              '<span><span class="st prov">◌</span><span class="prov-label">subdomain · </span><a href="' +
+              GH_TREE +
+              "examples/" +
+              pf.slug +
+              '-subdomain">source</a></span>'
+            out +=
+              '<span><span class="st prov">◌</span><span class="prov-label">tld · </span><a href="' +
+              GH_TREE +
+              "examples/" +
+              pf.slug +
+              '-tld">source</a></span>'
+            out +=
+              '<span><a href="' +
+              GH_TREE +
+              "examples/" +
+              pf.slug +
+              '-route">all source →</a></span>'
+            out += "</div></div></div>"
+          }
+          mount.innerHTML = out
+        }
+      })()
+    </script>
+  </body>
 </html>

--- a/docs/site/structure/drafts/design-a-spec-grid.html
+++ b/docs/site/structure/drafts/design-a-spec-grid.html
@@ -1,0 +1,1450 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Palamedes — Design draft A — Spec Grid</title>
+<style>
+/* ============================================================
+   DESIGN A — SWISS SPEC GRID
+   bg #fbfbf8 · ink #101010 · hairline #d8d8d2 · accent #0038ff
+   Zero radius, zero shadows, zero gradients. 8px base scale.
+   ============================================================ */
+
+:root {
+  --bg: #fbfbf8;
+  --ink: #101010;
+  --hair: #d8d8d2;
+  --accent: #0038ff;
+  --gray: #8a8a84;
+  --mono: ui-monospace, "SF Mono", "SFMono-Regular", Menlo, Consolas, "Liberation Mono", monospace;
+  --sans: "Helvetica Neue", Helvetica, Arial, Inter, sans-serif;
+}
+
+* { margin: 0; padding: 0; box-sizing: border-box; }
+
+html { background: var(--bg); }
+
+body {
+  font-family: var(--sans);
+  color: var(--ink);
+  background: var(--bg);
+  font-size: 16px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+}
+
+a { color: var(--accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+.mono { font-family: var(--mono); font-variant-numeric: tabular-nums; }
+
+/* ---------------------------------------------------- frame + hairlines -- */
+
+.frame {
+  max-width: 1120px;
+  margin: 0 auto;
+  border-left: 1px solid var(--hair);
+  border-right: 1px solid var(--hair);
+  min-height: 100vh;
+  background: var(--bg);
+}
+
+.sec { border-top: 1px solid var(--hair); padding: 56px 32px 64px; }
+.sec-head { display: flex; align-items: baseline; gap: 24px; margin-bottom: 32px; flex-wrap: wrap; }
+
+.sec-mark {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--gray);
+  white-space: nowrap;
+}
+
+.eyebrow {
+  font-size: 11px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--ink);
+  margin-bottom: 24px;
+}
+.eyebrow::before { content: "§ "; color: var(--accent); }
+
+h2 {
+  font-size: clamp(24px, 3.4vw, 34px);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1.15;
+  max-width: 22em;
+}
+
+.lede { max-width: 44em; margin-top: 16px; font-size: 16px; }
+
+.micro {
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--gray);
+}
+
+/* --------------------------------------------------------------- ribbon -- */
+
+.ribbon {
+  position: fixed;
+  left: 0;
+  bottom: 0;
+  z-index: 100;
+  background: var(--ink);
+  color: var(--bg);
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  padding: 6px 12px;
+  border-top: 1px solid var(--ink);
+  border-right: 1px solid var(--ink);
+}
+.ribbon b { color: #9db2ff; font-weight: 400; }
+
+/* ------------------------------------------------------------------ nav -- */
+
+nav.site {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  background: var(--bg);
+  border-bottom: 1px solid var(--hair);
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  padding: 0 32px;
+  min-height: 56px;
+  flex-wrap: wrap;
+}
+
+.wordmark {
+  font-weight: 700;
+  font-size: 17px;
+  letter-spacing: -0.02em;
+  color: var(--ink);
+}
+.wordmark:hover { text-decoration: none; }
+
+.nav-links { display: flex; gap: 20px; flex-wrap: wrap; flex: 1; }
+.nav-links a {
+  color: var(--ink);
+  font-size: 12px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  padding: 4px 0;
+  border-bottom: 2px solid transparent;
+}
+.nav-links a:hover { text-decoration: none; border-bottom-color: var(--hair); }
+.nav-links a.active { color: var(--accent); border-bottom-color: var(--accent); }
+.nav-links a.dead { color: var(--gray); cursor: default; }
+.nav-links a.dead:hover { border-bottom-color: transparent; }
+
+.nav-actions { display: flex; gap: 12px; align-items: center; }
+
+/* -------------------------------------------------------------- buttons -- */
+
+.btn {
+  display: inline-block;
+  border: 1px solid var(--ink);
+  color: var(--ink);
+  background: transparent;
+  padding: 12px 22px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  font-family: var(--sans);
+  cursor: pointer;
+}
+.btn:hover { text-decoration: none; background: var(--ink); color: var(--bg); }
+.btn.primary { background: var(--accent); border-color: var(--accent); color: #fff; }
+.btn.primary:hover { background: var(--ink); border-color: var(--ink); }
+.btn.small { padding: 8px 14px; font-size: 10px; }
+
+/* ----------------------------------------------------------------- hero -- */
+
+.hero { padding: 72px 32px 64px; }
+.hero-grid { display: grid; grid-template-columns: minmax(0, 7fr) minmax(0, 5fr); gap: 48px; align-items: start; }
+
+h1.display {
+  font-size: clamp(44px, 7.6vw, 88px);
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  line-height: 0.98;
+  margin: 0 0 28px;
+}
+
+.subline { font-size: 16px; max-width: 38em; color: var(--ink); }
+.subline .mono { font-size: 15px; }
+
+.hero-ctas { display: flex; gap: 12px; margin-top: 32px; flex-wrap: wrap; }
+
+/* -------------------------------------------------- booking-card visual -- */
+
+.locale-stack { display: grid; gap: 1px; background: var(--hair); border: 1px solid var(--hair); }
+
+.bcard { background: var(--bg); padding: 16px 18px; }
+.bcard-loc {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 8px;
+}
+.bcard-title { font-size: 17px; font-weight: 700; letter-spacing: -0.01em; }
+.bcard-row { display: flex; justify-content: space-between; align-items: baseline; gap: 12px; margin-top: 6px; flex-wrap: wrap; }
+.bcard-seats { font-size: 12.5px; border: 1px solid var(--hair); padding: 2px 8px; }
+.bcard-price { font-family: var(--mono); font-variant-numeric: tabular-nums; font-size: 15px; font-weight: 500; }
+.bcard-date { font-family: var(--mono); font-variant-numeric: tabular-nums; font-size: 12px; color: var(--gray); margin-top: 6px; }
+.locale-caption { border: 1px solid var(--hair); border-top: 0; padding: 10px 18px; font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--gray); }
+
+/* ------------------------------------------------------------ proofstrip -- */
+
+.proofstrip {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1px;
+  background: var(--hair);
+  border-top: 1px solid var(--hair);
+}
+.proofstrip a {
+  background: var(--bg);
+  padding: 24px 32px;
+  color: var(--ink);
+  display: block;
+}
+.proofstrip a:hover { text-decoration: none; background: #f2f2ec; }
+.stat-val {
+  font-family: var(--mono);
+  font-variant-numeric: tabular-nums;
+  font-size: 34px;
+  font-weight: 500;
+  letter-spacing: -0.02em;
+  color: var(--accent);
+  display: block;
+}
+.stat-label { display: block; font-size: 12px; margin-top: 6px; max-width: 22em; }
+
+/* --------------------------------------------------------- feature grid -- */
+
+.grid { display: grid; gap: 1px; background: var(--hair); border: 1px solid var(--hair); margin-top: 32px; }
+.grid.cols-3 { grid-template-columns: repeat(3, 1fr); }
+.grid.cols-4 { grid-template-columns: repeat(4, 1fr); }
+.grid.cols-2 { grid-template-columns: repeat(2, 1fr); }
+.cell { background: var(--bg); padding: 24px; }
+.cell h3 { font-size: 15px; font-weight: 700; letter-spacing: -0.01em; margin-bottom: 8px; }
+.cell p { font-size: 13.5px; }
+.cell .cell-num { font-family: var(--mono); font-size: 10px; letter-spacing: 0.18em; color: var(--gray); display: block; margin-bottom: 12px; text-transform: uppercase; }
+.cell a.more { display: inline-block; margin-top: 12px; font-size: 12px; letter-spacing: 0.08em; text-transform: uppercase; }
+
+/* ------------------------------------------------------------ code area -- */
+
+.tabs { display: flex; gap: 0; border: 1px solid var(--hair); border-bottom: 0; width: max-content; max-width: 100%; }
+.tabs button {
+  font-family: var(--sans);
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  background: var(--bg);
+  border: 0;
+  border-right: 1px solid var(--hair);
+  padding: 10px 18px;
+  cursor: pointer;
+  color: var(--ink);
+}
+.tabs button:last-child { border-right: 0; }
+.tabs button.active { background: var(--ink); color: var(--bg); }
+.tabs button[disabled] { color: var(--gray); cursor: not-allowed; }
+
+pre.code {
+  background: var(--ink);
+  color: var(--bg);
+  font-family: var(--mono);
+  font-size: 12.5px;
+  line-height: 1.7;
+  padding: 20px 24px;
+  overflow-x: auto;
+  border: 1px solid var(--ink);
+}
+pre.code .cm { color: #8a8a84; }
+pre.code .kw { color: #9db2ff; }
+
+.pane-caption { font-size: 12px; color: var(--gray); padding: 8px 2px; border-bottom: 1px solid var(--hair); }
+
+.result-panel { border: 1px solid var(--hair); border-top: 0; padding: 16px 24px; display: flex; gap: 16px; align-items: baseline; flex-wrap: wrap; }
+.result-panel .micro { color: var(--accent); }
+
+/* ----------------------------------------------------------- spec table -- */
+
+.table-scroll { overflow-x: auto; border: 1px solid var(--hair); margin-top: 32px; }
+table.spec { border-collapse: collapse; width: 100%; min-width: 720px; }
+table.spec th, table.spec td {
+  border: 1px solid var(--hair);
+  padding: 12px 14px;
+  text-align: left;
+  vertical-align: top;
+  font-size: 12.5px;
+  background: var(--bg);
+}
+table.spec th {
+  font-size: 10.5px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: var(--ink);
+}
+table.spec th .mono { color: var(--gray); font-size: 10px; display: block; margin-top: 2px; letter-spacing: 0.08em; text-transform: none; }
+table.spec td .fw-name { font-weight: 700; font-size: 13.5px; white-space: nowrap; }
+table.spec td .fw-slug { font-family: var(--mono); font-size: 10.5px; color: var(--gray); display: block; }
+
+.st { font-size: 13px; margin-right: 6px; }
+.st.live { color: var(--accent); }
+.st.prov { color: var(--gray); }
+.vf { font-family: var(--mono); font-size: 10px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--ink); }
+.cell-links { display: block; margin-top: 6px; font-family: var(--mono); font-size: 11.5px; }
+.cell-links .sep { color: var(--hair); }
+.prov-label { color: var(--gray); font-family: var(--mono); font-size: 11.5px; }
+
+.legend { display: flex; gap: 24px; flex-wrap: wrap; margin-top: 12px; font-size: 11.5px; color: var(--gray); }
+.legend span b { font-weight: 400; }
+.caption { font-size: 12.5px; color: var(--gray); margin-top: 16px; max-width: 52em; }
+
+/* ------------------------------------------------------- benchmark bars -- */
+
+.bench { border: 1px solid var(--hair); margin-top: 32px; }
+.bench-title {
+  border-bottom: 1px solid var(--hair);
+  padding: 12px 16px;
+  font-size: 11px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  font-weight: 600;
+}
+.bench-row {
+  display: grid;
+  grid-template-columns: minmax(120px, 170px) 1fr minmax(90px, 110px);
+  gap: 16px;
+  align-items: center;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--hair);
+}
+.bench-row:last-of-type { border-bottom: 0; }
+.bench-tool { font-size: 13px; font-weight: 600; }
+.bench-track { background: #efefe9; border: 1px solid var(--hair); height: 18px; position: relative; }
+.bench-bar { display: block; height: 100%; background: var(--gray); animation: grow 0.9s ease-out; transform-origin: left; }
+.bench-bar.accent { background: var(--accent); }
+.bench-val { font-family: var(--mono); font-variant-numeric: tabular-nums; font-size: 12.5px; text-align: right; white-space: nowrap; }
+.bench-note { border-top: 1px solid var(--hair); padding: 10px 16px; font-size: 11.5px; color: var(--gray); }
+.bench-note a { font-family: var(--mono); font-size: 11px; }
+
+@keyframes grow { from { transform: scaleX(0); } to { transform: scaleX(1); } }
+
+/* --------------------------------------------------------------- callout -- */
+
+.callout {
+  border: 1px solid var(--hair);
+  border-left: 4px solid var(--accent);
+  padding: 16px 20px;
+  font-size: 13.5px;
+  max-width: 56em;
+  margin-top: 32px;
+  background: var(--bg);
+}
+.callout .micro { display: block; margin-bottom: 6px; color: var(--accent); }
+.callout code, .aside code, p code {
+  font-family: var(--mono);
+  font-size: 12px;
+  background: #efefe9;
+  border: 1px solid var(--hair);
+  padding: 1px 5px;
+}
+
+/* --------------------------------------------------------- statement band -- */
+
+.band {
+  border-top: 1px solid var(--hair);
+  padding: 72px 32px;
+  background: var(--ink);
+  color: var(--bg);
+}
+.band p {
+  font-size: clamp(20px, 3vw, 30px);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1.25;
+  max-width: 32em;
+}
+.band .mark { color: #9db2ff; }
+
+/* -------------------------------------------------------------- stepflow -- */
+
+.steps { border: 1px solid var(--hair); margin-top: 32px; }
+.step { display: grid; grid-template-columns: 64px 1fr; border-bottom: 1px solid var(--hair); }
+.step:last-child { border-bottom: 0; }
+.step-num {
+  border-right: 1px solid var(--hair);
+  font-family: var(--mono);
+  font-size: 15px;
+  color: var(--accent);
+  padding: 20px 0;
+  text-align: center;
+}
+.step-body { padding: 20px 24px; min-width: 0; }
+.step-body h3 { font-size: 16px; font-weight: 700; letter-spacing: -0.01em; margin-bottom: 6px; }
+.step-body p { font-size: 13.5px; max-width: 46em; }
+.step-body pre.code { margin-top: 14px; }
+.aside {
+  border: 1px solid var(--hair);
+  border-left: 4px solid var(--gray);
+  padding: 10px 14px;
+  font-size: 12.5px;
+  color: var(--ink);
+  margin-top: 14px;
+  max-width: 46em;
+}
+.aside .micro { display: block; margin-bottom: 4px; }
+
+/* -------------------------------------------------------- framework panel -- */
+
+.fw-panel { border: 1px solid var(--hair); border-bottom: 0; padding: 20px 24px; display: grid; grid-template-columns: 180px 1fr; gap: 24px; }
+.fw-panel:last-of-type { border-bottom: 1px solid var(--hair); }
+.fw-panel h3 { font-size: 16px; font-weight: 700; }
+.fw-panel h3 .mono { display: block; font-size: 10.5px; color: var(--gray); font-weight: 400; margin-top: 2px; }
+.fw-panel p { font-size: 13.5px; max-width: 46em; }
+.fw-demos { margin-top: 10px; font-family: var(--mono); font-size: 11.5px; display: flex; gap: 14px; flex-wrap: wrap; }
+.fw-demos .prov-label { font-size: 11.5px; }
+
+/* -------------------------------------------------------------- CTA band -- */
+
+.ctaband { border-top: 1px solid var(--hair); padding: 64px 32px; text-align: left; }
+.ctaband h2 { margin-bottom: 24px; }
+.ctaband .hero-ctas { margin-top: 0; }
+
+/* ---------------------------------------------------------------- footer -- */
+
+footer.site { border-top: 1px solid var(--hair); }
+.foot-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 1px; background: var(--hair); }
+.foot-col { background: var(--bg); padding: 32px; }
+.foot-col h4 { font-size: 10.5px; letter-spacing: 0.18em; text-transform: uppercase; margin-bottom: 14px; color: var(--gray); font-weight: 600; }
+.foot-col a { display: block; color: var(--ink); font-size: 13px; padding: 3px 0; }
+.foot-col a:hover { color: var(--accent); }
+.legal {
+  border-top: 1px solid var(--hair);
+  padding: 20px 32px 40px;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  color: var(--gray);
+}
+
+/* ------------------------------------------------------------- stack pick -- */
+
+.stackpick { display: flex; align-items: center; gap: 16px; flex-wrap: wrap; padding: 24px 32px 0; }
+.stackpick .micro { white-space: nowrap; }
+
+/* ------------------------------------------------------------- screenshot -- */
+
+.shot { border: 1px solid var(--hair); margin-top: 32px; max-width: 860px; }
+.shot-chrome { border-bottom: 1px solid var(--hair); padding: 8px 14px; display: flex; gap: 8px; align-items: center; }
+.shot-chrome i { width: 8px; height: 8px; background: var(--hair); display: inline-block; }
+.shot-chrome .mono { font-size: 10.5px; color: var(--gray); }
+.shot-body { padding: 24px; display: grid; grid-template-columns: repeat(3, 1fr); gap: 1px; background: var(--hair); border: 1px solid var(--hair); margin: 16px; }
+.shot-cap { border-top: 1px solid var(--hair); padding: 10px 16px; font-size: 12px; color: var(--gray); }
+
+/* ------------------------------------------------------------- link lists -- */
+
+.linklist { margin-top: 24px; display: flex; flex-direction: column; gap: 6px; }
+.linklist a { font-size: 13.5px; width: max-content; max-width: 100%; }
+.linklist a::before { content: "→ "; font-family: var(--mono); }
+
+/* --------------------------------------------------------------- utility -- */
+
+[hidden] { display: none !important; }
+.mt-32 { margin-top: 32px; }
+.two-col { display: grid; grid-template-columns: 1fr 1fr; gap: 48px; align-items: start; margin-top: 0; }
+
+/* ------------------------------------------------------------- responsive -- */
+
+@media (max-width: 960px) {
+  .hero-grid, .two-col { grid-template-columns: 1fr; }
+  .proofstrip, .grid.cols-3, .grid.cols-4 { grid-template-columns: repeat(2, 1fr); }
+  .fw-panel { grid-template-columns: 1fr; gap: 8px; }
+}
+
+@media (max-width: 560px) {
+  .hero { padding: 48px 20px; }
+  .sec, .ctaband { padding-left: 20px; padding-right: 20px; }
+  nav.site { padding: 8px 20px; }
+  .band { padding: 48px 20px; }
+  .proofstrip, .grid.cols-3, .grid.cols-4 { grid-template-columns: 1fr; }
+  .proofstrip a { padding: 20px; }
+  .foot-grid { grid-template-columns: 1fr; }
+  .bench-row { grid-template-columns: 1fr; gap: 6px; }
+  .bench-val { text-align: left; }
+  .shot-body { grid-template-columns: 1fr; }
+  .legal { padding-left: 20px; padding-right: 20px; }
+  .step { grid-template-columns: 44px 1fr; }
+  .step-body { padding: 16px; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after { animation: none !important; transition: none !important; }
+}
+</style>
+</head>
+<body>
+
+<div class="ribbon">Design draft A — <b>Spec Grid</b> · not final</div>
+
+<div class="frame">
+
+  <!-- ================================================================ NAV -->
+  <nav class="site">
+    <a class="wordmark" href="#/">Palamedes</a>
+    <div class="nav-links">
+      <a href="#/frameworks" data-nav="/frameworks">Frameworks</a>
+      <a href="#/proof" data-nav="/proof">Proof</a>
+      <a class="dead" href="#/" onclick="return false" title="Not part of this draft">Compare</a>
+      <a class="dead" href="#/" onclick="return false" title="Not part of this draft">Blog</a>
+      <a href="https://github.com/sebastian-software/palamedes/tree/main/docs">Docs</a>
+    </div>
+    <div class="nav-actions">
+      <a class="btn small" href="https://github.com/sebastian-software/palamedes">GitHub ★</a>
+      <a class="btn small primary" href="#/get-started" data-nav="/get-started">Get started</a>
+    </div>
+  </nav>
+
+  <!-- =========================================================== HOME view -->
+  <main id="view-home" data-view>
+
+    <header class="hero">
+      <div class="hero-grid">
+        <div>
+          <p class="eyebrow">Open-source i18n tooling for JavaScript &amp; TypeScript</p>
+          <h1 class="display">One translation model. Every&nbsp;framework.</h1>
+          <p class="subline">Write messages where your UI happens. Keep source-string-first
+            <code>.po</code> catalogs your translators can actually read. Ship the same
+            runtime model across Next.js, TanStack Start, SolidStart, Waku, and
+            React Router — with a Rust core that ran the checked small-corpus extract/update benchmark 19.6× faster than Lingui on the recorded machine-local run.</p>
+          <div class="hero-ctas">
+            <a class="btn primary" href="#/get-started">Get started in 5 minutes</a>
+            <a class="btn" href="https://nextjs-cookie.examples.palamedes.dev">See it live</a>
+          </div>
+        </div>
+        <div>
+          <div class="locale-stack" role="img" aria-label="The same booking card rendered in English, German, and Spanish">
+            <div class="bcard">
+              <div class="bcard-loc">en-US</div>
+              <div class="bcard-title">Your trip to Lisbon</div>
+              <div class="bcard-row">
+                <span class="bcard-seats">3 seats left</span>
+                <span class="bcard-price">€1,234.00</span>
+              </div>
+              <div class="bcard-date">Jul 12, 2026</div>
+            </div>
+            <div class="bcard">
+              <div class="bcard-loc">de-DE</div>
+              <div class="bcard-title">Deine Reise nach Lissabon</div>
+              <div class="bcard-row">
+                <span class="bcard-seats">3 Plätze frei</span>
+                <span class="bcard-price">1.234,00&nbsp;€</span>
+              </div>
+              <div class="bcard-date">12. Juli 2026</div>
+            </div>
+            <div class="bcard">
+              <div class="bcard-loc">es-ES</div>
+              <div class="bcard-title">Tu viaje a Lisboa</div>
+              <div class="bcard-row">
+                <span class="bcard-seats">Quedan 3 asientos</span>
+                <span class="bcard-price">1234,00&nbsp;€</span>
+              </div>
+              <div class="bcard-date">12 jul 2026</div>
+            </div>
+          </div>
+          <div class="locale-caption">One component · copy, plurals, currency &amp; dates change together</div>
+        </div>
+      </div>
+    </header>
+
+    <div class="proofstrip">
+      <a href="#/frameworks">
+        <span class="stat-val">20</span>
+        <span class="stat-label">browser-verified example apps</span>
+      </a>
+      <a href="#/frameworks">
+        <span class="stat-val">5 × 4</span>
+        <span class="stat-label">frameworks × locale strategies</span>
+      </a>
+      <a href="#/proof">
+        <span class="stat-val">19.6×</span>
+        <span class="stat-label">faster than Lingui — checked extract/update benchmark, machine-local run</span>
+      </a>
+      <a href="https://github.com/sebastian-software/palamedes/tree/main/adr">
+        <span class="stat-val">16</span>
+        <span class="stat-label">ADRs documenting every tradeoff</span>
+      </a>
+    </div>
+
+    <!-- 01 — Model -->
+    <section class="sec" id="model">
+      <div class="sec-head">
+        <span class="sec-mark">01 — Model</span>
+        <h2>Your i18n setup should not splinter when your framework changes.</h2>
+      </div>
+      <p class="lede">Most teams relearn internationalization with every migration: new runtime, new message
+        IDs, new catalog quirks. Palamedes keeps the parts you touch every day stable — and lets
+        the framework be the only thing that changes.</p>
+      <div class="grid cols-3">
+        <div class="cell">
+          <span class="cell-num">01.1 / pen</span>
+          <h3>Write messages in place</h3>
+          <p>Macro-style authoring next to your JSX. No message-ID bookkeeping, no separate dictionary files to keep in sync.</p>
+          <a class="more" href="#/get-started">Get started</a>
+        </div>
+        <div class="cell">
+          <span class="cell-num">01.2 / fingerprint</span>
+          <h3>One identity model</h3>
+          <p>Messages are identified by message + context — stable across refactors, frameworks, and years of catalog history.</p>
+          <a class="more" href="https://github.com/sebastian-software/palamedes/blob/main/adr/003-source-string-first-message-identity.md">ADR-003</a>
+        </div>
+        <div class="cell">
+          <span class="cell-num">01.3 / plug</span>
+          <h3>One runtime call</h3>
+          <p>getI18n() resolves the active instance everywhere: server components, client islands, backend request handlers.</p>
+          <a class="more" href="https://github.com/sebastian-software/palamedes/blob/main/adr/005-universal-geti18n-runtime-model.md">ADR-005</a>
+        </div>
+      </div>
+    </section>
+
+    <!-- 02 — Workflow -->
+    <section class="sec" id="code">
+      <div class="sec-head">
+        <span class="sec-mark">02 — Workflow</span>
+        <h2>The whole workflow, honestly small.</h2>
+      </div>
+      <div data-tabs class="mt-32">
+        <div class="tabs" role="tablist">
+          <button data-tab="write" class="active">Write</button>
+          <button data-tab="extract">Extract</button>
+          <button data-tab="translate">Translate</button>
+        </div>
+        <div data-pane="write">
+          <pre class="code">import { t, plural } from "@palamedes/core/macro"
+import { Trans } from "@palamedes/react"
+
+export function Booking({ seats }: { seats: number }) {
+  return (
+    &lt;&gt;
+      &lt;h1&gt;{t`Your trip to Lisbon`}&lt;/h1&gt;
+      &lt;p&gt;{plural(seats, { one: "# seat left", other: "# seats left" })}&lt;/p&gt;
+      &lt;Trans&gt;Free cancellation until &lt;b&gt;24 hours&lt;/b&gt; before departure.&lt;/Trans&gt;
+    &lt;/&gt;
+  )
+}</pre>
+          <p class="pane-caption">Messages live where the UI happens.</p>
+        </div>
+        <div data-pane="extract" hidden>
+          <pre class="code">$ pmds extract
+
+  en  3 messages  (1 new)
+  de  3 messages  (1 missing translation)
+
+  done in 34 ms</pre>
+          <p class="pane-caption">One native command scans, extracts, and updates catalogs.</p>
+        </div>
+        <div data-pane="translate" hidden>
+          <pre class="code"><span class="cm">#: src/Booking.tsx:7</span>
+msgid "Your trip to Lisbon"
+msgstr "Deine Reise nach Lissabon"
+
+<span class="cm">#: src/Booking.tsx:8</span>
+msgid "{seats, plural, one {# seat left} other {# seats left}}"
+msgstr "{seats, plural, one {# Platz frei} other {# Plätze frei}}"</pre>
+          <p class="pane-caption">Source-string-first .po — readable by translators and every TMS.</p>
+        </div>
+        <div class="result-panel">
+          <span class="micro">Rendered</span>
+          <span style="font-size:13.5px">The same component, in every locale, in every framework.</span>
+        </div>
+      </div>
+    </section>
+
+    <!-- 03 — Proof -->
+    <section class="sec" id="proof-teaser">
+      <div class="sec-head">
+        <span class="sec-mark">03 — Proof</span>
+        <h2>We don't ask you to trust a slogan. The repo shows the work.</h2>
+      </div>
+      <p class="lede">Every framework/strategy combination is a real app, re-verified in CI through the same
+        Playwright flow — with public demos where the hosting is ready. Every benchmark number
+        links to a checked-in, re-runnable report.</p>
+
+      <div class="table-scroll">
+        <table class="spec home-matrix">
+          <!-- populated by buildMatrix() -->
+        </table>
+      </div>
+      <div class="legend">
+        <span><b style="color:var(--accent)">●</b> live — public demo hosted</span>
+        <span><b>◌</b> provisioning — hosting pending, verified source linked</span>
+        <span><b class="mono" style="font-size:10px">✓ VERIFIED</b> — CI browser-verified (Playwright), all 20 cells</span>
+      </div>
+
+      <div class="bench">
+        <div class="bench-title">End-to-end extract + catalog update (small corpus, median)</div>
+        <div class="bench-row">
+          <span class="bench-tool">Palamedes</span>
+          <span class="bench-track"><span class="bench-bar accent" style="width:5.1%"></span></span>
+          <span class="bench-val">33.53 ms</span>
+        </div>
+        <div class="bench-row">
+          <span class="bench-tool">i18next-parser</span>
+          <span class="bench-track"><span class="bench-bar" style="width:72.7%"></span></span>
+          <span class="bench-val">477.58 ms</span>
+        </div>
+        <div class="bench-row">
+          <span class="bench-tool">Lingui</span>
+          <span class="bench-track"><span class="bench-bar" style="width:100%"></span></span>
+          <span class="bench-val">657.00 ms</span>
+        </div>
+        <div class="bench-note">
+          Linear millisecond scale, no truncation — the Palamedes bar really is that short.
+          Machine-local numbers from the checked-in report; your hardware will differ, the ratios are the signal.
+          <a href="https://github.com/sebastian-software/palamedes/blob/main/docs/benchmark-e2e-workflow.md">Methodology →</a>
+        </div>
+      </div>
+
+      <p class="mt-32"><a class="btn" href="#/proof">All benchmarks &amp; the verification story</a></p>
+    </section>
+
+    <!-- 04 — Positioning -->
+    <div class="band">
+      <span class="sec-mark" style="color:#9db2ff; display:block; margin-bottom:24px">04 — Positioning</span>
+      <p><span class="mark">Palamedes is narrower than some alternatives on purpose:</span>
+        compile-time authoring, source-string-first catalogs, and a local
+        workflow your repo owns — with a Rust core doing the careful work.</p>
+    </div>
+
+    <!-- 05 — Maintainer -->
+    <section class="sec" id="maintainer">
+      <div class="sec-head">
+        <span class="sec-mark">05 — Maintainer</span>
+      </div>
+      <div class="two-col">
+        <h2>Built from repeat experience, not a weekend take.</h2>
+        <div>
+          <p style="font-size:14px; max-width:44em">Palamedes is maintained by Sebastian Software GmbH. It is the third generation of
+            source-string-first JavaScript i18n tooling from the same author — from gettext-style
+            macro systems in qooxdoo to a full enterprise Lingui migration at Regrello (acquired by
+            Salesforce in 2025). The lessons are written down as 16 ADRs before you depend on the
+            tool.</p>
+          <div class="linklist">
+            <a href="https://github.com/sebastian-software/palamedes/tree/main/adr">The decision trail (ADRs)</a>
+            <a href="#/" onclick="return false" title="Blog not part of this draft">Why this exists</a>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <div class="ctaband">
+      <h2>Your first working translation is 5 minutes away.</h2>
+      <div class="hero-ctas">
+        <a class="btn primary" href="#/get-started">Get started</a>
+        <a class="btn" href="https://github.com/sebastian-software/palamedes">Star on GitHub</a>
+      </div>
+    </div>
+
+  </main>
+
+  <!-- ===================================================== FRAMEWORKS view -->
+  <main id="view-frameworks" data-view hidden>
+
+    <header class="hero">
+      <p class="eyebrow">Framework matrix</p>
+      <h1 class="display">Five frameworks. Four locale strategies. One mental&nbsp;model.</h1>
+      <p class="subline">Every cell below is a real application — the same booking UI,
+        the same catalogs, the same runtime calls — browser-verified in CI.
+        Where public hosting is ready, open the demo, switch the language,
+        and watch copy, plurals, currency, and dates change together.</p>
+      <div class="hero-ctas">
+        <a class="btn primary" href="https://nextjs-cookie.examples.palamedes.dev">Open a live demo</a>
+        <a class="btn" href="https://github.com/sebastian-software/palamedes/tree/main/examples">Browse the example source</a>
+      </div>
+    </header>
+
+    <!-- 01 — Matrix -->
+    <section class="sec" id="matrix">
+      <div class="sec-head">
+        <span class="sec-mark">01 — Matrix</span>
+        <h2>The 5 × 4 verified matrix.</h2>
+      </div>
+      <div class="table-scroll" style="margin-top:0">
+        <table class="spec fw-matrix" data-longnames>
+          <!-- populated by buildMatrix() -->
+        </table>
+      </div>
+      <div class="legend">
+        <span><b style="color:var(--accent)">●</b> live — public demo hosted</span>
+        <span><b>◌</b> provisioning — hosting pending, verified source linked</span>
+        <span><b class="mono" style="font-size:10px">✓ VERIFIED</b> — CI browser-verified (Playwright), all 20 cells</span>
+      </div>
+      <p class="caption">All 20 apps are verified in CI with the same Playwright-driven browser flow: SSR output,
+        locale switching, localized server actions. Screenshots are versioned in the repo. Cookie
+        and route demos are publicly hosted today; subdomain and TLD hosting is being provisioned
+        — until then those cells link the verified source instead.</p>
+    </section>
+
+    <!-- 02 — Strategies -->
+    <section class="sec" id="strategies">
+      <div class="sec-head">
+        <span class="sec-mark">02 — Strategies</span>
+        <h2>Pick the locale strategy your product needs — not the one your framework dictates.</h2>
+      </div>
+      <div class="grid cols-4">
+        <div class="cell">
+          <span class="cell-num">02.1 / cookie</span>
+          <h3>Cookie</h3>
+          <p>One URL for all locales. Best for apps behind login where SEO is irrelevant and switching should be instant.</p>
+        </div>
+        <div class="cell">
+          <span class="cell-num">02.2 / route</span>
+          <h3>Route segment</h3>
+          <p>/de/checkout-style paths. The SEO-friendly default for public content with indexable localized pages.</p>
+        </div>
+        <div class="cell">
+          <span class="cell-num">02.3 / globe</span>
+          <h3>Subdomain</h3>
+          <p>de.example.com. Clean separation per market, works well with regional CDNs and analytics splits.</p>
+        </div>
+        <div class="cell">
+          <span class="cell-num">02.4 / flag</span>
+          <h3>Top-level domain</h3>
+          <p>example.de vs example.com. Maximum market trust; Palamedes maps each domain to its locale.</p>
+        </div>
+      </div>
+      <div class="linklist">
+        <a href="https://github.com/sebastian-software/palamedes/blob/main/docs/locale-strategies.md">Locale strategies in depth</a>
+      </div>
+    </section>
+
+    <!-- 03 — Per framework -->
+    <section class="sec" id="per-framework">
+      <div class="sec-head">
+        <span class="sec-mark">03 — Per framework</span>
+        <h2>Your stack, specifically.</h2>
+      </div>
+      <div class="mt-32" id="fw-panels">
+        <!-- populated by buildPanels() -->
+      </div>
+    </section>
+
+    <!-- 04 — Backend -->
+    <section class="sec" id="backend">
+      <div class="sec-head">
+        <span class="sec-mark">04 — Backend</span>
+        <h2>And it doesn't stop at the frontend.</h2>
+      </div>
+      <p class="lede">The same getI18n() model runs in Hono and Express with request-local locale resolution —
+        transactional emails, API error messages, and PDF generation speak the user's language
+        from the same catalogs.</p>
+      <p class="mt-32"><a class="btn" href="https://github.com/sebastian-software/palamedes/blob/main/docs/backend-servers.md">Backend servers guide</a></p>
+    </section>
+
+    <div class="ctaband">
+      <h2>See your framework speaking three languages — right now.</h2>
+      <div class="hero-ctas">
+        <a class="btn primary" href="https://nextjs-cookie.examples.palamedes.dev">Open the live matrix</a>
+        <a class="btn" href="#/get-started">Get started</a>
+      </div>
+    </div>
+
+  </main>
+
+  <!-- ========================================================== PROOF view -->
+  <main id="view-proof" data-view hidden>
+
+    <header class="hero">
+      <p class="eyebrow">Proof</p>
+      <h1 class="display">Claims you can re-run.</h1>
+      <p class="subline">Every number on this page comes from a checked-in,
+        machine-readable report with fixtures and commands in the repo.
+        If a claim can't be re-run, we don't make it.</p>
+      <div class="hero-ctas">
+        <a class="btn primary" href="https://github.com/sebastian-software/palamedes/blob/main/docs/benchmark-e2e-workflow.md">Re-run the benchmarks</a>
+        <a class="btn" href="https://github.com/sebastian-software/palamedes/tree/main/benchmarks/e2e-workflow/results">Browse checked-in reports</a>
+      </div>
+    </header>
+
+    <!-- 01 — Benchmarks -->
+    <section class="sec" id="benchmarks">
+      <div class="sec-head">
+        <span class="sec-mark">01 — Benchmarks</span>
+        <h2>The workflow you feel every day: extract &amp; update.</h2>
+      </div>
+      <p class="lede">The end-to-end benchmark measures what a developer actually waits for: scan sources,
+        extract messages, update catalogs, write files. Same generated message inventory, rendered
+        into each tool's idiomatic source shape, semantically validated after every run.</p>
+
+      <div class="bench">
+        <div class="bench-title">Small corpus — 80 files, 640 messages (median of 7 runs)</div>
+        <div class="bench-row">
+          <span class="bench-tool">Palamedes</span>
+          <span class="bench-track"><span class="bench-bar accent" style="width:5.1%"></span></span>
+          <span class="bench-val">33.53 ms</span>
+        </div>
+        <div class="bench-row">
+          <span class="bench-tool">i18next-parser 9.4</span>
+          <span class="bench-track"><span class="bench-bar" style="width:72.7%"></span></span>
+          <span class="bench-val">477.58 ms</span>
+        </div>
+        <div class="bench-row">
+          <span class="bench-tool">Lingui 6.4</span>
+          <span class="bench-track"><span class="bench-bar" style="width:100%"></span></span>
+          <span class="bench-val">657.00 ms</span>
+        </div>
+        <div class="bench-note">
+          Linear millisecond scale, no truncation — the ratios (19.59× vs Lingui, 14.24× vs i18next-parser)
+          are exactly as drawn. Machine-local run from the checked-in report.
+          <a href="https://github.com/sebastian-software/palamedes/blob/main/docs/benchmark-e2e-workflow.md">Methodology →</a>
+        </div>
+      </div>
+
+      <div class="bench">
+        <div class="bench-title">Medium corpus (median of 7 runs)</div>
+        <div class="bench-row">
+          <span class="bench-tool">Palamedes</span>
+          <span class="bench-track"><span class="bench-bar accent" style="width:6.5%"></span></span>
+          <span class="bench-val">42.92 ms</span>
+        </div>
+        <div class="bench-note">
+          Competitor medians for the medium corpus: see the checked-in report,
+          <a href="https://github.com/sebastian-software/palamedes/blob/main/benchmarks/e2e-workflow/results/latest.md">benchmarks/e2e-workflow/results/latest.md</a>.
+          Same linear scale as above. Machine-local run.
+          <a href="https://github.com/sebastian-software/palamedes/blob/main/docs/benchmark-e2e-workflow.md">Methodology →</a>
+        </div>
+      </div>
+
+      <div class="callout">
+        <span class="micro">Honest note</span>
+        These are machine-local numbers from the checked-in report, not a marketing average. Your
+        hardware will differ; the ratios are the signal. Commands to reproduce:
+        <code>pnpm benchmark:e2e-workflow</code>.
+      </div>
+    </section>
+
+    <!-- 02 — Verification -->
+    <section class="sec" id="verification">
+      <div class="sec-head">
+        <span class="sec-mark">02 — Verification</span>
+        <h2>20 apps, verified in a real browser, on every change.</h2>
+      </div>
+      <div class="steps">
+        <div class="step">
+          <div class="step-num mono">1</div>
+          <div class="step-body">
+            <h3>Build</h3>
+            <p>All 20 example apps build against the workspace packages — no mocked integrations.</p>
+          </div>
+        </div>
+        <div class="step">
+          <div class="step-num mono">2</div>
+          <div class="step-body">
+            <h3>Drive</h3>
+            <p>A Playwright flow loads each app, checks SSR output, switches locales, and exercises localized server actions.</p>
+          </div>
+        </div>
+        <div class="step">
+          <div class="step-num mono">3</div>
+          <div class="step-body">
+            <h3>Capture</h3>
+            <p>Screenshots are versioned in the repo, so 'works across frameworks' is a diffable artifact, not a slide.</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="shot">
+        <div class="shot-chrome">
+          <i></i><i></i><i></i>
+          <span class="mono">nextjs-cookie.examples.palamedes.dev — en · de · es</span>
+        </div>
+        <div class="shot-body">
+          <div class="bcard">
+            <div class="bcard-loc">en-US</div>
+            <div class="bcard-title">Your trip to Lisbon</div>
+            <div class="bcard-row">
+              <span class="bcard-seats">3 seats left</span>
+              <span class="bcard-price">€1,234.00</span>
+            </div>
+            <div class="bcard-date">Jul 12, 2026</div>
+          </div>
+          <div class="bcard">
+            <div class="bcard-loc">de-DE</div>
+            <div class="bcard-title">Deine Reise nach Lissabon</div>
+            <div class="bcard-row">
+              <span class="bcard-seats">3 Plätze frei</span>
+              <span class="bcard-price">1.234,00&nbsp;€</span>
+            </div>
+            <div class="bcard-date">12. Juli 2026</div>
+          </div>
+          <div class="bcard">
+            <div class="bcard-loc">es-ES</div>
+            <div class="bcard-title">Tu viaje a Lisboa</div>
+            <div class="bcard-row">
+              <span class="bcard-seats">Quedan 3 asientos</span>
+              <span class="bcard-price">1234,00&nbsp;€</span>
+            </div>
+            <div class="bcard-date">12 jul 2026</div>
+          </div>
+        </div>
+        <div class="shot-cap">One demo, three locales: copy, plural seat counts, currency, and dates change together.
+          <a href="https://github.com/sebastian-software/palamedes/blob/main/docs/example-screenshots/README.md">Versioned screenshots →</a></div>
+      </div>
+    </section>
+
+    <!-- 03 — Catalog quality -->
+    <section class="sec" id="catalog-qa">
+      <div class="sec-head">
+        <span class="sec-mark">03 — Catalog quality</span>
+        <h2>Fast would be worthless if the catalogs were wrong.</h2>
+      </div>
+      <p class="lede">Catalog semantics live in one dedicated engine (ferrocat): parsing, merging, structured
+        audits, and ICU authoring diagnostics. The benchmark harness validates every tool run
+        semantically — message inventories are compared, not just timed.</p>
+      <div class="grid cols-3">
+        <div class="cell">
+          <span class="cell-num">03.1 / shield</span>
+          <h3>Structured audits</h3>
+          <p>Machine-readable catalog audits catch missing translations, stale entries, and metadata drift in CI.</p>
+        </div>
+        <div class="cell">
+          <span class="cell-num">03.2 / brackets</span>
+          <h3>ICU diagnostics</h3>
+          <p>Authoring mistakes in plural/select syntax are flagged at extract time, not at runtime in production.</p>
+        </div>
+        <div class="cell">
+          <span class="cell-num">03.3 / merge</span>
+          <h3>Semantic merging</h3>
+          <p>A Git merge driver resolves catalog conflicts by meaning, not by line — no more broken .po files after rebases.</p>
+        </div>
+      </div>
+    </section>
+
+    <!-- 04 — Decision trail -->
+    <section class="sec" id="adrs">
+      <div class="sec-head">
+        <span class="sec-mark">04 — Decision trail</span>
+        <h2>16 decisions, written down before you depend on them.</h2>
+      </div>
+      <p class="lede">The ADRs cover message identity, the native boundary, adapter architecture — and, just as
+        deliberately, what Palamedes refuses to own. Reading them is the fastest way to know if
+        our tradeoffs match yours.</p>
+      <div class="linklist">
+        <a href="https://github.com/sebastian-software/palamedes/tree/main/adr">ADR index</a>
+        <a href="https://github.com/sebastian-software/palamedes/blob/main/docs/stability.md">Stability &amp; versioning policy</a>
+        <a href="https://github.com/sebastian-software/palamedes/blob/main/docs/principles.md">Palamedes principles</a>
+      </div>
+    </section>
+
+    <div class="ctaband">
+      <h2>Convinced by the receipts? The quickstart takes 5 minutes.</h2>
+      <div class="hero-ctas">
+        <a class="btn primary" href="#/get-started">Get started</a>
+        <a class="btn" href="#/" onclick="return false" title="Compare page not part of this draft">Compare with your current tool</a>
+      </div>
+    </div>
+
+  </main>
+
+  <!-- ==================================================== GET STARTED view -->
+  <main id="view-get-started" data-view hidden>
+
+    <header class="hero">
+      <p class="eyebrow">Quickstart</p>
+      <h1 class="display">First working translation in 5&nbsp;minutes.</h1>
+      <p class="subline">One translated component, one extraction run, one .po file,
+        one runtime instance. No message IDs to invent, no dictionary files
+        to maintain.</p>
+      <div class="hero-ctas">
+        <a class="btn primary" href="#install" onclick="document.getElementById('install').scrollIntoView(); return false">Skip to step 1</a>
+        <a class="btn" href="https://github.com/sebastian-software/palamedes/blob/main/docs/first-working-translation.md">Full written guide</a>
+      </div>
+    </header>
+
+    <div class="stackpick" style="border-top:1px solid var(--hair)">
+      <span class="micro">Stack</span>
+      <div class="tabs" style="border-bottom:1px solid var(--hair)">
+        <button class="active">Vite + React</button>
+        <button disabled title="Mock: switcher is non-functional in this draft">Vite + Solid</button>
+        <button disabled title="Mock: switcher is non-functional in this draft">Next.js</button>
+      </div>
+      <span class="micro">Draft mock — flow below shows Vite + React</span>
+    </div>
+
+    <section class="sec" id="install" style="border-top:0; padding-top:32px">
+      <div class="callout" style="margin-top:0">
+        <span class="micro">Honest note</span>
+        Heads-up: install the scoped <code>@palamedes/*</code> packages. The top-level
+        <code>palamedes</code> and <code>create-palamedes</code> names are reserved for a future
+        one-command setup and are not the entry point today.
+      </div>
+
+      <div class="steps">
+        <div class="step">
+          <div class="step-num mono">1</div>
+          <div class="step-body">
+            <h3>Install</h3>
+            <p>Core, runtime, host adapter, and the build plugin — plus the CLI as a dev dependency.</p>
+            <pre class="code">pnpm add @palamedes/core @palamedes/react @palamedes/runtime @palamedes/vite-plugin
+pnpm add -D @palamedes/cli @vitejs/plugin-react</pre>
+          </div>
+        </div>
+        <div class="step">
+          <div class="step-num mono">2</div>
+          <div class="step-body">
+            <h3>Configure</h3>
+            <p>One YAML file declares your locales and where catalogs live.</p>
+            <pre class="code"><span class="cm"># palamedes.yaml</span>
+locales: [en, de]
+source-locale: en
+catalogs:
+  - path: src/locales/{locale}
+    include: [src]</pre>
+          </div>
+        </div>
+        <div class="step">
+          <div class="step-num mono">3</div>
+          <div class="step-body">
+            <h3>Wire the plugin &amp; runtime</h3>
+            <p>The Vite plugin handles the macro transform; the runtime holds the active i18n instance.</p>
+            <pre class="code"><span class="cm">// vite.config.ts</span>
+import { palamedes } from "@palamedes/vite-plugin"
+export default defineConfig({ plugins: [palamedes(), react()] })
+
+<span class="cm">// src/i18n.ts</span>
+import { createI18n } from "@palamedes/core"
+import { setClientI18n } from "@palamedes/runtime"
+
+export const i18n = createI18n()
+setClientI18n(i18n)</pre>
+          </div>
+        </div>
+        <div class="step">
+          <div class="step-num mono">4</div>
+          <div class="step-body">
+            <h3>Write &amp; extract</h3>
+            <p>Author the message in your component, then run one command — it creates src/locales/en.po and de.po.</p>
+            <pre class="code"><span class="cm">// src/App.tsx</span>
+import { t } from "@palamedes/core/macro"
+export const App = () =&gt; &lt;h1&gt;{t`Welcome to Palamedes`}&lt;/h1&gt;
+
+$ pmds extract</pre>
+          </div>
+        </div>
+        <div class="step">
+          <div class="step-num mono">5</div>
+          <div class="step-body">
+            <h3>Translate</h3>
+            <p>Open the German catalog and fill in the translated string.</p>
+            <pre class="code"><span class="cm"># src/locales/de.po</span>
+msgid "Welcome to Palamedes"
+msgstr "Willkommen bei Palamedes"</pre>
+          </div>
+        </div>
+        <div class="step">
+          <div class="step-num mono">6</div>
+          <div class="step-body">
+            <h3>Load &amp; see it render</h3>
+            <p>Load the catalogs, activate a locale, and run the dev server — the page now renders
+              “Willkommen bei Palamedes”. That is the full local loop: transform, extraction, catalog, runtime.</p>
+            <pre class="code"><span class="cm">// src/main.tsx</span>
+import { i18n } from "./i18n"
+import { messages as enMessages } from "./locales/en.po"
+import { messages as deMessages } from "./locales/de.po"
+
+i18n.load("en", enMessages)
+i18n.load("de", deMessages)
+i18n.activate("de")
+
+$ pnpm dev</pre>
+            <div class="aside">
+              <span class="micro">Aside</span>
+              TypeScript needs an ambient declaration for .po imports — add a src/po.d.ts with
+              <code>declare module "*.po"</code> (see the
+              <a href="https://github.com/sebastian-software/palamedes/blob/main/docs/troubleshooting.md">troubleshooting guide</a>).
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- 02 — Next -->
+    <section class="sec" id="next">
+      <div class="sec-head">
+        <span class="sec-mark">02 — Next</span>
+        <h2>Where to go from here</h2>
+      </div>
+      <div class="grid cols-3">
+        <div class="cell">
+          <span class="cell-num">02.1 / book</span>
+          <h3>Plurals, dates &amp; currency</h3>
+          <p>ICU MessageFormat with authoring diagnostics that catch mistakes at extract time.</p>
+          <a class="more" href="https://github.com/sebastian-software/palamedes/blob/main/docs/api/core.md">Core API</a>
+        </div>
+        <div class="cell">
+          <span class="cell-num">02.2 / compass</span>
+          <h3>Pick a locale strategy</h3>
+          <p>Cookie, route, subdomain, or TLD — with a live demo for each, in your framework.</p>
+          <a class="more" href="#/frameworks">Frameworks</a>
+        </div>
+        <div class="cell">
+          <span class="cell-num">02.3 / server</span>
+          <h3>Localize your backend</h3>
+          <p>Request-local i18n for Hono and Express from the same catalogs.</p>
+          <a class="more" href="https://github.com/sebastian-software/palamedes/blob/main/docs/backend-servers.md">Backend guide</a>
+        </div>
+        <div class="cell">
+          <span class="cell-num">02.4 / arrows</span>
+          <h3>Migrating from Lingui?</h3>
+          <p>A step-by-step playbook. Source-string-first .po catalogs are often reusable after an extraction pass; explicit-ID setups need cleanup.</p>
+          <a class="more" href="https://github.com/sebastian-software/palamedes/blob/main/docs/migrate-from-lingui.md">Migration playbook</a>
+        </div>
+        <div class="cell">
+          <span class="cell-num">02.5 / wrench</span>
+          <h3>Something broke?</h3>
+          <p>The troubleshooting guide covers the common setup failures with exact error messages.</p>
+          <a class="more" href="https://github.com/sebastian-software/palamedes/blob/main/docs/troubleshooting.md">Troubleshooting</a>
+        </div>
+        <div class="cell">
+          <span class="cell-num">02.6 / robot</span>
+          <h3>Using an AI assistant?</h3>
+          <p>Point it at llms.txt — the whole API surface in one machine-readable file.</p>
+          <a class="more" href="https://github.com/sebastian-software/palamedes/blob/main/llms.txt">llms.txt</a>
+        </div>
+      </div>
+    </section>
+
+    <div class="ctaband">
+      <h2>Stuck? The maintainer reads every issue.</h2>
+      <div class="hero-ctas">
+        <a class="btn primary" href="https://github.com/sebastian-software/palamedes/issues">Open an issue</a>
+        <a class="btn" href="https://github.com/sebastian-software/palamedes/blob/main/docs/api/README.md">Read the docs</a>
+      </div>
+    </div>
+
+  </main>
+
+  <!-- ============================================================== FOOTER -->
+  <footer class="site">
+    <div class="foot-grid">
+      <div class="foot-col">
+        <h4>Product</h4>
+        <a href="#/get-started">Get started</a>
+        <a href="#/frameworks">Framework matrix</a>
+        <a href="#/proof">Benchmarks &amp; proof</a>
+        <a href="#/" onclick="return false" title="Not part of this draft">Comparison</a>
+      </div>
+      <div class="foot-col">
+        <h4>Documentation</h4>
+        <a href="https://github.com/sebastian-software/palamedes/blob/main/docs/first-working-translation.md">5-minute quickstart</a>
+        <a href="https://github.com/sebastian-software/palamedes/blob/main/docs/api/README.md">API reference</a>
+        <a href="https://github.com/sebastian-software/palamedes/blob/main/docs/configuration.md">Configuration</a>
+        <a href="https://github.com/sebastian-software/palamedes/blob/main/docs/cli.md">CLI</a>
+        <a href="https://github.com/sebastian-software/palamedes/blob/main/docs/troubleshooting.md">Troubleshooting</a>
+      </div>
+      <div class="foot-col">
+        <h4>Project</h4>
+        <a href="https://github.com/sebastian-software/palamedes/tree/main/adr">Architecture decisions</a>
+        <a href="https://github.com/sebastian-software/palamedes/blob/main/docs/stability.md">Stability &amp; versioning</a>
+        <a href="https://github.com/sebastian-software/palamedes/blob/main/CHANGELOG.md">Changelog</a>
+        <a href="https://github.com/sebastian-software/palamedes/blob/main/SECURITY.md">Security</a>
+        <a href="https://github.com/sebastian-software/palamedes/blob/main/LICENSE">MIT license</a>
+      </div>
+      <div class="foot-col">
+        <h4>Company</h4>
+        <a href="https://oss.sebastian-software.com/">Sebastian Software</a>
+        <a href="https://sebastian-software.de/werner">Sebastian Werner</a>
+        <a href="#/" onclick="return false" title="Blog not part of this draft">Blog</a>
+      </div>
+    </div>
+    <div class="legal">MIT © 2026 Sebastian Software GmbH — built in the open, verified in CI.</div>
+  </footer>
+
+</div><!-- /frame -->
+
+<script>
+/* ------------------------------------------------------------ hash router -- */
+(function () {
+  var VIEWS = {
+    "/": "view-home",
+    "/frameworks": "view-frameworks",
+    "/proof": "view-proof",
+    "/get-started": "view-get-started"
+  };
+  var current = "/";
+
+  function route(first) {
+    var h = location.hash.replace(/^#/, "");
+    if (h === "") h = "/";
+    if (!(h in VIEWS)) {
+      // Unknown hash (e.g. in-page anchors like #install): keep current view.
+      if (!first) return;
+      h = "/";
+    }
+    current = h;
+    var views = document.querySelectorAll("[data-view]");
+    for (var i = 0; i < views.length; i++) {
+      views[i].hidden = views[i].id !== VIEWS[h];
+    }
+    var links = document.querySelectorAll("[data-nav]");
+    for (var j = 0; j < links.length; j++) {
+      links[j].classList.toggle("active", links[j].getAttribute("data-nav") === h);
+    }
+    if (!first) window.scrollTo(0, 0);
+  }
+
+  window.addEventListener("hashchange", function () { route(false); });
+  route(true);
+})();
+
+/* ----------------------------------------------------- code-showcase tabs -- */
+(function () {
+  var groups = document.querySelectorAll("[data-tabs]");
+  for (var g = 0; g < groups.length; g++) {
+    (function (group) {
+      var btns = group.querySelectorAll("[data-tab]");
+      var panes = group.querySelectorAll("[data-pane]");
+      for (var i = 0; i < btns.length; i++) {
+        (function (btn) {
+          btn.addEventListener("click", function () {
+            for (var k = 0; k < btns.length; k++) {
+              btns[k].classList.toggle("active", btns[k] === btn);
+            }
+            for (var p = 0; p < panes.length; p++) {
+              panes[p].hidden = panes[p].getAttribute("data-pane") !== btn.getAttribute("data-tab");
+            }
+          });
+        })(btns[i]);
+      }
+    })(groups[g]);
+  }
+})();
+
+/* -------------------------------------------- framework matrix (5 × 4) ----
+   Mirrors FRAMEWORK_MATRIX_CELLS in components.jsx: explicit per-cell links
+   and status, never a generated URL pattern presented as such. Cookie/route
+   are live; subdomain/tld are provisioning (#306) and link source only.   -- */
+(function () {
+  var GH_TREE = "https://github.com/sebastian-software/palamedes/tree/main/";
+  var FRAMEWORKS = [
+    { name: "Next.js", slug: "nextjs" },
+    { name: "TanStack Start", slug: "tanstack" },
+    { name: "SolidStart", slug: "solidstart" },
+    { name: "Waku", slug: "waku" },
+    { name: "React Router", slug: "react-router" }
+  ];
+  var STRATEGIES = [
+    { slug: "cookie", short: "Cookie", long: "Cookie" },
+    { slug: "route", short: "Route", long: "Route segment" },
+    { slug: "subdomain", short: "Subdomain", long: "Subdomain" },
+    { slug: "tld", short: "TLD", long: "Top-level domain" }
+  ];
+
+  function cellHtml(fw, strategy) {
+    var src = GH_TREE + "examples/" + fw.slug + "-" + strategy.slug;
+    var html = "";
+    if (strategy.slug === "cookie") {
+      html += '<span class="st live">●</span><span class="vf">✓ verified</span>';
+      html += '<span class="cell-links"><a href="https://' + fw.slug + '-cookie.examples.palamedes.dev">open</a>';
+      html += ' <span class="sep">|</span> <a href="' + src + '">source</a></span>';
+    } else if (strategy.slug === "route") {
+      html += '<span class="st live">●</span><span class="vf">✓ verified</span>';
+      var locales = ["en", "de", "es"];
+      var links = [];
+      for (var i = 0; i < locales.length; i++) {
+        links.push('<a href="https://' + fw.slug + '-route.examples.palamedes.dev/' + locales[i] + '">' + locales[i] + "</a>");
+      }
+      html += '<span class="cell-links">' + links.join(" ") + ' <span class="sep">|</span> <a href="' + src + '">source</a></span>';
+    } else {
+      html += '<span class="st prov">◌</span><span class="vf">✓ verified</span>';
+      html += '<span class="cell-links"><span class="prov-label">provisioning</span> <span class="sep">|</span> <a href="' + src + '">source</a></span>';
+    }
+    return html;
+  }
+
+  function buildMatrix(table) {
+    var longNames = table.hasAttribute("data-longnames");
+    var html = "<thead><tr><th>Framework <span class=\"mono\">5 × 4 = 20 apps</span></th>";
+    for (var s = 0; s < STRATEGIES.length; s++) {
+      var st = STRATEGIES[s];
+      html += "<th>" + (longNames ? st.long : st.short) + ' <span class="mono">' + st.slug + "</span></th>";
+    }
+    html += "</tr></thead><tbody>";
+    for (var f = 0; f < FRAMEWORKS.length; f++) {
+      var fw = FRAMEWORKS[f];
+      html += '<tr><td><span class="fw-name">' + fw.name + '</span><span class="fw-slug">' + fw.slug + "</span></td>";
+      for (var c = 0; c < STRATEGIES.length; c++) {
+        html += "<td>" + cellHtml(fw, STRATEGIES[c]) + "</td>";
+      }
+      html += "</tr>";
+    }
+    html += "</tbody>";
+    table.innerHTML = html;
+  }
+
+  var tables = document.querySelectorAll("table.home-matrix, table.fw-matrix");
+  for (var t = 0; t < tables.length; t++) buildMatrix(tables[t]);
+
+  /* -------------------------------------------- per-framework panels ---- */
+  var PANELS = [
+    {
+      name: "Next.js", slug: "nextjs",
+      body: "App Router with server components and server actions. The @palamedes/next-plugin wires the transform into the Next build; everything else is the shared model."
+    },
+    {
+      name: "TanStack Start", slug: "tanstack",
+      body: "Server functions and file-based routing, integrated through @palamedes/vite-plugin. Locale resolution runs in a server function; the client stays island-light."
+    },
+    {
+      name: "SolidStart", slug: "solidstart",
+      body: "Fine-grained reactivity with @palamedes/solid — the same macro authoring and catalogs as React, no fork of your i18n strategy for a different renderer."
+    },
+    {
+      name: "Waku", slug: "waku",
+      body: "Minimal RSC framework. If the model holds here, it holds in your custom setup too — that's why Waku is in the matrix."
+    },
+    {
+      name: "React Router", slug: "react-router",
+      body: "Framework-mode React Router with loaders and actions. The classic SPA-plus-SSR shape, same catalogs, same runtime."
+    }
+  ];
+
+  var mount = document.getElementById("fw-panels");
+  if (mount) {
+    var out = "";
+    for (var p = 0; p < PANELS.length; p++) {
+      var pf = PANELS[p];
+      out += '<div class="fw-panel">';
+      out += "<h3>" + pf.name + '<span class="mono">examples/' + pf.slug + '-*</span></h3>';
+      out += "<div><p>" + pf.body + "</p>";
+      out += '<div class="fw-demos">';
+      out += '<span><span class="st live">●</span><a href="https://' + pf.slug + '-cookie.examples.palamedes.dev">cookie</a></span>';
+      out += '<span><span class="st live">●</span><a href="https://' + pf.slug + '-route.examples.palamedes.dev/en">route</a></span>';
+      out += '<span><span class="st prov">◌</span><span class="prov-label">subdomain · </span><a href="' + GH_TREE + "examples/" + pf.slug + '-subdomain">source</a></span>';
+      out += '<span><span class="st prov">◌</span><span class="prov-label">tld · </span><a href="' + GH_TREE + "examples/" + pf.slug + '-tld">source</a></span>';
+      out += '<span><a href="' + GH_TREE + "examples/" + pf.slug + '-route">all source →</a></span>';
+      out += "</div></div></div>";
+    }
+    mount.innerHTML = out;
+  }
+})();
+</script>
+
+</body>
+</html>

--- a/docs/site/structure/drafts/design-b-terminal.html
+++ b/docs/site/structure/drafts/design-b-terminal.html
@@ -1,0 +1,1485 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Palamedes — design draft B (Terminal)</title>
+<style>
+/* ============================================================
+   Design draft B — "TERMINAL / OPS"
+   Dark, developer-native, workflow-first. Static mock, not final.
+   ============================================================ */
+:root {
+  --bg: #0b0e14;
+  --panel: #11151d;
+  --panel-2: #0d1118;
+  --border: #1e2530;
+  --text: #c9d1d9;
+  --dim: #8b949e;
+  --green: #3fb950;
+  --cyan: #56d4dd;
+  --amber: #d29922;
+  --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+  --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+}
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; }
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--mono);
+  font-size: 15px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+}
+a { color: var(--cyan); text-decoration: none; }
+a:hover { text-decoration: underline; }
+a.dead { color: var(--dim); cursor: not-allowed; }
+a.dead:hover { text-decoration: none; }
+code { font-family: var(--mono); background: var(--panel); border: 1px solid var(--border); border-radius: 3px; padding: 0 4px; font-size: 0.92em; }
+h1, h2, h3, h4 { font-family: var(--mono); font-weight: 600; line-height: 1.25; margin: 0 0 14px; }
+h1 { font-size: clamp(26px, 4.6vw, 42px); letter-spacing: -0.5px; }
+h2 { font-size: clamp(19px, 2.6vw, 26px); }
+h3 { font-size: 16px; }
+p.body, .body p, .aside-note, .card p { font-family: var(--sans); }
+.wrap { max-width: 1120px; margin: 0 auto; padding: 0 24px; }
+section.block { padding: 56px 0; border-top: 1px solid var(--border); }
+.dimtxt { color: var(--dim); }
+
+/* prompt-style section labels */
+.sec-label {
+  font-family: var(--mono);
+  color: var(--green);
+  font-size: 13px;
+  letter-spacing: 0.5px;
+  margin-bottom: 10px;
+}
+.sec-label::before { content: "## "; color: var(--dim); }
+.path-label {
+  font-family: var(--mono);
+  color: var(--dim);
+  font-size: 13px;
+  margin-bottom: 10px;
+}
+.path-label b { color: var(--cyan); font-weight: 600; }
+
+/* ------------------------------------------------------- ribbon */
+.draft-ribbon {
+  position: fixed;
+  bottom: 12px;
+  left: 12px;
+  z-index: 99;
+  background: var(--panel);
+  border: 1px solid var(--amber);
+  color: var(--amber);
+  font-size: 11px;
+  padding: 4px 10px;
+  border-radius: 3px;
+  letter-spacing: 0.4px;
+  box-shadow: 0 0 12px rgba(210, 153, 34, 0.15);
+}
+
+/* ---------------------------------------------------------- nav */
+nav.site-nav {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  background: rgba(11, 14, 20, 0.92);
+  backdrop-filter: blur(6px);
+  border-bottom: 1px solid var(--border);
+}
+.nav-inner {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 10px 24px;
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  flex-wrap: wrap;
+}
+.wordmark {
+  font-weight: 700;
+  color: var(--text);
+  font-size: 16px;
+  letter-spacing: 0.3px;
+}
+.wordmark::before { content: "▮ "; color: var(--green); }
+.wordmark:hover { text-decoration: none; color: var(--green); }
+.nav-links { display: flex; gap: 16px; flex-wrap: wrap; font-size: 13.5px; flex: 1; }
+.nav-links a { color: var(--dim); }
+.nav-links a:hover { color: var(--cyan); text-decoration: none; }
+.nav-links a.active { color: var(--green); }
+.nav-links a.active::before { content: "> "; }
+.nav-actions { display: flex; gap: 10px; align-items: center; font-size: 13.5px; }
+
+/* keycap / command buttons */
+.btn {
+  display: inline-block;
+  font-family: var(--mono);
+  font-size: 13.5px;
+  padding: 8px 16px;
+  border-radius: 4px;
+  border: 1px solid var(--border);
+  background: var(--panel);
+  color: var(--text);
+  box-shadow: 0 2px 0 #060810;
+  white-space: nowrap;
+}
+.btn:hover { text-decoration: none; border-color: var(--dim); }
+.btn.primary {
+  border-color: var(--green);
+  color: var(--green);
+  box-shadow: 0 2px 0 rgba(63, 185, 80, 0.35), 0 0 14px rgba(63, 185, 80, 0.12);
+}
+.btn.primary::before { content: "> "; }
+.btn.secondary { color: var(--cyan); border-color: #2a4a52; }
+.btn.secondary::before { content: "$ "; color: var(--dim); }
+
+/* --------------------------------------------------------- hero */
+.hero { padding: 60px 0 48px; }
+.hero-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 44px; align-items: start; }
+@media (max-width: 960px) { .hero-grid { grid-template-columns: 1fr; } }
+.eyebrow {
+  color: var(--amber);
+  font-size: 12.5px;
+  letter-spacing: 1.2px;
+  text-transform: uppercase;
+  margin-bottom: 14px;
+}
+.eyebrow::before { content: "[ "; color: var(--dim); }
+.eyebrow::after { content: " ]"; color: var(--dim); }
+.subline { font-family: var(--sans); color: var(--dim); font-size: 16px; max-width: 60ch; }
+.subline strong { color: var(--text); font-weight: 600; }
+.cta-row { display: flex; gap: 12px; margin-top: 24px; flex-wrap: wrap; }
+
+/* terminal window */
+.term {
+  background: var(--panel-2);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 0 30px rgba(63, 185, 80, 0.05);
+  position: relative;
+}
+.term::after { /* faint scanlines, decorative */
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: repeating-linear-gradient(0deg, rgba(255,255,255,0.015) 0 1px, transparent 1px 3px);
+}
+.term-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  background: var(--panel);
+  border-bottom: 1px solid var(--border);
+}
+.term-dot { width: 10px; height: 10px; border-radius: 50%; background: var(--border); }
+.term-dot:nth-child(1) { background: #f85149; }
+.term-dot:nth-child(2) { background: var(--amber); }
+.term-dot:nth-child(3) { background: var(--green); }
+.term-title { margin-left: 8px; color: var(--dim); font-size: 12px; }
+.term-body { padding: 16px 18px; font-size: 13.5px; line-height: 1.75; overflow-x: auto; }
+.term-body .cmd { color: var(--text); }
+.term-body .cmd::before { content: "$ "; color: var(--green); }
+.term-body .out { color: var(--dim); white-space: pre; }
+.term-body .ok { color: var(--green); }
+.term-body .warn { color: var(--amber); }
+.cursor {
+  display: inline-block;
+  width: 8px;
+  height: 15px;
+  background: var(--green);
+  vertical-align: text-bottom;
+  animation: blink 1.1s steps(1) infinite;
+}
+@keyframes blink { 50% { opacity: 0; } }
+@media (prefers-reduced-motion: reduce) {
+  .cursor { animation: none; }
+  html { scroll-behavior: auto; }
+  .led { animation: none !important; }
+}
+
+/* booking card locale mock */
+.locale-row { display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px; margin-top: 14px; }
+@media (max-width: 640px) { .locale-row { grid-template-columns: 1fr; } }
+.bk-card {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 12px;
+  font-family: var(--sans);
+  font-size: 12.5px;
+}
+.bk-locale {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  color: var(--cyan);
+  letter-spacing: 1px;
+  margin-bottom: 8px;
+}
+.bk-locale::before { content: "locale="; color: var(--dim); }
+.bk-title { font-weight: 600; font-size: 13.5px; color: var(--text); margin-bottom: 4px; }
+.bk-seats { color: var(--green); margin-bottom: 8px; }
+.bk-meta { display: flex; justify-content: space-between; gap: 8px; border-top: 1px dashed var(--border); padding-top: 8px; }
+.bk-price { font-family: var(--mono); color: var(--text); font-weight: 600; }
+.bk-date { color: var(--dim); }
+.locale-caption { color: var(--dim); font-size: 12px; margin-top: 10px; font-family: var(--sans); }
+
+/* --------------------------------------------------- proof strip */
+.proof-strip {
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  background: var(--panel-2);
+}
+.proof-strip-inner {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 20px 24px;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 18px;
+}
+@media (max-width: 860px) { .proof-strip-inner { grid-template-columns: repeat(2, 1fr); } }
+@media (max-width: 460px) { .proof-strip-inner { grid-template-columns: 1fr; } }
+.stat a { display: block; color: inherit; }
+.stat a:hover { text-decoration: none; }
+.stat-value { font-size: 26px; font-weight: 700; color: var(--green); }
+.stat-label { font-size: 12px; color: var(--dim); font-family: var(--sans); margin-top: 2px; }
+.stat a:hover .stat-label { color: var(--cyan); }
+
+/* --------------------------------------------------------- cards */
+.grid { display: grid; gap: 14px; margin-top: 22px; }
+.grid.cols-3 { grid-template-columns: repeat(3, 1fr); }
+.grid.cols-4 { grid-template-columns: repeat(4, 1fr); }
+@media (max-width: 960px) { .grid.cols-3, .grid.cols-4 { grid-template-columns: repeat(2, 1fr); } }
+@media (max-width: 560px) { .grid.cols-3, .grid.cols-4 { grid-template-columns: 1fr; } }
+.card {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 16px;
+}
+.card h3 { color: var(--cyan); font-size: 14.5px; margin-bottom: 8px; }
+.card h3::before { content: "▸ "; color: var(--green); }
+.card p { color: var(--dim); font-size: 13.5px; margin: 0 0 10px; }
+.card a.more { font-size: 12.5px; }
+.card a.more::after { content: " ↗"; }
+
+/* --------------------------------------------------- code showcase */
+.tabs { display: flex; gap: 6px; margin-bottom: -1px; flex-wrap: wrap; }
+.tab-btn {
+  font-family: var(--mono);
+  font-size: 13px;
+  background: var(--panel-2);
+  color: var(--dim);
+  border: 1px solid var(--border);
+  border-bottom: none;
+  border-radius: 6px 6px 0 0;
+  padding: 7px 16px;
+  cursor: pointer;
+}
+.tab-btn.active { color: var(--green); background: var(--panel); }
+.tab-btn.active::before { content: "● "; font-size: 9px; vertical-align: 2px; }
+.tab-panels {
+  border: 1px solid var(--border);
+  border-radius: 0 6px 6px 6px;
+  background: var(--panel);
+}
+.tab-panel { display: none; }
+.tab-panel.active { display: block; }
+.tab-caption { padding: 10px 16px 0; color: var(--dim); font-size: 12.5px; font-family: var(--sans); }
+pre.code {
+  margin: 0;
+  padding: 14px 16px 18px;
+  overflow-x: auto;
+  font-family: var(--mono);
+  font-size: 13px;
+  line-height: 1.65;
+  color: var(--text);
+}
+pre.code .c-kw { color: var(--cyan); }
+pre.code .c-str { color: var(--green); }
+pre.code .c-dim { color: var(--dim); }
+pre.code .c-amber { color: var(--amber); }
+.result-panel {
+  border-top: 1px dashed var(--border);
+  padding: 12px 16px;
+  font-size: 13px;
+}
+.result-panel .rp-title { color: var(--amber); font-size: 12px; letter-spacing: 1px; text-transform: uppercase; }
+.result-panel .rp-body { color: var(--dim); font-family: var(--sans); margin-top: 4px; }
+
+/* --------------------------------------------------------- matrix */
+.matrix-scroll { overflow-x: auto; margin-top: 20px; border: 1px solid var(--border); border-radius: 6px; }
+table.matrix { border-collapse: collapse; width: 100%; min-width: 720px; background: var(--panel); font-size: 12.5px; }
+table.matrix th, table.matrix td { border: 1px solid var(--border); padding: 10px 12px; text-align: left; vertical-align: top; }
+table.matrix thead th { background: var(--panel-2); color: var(--cyan); font-weight: 600; font-size: 12px; letter-spacing: 0.5px; }
+table.matrix tbody th { color: var(--text); font-weight: 600; white-space: nowrap; background: var(--panel-2); }
+.led {
+  display: inline-block;
+  width: 8px; height: 8px;
+  border-radius: 50%;
+  margin-right: 6px;
+  vertical-align: 1px;
+}
+.led.live { background: var(--green); box-shadow: 0 0 6px rgba(63, 185, 80, 0.7); animation: pulse 2.4s ease-in-out infinite; }
+.led.prov { background: var(--amber); box-shadow: 0 0 6px rgba(210, 153, 34, 0.6); }
+@keyframes pulse { 50% { box-shadow: 0 0 2px rgba(63, 185, 80, 0.3); } }
+.chip-verified {
+  display: inline-block;
+  font-size: 10px;
+  letter-spacing: 0.8px;
+  color: var(--green);
+  border: 1px solid rgba(63, 185, 80, 0.45);
+  border-radius: 3px;
+  padding: 0 5px;
+  margin-left: 4px;
+}
+.cell-status { color: var(--amber); font-size: 11.5px; }
+.cell-links { margin-top: 6px; display: flex; gap: 8px; flex-wrap: wrap; }
+.cell-links a { font-size: 12px; }
+.cell-links a.src { color: var(--dim); }
+.cell-links a.src:hover { color: var(--cyan); }
+.matrix-caption { color: var(--dim); font-size: 13px; font-family: var(--sans); margin-top: 12px; max-width: 80ch; }
+
+/* ------------------------------------------------ benchmark meters */
+.bench {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 18px;
+  margin-top: 22px;
+}
+.bench-title { font-size: 14px; color: var(--text); margin-bottom: 14px; }
+.bench-title::before { content: "⏱ "; }
+.meter-row {
+  display: grid;
+  grid-template-columns: 150px 1fr 110px;
+  gap: 10px;
+  align-items: center;
+  margin-bottom: 10px;
+  font-size: 13px;
+}
+@media (max-width: 560px) {
+  .meter-row { grid-template-columns: 1fr; gap: 2px; margin-bottom: 14px; }
+}
+.meter-tool { color: var(--text); }
+.meter-tool.win { color: var(--green); font-weight: 700; }
+.meter-track {
+  display: flex;
+  align-items: center;
+  font-family: var(--mono);
+  color: var(--dim);
+  min-width: 0;
+}
+.meter-track::before { content: "["; }
+.meter-track::after { content: "]"; }
+.meter-rail { flex: 1; height: 12px; margin: 0 4px; position: relative; background: transparent; }
+.meter-fill {
+  position: absolute;
+  inset: 0 auto 0 0;
+  min-width: 6px;
+  background: repeating-linear-gradient(90deg, var(--dim) 0 5px, transparent 5px 8px);
+  opacity: 0.75;
+}
+.meter-fill.win { background: repeating-linear-gradient(90deg, var(--green) 0 5px, transparent 5px 8px); opacity: 1; }
+.meter-val { text-align: right; color: var(--dim); white-space: nowrap; }
+.meter-val b { color: var(--text); }
+.bench-note { color: var(--dim); font-size: 12px; font-family: var(--sans); margin-top: 12px; }
+.bench-note a::after { content: " ↗"; }
+
+/* honest callout */
+.callout {
+  border: 1px solid var(--amber);
+  border-left: 4px solid var(--amber);
+  background: rgba(210, 153, 34, 0.06);
+  border-radius: 4px;
+  padding: 12px 16px;
+  color: var(--text);
+  font-family: var(--sans);
+  font-size: 13.5px;
+  margin-top: 20px;
+}
+.callout::before { content: "# honest note"; display: block; font-family: var(--mono); color: var(--amber); font-size: 11px; letter-spacing: 1px; margin-bottom: 6px; }
+
+/* ------------------------------------------------------ statement */
+.statement {
+  border-top: 1px solid var(--border);
+  background: var(--panel-2);
+  padding: 44px 0;
+}
+.statement p {
+  font-family: var(--mono);
+  font-size: clamp(15px, 2vw, 19px);
+  color: var(--text);
+  max-width: 66ch;
+  margin: 0;
+  line-height: 1.7;
+}
+.statement p::before { content: "/* "; color: var(--dim); }
+.statement p::after { content: " */"; color: var(--dim); }
+
+/* --------------------------------------------------------- CI log */
+.ci-log {
+  background: var(--panel-2);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 16px 18px;
+  margin-top: 20px;
+  font-size: 13px;
+  line-height: 1.9;
+  overflow-x: auto;
+}
+.ci-log .ln { white-space: nowrap; }
+.ci-log .tick { color: var(--green); }
+.ci-log .step-name { color: var(--cyan); }
+.ci-log .desc { color: var(--dim); font-family: var(--sans); white-space: normal; display: block; padding-left: 26px; margin-bottom: 8px; }
+
+/* browser-frame screenshot mock */
+.shot-frame { margin-top: 24px; border: 1px solid var(--border); border-radius: 8px; overflow: hidden; background: var(--panel); }
+.shot-bar { display: flex; align-items: center; gap: 8px; padding: 8px 12px; background: var(--panel-2); border-bottom: 1px solid var(--border); }
+.shot-url { flex: 1; background: var(--bg); border: 1px solid var(--border); border-radius: 4px; padding: 2px 10px; font-size: 11.5px; color: var(--dim); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.shot-body { padding: 16px; }
+.shot-caption { color: var(--dim); font-size: 12.5px; font-family: var(--sans); padding: 0 16px 14px; }
+
+/* --------------------------------------------------------- steps */
+.steps { margin-top: 26px; display: grid; gap: 16px; }
+.step {
+  display: grid;
+  grid-template-columns: 44px 1fr;
+  gap: 14px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 16px;
+}
+@media (max-width: 560px) { .step { grid-template-columns: 1fr; } }
+.step-num {
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--green);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  width: 40px; height: 40px;
+  display: flex; align-items: center; justify-content: center;
+  background: var(--panel-2);
+}
+.step h3 { color: var(--text); margin-bottom: 6px; }
+.step .step-body { color: var(--dim); font-family: var(--sans); font-size: 13.5px; margin: 0 0 10px; }
+.step pre.code { border: 1px solid var(--border); border-radius: 4px; background: var(--panel-2); }
+.aside-note {
+  border-left: 3px solid var(--cyan);
+  background: rgba(86, 212, 221, 0.05);
+  padding: 8px 12px;
+  margin-top: 10px;
+  color: var(--dim);
+  font-size: 12.5px;
+  border-radius: 0 4px 4px 0;
+}
+.aside-note::before { content: "aside: "; font-family: var(--mono); color: var(--cyan); }
+
+/* stack picker */
+.stack-picker { display: flex; gap: 8px; align-items: center; margin: 26px 0 4px; flex-wrap: wrap; font-size: 13px; }
+.stack-picker .lbl { color: var(--dim); }
+.stack-chip {
+  font-family: var(--mono);
+  font-size: 12.5px;
+  border: 1px solid var(--border);
+  background: var(--panel);
+  color: var(--dim);
+  border-radius: 4px;
+  padding: 5px 12px;
+  cursor: pointer;
+}
+.stack-chip.active { color: var(--green); border-color: var(--green); }
+.stack-chip.active::before { content: "◉ "; }
+.stack-note { color: var(--dim); font-size: 12px; font-family: var(--sans); margin-top: 6px; }
+
+/* --------------------------------------------------- fw panels */
+.fw-panel {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 16px;
+  margin-top: 12px;
+}
+.fw-panel h3 { color: var(--green); }
+.fw-panel h3::before { content: "~/examples/"; color: var(--dim); font-weight: 400; }
+.fw-panel p { color: var(--dim); font-family: var(--sans); font-size: 13.5px; margin: 6px 0 10px; }
+.fw-demos { display: flex; gap: 10px; flex-wrap: wrap; font-size: 12px; align-items: center; }
+.fw-demos .grp { color: var(--dim); }
+
+/* ------------------------------------------------------ CTA band */
+.cta-band {
+  border-top: 1px solid var(--border);
+  background: linear-gradient(180deg, var(--panel-2), var(--bg));
+  padding: 52px 0;
+  text-align: center;
+}
+.cta-band h2 { margin-bottom: 22px; }
+.cta-band .cta-row { justify-content: center; }
+
+/* -------------------------------------------------------- footer */
+footer.site-footer { border-top: 1px solid var(--border); background: var(--panel-2); padding: 44px 0 20px; margin-top: 0; }
+.footer-cols { display: grid; grid-template-columns: repeat(4, 1fr); gap: 24px; }
+@media (max-width: 860px) { .footer-cols { grid-template-columns: repeat(2, 1fr); } }
+@media (max-width: 460px) { .footer-cols { grid-template-columns: 1fr; } }
+.footer-cols h4 { color: var(--text); font-size: 12.5px; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 10px; }
+.footer-cols h4::before { content: "// "; color: var(--dim); }
+.footer-cols ul { list-style: none; margin: 0; padding: 0; }
+.footer-cols li { margin-bottom: 7px; font-size: 13px; }
+.footer-cols a { color: var(--dim); }
+.footer-cols a:hover { color: var(--cyan); }
+.legal-strip {
+  border-top: 1px solid var(--border);
+  margin-top: 32px;
+  padding-top: 16px;
+  color: var(--dim);
+  font-size: 12px;
+}
+.legal-strip::before { content: "$ "; color: var(--green); }
+
+/* views (router) */
+.view { display: none; }
+.view.active { display: block; }
+.linklist { list-style: none; padding: 0; margin: 16px 0 0; }
+.linklist li { margin-bottom: 6px; font-size: 13.5px; }
+.linklist li::before { content: "→ "; color: var(--green); }
+</style>
+</head>
+<body>
+
+<div class="draft-ribbon">Design draft B — Terminal · not final</div>
+
+<!-- ======================================================= NAV -->
+<nav class="site-nav">
+  <div class="nav-inner">
+    <a class="wordmark" href="#/">Palamedes</a>
+    <div class="nav-links">
+      <a href="#/frameworks" data-route="frameworks">Frameworks</a>
+      <a href="#/proof" data-route="proof">Proof</a>
+      <a href="#" class="dead" title="Not part of this draft">Compare</a>
+      <a href="#" class="dead" title="Not part of this draft">Blog</a>
+      <a href="https://github.com/sebastian-software/palamedes/tree/main/docs">Docs</a>
+    </div>
+    <div class="nav-actions">
+      <a class="btn" href="https://github.com/sebastian-software/palamedes">★ GitHub</a>
+      <a class="btn primary" href="#/get-started">Get started</a>
+    </div>
+  </div>
+</nav>
+
+<!-- ================================================== VIEW: HOME -->
+<main id="view-home" class="view">
+
+  <div class="wrap hero">
+    <div class="hero-grid">
+      <div>
+        <div class="eyebrow">Open-source i18n tooling for JavaScript &amp; TypeScript</div>
+        <h1>One translation model. Every framework.</h1>
+        <p class="subline">Write messages where your UI happens. Keep source-string-first
+          .po catalogs your translators can actually read. Ship the same
+          runtime model across Next.js, TanStack Start, SolidStart, Waku, and
+          React Router — with a Rust core that ran the checked small-corpus
+          extract/update benchmark 19.6× faster than Lingui on the recorded
+          machine-local run.</p>
+        <div class="cta-row">
+          <a class="btn primary" href="#/get-started">Get started in 5 minutes</a>
+          <a class="btn secondary" href="https://nextjs-cookie.examples.palamedes.dev">See it live</a>
+        </div>
+      </div>
+      <div>
+        <div class="term">
+          <div class="term-bar">
+            <span class="term-dot"></span><span class="term-dot"></span><span class="term-dot"></span>
+            <span class="term-title">pmds — palamedes</span>
+          </div>
+          <div class="term-body">
+            <div class="cmd">pmds extract</div>
+            <div class="out">  en  3 messages  <span class="ok">(1 new)</span></div>
+            <div class="out">  de  3 messages  <span class="warn">(1 missing translation)</span></div>
+            <div class="out">&nbsp;</div>
+            <div class="out">  <span class="ok">done in 34 ms</span></div>
+            <div class="cmd"><span class="cursor" aria-hidden="true"></span></div>
+          </div>
+        </div>
+        <div class="locale-row" aria-label="The same booking card rendered in three locales">
+          <div class="bk-card">
+            <div class="bk-locale">en</div>
+            <div class="bk-title">Your trip to Lisbon</div>
+            <div class="bk-seats">3 seats left</div>
+            <div class="bk-meta"><span class="bk-price">€1,234.00</span><span class="bk-date">Jul 12, 2026</span></div>
+          </div>
+          <div class="bk-card">
+            <div class="bk-locale">de</div>
+            <div class="bk-title">Deine Reise nach Lissabon</div>
+            <div class="bk-seats">3 Plätze frei</div>
+            <div class="bk-meta"><span class="bk-price">1.234,00&nbsp;€</span><span class="bk-date">12. Juli 2026</span></div>
+          </div>
+          <div class="bk-card">
+            <div class="bk-locale">es</div>
+            <div class="bk-title">Tu viaje a Lisboa</div>
+            <div class="bk-seats">Quedan 3 asientos</div>
+            <div class="bk-meta"><span class="bk-price">1234,00&nbsp;€</span><span class="bk-date">12 jul 2026</span></div>
+          </div>
+        </div>
+        <p class="locale-caption">One component, three locales: copy, plurals, currency, and dates change together.</p>
+      </div>
+    </div>
+  </div>
+
+  <!-- proof strip -->
+  <div class="proof-strip">
+    <div class="proof-strip-inner">
+      <div class="stat"><a href="#/frameworks">
+        <div class="stat-value">20</div>
+        <div class="stat-label">browser-verified example apps</div>
+      </a></div>
+      <div class="stat"><a href="#/frameworks">
+        <div class="stat-value">5 × 4</div>
+        <div class="stat-label">frameworks × locale strategies</div>
+      </a></div>
+      <div class="stat"><a href="#/proof">
+        <div class="stat-value">19.6×</div>
+        <div class="stat-label">faster than Lingui — checked extract/update benchmark, machine-local run</div>
+      </a></div>
+      <div class="stat"><a href="https://github.com/sebastian-software/palamedes/tree/main/adr">
+        <div class="stat-value">16</div>
+        <div class="stat-label">ADRs documenting every tradeoff</div>
+      </a></div>
+    </div>
+  </div>
+
+  <!-- the core promise -->
+  <section class="block">
+    <div class="wrap">
+      <div class="sec-label">model</div>
+      <h2>Your i18n setup should not splinter when your framework changes.</h2>
+      <p class="body subline">Most teams relearn internationalization with every migration: new runtime, new message
+        IDs, new catalog quirks. Palamedes keeps the parts you touch every day stable — and lets
+        the framework be the only thing that changes.</p>
+      <div class="grid cols-3">
+        <div class="card">
+          <h3>Write messages in place</h3>
+          <p>Macro-style authoring next to your JSX. No message-ID bookkeeping, no separate dictionary files to keep in sync.</p>
+          <a class="more" href="#/get-started">get-started</a>
+        </div>
+        <div class="card">
+          <h3>One identity model</h3>
+          <p>Messages are identified by message + context — stable across refactors, frameworks, and years of catalog history.</p>
+          <a class="more" href="https://github.com/sebastian-software/palamedes/blob/main/adr/003-source-string-first-message-identity.md">adr/003</a>
+        </div>
+        <div class="card">
+          <h3>One runtime call</h3>
+          <p>getI18n() resolves the active instance everywhere: server components, client islands, backend request handlers.</p>
+          <a class="more" href="https://github.com/sebastian-software/palamedes/blob/main/adr/005-universal-geti18n-runtime-model.md">adr/005</a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- code showcase -->
+  <section class="block">
+    <div class="wrap">
+      <div class="sec-label">workflow</div>
+      <h2>The whole workflow, honestly small.</h2>
+      <div class="tabs" role="tablist">
+        <button class="tab-btn active" data-tab="write" role="tab" aria-selected="true">Write</button>
+        <button class="tab-btn" data-tab="extract" role="tab" aria-selected="false">Extract</button>
+        <button class="tab-btn" data-tab="translate" role="tab" aria-selected="false">Translate</button>
+      </div>
+      <div class="tab-panels">
+        <div class="tab-panel active" data-panel="write">
+          <div class="tab-caption">Messages live where the UI happens.</div>
+<pre class="code"><span class="c-kw">import</span> { t, plural } <span class="c-kw">from</span> <span class="c-str">"@palamedes/core/macro"</span>
+<span class="c-kw">import</span> { Trans } <span class="c-kw">from</span> <span class="c-str">"@palamedes/react"</span>
+
+<span class="c-kw">export function</span> Booking({ seats }: { seats: <span class="c-kw">number</span> }) {
+  <span class="c-kw">return</span> (
+    &lt;&gt;
+      &lt;h1&gt;{t<span class="c-str">`Your trip to Lisbon`</span>}&lt;/h1&gt;
+      &lt;p&gt;{plural(seats, { one: <span class="c-str">"# seat left"</span>, other: <span class="c-str">"# seats left"</span> })}&lt;/p&gt;
+      &lt;Trans&gt;Free cancellation until &lt;b&gt;24 hours&lt;/b&gt; before departure.&lt;/Trans&gt;
+    &lt;/&gt;
+  )
+}</pre>
+        </div>
+        <div class="tab-panel" data-panel="extract">
+          <div class="tab-caption">One native command scans, extracts, and updates catalogs.</div>
+<pre class="code"><span class="c-amber">$</span> pmds extract
+
+  en  3 messages  <span class="c-str">(1 new)</span>
+  de  3 messages  <span class="c-amber">(1 missing translation)</span>
+
+  <span class="c-str">done in 34 ms</span></pre>
+        </div>
+        <div class="tab-panel" data-panel="translate">
+          <div class="tab-caption">Source-string-first .po — readable by translators and every TMS.</div>
+<pre class="code"><span class="c-dim">#: src/Booking.tsx:7</span>
+<span class="c-kw">msgid</span> <span class="c-str">"Your trip to Lisbon"</span>
+<span class="c-kw">msgstr</span> <span class="c-str">"Deine Reise nach Lissabon"</span>
+
+<span class="c-dim">#: src/Booking.tsx:8</span>
+<span class="c-kw">msgid</span> <span class="c-str">"{seats, plural, one {# seat left} other {# seats left}}"</span>
+<span class="c-kw">msgstr</span> <span class="c-str">"{seats, plural, one {# Platz frei} other {# Plätze frei}}"</span></pre>
+        </div>
+        <div class="result-panel">
+          <div class="rp-title">Rendered</div>
+          <div class="rp-body">The same component, in every locale, in every framework.</div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- proof teaser -->
+  <section class="block">
+    <div class="wrap">
+      <div class="sec-label">proof</div>
+      <h2>We don't ask you to trust a slogan. The repo shows the work.</h2>
+      <p class="body subline">Every framework/strategy combination is a real app, re-verified in CI through the same
+        Playwright flow — with public demos where the hosting is ready. Every benchmark number
+        links to a checked-in, re-runnable report.</p>
+
+      <div class="matrix-scroll">
+        <div class="matrix-mount" data-strategy-labels="Cookie|Route|Subdomain|TLD"></div>
+      </div>
+
+      <div class="bench">
+        <div class="bench-title">End-to-end extract + catalog update (small corpus, median)</div>
+        <div class="meter-row">
+          <span class="meter-tool win">Palamedes</span>
+          <span class="meter-track"><span class="meter-rail"><span class="meter-fill win" style="width:5.1%"></span></span></span>
+          <span class="meter-val"><b>33.53 ms</b></span>
+        </div>
+        <div class="meter-row">
+          <span class="meter-tool">i18next-parser</span>
+          <span class="meter-track"><span class="meter-rail"><span class="meter-fill" style="width:72.7%"></span></span></span>
+          <span class="meter-val">477.58 ms</span>
+        </div>
+        <div class="meter-row">
+          <span class="meter-tool">Lingui</span>
+          <span class="meter-track"><span class="meter-rail"><span class="meter-fill" style="width:100%"></span></span></span>
+          <span class="meter-val">657.00 ms</span>
+        </div>
+        <div class="bench-note">Linear scale, full track = 657.00 ms — the Palamedes bar really is that short; nothing is truncated or distorted.
+          Machine-local numbers from the checked-in report; your hardware will differ, the ratios are the signal.
+          <a href="https://github.com/sebastian-software/palamedes/blob/main/docs/benchmark-e2e-workflow.md">Methodology</a></div>
+      </div>
+
+      <div class="cta-row">
+        <a class="btn secondary" href="#/proof">All benchmarks &amp; the verification story</a>
+      </div>
+    </div>
+  </section>
+
+  <!-- positioning -->
+  <div class="statement">
+    <div class="wrap">
+      <p>Palamedes is narrower than some alternatives on purpose:
+        compile-time authoring, source-string-first catalogs, and a local
+        workflow your repo owns — with a Rust core doing the careful work.</p>
+    </div>
+  </div>
+
+  <!-- who builds -->
+  <section class="block">
+    <div class="wrap">
+      <div class="sec-label">maintainer</div>
+      <h2>Built from repeat experience, not a weekend take.</h2>
+      <p class="body subline">Palamedes is maintained by Sebastian Software GmbH. It is the third generation of
+        source-string-first JavaScript i18n tooling from the same author — from gettext-style
+        macro systems in qooxdoo to a full enterprise Lingui migration at Regrello (acquired by
+        Salesforce in 2025). The lessons are written down as 16 ADRs before you depend on the
+        tool.</p>
+      <ul class="linklist">
+        <li><a href="https://github.com/sebastian-software/palamedes/tree/main/adr">The decision trail (ADRs)</a></li>
+        <li><a href="#" class="dead" title="Not part of this draft">Why this exists</a></li>
+      </ul>
+    </div>
+  </section>
+
+  <div class="cta-band">
+    <div class="wrap">
+      <h2>Your first working translation is 5 minutes away.</h2>
+      <div class="cta-row">
+        <a class="btn primary" href="#/get-started">Get started</a>
+        <a class="btn secondary" href="https://github.com/sebastian-software/palamedes">Star on GitHub</a>
+      </div>
+    </div>
+  </div>
+</main>
+
+<!-- ============================================ VIEW: FRAMEWORKS -->
+<main id="view-frameworks" class="view">
+  <div class="wrap hero">
+    <div class="path-label">~/palamedes › <b>frameworks</b></div>
+    <div class="eyebrow">Framework matrix</div>
+    <h1>Five frameworks. Four locale strategies. One mental model.</h1>
+    <p class="subline">Every cell below is a real application — the same booking UI,
+      the same catalogs, the same runtime calls — browser-verified in CI.
+      Where public hosting is ready, open the demo, switch the language,
+      and watch copy, plurals, currency, and dates change together.</p>
+    <div class="cta-row">
+      <a class="btn primary" href="https://nextjs-cookie.examples.palamedes.dev">Open a live demo</a>
+      <a class="btn secondary" href="https://github.com/sebastian-software/palamedes/tree/main/examples">Browse the example source</a>
+    </div>
+  </div>
+
+  <section class="block">
+    <div class="wrap">
+      <div class="sec-label">matrix</div>
+      <div class="matrix-scroll">
+        <div class="matrix-mount" data-strategy-labels="Cookie|Route segment|Subdomain|Top-level domain"></div>
+      </div>
+      <p class="matrix-caption">All 20 apps are verified in CI with the same Playwright-driven browser flow: SSR output,
+        locale switching, localized server actions. Screenshots are versioned in the repo. Cookie
+        and route demos are publicly hosted today; subdomain and TLD hosting is being provisioned
+        — until then those cells link the verified source instead.</p>
+    </div>
+  </section>
+
+  <section class="block">
+    <div class="wrap">
+      <div class="sec-label">strategies</div>
+      <h2>Pick the locale strategy your product needs — not the one your framework dictates.</h2>
+      <div class="grid cols-4">
+        <div class="card">
+          <h3>Cookie</h3>
+          <p>One URL for all locales. Best for apps behind login where SEO is irrelevant and switching should be instant.</p>
+        </div>
+        <div class="card">
+          <h3>Route segment</h3>
+          <p>/de/checkout-style paths. The SEO-friendly default for public content with indexable localized pages.</p>
+        </div>
+        <div class="card">
+          <h3>Subdomain</h3>
+          <p>de.example.com. Clean separation per market, works well with regional CDNs and analytics splits.</p>
+        </div>
+        <div class="card">
+          <h3>Top-level domain</h3>
+          <p>example.de vs example.com. Maximum market trust; Palamedes maps each domain to its locale.</p>
+        </div>
+      </div>
+      <ul class="linklist">
+        <li><a href="https://github.com/sebastian-software/palamedes/blob/main/docs/locale-strategies.md">Locale strategies in depth</a></li>
+      </ul>
+    </div>
+  </section>
+
+  <section class="block">
+    <div class="wrap">
+      <div class="sec-label">per-framework</div>
+      <h2>Your stack, specifically.</h2>
+
+      <div class="fw-panel">
+        <h3>Next.js</h3>
+        <p>App Router with server components and server actions. The @palamedes/next-plugin wires the transform into the Next build; everything else is the shared model.</p>
+        <div class="fw-demos">
+          <span class="grp">demos:</span>
+          <a href="https://nextjs-cookie.examples.palamedes.dev"><span class="led live"></span>cookie</a>
+          <span class="grp">route →</span>
+          <a href="https://nextjs-route.examples.palamedes.dev/en">en</a>
+          <a href="https://nextjs-route.examples.palamedes.dev/de">de</a>
+          <a href="https://nextjs-route.examples.palamedes.dev/es">es</a>
+          <a href="https://github.com/sebastian-software/palamedes/tree/main/examples/nextjs-subdomain"><span class="led prov"></span>subdomain src</a>
+          <a href="https://github.com/sebastian-software/palamedes/tree/main/examples/nextjs-tld"><span class="led prov"></span>tld src</a>
+          <a class="src" href="https://github.com/sebastian-software/palamedes/tree/main/examples/nextjs-route">source ↗</a>
+        </div>
+      </div>
+
+      <div class="fw-panel">
+        <h3>TanStack Start</h3>
+        <p>Server functions and file-based routing, integrated through @palamedes/vite-plugin. Locale resolution runs in a server function; the client stays island-light.</p>
+        <div class="fw-demos">
+          <span class="grp">demos:</span>
+          <a href="https://tanstack-cookie.examples.palamedes.dev"><span class="led live"></span>cookie</a>
+          <span class="grp">route →</span>
+          <a href="https://tanstack-route.examples.palamedes.dev/en">en</a>
+          <a href="https://tanstack-route.examples.palamedes.dev/de">de</a>
+          <a href="https://tanstack-route.examples.palamedes.dev/es">es</a>
+          <a href="https://github.com/sebastian-software/palamedes/tree/main/examples/tanstack-subdomain"><span class="led prov"></span>subdomain src</a>
+          <a href="https://github.com/sebastian-software/palamedes/tree/main/examples/tanstack-tld"><span class="led prov"></span>tld src</a>
+          <a class="src" href="https://github.com/sebastian-software/palamedes/tree/main/examples/tanstack-route">source ↗</a>
+        </div>
+      </div>
+
+      <div class="fw-panel">
+        <h3>SolidStart</h3>
+        <p>Fine-grained reactivity with @palamedes/solid — the same macro authoring and catalogs as React, no fork of your i18n strategy for a different renderer.</p>
+        <div class="fw-demos">
+          <span class="grp">demos:</span>
+          <a href="https://solidstart-cookie.examples.palamedes.dev"><span class="led live"></span>cookie</a>
+          <span class="grp">route →</span>
+          <a href="https://solidstart-route.examples.palamedes.dev/en">en</a>
+          <a href="https://solidstart-route.examples.palamedes.dev/de">de</a>
+          <a href="https://solidstart-route.examples.palamedes.dev/es">es</a>
+          <a href="https://github.com/sebastian-software/palamedes/tree/main/examples/solidstart-subdomain"><span class="led prov"></span>subdomain src</a>
+          <a href="https://github.com/sebastian-software/palamedes/tree/main/examples/solidstart-tld"><span class="led prov"></span>tld src</a>
+          <a class="src" href="https://github.com/sebastian-software/palamedes/tree/main/examples/solidstart-route">source ↗</a>
+        </div>
+      </div>
+
+      <div class="fw-panel">
+        <h3>Waku</h3>
+        <p>Minimal RSC framework. If the model holds here, it holds in your custom setup too — that's why Waku is in the matrix.</p>
+        <div class="fw-demos">
+          <span class="grp">demos:</span>
+          <a href="https://waku-cookie.examples.palamedes.dev"><span class="led live"></span>cookie</a>
+          <span class="grp">route →</span>
+          <a href="https://waku-route.examples.palamedes.dev/en">en</a>
+          <a href="https://waku-route.examples.palamedes.dev/de">de</a>
+          <a href="https://waku-route.examples.palamedes.dev/es">es</a>
+          <a href="https://github.com/sebastian-software/palamedes/tree/main/examples/waku-subdomain"><span class="led prov"></span>subdomain src</a>
+          <a href="https://github.com/sebastian-software/palamedes/tree/main/examples/waku-tld"><span class="led prov"></span>tld src</a>
+          <a class="src" href="https://github.com/sebastian-software/palamedes/tree/main/examples/waku-route">source ↗</a>
+        </div>
+      </div>
+
+      <div class="fw-panel">
+        <h3>React Router</h3>
+        <p>Framework-mode React Router with loaders and actions. The classic SPA-plus-SSR shape, same catalogs, same runtime.</p>
+        <div class="fw-demos">
+          <span class="grp">demos:</span>
+          <a href="https://react-router-cookie.examples.palamedes.dev"><span class="led live"></span>cookie</a>
+          <span class="grp">route →</span>
+          <a href="https://react-router-route.examples.palamedes.dev/en">en</a>
+          <a href="https://react-router-route.examples.palamedes.dev/de">de</a>
+          <a href="https://react-router-route.examples.palamedes.dev/es">es</a>
+          <a href="https://github.com/sebastian-software/palamedes/tree/main/examples/react-router-subdomain"><span class="led prov"></span>subdomain src</a>
+          <a href="https://github.com/sebastian-software/palamedes/tree/main/examples/react-router-tld"><span class="led prov"></span>tld src</a>
+          <a class="src" href="https://github.com/sebastian-software/palamedes/tree/main/examples/react-router-route">source ↗</a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="block">
+    <div class="wrap">
+      <div class="sec-label">backend</div>
+      <h2>And it doesn't stop at the frontend.</h2>
+      <p class="body subline">The same getI18n() model runs in Hono and Express with request-local locale resolution —
+        transactional emails, API error messages, and PDF generation speak the user's language
+        from the same catalogs.</p>
+      <div class="cta-row">
+        <a class="btn secondary" href="https://github.com/sebastian-software/palamedes/blob/main/docs/backend-servers.md">Backend servers guide</a>
+      </div>
+    </div>
+  </section>
+
+  <div class="cta-band">
+    <div class="wrap">
+      <h2>See your framework speaking three languages — right now.</h2>
+      <div class="cta-row">
+        <a class="btn primary" href="https://nextjs-cookie.examples.palamedes.dev">Open the live matrix</a>
+        <a class="btn secondary" href="#/get-started">Get started</a>
+      </div>
+    </div>
+  </div>
+</main>
+
+<!-- ================================================= VIEW: PROOF -->
+<main id="view-proof" class="view">
+  <div class="wrap hero">
+    <div class="path-label">~/palamedes › <b>proof</b></div>
+    <div class="eyebrow">Proof</div>
+    <h1>Claims you can re-run.</h1>
+    <p class="subline">Every number on this page comes from a checked-in,
+      machine-readable report with fixtures and commands in the repo.
+      If a claim can't be re-run, we don't make it.</p>
+    <div class="cta-row">
+      <a class="btn primary" href="https://github.com/sebastian-software/palamedes/blob/main/docs/benchmark-e2e-workflow.md">Re-run the benchmarks</a>
+      <a class="btn secondary" href="https://github.com/sebastian-software/palamedes/tree/main/benchmarks/e2e-workflow/results">Browse checked-in reports</a>
+    </div>
+  </div>
+
+  <section class="block">
+    <div class="wrap">
+      <div class="sec-label">benchmarks</div>
+      <h2>The workflow you feel every day: extract &amp; update.</h2>
+      <p class="body subline">The end-to-end benchmark measures what a developer actually waits for: scan sources,
+        extract messages, update catalogs, write files. Same generated message inventory, rendered
+        into each tool's idiomatic source shape, semantically validated after every run.</p>
+
+      <div class="bench">
+        <div class="bench-title">Small corpus — 80 files, 640 messages (median of 7 runs)</div>
+        <div class="meter-row">
+          <span class="meter-tool win">Palamedes</span>
+          <span class="meter-track"><span class="meter-rail"><span class="meter-fill win" style="width:5.1%"></span></span></span>
+          <span class="meter-val"><b>33.53 ms</b></span>
+        </div>
+        <div class="meter-row">
+          <span class="meter-tool">i18next-parser 9.4</span>
+          <span class="meter-track"><span class="meter-rail"><span class="meter-fill" style="width:72.7%"></span></span></span>
+          <span class="meter-val">477.58 ms</span>
+        </div>
+        <div class="meter-row">
+          <span class="meter-tool">Lingui 6.4</span>
+          <span class="meter-track"><span class="meter-rail"><span class="meter-fill" style="width:100%"></span></span></span>
+          <span class="meter-val">657.00 ms</span>
+        </div>
+        <div class="bench-note">Linear scale, full track = 657.00 ms — the fast bar really is that short; nothing is truncated or distorted.
+          <a href="https://github.com/sebastian-software/palamedes/blob/main/docs/benchmark-e2e-workflow.md">Methodology</a></div>
+      </div>
+
+      <div class="bench">
+        <div class="bench-title">Medium corpus (median of 7 runs)</div>
+        <div class="meter-row">
+          <span class="meter-tool win">Palamedes</span>
+          <span class="meter-track"><span class="meter-rail"><span class="meter-fill win" style="width:6.5%"></span></span></span>
+          <span class="meter-val"><b>42.92 ms</b></span>
+        </div>
+        <div class="bench-note">Competitor medians for the medium corpus live in the checked-in report:
+          <a href="https://github.com/sebastian-software/palamedes/blob/main/benchmarks/e2e-workflow/results/latest.md">results/latest.md</a> ·
+          <a href="https://github.com/sebastian-software/palamedes/blob/main/docs/benchmark-e2e-workflow.md">Methodology</a></div>
+      </div>
+
+      <div class="callout">These are machine-local numbers from the checked-in report, not a marketing average. Your
+        hardware will differ; the ratios are the signal. Commands to reproduce:
+        <code>pnpm benchmark:e2e-workflow</code>.</div>
+    </div>
+  </section>
+
+  <section class="block">
+    <div class="wrap">
+      <div class="sec-label">verification</div>
+      <h2>20 apps, verified in a real browser, on every change.</h2>
+      <div class="ci-log">
+        <div class="ln"><span class="tick">✓</span> [1/3] <span class="step-name">build</span></div>
+        <span class="desc">All 20 example apps build against the workspace packages — no mocked integrations.</span>
+        <div class="ln"><span class="tick">✓</span> [2/3] <span class="step-name">drive</span></div>
+        <span class="desc">A Playwright flow loads each app, checks SSR output, switches locales, and exercises localized server actions.</span>
+        <div class="ln"><span class="tick">✓</span> [3/3] <span class="step-name">capture</span></div>
+        <span class="desc">Screenshots are versioned in the repo, so 'works across frameworks' is a diffable artifact, not a slide.</span>
+      </div>
+
+      <div class="shot-frame">
+        <div class="shot-bar">
+          <span class="term-dot"></span><span class="term-dot"></span><span class="term-dot"></span>
+          <span class="shot-url">examples.palamedes.dev — the same booking UI in en · de · es</span>
+        </div>
+        <div class="shot-body">
+          <div class="locale-row" style="margin-top:0" aria-label="The same booking UI rendered in English, German, and Spanish">
+            <div class="bk-card">
+              <div class="bk-locale">en</div>
+              <div class="bk-title">Your trip to Lisbon</div>
+              <div class="bk-seats">3 seats left</div>
+              <div class="bk-meta"><span class="bk-price">€1,234.00</span><span class="bk-date">Jul 12, 2026</span></div>
+            </div>
+            <div class="bk-card">
+              <div class="bk-locale">de</div>
+              <div class="bk-title">Deine Reise nach Lissabon</div>
+              <div class="bk-seats">3 Plätze frei</div>
+              <div class="bk-meta"><span class="bk-price">1.234,00&nbsp;€</span><span class="bk-date">12. Juli 2026</span></div>
+            </div>
+            <div class="bk-card">
+              <div class="bk-locale">es</div>
+              <div class="bk-title">Tu viaje a Lisboa</div>
+              <div class="bk-seats">Quedan 3 asientos</div>
+              <div class="bk-meta"><span class="bk-price">1234,00&nbsp;€</span><span class="bk-date">12 jul 2026</span></div>
+            </div>
+          </div>
+        </div>
+        <div class="shot-caption">One demo, three locales: copy, plural seat counts, currency, and dates change together.
+          <a href="https://github.com/sebastian-software/palamedes/blob/main/docs/example-screenshots/README.md">Versioned screenshots ↗</a>
+          <span class="dimtxt">(CSS mock in this draft — the real page embeds the checked-in screenshot.)</span></div>
+      </div>
+    </div>
+  </section>
+
+  <section class="block">
+    <div class="wrap">
+      <div class="sec-label">catalog-qa</div>
+      <h2>Fast would be worthless if the catalogs were wrong.</h2>
+      <p class="body subline">Catalog semantics live in one dedicated engine (ferrocat): parsing, merging, structured
+        audits, and ICU authoring diagnostics. The benchmark harness validates every tool run
+        semantically — message inventories are compared, not just timed.</p>
+      <div class="grid cols-3">
+        <div class="card">
+          <h3>Structured audits</h3>
+          <p>Machine-readable catalog audits catch missing translations, stale entries, and metadata drift in CI.</p>
+        </div>
+        <div class="card">
+          <h3>ICU diagnostics</h3>
+          <p>Authoring mistakes in plural/select syntax are flagged at extract time, not at runtime in production.</p>
+        </div>
+        <div class="card">
+          <h3>Semantic merging</h3>
+          <p>A Git merge driver resolves catalog conflicts by meaning, not by line — no more broken .po files after rebases.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="block">
+    <div class="wrap">
+      <div class="sec-label">adrs</div>
+      <h2>16 decisions, written down before you depend on them.</h2>
+      <p class="body subline">The ADRs cover message identity, the native boundary, adapter architecture — and, just as
+        deliberately, what Palamedes refuses to own. Reading them is the fastest way to know if
+        our tradeoffs match yours.</p>
+      <ul class="linklist">
+        <li><a href="https://github.com/sebastian-software/palamedes/tree/main/adr">ADR index</a></li>
+        <li><a href="https://github.com/sebastian-software/palamedes/blob/main/docs/stability.md">Stability &amp; versioning policy</a></li>
+        <li><a href="https://github.com/sebastian-software/palamedes/blob/main/docs/principles.md">Palamedes principles</a></li>
+      </ul>
+    </div>
+  </section>
+
+  <div class="cta-band">
+    <div class="wrap">
+      <h2>Convinced by the receipts? The quickstart takes 5 minutes.</h2>
+      <div class="cta-row">
+        <a class="btn primary" href="#/get-started">Get started</a>
+        <a class="btn secondary dead" href="#" title="Not part of this draft">Compare with your current tool</a>
+      </div>
+    </div>
+  </div>
+</main>
+
+<!-- =========================================== VIEW: GET STARTED -->
+<main id="view-get-started" class="view">
+  <div class="wrap hero">
+    <div class="path-label">~/palamedes › <b>get-started</b></div>
+    <div class="eyebrow">Quickstart</div>
+    <h1>First working translation in 5 minutes.</h1>
+    <p class="subline">One translated component, one extraction run, one .po file,
+      one runtime instance. No message IDs to invent, no dictionary files
+      to maintain.</p>
+    <div class="cta-row">
+      <a class="btn primary" href="#install">Skip to step 1</a>
+      <a class="btn secondary" href="https://github.com/sebastian-software/palamedes/blob/main/docs/first-working-translation.md">Full written guide</a>
+    </div>
+
+    <div class="stack-picker" role="group" aria-label="Stack picker">
+      <span class="lbl">stack:</span>
+      <button class="stack-chip active" type="button">Vite + React</button>
+      <button class="stack-chip" type="button">Vite + Solid</button>
+      <button class="stack-chip" type="button">Next.js</button>
+    </div>
+    <p class="stack-note">This static draft mocks the Vite + React path; in the real page the picker switches every code block below.</p>
+
+    <div class="callout">Heads-up: install the scoped <code>@palamedes/*</code> packages. The top-level
+      <code>palamedes</code> and <code>create-palamedes</code> names are reserved for a future
+      one-command setup and are not the entry point today.</div>
+
+    <div class="steps">
+      <div class="step" id="install">
+        <div class="step-num">1</div>
+        <div>
+          <h3>Install</h3>
+          <p class="step-body">Core, runtime, host adapter, and the build plugin — plus the CLI as a dev dependency.</p>
+<pre class="code"><span class="c-amber">$</span> pnpm add @palamedes/core @palamedes/react @palamedes/runtime @palamedes/vite-plugin
+<span class="c-amber">$</span> pnpm add -D @palamedes/cli @vitejs/plugin-react</pre>
+        </div>
+      </div>
+
+      <div class="step">
+        <div class="step-num">2</div>
+        <div>
+          <h3>Configure</h3>
+          <p class="step-body">One YAML file declares your locales and where catalogs live.</p>
+<pre class="code"><span class="c-dim"># palamedes.yaml</span>
+<span class="c-kw">locales:</span> [en, de]
+<span class="c-kw">source-locale:</span> en
+<span class="c-kw">catalogs:</span>
+  - <span class="c-kw">path:</span> src/locales/{locale}
+    <span class="c-kw">include:</span> [src]</pre>
+        </div>
+      </div>
+
+      <div class="step">
+        <div class="step-num">3</div>
+        <div>
+          <h3>Wire the plugin &amp; runtime</h3>
+          <p class="step-body">The Vite plugin handles the macro transform; the runtime holds the active i18n instance.</p>
+<pre class="code"><span class="c-dim">// vite.config.ts</span>
+<span class="c-kw">import</span> { palamedes } <span class="c-kw">from</span> <span class="c-str">"@palamedes/vite-plugin"</span>
+<span class="c-kw">export default</span> defineConfig({ plugins: [palamedes(), react()] })
+
+<span class="c-dim">// src/i18n.ts</span>
+<span class="c-kw">import</span> { createI18n } <span class="c-kw">from</span> <span class="c-str">"@palamedes/core"</span>
+<span class="c-kw">import</span> { setClientI18n } <span class="c-kw">from</span> <span class="c-str">"@palamedes/runtime"</span>
+
+<span class="c-kw">export const</span> i18n = createI18n()
+setClientI18n(i18n)</pre>
+        </div>
+      </div>
+
+      <div class="step">
+        <div class="step-num">4</div>
+        <div>
+          <h3>Write &amp; extract</h3>
+          <p class="step-body">Author the message in your component, then run one command — it creates src/locales/en.po and de.po.</p>
+<pre class="code"><span class="c-dim">// src/App.tsx</span>
+<span class="c-kw">import</span> { t } <span class="c-kw">from</span> <span class="c-str">"@palamedes/core/macro"</span>
+<span class="c-kw">export const</span> App = () =&gt; &lt;h1&gt;{t<span class="c-str">`Welcome to Palamedes`</span>}&lt;/h1&gt;
+
+<span class="c-amber">$</span> pmds extract</pre>
+        </div>
+      </div>
+
+      <div class="step">
+        <div class="step-num">5</div>
+        <div>
+          <h3>Translate</h3>
+          <p class="step-body">Open the German catalog and fill in the translated string.</p>
+<pre class="code"><span class="c-dim"># src/locales/de.po</span>
+<span class="c-kw">msgid</span> <span class="c-str">"Welcome to Palamedes"</span>
+<span class="c-kw">msgstr</span> <span class="c-str">"Willkommen bei Palamedes"</span></pre>
+        </div>
+      </div>
+
+      <div class="step">
+        <div class="step-num">6</div>
+        <div>
+          <h3>Load &amp; see it render</h3>
+          <p class="step-body">Load the catalogs, activate a locale, and run the dev server — the page now renders “Willkommen bei Palamedes”. That is the full local loop: transform, extraction, catalog, runtime.</p>
+<pre class="code"><span class="c-dim">// src/main.tsx</span>
+<span class="c-kw">import</span> { i18n } <span class="c-kw">from</span> <span class="c-str">"./i18n"</span>
+<span class="c-kw">import</span> { messages <span class="c-kw">as</span> enMessages } <span class="c-kw">from</span> <span class="c-str">"./locales/en.po"</span>
+<span class="c-kw">import</span> { messages <span class="c-kw">as</span> deMessages } <span class="c-kw">from</span> <span class="c-str">"./locales/de.po"</span>
+
+i18n.load(<span class="c-str">"en"</span>, enMessages)
+i18n.load(<span class="c-str">"de"</span>, deMessages)
+i18n.activate(<span class="c-str">"de"</span>)
+
+<span class="c-amber">$</span> pnpm dev</pre>
+          <div class="aside-note">TypeScript needs an ambient declaration for .po imports — add a src/po.d.ts with <code>declare module "*.po"</code> (see the <a href="https://github.com/sebastian-software/palamedes/blob/main/docs/troubleshooting.md">troubleshooting guide</a>).</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <section class="block">
+    <div class="wrap">
+      <div class="sec-label">next</div>
+      <h2>Where to go from here</h2>
+      <div class="grid cols-3">
+        <div class="card">
+          <h3>Plurals, dates &amp; currency</h3>
+          <p>ICU MessageFormat with authoring diagnostics that catch mistakes at extract time.</p>
+          <a class="more" href="https://github.com/sebastian-software/palamedes/blob/main/docs/api/core.md">docs/api/core.md</a>
+        </div>
+        <div class="card">
+          <h3>Pick a locale strategy</h3>
+          <p>Cookie, route, subdomain, or TLD — with a live demo for each, in your framework.</p>
+          <a class="more" href="#/frameworks">frameworks</a>
+        </div>
+        <div class="card">
+          <h3>Localize your backend</h3>
+          <p>Request-local i18n for Hono and Express from the same catalogs.</p>
+          <a class="more" href="https://github.com/sebastian-software/palamedes/blob/main/docs/backend-servers.md">docs/backend-servers.md</a>
+        </div>
+        <div class="card">
+          <h3>Migrating from Lingui?</h3>
+          <p>A step-by-step playbook. Source-string-first .po catalogs are often reusable after an extraction pass; explicit-ID setups need cleanup.</p>
+          <a class="more" href="https://github.com/sebastian-software/palamedes/blob/main/docs/migrate-from-lingui.md">docs/migrate-from-lingui.md</a>
+        </div>
+        <div class="card">
+          <h3>Something broke?</h3>
+          <p>The troubleshooting guide covers the common setup failures with exact error messages.</p>
+          <a class="more" href="https://github.com/sebastian-software/palamedes/blob/main/docs/troubleshooting.md">docs/troubleshooting.md</a>
+        </div>
+        <div class="card">
+          <h3>Using an AI assistant?</h3>
+          <p>Point it at llms.txt — the whole API surface in one machine-readable file.</p>
+          <a class="more" href="https://github.com/sebastian-software/palamedes/blob/main/llms.txt">llms.txt</a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <div class="cta-band">
+    <div class="wrap">
+      <h2>Stuck? The maintainer reads every issue.</h2>
+      <div class="cta-row">
+        <a class="btn primary" href="https://github.com/sebastian-software/palamedes/issues">Open an issue</a>
+        <a class="btn secondary" href="https://github.com/sebastian-software/palamedes/blob/main/docs/api/README.md">Read the docs</a>
+      </div>
+    </div>
+  </div>
+</main>
+
+<!-- ==================================================== FOOTER -->
+<footer class="site-footer">
+  <div class="wrap">
+    <div class="footer-cols">
+      <div>
+        <h4>Product</h4>
+        <ul>
+          <li><a href="#/get-started">Get started</a></li>
+          <li><a href="#/frameworks">Framework matrix</a></li>
+          <li><a href="#/proof">Benchmarks &amp; proof</a></li>
+          <li><a href="#" class="dead" title="Not part of this draft">Comparison</a></li>
+        </ul>
+      </div>
+      <div>
+        <h4>Documentation</h4>
+        <ul>
+          <li><a href="https://github.com/sebastian-software/palamedes/blob/main/docs/first-working-translation.md">5-minute quickstart</a></li>
+          <li><a href="https://github.com/sebastian-software/palamedes/blob/main/docs/api/README.md">API reference</a></li>
+          <li><a href="https://github.com/sebastian-software/palamedes/blob/main/docs/configuration.md">Configuration</a></li>
+          <li><a href="https://github.com/sebastian-software/palamedes/blob/main/docs/cli.md">CLI</a></li>
+          <li><a href="https://github.com/sebastian-software/palamedes/blob/main/docs/troubleshooting.md">Troubleshooting</a></li>
+        </ul>
+      </div>
+      <div>
+        <h4>Project</h4>
+        <ul>
+          <li><a href="https://github.com/sebastian-software/palamedes/tree/main/adr">Architecture decisions</a></li>
+          <li><a href="https://github.com/sebastian-software/palamedes/blob/main/docs/stability.md">Stability &amp; versioning</a></li>
+          <li><a href="https://github.com/sebastian-software/palamedes/blob/main/CHANGELOG.md">Changelog</a></li>
+          <li><a href="https://github.com/sebastian-software/palamedes/blob/main/SECURITY.md">Security</a></li>
+          <li><a href="https://github.com/sebastian-software/palamedes/blob/main/LICENSE">MIT license</a></li>
+        </ul>
+      </div>
+      <div>
+        <h4>Company</h4>
+        <ul>
+          <li><a href="https://oss.sebastian-software.com/">Sebastian Software</a></li>
+          <li><a href="https://sebastian-software.de/werner">Sebastian Werner</a></li>
+          <li><a href="#" class="dead" title="Not part of this draft">Blog</a></li>
+        </ul>
+      </div>
+    </div>
+    <div class="legal-strip">MIT © 2026 Sebastian Software GmbH — built in the open, verified in CI.</div>
+  </div>
+</footer>
+
+<script>
+(function () {
+  "use strict";
+
+  /* ------------------------------------------- framework matrix -- */
+  var REPO = "https://github.com/sebastian-software/palamedes";
+  var FRAMEWORKS = [
+    ["Next.js", "nextjs"],
+    ["TanStack Start", "tanstack"],
+    ["SolidStart", "solidstart"],
+    ["Waku", "waku"],
+    ["React Router", "react-router"]
+  ];
+  var STRATEGIES = ["cookie", "route", "subdomain", "tld"];
+
+  function esc(s) {
+    return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  }
+
+  function cellHtml(slug, strategy) {
+    var src = REPO + "/tree/main/examples/" + slug + "-" + strategy;
+    var html = "";
+    if (strategy === "cookie") {
+      html += '<span class="led live" title="live"></span><span class="chip-verified">VERIFIED</span>';
+      html += '<div class="cell-links">';
+      html += '<a href="https://' + slug + '-cookie.examples.palamedes.dev">open ↗</a>';
+      html += '<a class="src" href="' + src + '">src</a>';
+      html += "</div>";
+    } else if (strategy === "route") {
+      html += '<span class="led live" title="live"></span><span class="chip-verified">VERIFIED</span>';
+      html += '<div class="cell-links">';
+      ["en", "de", "es"].forEach(function (loc) {
+        html += '<a href="https://' + slug + '-route.examples.palamedes.dev/' + loc + '">' + loc + "</a>";
+      });
+      html += '<a class="src" href="' + src + '">src</a>';
+      html += "</div>";
+    } else {
+      html += '<span class="led prov" title="provisioning"></span><span class="chip-verified">VERIFIED</span>';
+      html += '<div class="cell-links"><span class="cell-status">provisioning</span>';
+      html += '<a class="src" href="' + src + '">source ↗</a></div>';
+    }
+    return html;
+  }
+
+  function buildMatrix(mount) {
+    var labels = (mount.getAttribute("data-strategy-labels") || "Cookie|Route|Subdomain|TLD").split("|");
+    var html = '<table class="matrix"><thead><tr><th scope="col">framework \\ strategy</th>';
+    labels.forEach(function (l) { html += '<th scope="col">' + esc(l) + "</th>"; });
+    html += "</tr></thead><tbody>";
+    FRAMEWORKS.forEach(function (fw) {
+      html += '<tr><th scope="row">' + esc(fw[0]) + "</th>";
+      STRATEGIES.forEach(function (st) { html += "<td>" + cellHtml(fw[1], st) + "</td>"; });
+      html += "</tr>";
+    });
+    html += "</tbody></table>";
+    mount.innerHTML = html;
+  }
+
+  Array.prototype.forEach.call(document.querySelectorAll(".matrix-mount"), buildMatrix);
+
+  /* ------------------------------------------------- hash router -- */
+  var ROUTES = {
+    "": "view-home",
+    "#": "view-home",
+    "#/": "view-home",
+    "#/frameworks": "view-frameworks",
+    "#/proof": "view-proof",
+    "#/get-started": "view-get-started"
+  };
+  var views = document.querySelectorAll(".view");
+  var navLinks = document.querySelectorAll(".nav-links a[data-route]");
+  var shown = false;
+
+  function show(id, hash) {
+    Array.prototype.forEach.call(views, function (v) {
+      v.classList.toggle("active", v.id === id);
+    });
+    Array.prototype.forEach.call(navLinks, function (a) {
+      a.classList.toggle("active", "#/" + a.getAttribute("data-route") === hash);
+    });
+    shown = true;
+    window.scrollTo(0, 0);
+  }
+
+  function route() {
+    var hash = window.location.hash;
+    if (Object.prototype.hasOwnProperty.call(ROUTES, hash)) {
+      show(ROUTES[hash], hash);
+    } else if (!shown) {
+      show("view-home", "#/");
+    }
+    /* unknown hashes (e.g. #install) keep the current view so
+       in-page anchors work; the browser handles the scroll. */
+  }
+
+  window.addEventListener("hashchange", route);
+  route();
+
+  /* ------------------------------------------------- dead links -- */
+  document.addEventListener("click", function (e) {
+    var el = e.target.closest ? e.target.closest("a.dead") : null;
+    if (el) e.preventDefault();
+  });
+
+  /* -------------------------------------------- code showcase tabs -- */
+  var tabButtons = document.querySelectorAll(".tab-btn");
+  Array.prototype.forEach.call(tabButtons, function (btn) {
+    btn.addEventListener("click", function () {
+      var name = btn.getAttribute("data-tab");
+      Array.prototype.forEach.call(tabButtons, function (b) {
+        var on = b === btn;
+        b.classList.toggle("active", on);
+        b.setAttribute("aria-selected", on ? "true" : "false");
+      });
+      Array.prototype.forEach.call(document.querySelectorAll(".tab-panel"), function (p) {
+        p.classList.toggle("active", p.getAttribute("data-panel") === name);
+      });
+    });
+  });
+
+  /* ------------------------------------------- stack picker (mock) -- */
+  var chips = document.querySelectorAll(".stack-chip");
+  Array.prototype.forEach.call(chips, function (chip) {
+    chip.addEventListener("click", function () {
+      Array.prototype.forEach.call(chips, function (c) {
+        c.classList.toggle("active", c === chip);
+      });
+    });
+  });
+})();
+</script>
+</body>
+</html>

--- a/docs/site/structure/drafts/design-b-terminal.html
+++ b/docs/site/structure/drafts/design-b-terminal.html
@@ -1,701 +1,1338 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Palamedes — design draft B (Terminal)</title>
-<style>
-/* ============================================================
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Palamedes — design draft B (Terminal)</title>
+    <style>
+      /* ============================================================
    Design draft B — "TERMINAL / OPS"
    Dark, developer-native, workflow-first. Static mock, not final.
    ============================================================ */
-:root {
-  --bg: #0b0e14;
-  --panel: #11151d;
-  --panel-2: #0d1118;
-  --border: #1e2530;
-  --text: #c9d1d9;
-  --dim: #8b949e;
-  --green: #3fb950;
-  --cyan: #56d4dd;
-  --amber: #d29922;
-  --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
-  --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
-}
-* { box-sizing: border-box; }
-html { scroll-behavior: smooth; }
-body {
-  margin: 0;
-  background: var(--bg);
-  color: var(--text);
-  font-family: var(--mono);
-  font-size: 15px;
-  line-height: 1.55;
-  -webkit-font-smoothing: antialiased;
-}
-a { color: var(--cyan); text-decoration: none; }
-a:hover { text-decoration: underline; }
-a.dead { color: var(--dim); cursor: not-allowed; }
-a.dead:hover { text-decoration: none; }
-code { font-family: var(--mono); background: var(--panel); border: 1px solid var(--border); border-radius: 3px; padding: 0 4px; font-size: 0.92em; }
-h1, h2, h3, h4 { font-family: var(--mono); font-weight: 600; line-height: 1.25; margin: 0 0 14px; }
-h1 { font-size: clamp(26px, 4.6vw, 42px); letter-spacing: -0.5px; }
-h2 { font-size: clamp(19px, 2.6vw, 26px); }
-h3 { font-size: 16px; }
-p.body, .body p, .aside-note, .card p { font-family: var(--sans); }
-.wrap { max-width: 1120px; margin: 0 auto; padding: 0 24px; }
-section.block { padding: 56px 0; border-top: 1px solid var(--border); }
-.dimtxt { color: var(--dim); }
+      :root {
+        --bg: #0b0e14;
+        --panel: #11151d;
+        --panel-2: #0d1118;
+        --border: #1e2530;
+        --text: #c9d1d9;
+        --dim: #8b949e;
+        --green: #3fb950;
+        --cyan: #56d4dd;
+        --amber: #d29922;
+        --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+        --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html {
+        scroll-behavior: smooth;
+      }
+      body {
+        margin: 0;
+        background: var(--bg);
+        color: var(--text);
+        font-family: var(--mono);
+        font-size: 15px;
+        line-height: 1.55;
+        -webkit-font-smoothing: antialiased;
+      }
+      a {
+        color: var(--cyan);
+        text-decoration: none;
+      }
+      a:hover {
+        text-decoration: underline;
+      }
+      a.dead {
+        color: var(--dim);
+        cursor: not-allowed;
+      }
+      a.dead:hover {
+        text-decoration: none;
+      }
+      code {
+        font-family: var(--mono);
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-radius: 3px;
+        padding: 0 4px;
+        font-size: 0.92em;
+      }
+      h1,
+      h2,
+      h3,
+      h4 {
+        font-family: var(--mono);
+        font-weight: 600;
+        line-height: 1.25;
+        margin: 0 0 14px;
+      }
+      h1 {
+        font-size: clamp(26px, 4.6vw, 42px);
+        letter-spacing: -0.5px;
+      }
+      h2 {
+        font-size: clamp(19px, 2.6vw, 26px);
+      }
+      h3 {
+        font-size: 16px;
+      }
+      p.body,
+      .body p,
+      .aside-note,
+      .card p {
+        font-family: var(--sans);
+      }
+      .wrap {
+        max-width: 1120px;
+        margin: 0 auto;
+        padding: 0 24px;
+      }
+      section.block {
+        padding: 56px 0;
+        border-top: 1px solid var(--border);
+      }
+      .dimtxt {
+        color: var(--dim);
+      }
 
-/* prompt-style section labels */
-.sec-label {
-  font-family: var(--mono);
-  color: var(--green);
-  font-size: 13px;
-  letter-spacing: 0.5px;
-  margin-bottom: 10px;
-}
-.sec-label::before { content: "## "; color: var(--dim); }
-.path-label {
-  font-family: var(--mono);
-  color: var(--dim);
-  font-size: 13px;
-  margin-bottom: 10px;
-}
-.path-label b { color: var(--cyan); font-weight: 600; }
+      /* prompt-style section labels */
+      .sec-label {
+        font-family: var(--mono);
+        color: var(--green);
+        font-size: 13px;
+        letter-spacing: 0.5px;
+        margin-bottom: 10px;
+      }
+      .sec-label::before {
+        content: "## ";
+        color: var(--dim);
+      }
+      .path-label {
+        font-family: var(--mono);
+        color: var(--dim);
+        font-size: 13px;
+        margin-bottom: 10px;
+      }
+      .path-label b {
+        color: var(--cyan);
+        font-weight: 600;
+      }
 
-/* ------------------------------------------------------- ribbon */
-.draft-ribbon {
-  position: fixed;
-  bottom: 12px;
-  left: 12px;
-  z-index: 99;
-  background: var(--panel);
-  border: 1px solid var(--amber);
-  color: var(--amber);
-  font-size: 11px;
-  padding: 4px 10px;
-  border-radius: 3px;
-  letter-spacing: 0.4px;
-  box-shadow: 0 0 12px rgba(210, 153, 34, 0.15);
-}
+      /* ------------------------------------------------------- ribbon */
+      .draft-ribbon {
+        position: fixed;
+        bottom: 12px;
+        left: 12px;
+        z-index: 99;
+        background: var(--panel);
+        border: 1px solid var(--amber);
+        color: var(--amber);
+        font-size: 11px;
+        padding: 4px 10px;
+        border-radius: 3px;
+        letter-spacing: 0.4px;
+        box-shadow: 0 0 12px rgba(210, 153, 34, 0.15);
+      }
 
-/* ---------------------------------------------------------- nav */
-nav.site-nav {
-  position: sticky;
-  top: 0;
-  z-index: 50;
-  background: rgba(11, 14, 20, 0.92);
-  backdrop-filter: blur(6px);
-  border-bottom: 1px solid var(--border);
-}
-.nav-inner {
-  max-width: 1120px;
-  margin: 0 auto;
-  padding: 10px 24px;
-  display: flex;
-  align-items: center;
-  gap: 18px;
-  flex-wrap: wrap;
-}
-.wordmark {
-  font-weight: 700;
-  color: var(--text);
-  font-size: 16px;
-  letter-spacing: 0.3px;
-}
-.wordmark::before { content: "▮ "; color: var(--green); }
-.wordmark:hover { text-decoration: none; color: var(--green); }
-.nav-links { display: flex; gap: 16px; flex-wrap: wrap; font-size: 13.5px; flex: 1; }
-.nav-links a { color: var(--dim); }
-.nav-links a:hover { color: var(--cyan); text-decoration: none; }
-.nav-links a.active { color: var(--green); }
-.nav-links a.active::before { content: "> "; }
-.nav-actions { display: flex; gap: 10px; align-items: center; font-size: 13.5px; }
+      /* ---------------------------------------------------------- nav */
+      nav.site-nav {
+        position: sticky;
+        top: 0;
+        z-index: 50;
+        background: rgba(11, 14, 20, 0.92);
+        backdrop-filter: blur(6px);
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-inner {
+        max-width: 1120px;
+        margin: 0 auto;
+        padding: 10px 24px;
+        display: flex;
+        align-items: center;
+        gap: 18px;
+        flex-wrap: wrap;
+      }
+      .wordmark {
+        font-weight: 700;
+        color: var(--text);
+        font-size: 16px;
+        letter-spacing: 0.3px;
+      }
+      .wordmark::before {
+        content: "▮ ";
+        color: var(--green);
+      }
+      .wordmark:hover {
+        text-decoration: none;
+        color: var(--green);
+      }
+      .nav-links {
+        display: flex;
+        gap: 16px;
+        flex-wrap: wrap;
+        font-size: 13.5px;
+        flex: 1;
+      }
+      .nav-links a {
+        color: var(--dim);
+      }
+      .nav-links a:hover {
+        color: var(--cyan);
+        text-decoration: none;
+      }
+      .nav-links a.active {
+        color: var(--green);
+      }
+      .nav-links a.active::before {
+        content: "> ";
+      }
+      .nav-actions {
+        display: flex;
+        gap: 10px;
+        align-items: center;
+        font-size: 13.5px;
+      }
 
-/* keycap / command buttons */
-.btn {
-  display: inline-block;
-  font-family: var(--mono);
-  font-size: 13.5px;
-  padding: 8px 16px;
-  border-radius: 4px;
-  border: 1px solid var(--border);
-  background: var(--panel);
-  color: var(--text);
-  box-shadow: 0 2px 0 #060810;
-  white-space: nowrap;
-}
-.btn:hover { text-decoration: none; border-color: var(--dim); }
-.btn.primary {
-  border-color: var(--green);
-  color: var(--green);
-  box-shadow: 0 2px 0 rgba(63, 185, 80, 0.35), 0 0 14px rgba(63, 185, 80, 0.12);
-}
-.btn.primary::before { content: "> "; }
-.btn.secondary { color: var(--cyan); border-color: #2a4a52; }
-.btn.secondary::before { content: "$ "; color: var(--dim); }
+      /* keycap / command buttons */
+      .btn {
+        display: inline-block;
+        font-family: var(--mono);
+        font-size: 13.5px;
+        padding: 8px 16px;
+        border-radius: 4px;
+        border: 1px solid var(--border);
+        background: var(--panel);
+        color: var(--text);
+        box-shadow: 0 2px 0 #060810;
+        white-space: nowrap;
+      }
+      .btn:hover {
+        text-decoration: none;
+        border-color: var(--dim);
+      }
+      .btn.primary {
+        border-color: var(--green);
+        color: var(--green);
+        box-shadow:
+          0 2px 0 rgba(63, 185, 80, 0.35),
+          0 0 14px rgba(63, 185, 80, 0.12);
+      }
+      .btn.primary::before {
+        content: "> ";
+      }
+      .btn.secondary {
+        color: var(--cyan);
+        border-color: #2a4a52;
+      }
+      .btn.secondary::before {
+        content: "$ ";
+        color: var(--dim);
+      }
 
-/* --------------------------------------------------------- hero */
-.hero { padding: 60px 0 48px; }
-.hero-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 44px; align-items: start; }
-@media (max-width: 960px) { .hero-grid { grid-template-columns: 1fr; } }
-.eyebrow {
-  color: var(--amber);
-  font-size: 12.5px;
-  letter-spacing: 1.2px;
-  text-transform: uppercase;
-  margin-bottom: 14px;
-}
-.eyebrow::before { content: "[ "; color: var(--dim); }
-.eyebrow::after { content: " ]"; color: var(--dim); }
-.subline { font-family: var(--sans); color: var(--dim); font-size: 16px; max-width: 60ch; }
-.subline strong { color: var(--text); font-weight: 600; }
-.cta-row { display: flex; gap: 12px; margin-top: 24px; flex-wrap: wrap; }
+      /* --------------------------------------------------------- hero */
+      .hero {
+        padding: 60px 0 48px;
+      }
+      .hero-grid {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 44px;
+        align-items: start;
+      }
+      @media (max-width: 960px) {
+        .hero-grid {
+          grid-template-columns: 1fr;
+        }
+      }
+      .eyebrow {
+        color: var(--amber);
+        font-size: 12.5px;
+        letter-spacing: 1.2px;
+        text-transform: uppercase;
+        margin-bottom: 14px;
+      }
+      .eyebrow::before {
+        content: "[ ";
+        color: var(--dim);
+      }
+      .eyebrow::after {
+        content: " ]";
+        color: var(--dim);
+      }
+      .subline {
+        font-family: var(--sans);
+        color: var(--dim);
+        font-size: 16px;
+        max-width: 60ch;
+      }
+      .subline strong {
+        color: var(--text);
+        font-weight: 600;
+      }
+      .cta-row {
+        display: flex;
+        gap: 12px;
+        margin-top: 24px;
+        flex-wrap: wrap;
+      }
 
-/* terminal window */
-.term {
-  background: var(--panel-2);
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  overflow: hidden;
-  box-shadow: 0 0 30px rgba(63, 185, 80, 0.05);
-  position: relative;
-}
-.term::after { /* faint scanlines, decorative */
-  content: "";
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  background: repeating-linear-gradient(0deg, rgba(255,255,255,0.015) 0 1px, transparent 1px 3px);
-}
-.term-bar {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 8px 12px;
-  background: var(--panel);
-  border-bottom: 1px solid var(--border);
-}
-.term-dot { width: 10px; height: 10px; border-radius: 50%; background: var(--border); }
-.term-dot:nth-child(1) { background: #f85149; }
-.term-dot:nth-child(2) { background: var(--amber); }
-.term-dot:nth-child(3) { background: var(--green); }
-.term-title { margin-left: 8px; color: var(--dim); font-size: 12px; }
-.term-body { padding: 16px 18px; font-size: 13.5px; line-height: 1.75; overflow-x: auto; }
-.term-body .cmd { color: var(--text); }
-.term-body .cmd::before { content: "$ "; color: var(--green); }
-.term-body .out { color: var(--dim); white-space: pre; }
-.term-body .ok { color: var(--green); }
-.term-body .warn { color: var(--amber); }
-.cursor {
-  display: inline-block;
-  width: 8px;
-  height: 15px;
-  background: var(--green);
-  vertical-align: text-bottom;
-  animation: blink 1.1s steps(1) infinite;
-}
-@keyframes blink { 50% { opacity: 0; } }
-@media (prefers-reduced-motion: reduce) {
-  .cursor { animation: none; }
-  html { scroll-behavior: auto; }
-  .led { animation: none !important; }
-}
+      /* terminal window */
+      .term {
+        background: var(--panel-2);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        overflow: hidden;
+        box-shadow: 0 0 30px rgba(63, 185, 80, 0.05);
+        position: relative;
+      }
+      .term::after {
+        /* faint scanlines, decorative */
+        content: "";
+        position: absolute;
+        inset: 0;
+        pointer-events: none;
+        background: repeating-linear-gradient(
+          0deg,
+          rgba(255, 255, 255, 0.015) 0 1px,
+          transparent 1px 3px
+        );
+      }
+      .term-bar {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 8px 12px;
+        background: var(--panel);
+        border-bottom: 1px solid var(--border);
+      }
+      .term-dot {
+        width: 10px;
+        height: 10px;
+        border-radius: 50%;
+        background: var(--border);
+      }
+      .term-dot:nth-child(1) {
+        background: #f85149;
+      }
+      .term-dot:nth-child(2) {
+        background: var(--amber);
+      }
+      .term-dot:nth-child(3) {
+        background: var(--green);
+      }
+      .term-title {
+        margin-left: 8px;
+        color: var(--dim);
+        font-size: 12px;
+      }
+      .term-body {
+        padding: 16px 18px;
+        font-size: 13.5px;
+        line-height: 1.75;
+        overflow-x: auto;
+      }
+      .term-body .cmd {
+        color: var(--text);
+      }
+      .term-body .cmd::before {
+        content: "$ ";
+        color: var(--green);
+      }
+      .term-body .out {
+        color: var(--dim);
+        white-space: pre;
+      }
+      .term-body .ok {
+        color: var(--green);
+      }
+      .term-body .warn {
+        color: var(--amber);
+      }
+      .cursor {
+        display: inline-block;
+        width: 8px;
+        height: 15px;
+        background: var(--green);
+        vertical-align: text-bottom;
+        animation: blink 1.1s steps(1) infinite;
+      }
+      @keyframes blink {
+        50% {
+          opacity: 0;
+        }
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .cursor {
+          animation: none;
+        }
+        html {
+          scroll-behavior: auto;
+        }
+        .led {
+          animation: none !important;
+        }
+      }
 
-/* booking card locale mock */
-.locale-row { display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px; margin-top: 14px; }
-@media (max-width: 640px) { .locale-row { grid-template-columns: 1fr; } }
-.bk-card {
-  background: var(--panel);
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  padding: 12px;
-  font-family: var(--sans);
-  font-size: 12.5px;
-}
-.bk-locale {
-  font-family: var(--mono);
-  font-size: 10.5px;
-  color: var(--cyan);
-  letter-spacing: 1px;
-  margin-bottom: 8px;
-}
-.bk-locale::before { content: "locale="; color: var(--dim); }
-.bk-title { font-weight: 600; font-size: 13.5px; color: var(--text); margin-bottom: 4px; }
-.bk-seats { color: var(--green); margin-bottom: 8px; }
-.bk-meta { display: flex; justify-content: space-between; gap: 8px; border-top: 1px dashed var(--border); padding-top: 8px; }
-.bk-price { font-family: var(--mono); color: var(--text); font-weight: 600; }
-.bk-date { color: var(--dim); }
-.locale-caption { color: var(--dim); font-size: 12px; margin-top: 10px; font-family: var(--sans); }
+      /* booking card locale mock */
+      .locale-row {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 10px;
+        margin-top: 14px;
+      }
+      @media (max-width: 640px) {
+        .locale-row {
+          grid-template-columns: 1fr;
+        }
+      }
+      .bk-card {
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-radius: 6px;
+        padding: 12px;
+        font-family: var(--sans);
+        font-size: 12.5px;
+      }
+      .bk-locale {
+        font-family: var(--mono);
+        font-size: 10.5px;
+        color: var(--cyan);
+        letter-spacing: 1px;
+        margin-bottom: 8px;
+      }
+      .bk-locale::before {
+        content: "locale=";
+        color: var(--dim);
+      }
+      .bk-title {
+        font-weight: 600;
+        font-size: 13.5px;
+        color: var(--text);
+        margin-bottom: 4px;
+      }
+      .bk-seats {
+        color: var(--green);
+        margin-bottom: 8px;
+      }
+      .bk-meta {
+        display: flex;
+        justify-content: space-between;
+        gap: 8px;
+        border-top: 1px dashed var(--border);
+        padding-top: 8px;
+      }
+      .bk-price {
+        font-family: var(--mono);
+        color: var(--text);
+        font-weight: 600;
+      }
+      .bk-date {
+        color: var(--dim);
+      }
+      .locale-caption {
+        color: var(--dim);
+        font-size: 12px;
+        margin-top: 10px;
+        font-family: var(--sans);
+      }
 
-/* --------------------------------------------------- proof strip */
-.proof-strip {
-  border-top: 1px solid var(--border);
-  border-bottom: 1px solid var(--border);
-  background: var(--panel-2);
-}
-.proof-strip-inner {
-  max-width: 1120px;
-  margin: 0 auto;
-  padding: 20px 24px;
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 18px;
-}
-@media (max-width: 860px) { .proof-strip-inner { grid-template-columns: repeat(2, 1fr); } }
-@media (max-width: 460px) { .proof-strip-inner { grid-template-columns: 1fr; } }
-.stat a { display: block; color: inherit; }
-.stat a:hover { text-decoration: none; }
-.stat-value { font-size: 26px; font-weight: 700; color: var(--green); }
-.stat-label { font-size: 12px; color: var(--dim); font-family: var(--sans); margin-top: 2px; }
-.stat a:hover .stat-label { color: var(--cyan); }
+      /* --------------------------------------------------- proof strip */
+      .proof-strip {
+        border-top: 1px solid var(--border);
+        border-bottom: 1px solid var(--border);
+        background: var(--panel-2);
+      }
+      .proof-strip-inner {
+        max-width: 1120px;
+        margin: 0 auto;
+        padding: 20px 24px;
+        display: grid;
+        grid-template-columns: repeat(4, 1fr);
+        gap: 18px;
+      }
+      @media (max-width: 860px) {
+        .proof-strip-inner {
+          grid-template-columns: repeat(2, 1fr);
+        }
+      }
+      @media (max-width: 460px) {
+        .proof-strip-inner {
+          grid-template-columns: 1fr;
+        }
+      }
+      .stat a {
+        display: block;
+        color: inherit;
+      }
+      .stat a:hover {
+        text-decoration: none;
+      }
+      .stat-value {
+        font-size: 26px;
+        font-weight: 700;
+        color: var(--green);
+      }
+      .stat-label {
+        font-size: 12px;
+        color: var(--dim);
+        font-family: var(--sans);
+        margin-top: 2px;
+      }
+      .stat a:hover .stat-label {
+        color: var(--cyan);
+      }
 
-/* --------------------------------------------------------- cards */
-.grid { display: grid; gap: 14px; margin-top: 22px; }
-.grid.cols-3 { grid-template-columns: repeat(3, 1fr); }
-.grid.cols-4 { grid-template-columns: repeat(4, 1fr); }
-@media (max-width: 960px) { .grid.cols-3, .grid.cols-4 { grid-template-columns: repeat(2, 1fr); } }
-@media (max-width: 560px) { .grid.cols-3, .grid.cols-4 { grid-template-columns: 1fr; } }
-.card {
-  background: var(--panel);
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  padding: 16px;
-}
-.card h3 { color: var(--cyan); font-size: 14.5px; margin-bottom: 8px; }
-.card h3::before { content: "▸ "; color: var(--green); }
-.card p { color: var(--dim); font-size: 13.5px; margin: 0 0 10px; }
-.card a.more { font-size: 12.5px; }
-.card a.more::after { content: " ↗"; }
+      /* --------------------------------------------------------- cards */
+      .grid {
+        display: grid;
+        gap: 14px;
+        margin-top: 22px;
+      }
+      .grid.cols-3 {
+        grid-template-columns: repeat(3, 1fr);
+      }
+      .grid.cols-4 {
+        grid-template-columns: repeat(4, 1fr);
+      }
+      @media (max-width: 960px) {
+        .grid.cols-3,
+        .grid.cols-4 {
+          grid-template-columns: repeat(2, 1fr);
+        }
+      }
+      @media (max-width: 560px) {
+        .grid.cols-3,
+        .grid.cols-4 {
+          grid-template-columns: 1fr;
+        }
+      }
+      .card {
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-radius: 6px;
+        padding: 16px;
+      }
+      .card h3 {
+        color: var(--cyan);
+        font-size: 14.5px;
+        margin-bottom: 8px;
+      }
+      .card h3::before {
+        content: "▸ ";
+        color: var(--green);
+      }
+      .card p {
+        color: var(--dim);
+        font-size: 13.5px;
+        margin: 0 0 10px;
+      }
+      .card a.more {
+        font-size: 12.5px;
+      }
+      .card a.more::after {
+        content: " ↗";
+      }
 
-/* --------------------------------------------------- code showcase */
-.tabs { display: flex; gap: 6px; margin-bottom: -1px; flex-wrap: wrap; }
-.tab-btn {
-  font-family: var(--mono);
-  font-size: 13px;
-  background: var(--panel-2);
-  color: var(--dim);
-  border: 1px solid var(--border);
-  border-bottom: none;
-  border-radius: 6px 6px 0 0;
-  padding: 7px 16px;
-  cursor: pointer;
-}
-.tab-btn.active { color: var(--green); background: var(--panel); }
-.tab-btn.active::before { content: "● "; font-size: 9px; vertical-align: 2px; }
-.tab-panels {
-  border: 1px solid var(--border);
-  border-radius: 0 6px 6px 6px;
-  background: var(--panel);
-}
-.tab-panel { display: none; }
-.tab-panel.active { display: block; }
-.tab-caption { padding: 10px 16px 0; color: var(--dim); font-size: 12.5px; font-family: var(--sans); }
-pre.code {
-  margin: 0;
-  padding: 14px 16px 18px;
-  overflow-x: auto;
-  font-family: var(--mono);
-  font-size: 13px;
-  line-height: 1.65;
-  color: var(--text);
-}
-pre.code .c-kw { color: var(--cyan); }
-pre.code .c-str { color: var(--green); }
-pre.code .c-dim { color: var(--dim); }
-pre.code .c-amber { color: var(--amber); }
-.result-panel {
-  border-top: 1px dashed var(--border);
-  padding: 12px 16px;
-  font-size: 13px;
-}
-.result-panel .rp-title { color: var(--amber); font-size: 12px; letter-spacing: 1px; text-transform: uppercase; }
-.result-panel .rp-body { color: var(--dim); font-family: var(--sans); margin-top: 4px; }
+      /* --------------------------------------------------- code showcase */
+      .tabs {
+        display: flex;
+        gap: 6px;
+        margin-bottom: -1px;
+        flex-wrap: wrap;
+      }
+      .tab-btn {
+        font-family: var(--mono);
+        font-size: 13px;
+        background: var(--panel-2);
+        color: var(--dim);
+        border: 1px solid var(--border);
+        border-bottom: none;
+        border-radius: 6px 6px 0 0;
+        padding: 7px 16px;
+        cursor: pointer;
+      }
+      .tab-btn.active {
+        color: var(--green);
+        background: var(--panel);
+      }
+      .tab-btn.active::before {
+        content: "● ";
+        font-size: 9px;
+        vertical-align: 2px;
+      }
+      .tab-panels {
+        border: 1px solid var(--border);
+        border-radius: 0 6px 6px 6px;
+        background: var(--panel);
+      }
+      .tab-panel {
+        display: none;
+      }
+      .tab-panel.active {
+        display: block;
+      }
+      .tab-caption {
+        padding: 10px 16px 0;
+        color: var(--dim);
+        font-size: 12.5px;
+        font-family: var(--sans);
+      }
+      pre.code {
+        margin: 0;
+        padding: 14px 16px 18px;
+        overflow-x: auto;
+        font-family: var(--mono);
+        font-size: 13px;
+        line-height: 1.65;
+        color: var(--text);
+      }
+      pre.code .c-kw {
+        color: var(--cyan);
+      }
+      pre.code .c-str {
+        color: var(--green);
+      }
+      pre.code .c-dim {
+        color: var(--dim);
+      }
+      pre.code .c-amber {
+        color: var(--amber);
+      }
+      .result-panel {
+        border-top: 1px dashed var(--border);
+        padding: 12px 16px;
+        font-size: 13px;
+      }
+      .result-panel .rp-title {
+        color: var(--amber);
+        font-size: 12px;
+        letter-spacing: 1px;
+        text-transform: uppercase;
+      }
+      .result-panel .rp-body {
+        color: var(--dim);
+        font-family: var(--sans);
+        margin-top: 4px;
+      }
 
-/* --------------------------------------------------------- matrix */
-.matrix-scroll { overflow-x: auto; margin-top: 20px; border: 1px solid var(--border); border-radius: 6px; }
-table.matrix { border-collapse: collapse; width: 100%; min-width: 720px; background: var(--panel); font-size: 12.5px; }
-table.matrix th, table.matrix td { border: 1px solid var(--border); padding: 10px 12px; text-align: left; vertical-align: top; }
-table.matrix thead th { background: var(--panel-2); color: var(--cyan); font-weight: 600; font-size: 12px; letter-spacing: 0.5px; }
-table.matrix tbody th { color: var(--text); font-weight: 600; white-space: nowrap; background: var(--panel-2); }
-.led {
-  display: inline-block;
-  width: 8px; height: 8px;
-  border-radius: 50%;
-  margin-right: 6px;
-  vertical-align: 1px;
-}
-.led.live { background: var(--green); box-shadow: 0 0 6px rgba(63, 185, 80, 0.7); animation: pulse 2.4s ease-in-out infinite; }
-.led.prov { background: var(--amber); box-shadow: 0 0 6px rgba(210, 153, 34, 0.6); }
-@keyframes pulse { 50% { box-shadow: 0 0 2px rgba(63, 185, 80, 0.3); } }
-.chip-verified {
-  display: inline-block;
-  font-size: 10px;
-  letter-spacing: 0.8px;
-  color: var(--green);
-  border: 1px solid rgba(63, 185, 80, 0.45);
-  border-radius: 3px;
-  padding: 0 5px;
-  margin-left: 4px;
-}
-.cell-status { color: var(--amber); font-size: 11.5px; }
-.cell-links { margin-top: 6px; display: flex; gap: 8px; flex-wrap: wrap; }
-.cell-links a { font-size: 12px; }
-.cell-links a.src { color: var(--dim); }
-.cell-links a.src:hover { color: var(--cyan); }
-.matrix-caption { color: var(--dim); font-size: 13px; font-family: var(--sans); margin-top: 12px; max-width: 80ch; }
+      /* --------------------------------------------------------- matrix */
+      .matrix-scroll {
+        overflow-x: auto;
+        margin-top: 20px;
+        border: 1px solid var(--border);
+        border-radius: 6px;
+      }
+      table.matrix {
+        border-collapse: collapse;
+        width: 100%;
+        min-width: 720px;
+        background: var(--panel);
+        font-size: 12.5px;
+      }
+      table.matrix th,
+      table.matrix td {
+        border: 1px solid var(--border);
+        padding: 10px 12px;
+        text-align: left;
+        vertical-align: top;
+      }
+      table.matrix thead th {
+        background: var(--panel-2);
+        color: var(--cyan);
+        font-weight: 600;
+        font-size: 12px;
+        letter-spacing: 0.5px;
+      }
+      table.matrix tbody th {
+        color: var(--text);
+        font-weight: 600;
+        white-space: nowrap;
+        background: var(--panel-2);
+      }
+      .led {
+        display: inline-block;
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        margin-right: 6px;
+        vertical-align: 1px;
+      }
+      .led.live {
+        background: var(--green);
+        box-shadow: 0 0 6px rgba(63, 185, 80, 0.7);
+        animation: pulse 2.4s ease-in-out infinite;
+      }
+      .led.prov {
+        background: var(--amber);
+        box-shadow: 0 0 6px rgba(210, 153, 34, 0.6);
+      }
+      @keyframes pulse {
+        50% {
+          box-shadow: 0 0 2px rgba(63, 185, 80, 0.3);
+        }
+      }
+      .chip-verified {
+        display: inline-block;
+        font-size: 10px;
+        letter-spacing: 0.8px;
+        color: var(--green);
+        border: 1px solid rgba(63, 185, 80, 0.45);
+        border-radius: 3px;
+        padding: 0 5px;
+        margin-left: 4px;
+      }
+      .cell-status {
+        color: var(--amber);
+        font-size: 11.5px;
+      }
+      .cell-links {
+        margin-top: 6px;
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+      }
+      .cell-links a {
+        font-size: 12px;
+      }
+      .cell-links a.src {
+        color: var(--dim);
+      }
+      .cell-links a.src:hover {
+        color: var(--cyan);
+      }
+      .matrix-caption {
+        color: var(--dim);
+        font-size: 13px;
+        font-family: var(--sans);
+        margin-top: 12px;
+        max-width: 80ch;
+      }
 
-/* ------------------------------------------------ benchmark meters */
-.bench {
-  background: var(--panel);
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  padding: 18px;
-  margin-top: 22px;
-}
-.bench-title { font-size: 14px; color: var(--text); margin-bottom: 14px; }
-.bench-title::before { content: "⏱ "; }
-.meter-row {
-  display: grid;
-  grid-template-columns: 150px 1fr 110px;
-  gap: 10px;
-  align-items: center;
-  margin-bottom: 10px;
-  font-size: 13px;
-}
-@media (max-width: 560px) {
-  .meter-row { grid-template-columns: 1fr; gap: 2px; margin-bottom: 14px; }
-}
-.meter-tool { color: var(--text); }
-.meter-tool.win { color: var(--green); font-weight: 700; }
-.meter-track {
-  display: flex;
-  align-items: center;
-  font-family: var(--mono);
-  color: var(--dim);
-  min-width: 0;
-}
-.meter-track::before { content: "["; }
-.meter-track::after { content: "]"; }
-.meter-rail { flex: 1; height: 12px; margin: 0 4px; position: relative; background: transparent; }
-.meter-fill {
-  position: absolute;
-  inset: 0 auto 0 0;
-  min-width: 6px;
-  background: repeating-linear-gradient(90deg, var(--dim) 0 5px, transparent 5px 8px);
-  opacity: 0.75;
-}
-.meter-fill.win { background: repeating-linear-gradient(90deg, var(--green) 0 5px, transparent 5px 8px); opacity: 1; }
-.meter-val { text-align: right; color: var(--dim); white-space: nowrap; }
-.meter-val b { color: var(--text); }
-.bench-note { color: var(--dim); font-size: 12px; font-family: var(--sans); margin-top: 12px; }
-.bench-note a::after { content: " ↗"; }
+      /* ------------------------------------------------ benchmark meters */
+      .bench {
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-radius: 6px;
+        padding: 18px;
+        margin-top: 22px;
+      }
+      .bench-title {
+        font-size: 14px;
+        color: var(--text);
+        margin-bottom: 14px;
+      }
+      .bench-title::before {
+        content: "⏱ ";
+      }
+      .meter-row {
+        display: grid;
+        grid-template-columns: 150px 1fr 110px;
+        gap: 10px;
+        align-items: center;
+        margin-bottom: 10px;
+        font-size: 13px;
+      }
+      @media (max-width: 560px) {
+        .meter-row {
+          grid-template-columns: 1fr;
+          gap: 2px;
+          margin-bottom: 14px;
+        }
+      }
+      .meter-tool {
+        color: var(--text);
+      }
+      .meter-tool.win {
+        color: var(--green);
+        font-weight: 700;
+      }
+      .meter-track {
+        display: flex;
+        align-items: center;
+        font-family: var(--mono);
+        color: var(--dim);
+        min-width: 0;
+      }
+      .meter-track::before {
+        content: "[";
+      }
+      .meter-track::after {
+        content: "]";
+      }
+      .meter-rail {
+        flex: 1;
+        height: 12px;
+        margin: 0 4px;
+        position: relative;
+        background: transparent;
+      }
+      .meter-fill {
+        position: absolute;
+        inset: 0 auto 0 0;
+        min-width: 6px;
+        background: repeating-linear-gradient(90deg, var(--dim) 0 5px, transparent 5px 8px);
+        opacity: 0.75;
+      }
+      .meter-fill.win {
+        background: repeating-linear-gradient(90deg, var(--green) 0 5px, transparent 5px 8px);
+        opacity: 1;
+      }
+      .meter-val {
+        text-align: right;
+        color: var(--dim);
+        white-space: nowrap;
+      }
+      .meter-val b {
+        color: var(--text);
+      }
+      .bench-note {
+        color: var(--dim);
+        font-size: 12px;
+        font-family: var(--sans);
+        margin-top: 12px;
+      }
+      .bench-note a::after {
+        content: " ↗";
+      }
 
-/* honest callout */
-.callout {
-  border: 1px solid var(--amber);
-  border-left: 4px solid var(--amber);
-  background: rgba(210, 153, 34, 0.06);
-  border-radius: 4px;
-  padding: 12px 16px;
-  color: var(--text);
-  font-family: var(--sans);
-  font-size: 13.5px;
-  margin-top: 20px;
-}
-.callout::before { content: "# honest note"; display: block; font-family: var(--mono); color: var(--amber); font-size: 11px; letter-spacing: 1px; margin-bottom: 6px; }
+      /* honest callout */
+      .callout {
+        border: 1px solid var(--amber);
+        border-left: 4px solid var(--amber);
+        background: rgba(210, 153, 34, 0.06);
+        border-radius: 4px;
+        padding: 12px 16px;
+        color: var(--text);
+        font-family: var(--sans);
+        font-size: 13.5px;
+        margin-top: 20px;
+      }
+      .callout::before {
+        content: "# honest note";
+        display: block;
+        font-family: var(--mono);
+        color: var(--amber);
+        font-size: 11px;
+        letter-spacing: 1px;
+        margin-bottom: 6px;
+      }
 
-/* ------------------------------------------------------ statement */
-.statement {
-  border-top: 1px solid var(--border);
-  background: var(--panel-2);
-  padding: 44px 0;
-}
-.statement p {
-  font-family: var(--mono);
-  font-size: clamp(15px, 2vw, 19px);
-  color: var(--text);
-  max-width: 66ch;
-  margin: 0;
-  line-height: 1.7;
-}
-.statement p::before { content: "/* "; color: var(--dim); }
-.statement p::after { content: " */"; color: var(--dim); }
+      /* ------------------------------------------------------ statement */
+      .statement {
+        border-top: 1px solid var(--border);
+        background: var(--panel-2);
+        padding: 44px 0;
+      }
+      .statement p {
+        font-family: var(--mono);
+        font-size: clamp(15px, 2vw, 19px);
+        color: var(--text);
+        max-width: 66ch;
+        margin: 0;
+        line-height: 1.7;
+      }
+      .statement p::before {
+        content: "/* ";
+        color: var(--dim);
+      }
+      .statement p::after {
+        content: " */";
+        color: var(--dim);
+      }
 
-/* --------------------------------------------------------- CI log */
-.ci-log {
-  background: var(--panel-2);
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  padding: 16px 18px;
-  margin-top: 20px;
-  font-size: 13px;
-  line-height: 1.9;
-  overflow-x: auto;
-}
-.ci-log .ln { white-space: nowrap; }
-.ci-log .tick { color: var(--green); }
-.ci-log .step-name { color: var(--cyan); }
-.ci-log .desc { color: var(--dim); font-family: var(--sans); white-space: normal; display: block; padding-left: 26px; margin-bottom: 8px; }
+      /* --------------------------------------------------------- CI log */
+      .ci-log {
+        background: var(--panel-2);
+        border: 1px solid var(--border);
+        border-radius: 6px;
+        padding: 16px 18px;
+        margin-top: 20px;
+        font-size: 13px;
+        line-height: 1.9;
+        overflow-x: auto;
+      }
+      .ci-log .ln {
+        white-space: nowrap;
+      }
+      .ci-log .tick {
+        color: var(--green);
+      }
+      .ci-log .step-name {
+        color: var(--cyan);
+      }
+      .ci-log .desc {
+        color: var(--dim);
+        font-family: var(--sans);
+        white-space: normal;
+        display: block;
+        padding-left: 26px;
+        margin-bottom: 8px;
+      }
 
-/* browser-frame screenshot mock */
-.shot-frame { margin-top: 24px; border: 1px solid var(--border); border-radius: 8px; overflow: hidden; background: var(--panel); }
-.shot-bar { display: flex; align-items: center; gap: 8px; padding: 8px 12px; background: var(--panel-2); border-bottom: 1px solid var(--border); }
-.shot-url { flex: 1; background: var(--bg); border: 1px solid var(--border); border-radius: 4px; padding: 2px 10px; font-size: 11.5px; color: var(--dim); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.shot-body { padding: 16px; }
-.shot-caption { color: var(--dim); font-size: 12.5px; font-family: var(--sans); padding: 0 16px 14px; }
+      /* browser-frame screenshot mock */
+      .shot-frame {
+        margin-top: 24px;
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        overflow: hidden;
+        background: var(--panel);
+      }
+      .shot-bar {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 8px 12px;
+        background: var(--panel-2);
+        border-bottom: 1px solid var(--border);
+      }
+      .shot-url {
+        flex: 1;
+        background: var(--bg);
+        border: 1px solid var(--border);
+        border-radius: 4px;
+        padding: 2px 10px;
+        font-size: 11.5px;
+        color: var(--dim);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .shot-body {
+        padding: 16px;
+      }
+      .shot-caption {
+        color: var(--dim);
+        font-size: 12.5px;
+        font-family: var(--sans);
+        padding: 0 16px 14px;
+      }
 
-/* --------------------------------------------------------- steps */
-.steps { margin-top: 26px; display: grid; gap: 16px; }
-.step {
-  display: grid;
-  grid-template-columns: 44px 1fr;
-  gap: 14px;
-  background: var(--panel);
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  padding: 16px;
-}
-@media (max-width: 560px) { .step { grid-template-columns: 1fr; } }
-.step-num {
-  font-size: 18px;
-  font-weight: 700;
-  color: var(--green);
-  border: 1px solid var(--border);
-  border-radius: 4px;
-  width: 40px; height: 40px;
-  display: flex; align-items: center; justify-content: center;
-  background: var(--panel-2);
-}
-.step h3 { color: var(--text); margin-bottom: 6px; }
-.step .step-body { color: var(--dim); font-family: var(--sans); font-size: 13.5px; margin: 0 0 10px; }
-.step pre.code { border: 1px solid var(--border); border-radius: 4px; background: var(--panel-2); }
-.aside-note {
-  border-left: 3px solid var(--cyan);
-  background: rgba(86, 212, 221, 0.05);
-  padding: 8px 12px;
-  margin-top: 10px;
-  color: var(--dim);
-  font-size: 12.5px;
-  border-radius: 0 4px 4px 0;
-}
-.aside-note::before { content: "aside: "; font-family: var(--mono); color: var(--cyan); }
+      /* --------------------------------------------------------- steps */
+      .steps {
+        margin-top: 26px;
+        display: grid;
+        gap: 16px;
+      }
+      .step {
+        display: grid;
+        grid-template-columns: 44px 1fr;
+        gap: 14px;
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-radius: 6px;
+        padding: 16px;
+      }
+      @media (max-width: 560px) {
+        .step {
+          grid-template-columns: 1fr;
+        }
+      }
+      .step-num {
+        font-size: 18px;
+        font-weight: 700;
+        color: var(--green);
+        border: 1px solid var(--border);
+        border-radius: 4px;
+        width: 40px;
+        height: 40px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: var(--panel-2);
+      }
+      .step h3 {
+        color: var(--text);
+        margin-bottom: 6px;
+      }
+      .step .step-body {
+        color: var(--dim);
+        font-family: var(--sans);
+        font-size: 13.5px;
+        margin: 0 0 10px;
+      }
+      .step pre.code {
+        border: 1px solid var(--border);
+        border-radius: 4px;
+        background: var(--panel-2);
+      }
+      .aside-note {
+        border-left: 3px solid var(--cyan);
+        background: rgba(86, 212, 221, 0.05);
+        padding: 8px 12px;
+        margin-top: 10px;
+        color: var(--dim);
+        font-size: 12.5px;
+        border-radius: 0 4px 4px 0;
+      }
+      .aside-note::before {
+        content: "aside: ";
+        font-family: var(--mono);
+        color: var(--cyan);
+      }
 
-/* stack picker */
-.stack-picker { display: flex; gap: 8px; align-items: center; margin: 26px 0 4px; flex-wrap: wrap; font-size: 13px; }
-.stack-picker .lbl { color: var(--dim); }
-.stack-chip {
-  font-family: var(--mono);
-  font-size: 12.5px;
-  border: 1px solid var(--border);
-  background: var(--panel);
-  color: var(--dim);
-  border-radius: 4px;
-  padding: 5px 12px;
-  cursor: pointer;
-}
-.stack-chip.active { color: var(--green); border-color: var(--green); }
-.stack-chip.active::before { content: "◉ "; }
-.stack-note { color: var(--dim); font-size: 12px; font-family: var(--sans); margin-top: 6px; }
+      /* stack picker */
+      .stack-picker {
+        display: flex;
+        gap: 8px;
+        align-items: center;
+        margin: 26px 0 4px;
+        flex-wrap: wrap;
+        font-size: 13px;
+      }
+      .stack-picker .lbl {
+        color: var(--dim);
+      }
+      .stack-chip {
+        font-family: var(--mono);
+        font-size: 12.5px;
+        border: 1px solid var(--border);
+        background: var(--panel);
+        color: var(--dim);
+        border-radius: 4px;
+        padding: 5px 12px;
+        cursor: pointer;
+      }
+      .stack-chip.active {
+        color: var(--green);
+        border-color: var(--green);
+      }
+      .stack-chip.active::before {
+        content: "◉ ";
+      }
+      .stack-note {
+        color: var(--dim);
+        font-size: 12px;
+        font-family: var(--sans);
+        margin-top: 6px;
+      }
 
-/* --------------------------------------------------- fw panels */
-.fw-panel {
-  background: var(--panel);
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  padding: 16px;
-  margin-top: 12px;
-}
-.fw-panel h3 { color: var(--green); }
-.fw-panel h3::before { content: "~/examples/"; color: var(--dim); font-weight: 400; }
-.fw-panel p { color: var(--dim); font-family: var(--sans); font-size: 13.5px; margin: 6px 0 10px; }
-.fw-demos { display: flex; gap: 10px; flex-wrap: wrap; font-size: 12px; align-items: center; }
-.fw-demos .grp { color: var(--dim); }
+      /* --------------------------------------------------- fw panels */
+      .fw-panel {
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-radius: 6px;
+        padding: 16px;
+        margin-top: 12px;
+      }
+      .fw-panel h3 {
+        color: var(--green);
+      }
+      .fw-panel h3::before {
+        content: "~/examples/";
+        color: var(--dim);
+        font-weight: 400;
+      }
+      .fw-panel p {
+        color: var(--dim);
+        font-family: var(--sans);
+        font-size: 13.5px;
+        margin: 6px 0 10px;
+      }
+      .fw-demos {
+        display: flex;
+        gap: 10px;
+        flex-wrap: wrap;
+        font-size: 12px;
+        align-items: center;
+      }
+      .fw-demos .grp {
+        color: var(--dim);
+      }
 
-/* ------------------------------------------------------ CTA band */
-.cta-band {
-  border-top: 1px solid var(--border);
-  background: linear-gradient(180deg, var(--panel-2), var(--bg));
-  padding: 52px 0;
-  text-align: center;
-}
-.cta-band h2 { margin-bottom: 22px; }
-.cta-band .cta-row { justify-content: center; }
+      /* ------------------------------------------------------ CTA band */
+      .cta-band {
+        border-top: 1px solid var(--border);
+        background: linear-gradient(180deg, var(--panel-2), var(--bg));
+        padding: 52px 0;
+        text-align: center;
+      }
+      .cta-band h2 {
+        margin-bottom: 22px;
+      }
+      .cta-band .cta-row {
+        justify-content: center;
+      }
 
-/* -------------------------------------------------------- footer */
-footer.site-footer { border-top: 1px solid var(--border); background: var(--panel-2); padding: 44px 0 20px; margin-top: 0; }
-.footer-cols { display: grid; grid-template-columns: repeat(4, 1fr); gap: 24px; }
-@media (max-width: 860px) { .footer-cols { grid-template-columns: repeat(2, 1fr); } }
-@media (max-width: 460px) { .footer-cols { grid-template-columns: 1fr; } }
-.footer-cols h4 { color: var(--text); font-size: 12.5px; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 10px; }
-.footer-cols h4::before { content: "// "; color: var(--dim); }
-.footer-cols ul { list-style: none; margin: 0; padding: 0; }
-.footer-cols li { margin-bottom: 7px; font-size: 13px; }
-.footer-cols a { color: var(--dim); }
-.footer-cols a:hover { color: var(--cyan); }
-.legal-strip {
-  border-top: 1px solid var(--border);
-  margin-top: 32px;
-  padding-top: 16px;
-  color: var(--dim);
-  font-size: 12px;
-}
-.legal-strip::before { content: "$ "; color: var(--green); }
+      /* -------------------------------------------------------- footer */
+      footer.site-footer {
+        border-top: 1px solid var(--border);
+        background: var(--panel-2);
+        padding: 44px 0 20px;
+        margin-top: 0;
+      }
+      .footer-cols {
+        display: grid;
+        grid-template-columns: repeat(4, 1fr);
+        gap: 24px;
+      }
+      @media (max-width: 860px) {
+        .footer-cols {
+          grid-template-columns: repeat(2, 1fr);
+        }
+      }
+      @media (max-width: 460px) {
+        .footer-cols {
+          grid-template-columns: 1fr;
+        }
+      }
+      .footer-cols h4 {
+        color: var(--text);
+        font-size: 12.5px;
+        letter-spacing: 1px;
+        text-transform: uppercase;
+        margin-bottom: 10px;
+      }
+      .footer-cols h4::before {
+        content: "// ";
+        color: var(--dim);
+      }
+      .footer-cols ul {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+      }
+      .footer-cols li {
+        margin-bottom: 7px;
+        font-size: 13px;
+      }
+      .footer-cols a {
+        color: var(--dim);
+      }
+      .footer-cols a:hover {
+        color: var(--cyan);
+      }
+      .legal-strip {
+        border-top: 1px solid var(--border);
+        margin-top: 32px;
+        padding-top: 16px;
+        color: var(--dim);
+        font-size: 12px;
+      }
+      .legal-strip::before {
+        content: "$ ";
+        color: var(--green);
+      }
 
-/* views (router) */
-.view { display: none; }
-.view.active { display: block; }
-.linklist { list-style: none; padding: 0; margin: 16px 0 0; }
-.linklist li { margin-bottom: 6px; font-size: 13.5px; }
-.linklist li::before { content: "→ "; color: var(--green); }
-</style>
-</head>
-<body>
+      /* views (router) */
+      .view {
+        display: none;
+      }
+      .view.active {
+        display: block;
+      }
+      .linklist {
+        list-style: none;
+        padding: 0;
+        margin: 16px 0 0;
+      }
+      .linklist li {
+        margin-bottom: 6px;
+        font-size: 13.5px;
+      }
+      .linklist li::before {
+        content: "→ ";
+        color: var(--green);
+      }
+    </style>
+  </head>
+  <body>
+    <div class="draft-ribbon">Design draft B — Terminal · not final</div>
 
-<div class="draft-ribbon">Design draft B — Terminal · not final</div>
-
-<!-- ======================================================= NAV -->
-<nav class="site-nav">
-  <div class="nav-inner">
-    <a class="wordmark" href="#/">Palamedes</a>
-    <div class="nav-links">
-      <a href="#/frameworks" data-route="frameworks">Frameworks</a>
-      <a href="#/proof" data-route="proof">Proof</a>
-      <a href="#" class="dead" title="Not part of this draft">Compare</a>
-      <a href="#" class="dead" title="Not part of this draft">Blog</a>
-      <a href="https://github.com/sebastian-software/palamedes/tree/main/docs">Docs</a>
-    </div>
-    <div class="nav-actions">
-      <a class="btn" href="https://github.com/sebastian-software/palamedes">★ GitHub</a>
-      <a class="btn primary" href="#/get-started">Get started</a>
-    </div>
-  </div>
-</nav>
-
-<!-- ================================================== VIEW: HOME -->
-<main id="view-home" class="view">
-
-  <div class="wrap hero">
-    <div class="hero-grid">
-      <div>
-        <div class="eyebrow">Open-source i18n tooling for JavaScript &amp; TypeScript</div>
-        <h1>One translation model. Every framework.</h1>
-        <p class="subline">Write messages where your UI happens. Keep source-string-first
-          .po catalogs your translators can actually read. Ship the same
-          runtime model across Next.js, TanStack Start, SolidStart, Waku, and
-          React Router — with a Rust core that ran the checked small-corpus
-          extract/update benchmark 19.6× faster than Lingui on the recorded
-          machine-local run.</p>
-        <div class="cta-row">
-          <a class="btn primary" href="#/get-started">Get started in 5 minutes</a>
-          <a class="btn secondary" href="https://nextjs-cookie.examples.palamedes.dev">See it live</a>
+    <!-- ======================================================= NAV -->
+    <nav class="site-nav">
+      <div class="nav-inner">
+        <a class="wordmark" href="#/">Palamedes</a>
+        <div class="nav-links">
+          <a href="#/frameworks" data-route="frameworks">Frameworks</a>
+          <a href="#/proof" data-route="proof">Proof</a>
+          <a href="#" class="dead" title="Not part of this draft">Compare</a>
+          <a href="#" class="dead" title="Not part of this draft">Blog</a>
+          <a href="https://github.com/sebastian-software/palamedes/tree/main/docs">Docs</a>
+        </div>
+        <div class="nav-actions">
+          <a class="btn" href="https://github.com/sebastian-software/palamedes">★ GitHub</a>
+          <a class="btn primary" href="#/get-started">Get started</a>
         </div>
       </div>
-      <div>
-        <div class="term">
-          <div class="term-bar">
-            <span class="term-dot"></span><span class="term-dot"></span><span class="term-dot"></span>
-            <span class="term-title">pmds — palamedes</span>
-          </div>
-          <div class="term-body">
-            <div class="cmd">pmds extract</div>
-            <div class="out">  en  3 messages  <span class="ok">(1 new)</span></div>
-            <div class="out">  de  3 messages  <span class="warn">(1 missing translation)</span></div>
-            <div class="out">&nbsp;</div>
-            <div class="out">  <span class="ok">done in 34 ms</span></div>
-            <div class="cmd"><span class="cursor" aria-hidden="true"></span></div>
-          </div>
-        </div>
-        <div class="locale-row" aria-label="The same booking card rendered in three locales">
-          <div class="bk-card">
-            <div class="bk-locale">en</div>
-            <div class="bk-title">Your trip to Lisbon</div>
-            <div class="bk-seats">3 seats left</div>
-            <div class="bk-meta"><span class="bk-price">€1,234.00</span><span class="bk-date">Jul 12, 2026</span></div>
-          </div>
-          <div class="bk-card">
-            <div class="bk-locale">de</div>
-            <div class="bk-title">Deine Reise nach Lissabon</div>
-            <div class="bk-seats">3 Plätze frei</div>
-            <div class="bk-meta"><span class="bk-price">1.234,00&nbsp;€</span><span class="bk-date">12. Juli 2026</span></div>
-          </div>
-          <div class="bk-card">
-            <div class="bk-locale">es</div>
-            <div class="bk-title">Tu viaje a Lisboa</div>
-            <div class="bk-seats">Quedan 3 asientos</div>
-            <div class="bk-meta"><span class="bk-price">1234,00&nbsp;€</span><span class="bk-date">12 jul 2026</span></div>
-          </div>
-        </div>
-        <p class="locale-caption">One component, three locales: copy, plurals, currency, and dates change together.</p>
-      </div>
-    </div>
-  </div>
+    </nav>
 
-  <!-- proof strip -->
-  <div class="proof-strip">
-    <div class="proof-strip-inner">
-      <div class="stat"><a href="#/frameworks">
-        <div class="stat-value">20</div>
-        <div class="stat-label">browser-verified example apps</div>
-      </a></div>
-      <div class="stat"><a href="#/frameworks">
-        <div class="stat-value">5 × 4</div>
-        <div class="stat-label">frameworks × locale strategies</div>
-      </a></div>
-      <div class="stat"><a href="#/proof">
-        <div class="stat-value">19.6×</div>
-        <div class="stat-label">faster than Lingui — checked extract/update benchmark, machine-local run</div>
-      </a></div>
-      <div class="stat"><a href="https://github.com/sebastian-software/palamedes/tree/main/adr">
-        <div class="stat-value">16</div>
-        <div class="stat-label">ADRs documenting every tradeoff</div>
-      </a></div>
-    </div>
-  </div>
-
-  <!-- the core promise -->
-  <section class="block">
-    <div class="wrap">
-      <div class="sec-label">model</div>
-      <h2>Your i18n setup should not splinter when your framework changes.</h2>
-      <p class="body subline">Most teams relearn internationalization with every migration: new runtime, new message
-        IDs, new catalog quirks. Palamedes keeps the parts you touch every day stable — and lets
-        the framework be the only thing that changes.</p>
-      <div class="grid cols-3">
-        <div class="card">
-          <h3>Write messages in place</h3>
-          <p>Macro-style authoring next to your JSX. No message-ID bookkeeping, no separate dictionary files to keep in sync.</p>
-          <a class="more" href="#/get-started">get-started</a>
-        </div>
-        <div class="card">
-          <h3>One identity model</h3>
-          <p>Messages are identified by message + context — stable across refactors, frameworks, and years of catalog history.</p>
-          <a class="more" href="https://github.com/sebastian-software/palamedes/blob/main/adr/003-source-string-first-message-identity.md">adr/003</a>
-        </div>
-        <div class="card">
-          <h3>One runtime call</h3>
-          <p>getI18n() resolves the active instance everywhere: server components, client islands, backend request handlers.</p>
-          <a class="more" href="https://github.com/sebastian-software/palamedes/blob/main/adr/005-universal-geti18n-runtime-model.md">adr/005</a>
+    <!-- ================================================== VIEW: HOME -->
+    <main id="view-home" class="view">
+      <div class="wrap hero">
+        <div class="hero-grid">
+          <div>
+            <div class="eyebrow">Open-source i18n tooling for JavaScript &amp; TypeScript</div>
+            <h1>One translation model. Every framework.</h1>
+            <p class="subline">
+              Write messages where your UI happens. Keep source-string-first .po catalogs your
+              translators can actually read. Ship the same runtime model across Next.js, TanStack
+              Start, SolidStart, Waku, and React Router — with a Rust core that ran the checked
+              small-corpus extract/update benchmark 19.6× faster than Lingui on the recorded
+              machine-local run.
+            </p>
+            <div class="cta-row">
+              <a class="btn primary" href="#/get-started">Get started in 5 minutes</a>
+              <a class="btn secondary" href="https://nextjs-cookie.examples.palamedes.dev"
+                >See it live</a
+              >
+            </div>
+          </div>
+          <div>
+            <div class="term">
+              <div class="term-bar">
+                <span class="term-dot"></span><span class="term-dot"></span
+                ><span class="term-dot"></span>
+                <span class="term-title">pmds — palamedes</span>
+              </div>
+              <div class="term-body">
+                <div class="cmd">pmds extract</div>
+                <div class="out">en 3 messages <span class="ok">(1 new)</span></div>
+                <div class="out">
+                  de 3 messages <span class="warn">(1 missing translation)</span>
+                </div>
+                <div class="out">&nbsp;</div>
+                <div class="out"><span class="ok">done in 34 ms</span></div>
+                <div class="cmd"><span class="cursor" aria-hidden="true"></span></div>
+              </div>
+            </div>
+            <div class="locale-row" aria-label="The same booking card rendered in three locales">
+              <div class="bk-card">
+                <div class="bk-locale">en</div>
+                <div class="bk-title">Your trip to Lisbon</div>
+                <div class="bk-seats">3 seats left</div>
+                <div class="bk-meta">
+                  <span class="bk-price">€1,234.00</span><span class="bk-date">Jul 12, 2026</span>
+                </div>
+              </div>
+              <div class="bk-card">
+                <div class="bk-locale">de</div>
+                <div class="bk-title">Deine Reise nach Lissabon</div>
+                <div class="bk-seats">3 Plätze frei</div>
+                <div class="bk-meta">
+                  <span class="bk-price">1.234,00&nbsp;€</span
+                  ><span class="bk-date">12. Juli 2026</span>
+                </div>
+              </div>
+              <div class="bk-card">
+                <div class="bk-locale">es</div>
+                <div class="bk-title">Tu viaje a Lisboa</div>
+                <div class="bk-seats">Quedan 3 asientos</div>
+                <div class="bk-meta">
+                  <span class="bk-price">1234,00&nbsp;€</span
+                  ><span class="bk-date">12 jul 2026</span>
+                </div>
+              </div>
+            </div>
+            <p class="locale-caption">
+              One component, three locales: copy, plurals, currency, and dates change together.
+            </p>
+          </div>
         </div>
       </div>
-    </div>
-  </section>
 
-  <!-- code showcase -->
-  <section class="block">
-    <div class="wrap">
-      <div class="sec-label">workflow</div>
-      <h2>The whole workflow, honestly small.</h2>
-      <div class="tabs" role="tablist">
-        <button class="tab-btn active" data-tab="write" role="tab" aria-selected="true">Write</button>
-        <button class="tab-btn" data-tab="extract" role="tab" aria-selected="false">Extract</button>
-        <button class="tab-btn" data-tab="translate" role="tab" aria-selected="false">Translate</button>
+      <!-- proof strip -->
+      <div class="proof-strip">
+        <div class="proof-strip-inner">
+          <div class="stat">
+            <a href="#/frameworks">
+              <div class="stat-value">20</div>
+              <div class="stat-label">browser-verified example apps</div>
+            </a>
+          </div>
+          <div class="stat">
+            <a href="#/frameworks">
+              <div class="stat-value">5 × 4</div>
+              <div class="stat-label">frameworks × locale strategies</div>
+            </a>
+          </div>
+          <div class="stat">
+            <a href="#/proof">
+              <div class="stat-value">19.6×</div>
+              <div class="stat-label">
+                faster than Lingui — checked extract/update benchmark, machine-local run
+              </div>
+            </a>
+          </div>
+          <div class="stat">
+            <a href="https://github.com/sebastian-software/palamedes/tree/main/adr">
+              <div class="stat-value">16</div>
+              <div class="stat-label">ADRs documenting every tradeoff</div>
+            </a>
+          </div>
+        </div>
       </div>
-      <div class="tab-panels">
-        <div class="tab-panel active" data-panel="write">
-          <div class="tab-caption">Messages live where the UI happens.</div>
-<pre class="code"><span class="c-kw">import</span> { t, plural } <span class="c-kw">from</span> <span class="c-str">"@palamedes/core/macro"</span>
+
+      <!-- the core promise -->
+      <section class="block">
+        <div class="wrap">
+          <div class="sec-label">model</div>
+          <h2>Your i18n setup should not splinter when your framework changes.</h2>
+          <p class="body subline">
+            Most teams relearn internationalization with every migration: new runtime, new message
+            IDs, new catalog quirks. Palamedes keeps the parts you touch every day stable — and lets
+            the framework be the only thing that changes.
+          </p>
+          <div class="grid cols-3">
+            <div class="card">
+              <h3>Write messages in place</h3>
+              <p>
+                Macro-style authoring next to your JSX. No message-ID bookkeeping, no separate
+                dictionary files to keep in sync.
+              </p>
+              <a class="more" href="#/get-started">get-started</a>
+            </div>
+            <div class="card">
+              <h3>One identity model</h3>
+              <p>
+                Messages are identified by message + context — stable across refactors, frameworks,
+                and years of catalog history.
+              </p>
+              <a
+                class="more"
+                href="https://github.com/sebastian-software/palamedes/blob/main/adr/003-source-string-first-message-identity.md"
+                >adr/003</a
+              >
+            </div>
+            <div class="card">
+              <h3>One runtime call</h3>
+              <p>
+                getI18n() resolves the active instance everywhere: server components, client
+                islands, backend request handlers.
+              </p>
+              <a
+                class="more"
+                href="https://github.com/sebastian-software/palamedes/blob/main/adr/005-universal-geti18n-runtime-model.md"
+                >adr/005</a
+              >
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- code showcase -->
+      <section class="block">
+        <div class="wrap">
+          <div class="sec-label">workflow</div>
+          <h2>The whole workflow, honestly small.</h2>
+          <div class="tabs" role="tablist">
+            <button class="tab-btn active" data-tab="write" role="tab" aria-selected="true">
+              Write
+            </button>
+            <button class="tab-btn" data-tab="extract" role="tab" aria-selected="false">
+              Extract
+            </button>
+            <button class="tab-btn" data-tab="translate" role="tab" aria-selected="false">
+              Translate
+            </button>
+          </div>
+          <div class="tab-panels">
+            <div class="tab-panel active" data-panel="write">
+              <div class="tab-caption">Messages live where the UI happens.</div>
+              <pre
+                class="code"
+              ><span class="c-kw">import</span> { t, plural } <span class="c-kw">from</span> <span class="c-str">"@palamedes/core/macro"</span>
 <span class="c-kw">import</span> { Trans } <span class="c-kw">from</span> <span class="c-str">"@palamedes/react"</span>
 
 <span class="c-kw">export function</span> Booking({ seats }: { seats: <span class="c-kw">number</span> }) {
@@ -707,496 +1344,762 @@ footer.site-footer { border-top: 1px solid var(--border); background: var(--pane
     &lt;/&gt;
   )
 }</pre>
-        </div>
-        <div class="tab-panel" data-panel="extract">
-          <div class="tab-caption">One native command scans, extracts, and updates catalogs.</div>
-<pre class="code"><span class="c-amber">$</span> pmds extract
+            </div>
+            <div class="tab-panel" data-panel="extract">
+              <div class="tab-caption">
+                One native command scans, extracts, and updates catalogs.
+              </div>
+              <pre class="code"><span class="c-amber">$</span> pmds extract
 
   en  3 messages  <span class="c-str">(1 new)</span>
   de  3 messages  <span class="c-amber">(1 missing translation)</span>
 
   <span class="c-str">done in 34 ms</span></pre>
-        </div>
-        <div class="tab-panel" data-panel="translate">
-          <div class="tab-caption">Source-string-first .po — readable by translators and every TMS.</div>
-<pre class="code"><span class="c-dim">#: src/Booking.tsx:7</span>
+            </div>
+            <div class="tab-panel" data-panel="translate">
+              <div class="tab-caption">
+                Source-string-first .po — readable by translators and every TMS.
+              </div>
+              <pre class="code"><span class="c-dim">#: src/Booking.tsx:7</span>
 <span class="c-kw">msgid</span> <span class="c-str">"Your trip to Lisbon"</span>
 <span class="c-kw">msgstr</span> <span class="c-str">"Deine Reise nach Lissabon"</span>
 
 <span class="c-dim">#: src/Booking.tsx:8</span>
 <span class="c-kw">msgid</span> <span class="c-str">"{seats, plural, one {# seat left} other {# seats left}}"</span>
 <span class="c-kw">msgstr</span> <span class="c-str">"{seats, plural, one {# Platz frei} other {# Plätze frei}}"</span></pre>
-        </div>
-        <div class="result-panel">
-          <div class="rp-title">Rendered</div>
-          <div class="rp-body">The same component, in every locale, in every framework.</div>
-        </div>
-      </div>
-    </div>
-  </section>
-
-  <!-- proof teaser -->
-  <section class="block">
-    <div class="wrap">
-      <div class="sec-label">proof</div>
-      <h2>We don't ask you to trust a slogan. The repo shows the work.</h2>
-      <p class="body subline">Every framework/strategy combination is a real app, re-verified in CI through the same
-        Playwright flow — with public demos where the hosting is ready. Every benchmark number
-        links to a checked-in, re-runnable report.</p>
-
-      <div class="matrix-scroll">
-        <div class="matrix-mount" data-strategy-labels="Cookie|Route|Subdomain|TLD"></div>
-      </div>
-
-      <div class="bench">
-        <div class="bench-title">End-to-end extract + catalog update (small corpus, median)</div>
-        <div class="meter-row">
-          <span class="meter-tool win">Palamedes</span>
-          <span class="meter-track"><span class="meter-rail"><span class="meter-fill win" style="width:5.1%"></span></span></span>
-          <span class="meter-val"><b>33.53 ms</b></span>
-        </div>
-        <div class="meter-row">
-          <span class="meter-tool">i18next-parser</span>
-          <span class="meter-track"><span class="meter-rail"><span class="meter-fill" style="width:72.7%"></span></span></span>
-          <span class="meter-val">477.58 ms</span>
-        </div>
-        <div class="meter-row">
-          <span class="meter-tool">Lingui</span>
-          <span class="meter-track"><span class="meter-rail"><span class="meter-fill" style="width:100%"></span></span></span>
-          <span class="meter-val">657.00 ms</span>
-        </div>
-        <div class="bench-note">Linear scale, full track = 657.00 ms — the Palamedes bar really is that short; nothing is truncated or distorted.
-          Machine-local numbers from the checked-in report; your hardware will differ, the ratios are the signal.
-          <a href="https://github.com/sebastian-software/palamedes/blob/main/docs/benchmark-e2e-workflow.md">Methodology</a></div>
-      </div>
-
-      <div class="cta-row">
-        <a class="btn secondary" href="#/proof">All benchmarks &amp; the verification story</a>
-      </div>
-    </div>
-  </section>
-
-  <!-- positioning -->
-  <div class="statement">
-    <div class="wrap">
-      <p>Palamedes is narrower than some alternatives on purpose:
-        compile-time authoring, source-string-first catalogs, and a local
-        workflow your repo owns — with a Rust core doing the careful work.</p>
-    </div>
-  </div>
-
-  <!-- who builds -->
-  <section class="block">
-    <div class="wrap">
-      <div class="sec-label">maintainer</div>
-      <h2>Built from repeat experience, not a weekend take.</h2>
-      <p class="body subline">Palamedes is maintained by Sebastian Software GmbH. It is the third generation of
-        source-string-first JavaScript i18n tooling from the same author — from gettext-style
-        macro systems in qooxdoo to a full enterprise Lingui migration at Regrello (acquired by
-        Salesforce in 2025). The lessons are written down as 16 ADRs before you depend on the
-        tool.</p>
-      <ul class="linklist">
-        <li><a href="https://github.com/sebastian-software/palamedes/tree/main/adr">The decision trail (ADRs)</a></li>
-        <li><a href="#" class="dead" title="Not part of this draft">Why this exists</a></li>
-      </ul>
-    </div>
-  </section>
-
-  <div class="cta-band">
-    <div class="wrap">
-      <h2>Your first working translation is 5 minutes away.</h2>
-      <div class="cta-row">
-        <a class="btn primary" href="#/get-started">Get started</a>
-        <a class="btn secondary" href="https://github.com/sebastian-software/palamedes">Star on GitHub</a>
-      </div>
-    </div>
-  </div>
-</main>
-
-<!-- ============================================ VIEW: FRAMEWORKS -->
-<main id="view-frameworks" class="view">
-  <div class="wrap hero">
-    <div class="path-label">~/palamedes › <b>frameworks</b></div>
-    <div class="eyebrow">Framework matrix</div>
-    <h1>Five frameworks. Four locale strategies. One mental model.</h1>
-    <p class="subline">Every cell below is a real application — the same booking UI,
-      the same catalogs, the same runtime calls — browser-verified in CI.
-      Where public hosting is ready, open the demo, switch the language,
-      and watch copy, plurals, currency, and dates change together.</p>
-    <div class="cta-row">
-      <a class="btn primary" href="https://nextjs-cookie.examples.palamedes.dev">Open a live demo</a>
-      <a class="btn secondary" href="https://github.com/sebastian-software/palamedes/tree/main/examples">Browse the example source</a>
-    </div>
-  </div>
-
-  <section class="block">
-    <div class="wrap">
-      <div class="sec-label">matrix</div>
-      <div class="matrix-scroll">
-        <div class="matrix-mount" data-strategy-labels="Cookie|Route segment|Subdomain|Top-level domain"></div>
-      </div>
-      <p class="matrix-caption">All 20 apps are verified in CI with the same Playwright-driven browser flow: SSR output,
-        locale switching, localized server actions. Screenshots are versioned in the repo. Cookie
-        and route demos are publicly hosted today; subdomain and TLD hosting is being provisioned
-        — until then those cells link the verified source instead.</p>
-    </div>
-  </section>
-
-  <section class="block">
-    <div class="wrap">
-      <div class="sec-label">strategies</div>
-      <h2>Pick the locale strategy your product needs — not the one your framework dictates.</h2>
-      <div class="grid cols-4">
-        <div class="card">
-          <h3>Cookie</h3>
-          <p>One URL for all locales. Best for apps behind login where SEO is irrelevant and switching should be instant.</p>
-        </div>
-        <div class="card">
-          <h3>Route segment</h3>
-          <p>/de/checkout-style paths. The SEO-friendly default for public content with indexable localized pages.</p>
-        </div>
-        <div class="card">
-          <h3>Subdomain</h3>
-          <p>de.example.com. Clean separation per market, works well with regional CDNs and analytics splits.</p>
-        </div>
-        <div class="card">
-          <h3>Top-level domain</h3>
-          <p>example.de vs example.com. Maximum market trust; Palamedes maps each domain to its locale.</p>
-        </div>
-      </div>
-      <ul class="linklist">
-        <li><a href="https://github.com/sebastian-software/palamedes/blob/main/docs/locale-strategies.md">Locale strategies in depth</a></li>
-      </ul>
-    </div>
-  </section>
-
-  <section class="block">
-    <div class="wrap">
-      <div class="sec-label">per-framework</div>
-      <h2>Your stack, specifically.</h2>
-
-      <div class="fw-panel">
-        <h3>Next.js</h3>
-        <p>App Router with server components and server actions. The @palamedes/next-plugin wires the transform into the Next build; everything else is the shared model.</p>
-        <div class="fw-demos">
-          <span class="grp">demos:</span>
-          <a href="https://nextjs-cookie.examples.palamedes.dev"><span class="led live"></span>cookie</a>
-          <span class="grp">route →</span>
-          <a href="https://nextjs-route.examples.palamedes.dev/en">en</a>
-          <a href="https://nextjs-route.examples.palamedes.dev/de">de</a>
-          <a href="https://nextjs-route.examples.palamedes.dev/es">es</a>
-          <a href="https://github.com/sebastian-software/palamedes/tree/main/examples/nextjs-subdomain"><span class="led prov"></span>subdomain src</a>
-          <a href="https://github.com/sebastian-software/palamedes/tree/main/examples/nextjs-tld"><span class="led prov"></span>tld src</a>
-          <a class="src" href="https://github.com/sebastian-software/palamedes/tree/main/examples/nextjs-route">source ↗</a>
-        </div>
-      </div>
-
-      <div class="fw-panel">
-        <h3>TanStack Start</h3>
-        <p>Server functions and file-based routing, integrated through @palamedes/vite-plugin. Locale resolution runs in a server function; the client stays island-light.</p>
-        <div class="fw-demos">
-          <span class="grp">demos:</span>
-          <a href="https://tanstack-cookie.examples.palamedes.dev"><span class="led live"></span>cookie</a>
-          <span class="grp">route →</span>
-          <a href="https://tanstack-route.examples.palamedes.dev/en">en</a>
-          <a href="https://tanstack-route.examples.palamedes.dev/de">de</a>
-          <a href="https://tanstack-route.examples.palamedes.dev/es">es</a>
-          <a href="https://github.com/sebastian-software/palamedes/tree/main/examples/tanstack-subdomain"><span class="led prov"></span>subdomain src</a>
-          <a href="https://github.com/sebastian-software/palamedes/tree/main/examples/tanstack-tld"><span class="led prov"></span>tld src</a>
-          <a class="src" href="https://github.com/sebastian-software/palamedes/tree/main/examples/tanstack-route">source ↗</a>
-        </div>
-      </div>
-
-      <div class="fw-panel">
-        <h3>SolidStart</h3>
-        <p>Fine-grained reactivity with @palamedes/solid — the same macro authoring and catalogs as React, no fork of your i18n strategy for a different renderer.</p>
-        <div class="fw-demos">
-          <span class="grp">demos:</span>
-          <a href="https://solidstart-cookie.examples.palamedes.dev"><span class="led live"></span>cookie</a>
-          <span class="grp">route →</span>
-          <a href="https://solidstart-route.examples.palamedes.dev/en">en</a>
-          <a href="https://solidstart-route.examples.palamedes.dev/de">de</a>
-          <a href="https://solidstart-route.examples.palamedes.dev/es">es</a>
-          <a href="https://github.com/sebastian-software/palamedes/tree/main/examples/solidstart-subdomain"><span class="led prov"></span>subdomain src</a>
-          <a href="https://github.com/sebastian-software/palamedes/tree/main/examples/solidstart-tld"><span class="led prov"></span>tld src</a>
-          <a class="src" href="https://github.com/sebastian-software/palamedes/tree/main/examples/solidstart-route">source ↗</a>
-        </div>
-      </div>
-
-      <div class="fw-panel">
-        <h3>Waku</h3>
-        <p>Minimal RSC framework. If the model holds here, it holds in your custom setup too — that's why Waku is in the matrix.</p>
-        <div class="fw-demos">
-          <span class="grp">demos:</span>
-          <a href="https://waku-cookie.examples.palamedes.dev"><span class="led live"></span>cookie</a>
-          <span class="grp">route →</span>
-          <a href="https://waku-route.examples.palamedes.dev/en">en</a>
-          <a href="https://waku-route.examples.palamedes.dev/de">de</a>
-          <a href="https://waku-route.examples.palamedes.dev/es">es</a>
-          <a href="https://github.com/sebastian-software/palamedes/tree/main/examples/waku-subdomain"><span class="led prov"></span>subdomain src</a>
-          <a href="https://github.com/sebastian-software/palamedes/tree/main/examples/waku-tld"><span class="led prov"></span>tld src</a>
-          <a class="src" href="https://github.com/sebastian-software/palamedes/tree/main/examples/waku-route">source ↗</a>
-        </div>
-      </div>
-
-      <div class="fw-panel">
-        <h3>React Router</h3>
-        <p>Framework-mode React Router with loaders and actions. The classic SPA-plus-SSR shape, same catalogs, same runtime.</p>
-        <div class="fw-demos">
-          <span class="grp">demos:</span>
-          <a href="https://react-router-cookie.examples.palamedes.dev"><span class="led live"></span>cookie</a>
-          <span class="grp">route →</span>
-          <a href="https://react-router-route.examples.palamedes.dev/en">en</a>
-          <a href="https://react-router-route.examples.palamedes.dev/de">de</a>
-          <a href="https://react-router-route.examples.palamedes.dev/es">es</a>
-          <a href="https://github.com/sebastian-software/palamedes/tree/main/examples/react-router-subdomain"><span class="led prov"></span>subdomain src</a>
-          <a href="https://github.com/sebastian-software/palamedes/tree/main/examples/react-router-tld"><span class="led prov"></span>tld src</a>
-          <a class="src" href="https://github.com/sebastian-software/palamedes/tree/main/examples/react-router-route">source ↗</a>
-        </div>
-      </div>
-    </div>
-  </section>
-
-  <section class="block">
-    <div class="wrap">
-      <div class="sec-label">backend</div>
-      <h2>And it doesn't stop at the frontend.</h2>
-      <p class="body subline">The same getI18n() model runs in Hono and Express with request-local locale resolution —
-        transactional emails, API error messages, and PDF generation speak the user's language
-        from the same catalogs.</p>
-      <div class="cta-row">
-        <a class="btn secondary" href="https://github.com/sebastian-software/palamedes/blob/main/docs/backend-servers.md">Backend servers guide</a>
-      </div>
-    </div>
-  </section>
-
-  <div class="cta-band">
-    <div class="wrap">
-      <h2>See your framework speaking three languages — right now.</h2>
-      <div class="cta-row">
-        <a class="btn primary" href="https://nextjs-cookie.examples.palamedes.dev">Open the live matrix</a>
-        <a class="btn secondary" href="#/get-started">Get started</a>
-      </div>
-    </div>
-  </div>
-</main>
-
-<!-- ================================================= VIEW: PROOF -->
-<main id="view-proof" class="view">
-  <div class="wrap hero">
-    <div class="path-label">~/palamedes › <b>proof</b></div>
-    <div class="eyebrow">Proof</div>
-    <h1>Claims you can re-run.</h1>
-    <p class="subline">Every number on this page comes from a checked-in,
-      machine-readable report with fixtures and commands in the repo.
-      If a claim can't be re-run, we don't make it.</p>
-    <div class="cta-row">
-      <a class="btn primary" href="https://github.com/sebastian-software/palamedes/blob/main/docs/benchmark-e2e-workflow.md">Re-run the benchmarks</a>
-      <a class="btn secondary" href="https://github.com/sebastian-software/palamedes/tree/main/benchmarks/e2e-workflow/results">Browse checked-in reports</a>
-    </div>
-  </div>
-
-  <section class="block">
-    <div class="wrap">
-      <div class="sec-label">benchmarks</div>
-      <h2>The workflow you feel every day: extract &amp; update.</h2>
-      <p class="body subline">The end-to-end benchmark measures what a developer actually waits for: scan sources,
-        extract messages, update catalogs, write files. Same generated message inventory, rendered
-        into each tool's idiomatic source shape, semantically validated after every run.</p>
-
-      <div class="bench">
-        <div class="bench-title">Small corpus — 80 files, 640 messages (median of 7 runs)</div>
-        <div class="meter-row">
-          <span class="meter-tool win">Palamedes</span>
-          <span class="meter-track"><span class="meter-rail"><span class="meter-fill win" style="width:5.1%"></span></span></span>
-          <span class="meter-val"><b>33.53 ms</b></span>
-        </div>
-        <div class="meter-row">
-          <span class="meter-tool">i18next-parser 9.4</span>
-          <span class="meter-track"><span class="meter-rail"><span class="meter-fill" style="width:72.7%"></span></span></span>
-          <span class="meter-val">477.58 ms</span>
-        </div>
-        <div class="meter-row">
-          <span class="meter-tool">Lingui 6.4</span>
-          <span class="meter-track"><span class="meter-rail"><span class="meter-fill" style="width:100%"></span></span></span>
-          <span class="meter-val">657.00 ms</span>
-        </div>
-        <div class="bench-note">Linear scale, full track = 657.00 ms — the fast bar really is that short; nothing is truncated or distorted.
-          <a href="https://github.com/sebastian-software/palamedes/blob/main/docs/benchmark-e2e-workflow.md">Methodology</a></div>
-      </div>
-
-      <div class="bench">
-        <div class="bench-title">Medium corpus (median of 7 runs)</div>
-        <div class="meter-row">
-          <span class="meter-tool win">Palamedes</span>
-          <span class="meter-track"><span class="meter-rail"><span class="meter-fill win" style="width:6.5%"></span></span></span>
-          <span class="meter-val"><b>42.92 ms</b></span>
-        </div>
-        <div class="bench-note">Competitor medians for the medium corpus live in the checked-in report:
-          <a href="https://github.com/sebastian-software/palamedes/blob/main/benchmarks/e2e-workflow/results/latest.md">results/latest.md</a> ·
-          <a href="https://github.com/sebastian-software/palamedes/blob/main/docs/benchmark-e2e-workflow.md">Methodology</a></div>
-      </div>
-
-      <div class="callout">These are machine-local numbers from the checked-in report, not a marketing average. Your
-        hardware will differ; the ratios are the signal. Commands to reproduce:
-        <code>pnpm benchmark:e2e-workflow</code>.</div>
-    </div>
-  </section>
-
-  <section class="block">
-    <div class="wrap">
-      <div class="sec-label">verification</div>
-      <h2>20 apps, verified in a real browser, on every change.</h2>
-      <div class="ci-log">
-        <div class="ln"><span class="tick">✓</span> [1/3] <span class="step-name">build</span></div>
-        <span class="desc">All 20 example apps build against the workspace packages — no mocked integrations.</span>
-        <div class="ln"><span class="tick">✓</span> [2/3] <span class="step-name">drive</span></div>
-        <span class="desc">A Playwright flow loads each app, checks SSR output, switches locales, and exercises localized server actions.</span>
-        <div class="ln"><span class="tick">✓</span> [3/3] <span class="step-name">capture</span></div>
-        <span class="desc">Screenshots are versioned in the repo, so 'works across frameworks' is a diffable artifact, not a slide.</span>
-      </div>
-
-      <div class="shot-frame">
-        <div class="shot-bar">
-          <span class="term-dot"></span><span class="term-dot"></span><span class="term-dot"></span>
-          <span class="shot-url">examples.palamedes.dev — the same booking UI in en · de · es</span>
-        </div>
-        <div class="shot-body">
-          <div class="locale-row" style="margin-top:0" aria-label="The same booking UI rendered in English, German, and Spanish">
-            <div class="bk-card">
-              <div class="bk-locale">en</div>
-              <div class="bk-title">Your trip to Lisbon</div>
-              <div class="bk-seats">3 seats left</div>
-              <div class="bk-meta"><span class="bk-price">€1,234.00</span><span class="bk-date">Jul 12, 2026</span></div>
             </div>
-            <div class="bk-card">
-              <div class="bk-locale">de</div>
-              <div class="bk-title">Deine Reise nach Lissabon</div>
-              <div class="bk-seats">3 Plätze frei</div>
-              <div class="bk-meta"><span class="bk-price">1.234,00&nbsp;€</span><span class="bk-date">12. Juli 2026</span></div>
-            </div>
-            <div class="bk-card">
-              <div class="bk-locale">es</div>
-              <div class="bk-title">Tu viaje a Lisboa</div>
-              <div class="bk-seats">Quedan 3 asientos</div>
-              <div class="bk-meta"><span class="bk-price">1234,00&nbsp;€</span><span class="bk-date">12 jul 2026</span></div>
+            <div class="result-panel">
+              <div class="rp-title">Rendered</div>
+              <div class="rp-body">The same component, in every locale, in every framework.</div>
             </div>
           </div>
         </div>
-        <div class="shot-caption">One demo, three locales: copy, plural seat counts, currency, and dates change together.
-          <a href="https://github.com/sebastian-software/palamedes/blob/main/docs/example-screenshots/README.md">Versioned screenshots ↗</a>
-          <span class="dimtxt">(CSS mock in this draft — the real page embeds the checked-in screenshot.)</span></div>
-      </div>
-    </div>
-  </section>
+      </section>
 
-  <section class="block">
-    <div class="wrap">
-      <div class="sec-label">catalog-qa</div>
-      <h2>Fast would be worthless if the catalogs were wrong.</h2>
-      <p class="body subline">Catalog semantics live in one dedicated engine (ferrocat): parsing, merging, structured
-        audits, and ICU authoring diagnostics. The benchmark harness validates every tool run
-        semantically — message inventories are compared, not just timed.</p>
-      <div class="grid cols-3">
-        <div class="card">
-          <h3>Structured audits</h3>
-          <p>Machine-readable catalog audits catch missing translations, stale entries, and metadata drift in CI.</p>
+      <!-- proof teaser -->
+      <section class="block">
+        <div class="wrap">
+          <div class="sec-label">proof</div>
+          <h2>We don't ask you to trust a slogan. The repo shows the work.</h2>
+          <p class="body subline">
+            Every framework/strategy combination is a real app, re-verified in CI through the same
+            Playwright flow — with public demos where the hosting is ready. Every benchmark number
+            links to a checked-in, re-runnable report.
+          </p>
+
+          <div class="matrix-scroll">
+            <div class="matrix-mount" data-strategy-labels="Cookie|Route|Subdomain|TLD"></div>
+          </div>
+
+          <div class="bench">
+            <div class="bench-title">
+              End-to-end extract + catalog update (small corpus, median)
+            </div>
+            <div class="meter-row">
+              <span class="meter-tool win">Palamedes</span>
+              <span class="meter-track"
+                ><span class="meter-rail"
+                  ><span class="meter-fill win" style="width: 5.1%"></span></span
+              ></span>
+              <span class="meter-val"><b>33.53 ms</b></span>
+            </div>
+            <div class="meter-row">
+              <span class="meter-tool">i18next-parser</span>
+              <span class="meter-track"
+                ><span class="meter-rail"
+                  ><span class="meter-fill" style="width: 72.7%"></span></span
+              ></span>
+              <span class="meter-val">477.58 ms</span>
+            </div>
+            <div class="meter-row">
+              <span class="meter-tool">Lingui</span>
+              <span class="meter-track"
+                ><span class="meter-rail"><span class="meter-fill" style="width: 100%"></span></span
+              ></span>
+              <span class="meter-val">657.00 ms</span>
+            </div>
+            <div class="bench-note">
+              Linear scale, full track = 657.00 ms — the Palamedes bar really is that short; nothing
+              is truncated or distorted. Machine-local numbers from the checked-in report; your
+              hardware will differ, the ratios are the signal.
+              <a
+                href="https://github.com/sebastian-software/palamedes/blob/main/docs/benchmark-e2e-workflow.md"
+                >Methodology</a
+              >
+            </div>
+          </div>
+
+          <div class="cta-row">
+            <a class="btn secondary" href="#/proof">All benchmarks &amp; the verification story</a>
+          </div>
         </div>
-        <div class="card">
-          <h3>ICU diagnostics</h3>
-          <p>Authoring mistakes in plural/select syntax are flagged at extract time, not at runtime in production.</p>
-        </div>
-        <div class="card">
-          <h3>Semantic merging</h3>
-          <p>A Git merge driver resolves catalog conflicts by meaning, not by line — no more broken .po files after rebases.</p>
+      </section>
+
+      <!-- positioning -->
+      <div class="statement">
+        <div class="wrap">
+          <p>
+            Palamedes is narrower than some alternatives on purpose: compile-time authoring,
+            source-string-first catalogs, and a local workflow your repo owns — with a Rust core
+            doing the careful work.
+          </p>
         </div>
       </div>
-    </div>
-  </section>
 
-  <section class="block">
-    <div class="wrap">
-      <div class="sec-label">adrs</div>
-      <h2>16 decisions, written down before you depend on them.</h2>
-      <p class="body subline">The ADRs cover message identity, the native boundary, adapter architecture — and, just as
-        deliberately, what Palamedes refuses to own. Reading them is the fastest way to know if
-        our tradeoffs match yours.</p>
-      <ul class="linklist">
-        <li><a href="https://github.com/sebastian-software/palamedes/tree/main/adr">ADR index</a></li>
-        <li><a href="https://github.com/sebastian-software/palamedes/blob/main/docs/stability.md">Stability &amp; versioning policy</a></li>
-        <li><a href="https://github.com/sebastian-software/palamedes/blob/main/docs/principles.md">Palamedes principles</a></li>
-      </ul>
-    </div>
-  </section>
+      <!-- who builds -->
+      <section class="block">
+        <div class="wrap">
+          <div class="sec-label">maintainer</div>
+          <h2>Built from repeat experience, not a weekend take.</h2>
+          <p class="body subline">
+            Palamedes is maintained by Sebastian Software GmbH. It is the third generation of
+            source-string-first JavaScript i18n tooling from the same author — from gettext-style
+            macro systems in qooxdoo to a full enterprise Lingui migration at Regrello (acquired by
+            Salesforce in 2025). The lessons are written down as 16 ADRs before you depend on the
+            tool.
+          </p>
+          <ul class="linklist">
+            <li>
+              <a href="https://github.com/sebastian-software/palamedes/tree/main/adr"
+                >The decision trail (ADRs)</a
+              >
+            </li>
+            <li><a href="#" class="dead" title="Not part of this draft">Why this exists</a></li>
+          </ul>
+        </div>
+      </section>
 
-  <div class="cta-band">
-    <div class="wrap">
-      <h2>Convinced by the receipts? The quickstart takes 5 minutes.</h2>
-      <div class="cta-row">
-        <a class="btn primary" href="#/get-started">Get started</a>
-        <a class="btn secondary dead" href="#" title="Not part of this draft">Compare with your current tool</a>
+      <div class="cta-band">
+        <div class="wrap">
+          <h2>Your first working translation is 5 minutes away.</h2>
+          <div class="cta-row">
+            <a class="btn primary" href="#/get-started">Get started</a>
+            <a class="btn secondary" href="https://github.com/sebastian-software/palamedes"
+              >Star on GitHub</a
+            >
+          </div>
+        </div>
       </div>
-    </div>
-  </div>
-</main>
+    </main>
 
-<!-- =========================================== VIEW: GET STARTED -->
-<main id="view-get-started" class="view">
-  <div class="wrap hero">
-    <div class="path-label">~/palamedes › <b>get-started</b></div>
-    <div class="eyebrow">Quickstart</div>
-    <h1>First working translation in 5 minutes.</h1>
-    <p class="subline">One translated component, one extraction run, one .po file,
-      one runtime instance. No message IDs to invent, no dictionary files
-      to maintain.</p>
-    <div class="cta-row">
-      <a class="btn primary" href="#install">Skip to step 1</a>
-      <a class="btn secondary" href="https://github.com/sebastian-software/palamedes/blob/main/docs/first-working-translation.md">Full written guide</a>
-    </div>
+    <!-- ============================================ VIEW: FRAMEWORKS -->
+    <main id="view-frameworks" class="view">
+      <div class="wrap hero">
+        <div class="path-label">~/palamedes › <b>frameworks</b></div>
+        <div class="eyebrow">Framework matrix</div>
+        <h1>Five frameworks. Four locale strategies. One mental model.</h1>
+        <p class="subline">
+          Every cell below is a real application — the same booking UI, the same catalogs, the same
+          runtime calls — browser-verified in CI. Where public hosting is ready, open the demo,
+          switch the language, and watch copy, plurals, currency, and dates change together.
+        </p>
+        <div class="cta-row">
+          <a class="btn primary" href="https://nextjs-cookie.examples.palamedes.dev"
+            >Open a live demo</a
+          >
+          <a
+            class="btn secondary"
+            href="https://github.com/sebastian-software/palamedes/tree/main/examples"
+            >Browse the example source</a
+          >
+        </div>
+      </div>
 
-    <div class="stack-picker" role="group" aria-label="Stack picker">
-      <span class="lbl">stack:</span>
-      <button class="stack-chip active" type="button">Vite + React</button>
-      <button class="stack-chip" type="button">Vite + Solid</button>
-      <button class="stack-chip" type="button">Next.js</button>
-    </div>
-    <p class="stack-note">This static draft mocks the Vite + React path; in the real page the picker switches every code block below.</p>
+      <section class="block">
+        <div class="wrap">
+          <div class="sec-label">matrix</div>
+          <div class="matrix-scroll">
+            <div
+              class="matrix-mount"
+              data-strategy-labels="Cookie|Route segment|Subdomain|Top-level domain"
+            ></div>
+          </div>
+          <p class="matrix-caption">
+            All 20 apps are verified in CI with the same Playwright-driven browser flow: SSR output,
+            locale switching, localized server actions. Screenshots are versioned in the repo.
+            Cookie and route demos are publicly hosted today; subdomain and TLD hosting is being
+            provisioned — until then those cells link the verified source instead.
+          </p>
+        </div>
+      </section>
 
-    <div class="callout">Heads-up: install the scoped <code>@palamedes/*</code> packages. The top-level
-      <code>palamedes</code> and <code>create-palamedes</code> names are reserved for a future
-      one-command setup and are not the entry point today.</div>
+      <section class="block">
+        <div class="wrap">
+          <div class="sec-label">strategies</div>
+          <h2>
+            Pick the locale strategy your product needs — not the one your framework dictates.
+          </h2>
+          <div class="grid cols-4">
+            <div class="card">
+              <h3>Cookie</h3>
+              <p>
+                One URL for all locales. Best for apps behind login where SEO is irrelevant and
+                switching should be instant.
+              </p>
+            </div>
+            <div class="card">
+              <h3>Route segment</h3>
+              <p>
+                /de/checkout-style paths. The SEO-friendly default for public content with indexable
+                localized pages.
+              </p>
+            </div>
+            <div class="card">
+              <h3>Subdomain</h3>
+              <p>
+                de.example.com. Clean separation per market, works well with regional CDNs and
+                analytics splits.
+              </p>
+            </div>
+            <div class="card">
+              <h3>Top-level domain</h3>
+              <p>
+                example.de vs example.com. Maximum market trust; Palamedes maps each domain to its
+                locale.
+              </p>
+            </div>
+          </div>
+          <ul class="linklist">
+            <li>
+              <a
+                href="https://github.com/sebastian-software/palamedes/blob/main/docs/locale-strategies.md"
+                >Locale strategies in depth</a
+              >
+            </li>
+          </ul>
+        </div>
+      </section>
 
-    <div class="steps">
-      <div class="step" id="install">
-        <div class="step-num">1</div>
-        <div>
-          <h3>Install</h3>
-          <p class="step-body">Core, runtime, host adapter, and the build plugin — plus the CLI as a dev dependency.</p>
-<pre class="code"><span class="c-amber">$</span> pnpm add @palamedes/core @palamedes/react @palamedes/runtime @palamedes/vite-plugin
+      <section class="block">
+        <div class="wrap">
+          <div class="sec-label">per-framework</div>
+          <h2>Your stack, specifically.</h2>
+
+          <div class="fw-panel">
+            <h3>Next.js</h3>
+            <p>
+              App Router with server components and server actions. The @palamedes/next-plugin wires
+              the transform into the Next build; everything else is the shared model.
+            </p>
+            <div class="fw-demos">
+              <span class="grp">demos:</span>
+              <a href="https://nextjs-cookie.examples.palamedes.dev"
+                ><span class="led live"></span>cookie</a
+              >
+              <span class="grp">route →</span>
+              <a href="https://nextjs-route.examples.palamedes.dev/en">en</a>
+              <a href="https://nextjs-route.examples.palamedes.dev/de">de</a>
+              <a href="https://nextjs-route.examples.palamedes.dev/es">es</a>
+              <a
+                href="https://github.com/sebastian-software/palamedes/tree/main/examples/nextjs-subdomain"
+                ><span class="led prov"></span>subdomain src</a
+              >
+              <a
+                href="https://github.com/sebastian-software/palamedes/tree/main/examples/nextjs-tld"
+                ><span class="led prov"></span>tld src</a
+              >
+              <a
+                class="src"
+                href="https://github.com/sebastian-software/palamedes/tree/main/examples/nextjs-route"
+                >source ↗</a
+              >
+            </div>
+          </div>
+
+          <div class="fw-panel">
+            <h3>TanStack Start</h3>
+            <p>
+              Server functions and file-based routing, integrated through @palamedes/vite-plugin.
+              Locale resolution runs in a server function; the client stays island-light.
+            </p>
+            <div class="fw-demos">
+              <span class="grp">demos:</span>
+              <a href="https://tanstack-cookie.examples.palamedes.dev"
+                ><span class="led live"></span>cookie</a
+              >
+              <span class="grp">route →</span>
+              <a href="https://tanstack-route.examples.palamedes.dev/en">en</a>
+              <a href="https://tanstack-route.examples.palamedes.dev/de">de</a>
+              <a href="https://tanstack-route.examples.palamedes.dev/es">es</a>
+              <a
+                href="https://github.com/sebastian-software/palamedes/tree/main/examples/tanstack-subdomain"
+                ><span class="led prov"></span>subdomain src</a
+              >
+              <a
+                href="https://github.com/sebastian-software/palamedes/tree/main/examples/tanstack-tld"
+                ><span class="led prov"></span>tld src</a
+              >
+              <a
+                class="src"
+                href="https://github.com/sebastian-software/palamedes/tree/main/examples/tanstack-route"
+                >source ↗</a
+              >
+            </div>
+          </div>
+
+          <div class="fw-panel">
+            <h3>SolidStart</h3>
+            <p>
+              Fine-grained reactivity with @palamedes/solid — the same macro authoring and catalogs
+              as React, no fork of your i18n strategy for a different renderer.
+            </p>
+            <div class="fw-demos">
+              <span class="grp">demos:</span>
+              <a href="https://solidstart-cookie.examples.palamedes.dev"
+                ><span class="led live"></span>cookie</a
+              >
+              <span class="grp">route →</span>
+              <a href="https://solidstart-route.examples.palamedes.dev/en">en</a>
+              <a href="https://solidstart-route.examples.palamedes.dev/de">de</a>
+              <a href="https://solidstart-route.examples.palamedes.dev/es">es</a>
+              <a
+                href="https://github.com/sebastian-software/palamedes/tree/main/examples/solidstart-subdomain"
+                ><span class="led prov"></span>subdomain src</a
+              >
+              <a
+                href="https://github.com/sebastian-software/palamedes/tree/main/examples/solidstart-tld"
+                ><span class="led prov"></span>tld src</a
+              >
+              <a
+                class="src"
+                href="https://github.com/sebastian-software/palamedes/tree/main/examples/solidstart-route"
+                >source ↗</a
+              >
+            </div>
+          </div>
+
+          <div class="fw-panel">
+            <h3>Waku</h3>
+            <p>
+              Minimal RSC framework. If the model holds here, it holds in your custom setup too —
+              that's why Waku is in the matrix.
+            </p>
+            <div class="fw-demos">
+              <span class="grp">demos:</span>
+              <a href="https://waku-cookie.examples.palamedes.dev"
+                ><span class="led live"></span>cookie</a
+              >
+              <span class="grp">route →</span>
+              <a href="https://waku-route.examples.palamedes.dev/en">en</a>
+              <a href="https://waku-route.examples.palamedes.dev/de">de</a>
+              <a href="https://waku-route.examples.palamedes.dev/es">es</a>
+              <a
+                href="https://github.com/sebastian-software/palamedes/tree/main/examples/waku-subdomain"
+                ><span class="led prov"></span>subdomain src</a
+              >
+              <a href="https://github.com/sebastian-software/palamedes/tree/main/examples/waku-tld"
+                ><span class="led prov"></span>tld src</a
+              >
+              <a
+                class="src"
+                href="https://github.com/sebastian-software/palamedes/tree/main/examples/waku-route"
+                >source ↗</a
+              >
+            </div>
+          </div>
+
+          <div class="fw-panel">
+            <h3>React Router</h3>
+            <p>
+              Framework-mode React Router with loaders and actions. The classic SPA-plus-SSR shape,
+              same catalogs, same runtime.
+            </p>
+            <div class="fw-demos">
+              <span class="grp">demos:</span>
+              <a href="https://react-router-cookie.examples.palamedes.dev"
+                ><span class="led live"></span>cookie</a
+              >
+              <span class="grp">route →</span>
+              <a href="https://react-router-route.examples.palamedes.dev/en">en</a>
+              <a href="https://react-router-route.examples.palamedes.dev/de">de</a>
+              <a href="https://react-router-route.examples.palamedes.dev/es">es</a>
+              <a
+                href="https://github.com/sebastian-software/palamedes/tree/main/examples/react-router-subdomain"
+                ><span class="led prov"></span>subdomain src</a
+              >
+              <a
+                href="https://github.com/sebastian-software/palamedes/tree/main/examples/react-router-tld"
+                ><span class="led prov"></span>tld src</a
+              >
+              <a
+                class="src"
+                href="https://github.com/sebastian-software/palamedes/tree/main/examples/react-router-route"
+                >source ↗</a
+              >
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="block">
+        <div class="wrap">
+          <div class="sec-label">backend</div>
+          <h2>And it doesn't stop at the frontend.</h2>
+          <p class="body subline">
+            The same getI18n() model runs in Hono and Express with request-local locale resolution —
+            transactional emails, API error messages, and PDF generation speak the user's language
+            from the same catalogs.
+          </p>
+          <div class="cta-row">
+            <a
+              class="btn secondary"
+              href="https://github.com/sebastian-software/palamedes/blob/main/docs/backend-servers.md"
+              >Backend servers guide</a
+            >
+          </div>
+        </div>
+      </section>
+
+      <div class="cta-band">
+        <div class="wrap">
+          <h2>See your framework speaking three languages — right now.</h2>
+          <div class="cta-row">
+            <a class="btn primary" href="https://nextjs-cookie.examples.palamedes.dev"
+              >Open the live matrix</a
+            >
+            <a class="btn secondary" href="#/get-started">Get started</a>
+          </div>
+        </div>
+      </div>
+    </main>
+
+    <!-- ================================================= VIEW: PROOF -->
+    <main id="view-proof" class="view">
+      <div class="wrap hero">
+        <div class="path-label">~/palamedes › <b>proof</b></div>
+        <div class="eyebrow">Proof</div>
+        <h1>Claims you can re-run.</h1>
+        <p class="subline">
+          Every number on this page comes from a checked-in, machine-readable report with fixtures
+          and commands in the repo. If a claim can't be re-run, we don't make it.
+        </p>
+        <div class="cta-row">
+          <a
+            class="btn primary"
+            href="https://github.com/sebastian-software/palamedes/blob/main/docs/benchmark-e2e-workflow.md"
+            >Re-run the benchmarks</a
+          >
+          <a
+            class="btn secondary"
+            href="https://github.com/sebastian-software/palamedes/tree/main/benchmarks/e2e-workflow/results"
+            >Browse checked-in reports</a
+          >
+        </div>
+      </div>
+
+      <section class="block">
+        <div class="wrap">
+          <div class="sec-label">benchmarks</div>
+          <h2>The workflow you feel every day: extract &amp; update.</h2>
+          <p class="body subline">
+            The end-to-end benchmark measures what a developer actually waits for: scan sources,
+            extract messages, update catalogs, write files. Same generated message inventory,
+            rendered into each tool's idiomatic source shape, semantically validated after every
+            run.
+          </p>
+
+          <div class="bench">
+            <div class="bench-title">Small corpus — 80 files, 640 messages (median of 7 runs)</div>
+            <div class="meter-row">
+              <span class="meter-tool win">Palamedes</span>
+              <span class="meter-track"
+                ><span class="meter-rail"
+                  ><span class="meter-fill win" style="width: 5.1%"></span></span
+              ></span>
+              <span class="meter-val"><b>33.53 ms</b></span>
+            </div>
+            <div class="meter-row">
+              <span class="meter-tool">i18next-parser 9.4</span>
+              <span class="meter-track"
+                ><span class="meter-rail"
+                  ><span class="meter-fill" style="width: 72.7%"></span></span
+              ></span>
+              <span class="meter-val">477.58 ms</span>
+            </div>
+            <div class="meter-row">
+              <span class="meter-tool">Lingui 6.4</span>
+              <span class="meter-track"
+                ><span class="meter-rail"><span class="meter-fill" style="width: 100%"></span></span
+              ></span>
+              <span class="meter-val">657.00 ms</span>
+            </div>
+            <div class="bench-note">
+              Linear scale, full track = 657.00 ms — the fast bar really is that short; nothing is
+              truncated or distorted.
+              <a
+                href="https://github.com/sebastian-software/palamedes/blob/main/docs/benchmark-e2e-workflow.md"
+                >Methodology</a
+              >
+            </div>
+          </div>
+
+          <div class="bench">
+            <div class="bench-title">Medium corpus (median of 7 runs)</div>
+            <div class="meter-row">
+              <span class="meter-tool win">Palamedes</span>
+              <span class="meter-track"
+                ><span class="meter-rail"
+                  ><span class="meter-fill win" style="width: 6.5%"></span></span
+              ></span>
+              <span class="meter-val"><b>42.92 ms</b></span>
+            </div>
+            <div class="bench-note">
+              Competitor medians for the medium corpus live in the checked-in report:
+              <a
+                href="https://github.com/sebastian-software/palamedes/blob/main/benchmarks/e2e-workflow/results/latest.md"
+                >results/latest.md</a
+              >
+              ·
+              <a
+                href="https://github.com/sebastian-software/palamedes/blob/main/docs/benchmark-e2e-workflow.md"
+                >Methodology</a
+              >
+            </div>
+          </div>
+
+          <div class="callout">
+            These are machine-local numbers from the checked-in report, not a marketing average.
+            Your hardware will differ; the ratios are the signal. Commands to reproduce:
+            <code>pnpm benchmark:e2e-workflow</code>.
+          </div>
+        </div>
+      </section>
+
+      <section class="block">
+        <div class="wrap">
+          <div class="sec-label">verification</div>
+          <h2>20 apps, verified in a real browser, on every change.</h2>
+          <div class="ci-log">
+            <div class="ln">
+              <span class="tick">✓</span> [1/3] <span class="step-name">build</span>
+            </div>
+            <span class="desc"
+              >All 20 example apps build against the workspace packages — no mocked
+              integrations.</span
+            >
+            <div class="ln">
+              <span class="tick">✓</span> [2/3] <span class="step-name">drive</span>
+            </div>
+            <span class="desc"
+              >A Playwright flow loads each app, checks SSR output, switches locales, and exercises
+              localized server actions.</span
+            >
+            <div class="ln">
+              <span class="tick">✓</span> [3/3] <span class="step-name">capture</span>
+            </div>
+            <span class="desc"
+              >Screenshots are versioned in the repo, so 'works across frameworks' is a diffable
+              artifact, not a slide.</span
+            >
+          </div>
+
+          <div class="shot-frame">
+            <div class="shot-bar">
+              <span class="term-dot"></span><span class="term-dot"></span
+              ><span class="term-dot"></span>
+              <span class="shot-url"
+                >examples.palamedes.dev — the same booking UI in en · de · es</span
+              >
+            </div>
+            <div class="shot-body">
+              <div
+                class="locale-row"
+                style="margin-top: 0"
+                aria-label="The same booking UI rendered in English, German, and Spanish"
+              >
+                <div class="bk-card">
+                  <div class="bk-locale">en</div>
+                  <div class="bk-title">Your trip to Lisbon</div>
+                  <div class="bk-seats">3 seats left</div>
+                  <div class="bk-meta">
+                    <span class="bk-price">€1,234.00</span><span class="bk-date">Jul 12, 2026</span>
+                  </div>
+                </div>
+                <div class="bk-card">
+                  <div class="bk-locale">de</div>
+                  <div class="bk-title">Deine Reise nach Lissabon</div>
+                  <div class="bk-seats">3 Plätze frei</div>
+                  <div class="bk-meta">
+                    <span class="bk-price">1.234,00&nbsp;€</span
+                    ><span class="bk-date">12. Juli 2026</span>
+                  </div>
+                </div>
+                <div class="bk-card">
+                  <div class="bk-locale">es</div>
+                  <div class="bk-title">Tu viaje a Lisboa</div>
+                  <div class="bk-seats">Quedan 3 asientos</div>
+                  <div class="bk-meta">
+                    <span class="bk-price">1234,00&nbsp;€</span
+                    ><span class="bk-date">12 jul 2026</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="shot-caption">
+              One demo, three locales: copy, plural seat counts, currency, and dates change
+              together.
+              <a
+                href="https://github.com/sebastian-software/palamedes/blob/main/docs/example-screenshots/README.md"
+                >Versioned screenshots ↗</a
+              >
+              <span class="dimtxt"
+                >(CSS mock in this draft — the real page embeds the checked-in screenshot.)</span
+              >
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="block">
+        <div class="wrap">
+          <div class="sec-label">catalog-qa</div>
+          <h2>Fast would be worthless if the catalogs were wrong.</h2>
+          <p class="body subline">
+            Catalog semantics live in one dedicated engine (ferrocat): parsing, merging, structured
+            audits, and ICU authoring diagnostics. The benchmark harness validates every tool run
+            semantically — message inventories are compared, not just timed.
+          </p>
+          <div class="grid cols-3">
+            <div class="card">
+              <h3>Structured audits</h3>
+              <p>
+                Machine-readable catalog audits catch missing translations, stale entries, and
+                metadata drift in CI.
+              </p>
+            </div>
+            <div class="card">
+              <h3>ICU diagnostics</h3>
+              <p>
+                Authoring mistakes in plural/select syntax are flagged at extract time, not at
+                runtime in production.
+              </p>
+            </div>
+            <div class="card">
+              <h3>Semantic merging</h3>
+              <p>
+                A Git merge driver resolves catalog conflicts by meaning, not by line — no more
+                broken .po files after rebases.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="block">
+        <div class="wrap">
+          <div class="sec-label">adrs</div>
+          <h2>16 decisions, written down before you depend on them.</h2>
+          <p class="body subline">
+            The ADRs cover message identity, the native boundary, adapter architecture — and, just
+            as deliberately, what Palamedes refuses to own. Reading them is the fastest way to know
+            if our tradeoffs match yours.
+          </p>
+          <ul class="linklist">
+            <li>
+              <a href="https://github.com/sebastian-software/palamedes/tree/main/adr">ADR index</a>
+            </li>
+            <li>
+              <a href="https://github.com/sebastian-software/palamedes/blob/main/docs/stability.md"
+                >Stability &amp; versioning policy</a
+              >
+            </li>
+            <li>
+              <a href="https://github.com/sebastian-software/palamedes/blob/main/docs/principles.md"
+                >Palamedes principles</a
+              >
+            </li>
+          </ul>
+        </div>
+      </section>
+
+      <div class="cta-band">
+        <div class="wrap">
+          <h2>Convinced by the receipts? The quickstart takes 5 minutes.</h2>
+          <div class="cta-row">
+            <a class="btn primary" href="#/get-started">Get started</a>
+            <a class="btn secondary dead" href="#" title="Not part of this draft"
+              >Compare with your current tool</a
+            >
+          </div>
+        </div>
+      </div>
+    </main>
+
+    <!-- =========================================== VIEW: GET STARTED -->
+    <main id="view-get-started" class="view">
+      <div class="wrap hero">
+        <div class="path-label">~/palamedes › <b>get-started</b></div>
+        <div class="eyebrow">Quickstart</div>
+        <h1>First working translation in 5 minutes.</h1>
+        <p class="subline">
+          One translated component, one extraction run, one .po file, one runtime instance. No
+          message IDs to invent, no dictionary files to maintain.
+        </p>
+        <div class="cta-row">
+          <a class="btn primary" href="#install">Skip to step 1</a>
+          <a
+            class="btn secondary"
+            href="https://github.com/sebastian-software/palamedes/blob/main/docs/first-working-translation.md"
+            >Full written guide</a
+          >
+        </div>
+
+        <div class="stack-picker" role="group" aria-label="Stack picker">
+          <span class="lbl">stack:</span>
+          <button class="stack-chip active" type="button">Vite + React</button>
+          <button class="stack-chip" type="button">Vite + Solid</button>
+          <button class="stack-chip" type="button">Next.js</button>
+        </div>
+        <p class="stack-note">
+          This static draft mocks the Vite + React path; in the real page the picker switches every
+          code block below.
+        </p>
+
+        <div class="callout">
+          Heads-up: install the scoped <code>@palamedes/*</code> packages. The top-level
+          <code>palamedes</code> and <code>create-palamedes</code> names are reserved for a future
+          one-command setup and are not the entry point today.
+        </div>
+
+        <div class="steps">
+          <div class="step" id="install">
+            <div class="step-num">1</div>
+            <div>
+              <h3>Install</h3>
+              <p class="step-body">
+                Core, runtime, host adapter, and the build plugin — plus the CLI as a dev
+                dependency.
+              </p>
+              <pre
+                class="code"
+              ><span class="c-amber">$</span> pnpm add @palamedes/core @palamedes/react @palamedes/runtime @palamedes/vite-plugin
 <span class="c-amber">$</span> pnpm add -D @palamedes/cli @vitejs/plugin-react</pre>
-        </div>
-      </div>
+            </div>
+          </div>
 
-      <div class="step">
-        <div class="step-num">2</div>
-        <div>
-          <h3>Configure</h3>
-          <p class="step-body">One YAML file declares your locales and where catalogs live.</p>
-<pre class="code"><span class="c-dim"># palamedes.yaml</span>
+          <div class="step">
+            <div class="step-num">2</div>
+            <div>
+              <h3>Configure</h3>
+              <p class="step-body">One YAML file declares your locales and where catalogs live.</p>
+              <pre class="code"><span class="c-dim"># palamedes.yaml</span>
 <span class="c-kw">locales:</span> [en, de]
 <span class="c-kw">source-locale:</span> en
 <span class="c-kw">catalogs:</span>
   - <span class="c-kw">path:</span> src/locales/{locale}
     <span class="c-kw">include:</span> [src]</pre>
-        </div>
-      </div>
+            </div>
+          </div>
 
-      <div class="step">
-        <div class="step-num">3</div>
-        <div>
-          <h3>Wire the plugin &amp; runtime</h3>
-          <p class="step-body">The Vite plugin handles the macro transform; the runtime holds the active i18n instance.</p>
-<pre class="code"><span class="c-dim">// vite.config.ts</span>
+          <div class="step">
+            <div class="step-num">3</div>
+            <div>
+              <h3>Wire the plugin &amp; runtime</h3>
+              <p class="step-body">
+                The Vite plugin handles the macro transform; the runtime holds the active i18n
+                instance.
+              </p>
+              <pre class="code"><span class="c-dim">// vite.config.ts</span>
 <span class="c-kw">import</span> { palamedes } <span class="c-kw">from</span> <span class="c-str">"@palamedes/vite-plugin"</span>
 <span class="c-kw">export default</span> defineConfig({ plugins: [palamedes(), react()] })
 
@@ -1206,39 +2109,46 @@ footer.site-footer { border-top: 1px solid var(--border); background: var(--pane
 
 <span class="c-kw">export const</span> i18n = createI18n()
 setClientI18n(i18n)</pre>
-        </div>
-      </div>
+            </div>
+          </div>
 
-      <div class="step">
-        <div class="step-num">4</div>
-        <div>
-          <h3>Write &amp; extract</h3>
-          <p class="step-body">Author the message in your component, then run one command — it creates src/locales/en.po and de.po.</p>
-<pre class="code"><span class="c-dim">// src/App.tsx</span>
+          <div class="step">
+            <div class="step-num">4</div>
+            <div>
+              <h3>Write &amp; extract</h3>
+              <p class="step-body">
+                Author the message in your component, then run one command — it creates
+                src/locales/en.po and de.po.
+              </p>
+              <pre class="code"><span class="c-dim">// src/App.tsx</span>
 <span class="c-kw">import</span> { t } <span class="c-kw">from</span> <span class="c-str">"@palamedes/core/macro"</span>
 <span class="c-kw">export const</span> App = () =&gt; &lt;h1&gt;{t<span class="c-str">`Welcome to Palamedes`</span>}&lt;/h1&gt;
 
 <span class="c-amber">$</span> pmds extract</pre>
-        </div>
-      </div>
+            </div>
+          </div>
 
-      <div class="step">
-        <div class="step-num">5</div>
-        <div>
-          <h3>Translate</h3>
-          <p class="step-body">Open the German catalog and fill in the translated string.</p>
-<pre class="code"><span class="c-dim"># src/locales/de.po</span>
+          <div class="step">
+            <div class="step-num">5</div>
+            <div>
+              <h3>Translate</h3>
+              <p class="step-body">Open the German catalog and fill in the translated string.</p>
+              <pre class="code"><span class="c-dim"># src/locales/de.po</span>
 <span class="c-kw">msgid</span> <span class="c-str">"Welcome to Palamedes"</span>
 <span class="c-kw">msgstr</span> <span class="c-str">"Willkommen bei Palamedes"</span></pre>
-        </div>
-      </div>
+            </div>
+          </div>
 
-      <div class="step">
-        <div class="step-num">6</div>
-        <div>
-          <h3>Load &amp; see it render</h3>
-          <p class="step-body">Load the catalogs, activate a locale, and run the dev server — the page now renders “Willkommen bei Palamedes”. That is the full local loop: transform, extraction, catalog, runtime.</p>
-<pre class="code"><span class="c-dim">// src/main.tsx</span>
+          <div class="step">
+            <div class="step-num">6</div>
+            <div>
+              <h3>Load &amp; see it render</h3>
+              <p class="step-body">
+                Load the catalogs, activate a locale, and run the dev server — the page now renders
+                “Willkommen bei Palamedes”. That is the full local loop: transform, extraction,
+                catalog, runtime.
+              </p>
+              <pre class="code"><span class="c-dim">// src/main.tsx</span>
 <span class="c-kw">import</span> { i18n } <span class="c-kw">from</span> <span class="c-str">"./i18n"</span>
 <span class="c-kw">import</span> { messages <span class="c-kw">as</span> enMessages } <span class="c-kw">from</span> <span class="c-str">"./locales/en.po"</span>
 <span class="c-kw">import</span> { messages <span class="c-kw">as</span> deMessages } <span class="c-kw">from</span> <span class="c-str">"./locales/de.po"</span>
@@ -1248,238 +2158,344 @@ i18n.load(<span class="c-str">"de"</span>, deMessages)
 i18n.activate(<span class="c-str">"de"</span>)
 
 <span class="c-amber">$</span> pnpm dev</pre>
-          <div class="aside-note">TypeScript needs an ambient declaration for .po imports — add a src/po.d.ts with <code>declare module "*.po"</code> (see the <a href="https://github.com/sebastian-software/palamedes/blob/main/docs/troubleshooting.md">troubleshooting guide</a>).</div>
+              <div class="aside-note">
+                TypeScript needs an ambient declaration for .po imports — add a src/po.d.ts with
+                <code>declare module "*.po"</code> (see the
+                <a
+                  href="https://github.com/sebastian-software/palamedes/blob/main/docs/troubleshooting.md"
+                  >troubleshooting guide</a
+                >).
+              </div>
+            </div>
+          </div>
         </div>
       </div>
-    </div>
-  </div>
 
-  <section class="block">
-    <div class="wrap">
-      <div class="sec-label">next</div>
-      <h2>Where to go from here</h2>
-      <div class="grid cols-3">
-        <div class="card">
-          <h3>Plurals, dates &amp; currency</h3>
-          <p>ICU MessageFormat with authoring diagnostics that catch mistakes at extract time.</p>
-          <a class="more" href="https://github.com/sebastian-software/palamedes/blob/main/docs/api/core.md">docs/api/core.md</a>
+      <section class="block">
+        <div class="wrap">
+          <div class="sec-label">next</div>
+          <h2>Where to go from here</h2>
+          <div class="grid cols-3">
+            <div class="card">
+              <h3>Plurals, dates &amp; currency</h3>
+              <p>
+                ICU MessageFormat with authoring diagnostics that catch mistakes at extract time.
+              </p>
+              <a
+                class="more"
+                href="https://github.com/sebastian-software/palamedes/blob/main/docs/api/core.md"
+                >docs/api/core.md</a
+              >
+            </div>
+            <div class="card">
+              <h3>Pick a locale strategy</h3>
+              <p>
+                Cookie, route, subdomain, or TLD — with a live demo for each, in your framework.
+              </p>
+              <a class="more" href="#/frameworks">frameworks</a>
+            </div>
+            <div class="card">
+              <h3>Localize your backend</h3>
+              <p>Request-local i18n for Hono and Express from the same catalogs.</p>
+              <a
+                class="more"
+                href="https://github.com/sebastian-software/palamedes/blob/main/docs/backend-servers.md"
+                >docs/backend-servers.md</a
+              >
+            </div>
+            <div class="card">
+              <h3>Migrating from Lingui?</h3>
+              <p>
+                A step-by-step playbook. Source-string-first .po catalogs are often reusable after
+                an extraction pass; explicit-ID setups need cleanup.
+              </p>
+              <a
+                class="more"
+                href="https://github.com/sebastian-software/palamedes/blob/main/docs/migrate-from-lingui.md"
+                >docs/migrate-from-lingui.md</a
+              >
+            </div>
+            <div class="card">
+              <h3>Something broke?</h3>
+              <p>
+                The troubleshooting guide covers the common setup failures with exact error
+                messages.
+              </p>
+              <a
+                class="more"
+                href="https://github.com/sebastian-software/palamedes/blob/main/docs/troubleshooting.md"
+                >docs/troubleshooting.md</a
+              >
+            </div>
+            <div class="card">
+              <h3>Using an AI assistant?</h3>
+              <p>Point it at llms.txt — the whole API surface in one machine-readable file.</p>
+              <a
+                class="more"
+                href="https://github.com/sebastian-software/palamedes/blob/main/llms.txt"
+                >llms.txt</a
+              >
+            </div>
+          </div>
         </div>
-        <div class="card">
-          <h3>Pick a locale strategy</h3>
-          <p>Cookie, route, subdomain, or TLD — with a live demo for each, in your framework.</p>
-          <a class="more" href="#/frameworks">frameworks</a>
-        </div>
-        <div class="card">
-          <h3>Localize your backend</h3>
-          <p>Request-local i18n for Hono and Express from the same catalogs.</p>
-          <a class="more" href="https://github.com/sebastian-software/palamedes/blob/main/docs/backend-servers.md">docs/backend-servers.md</a>
-        </div>
-        <div class="card">
-          <h3>Migrating from Lingui?</h3>
-          <p>A step-by-step playbook. Source-string-first .po catalogs are often reusable after an extraction pass; explicit-ID setups need cleanup.</p>
-          <a class="more" href="https://github.com/sebastian-software/palamedes/blob/main/docs/migrate-from-lingui.md">docs/migrate-from-lingui.md</a>
-        </div>
-        <div class="card">
-          <h3>Something broke?</h3>
-          <p>The troubleshooting guide covers the common setup failures with exact error messages.</p>
-          <a class="more" href="https://github.com/sebastian-software/palamedes/blob/main/docs/troubleshooting.md">docs/troubleshooting.md</a>
-        </div>
-        <div class="card">
-          <h3>Using an AI assistant?</h3>
-          <p>Point it at llms.txt — the whole API surface in one machine-readable file.</p>
-          <a class="more" href="https://github.com/sebastian-software/palamedes/blob/main/llms.txt">llms.txt</a>
+      </section>
+
+      <div class="cta-band">
+        <div class="wrap">
+          <h2>Stuck? The maintainer reads every issue.</h2>
+          <div class="cta-row">
+            <a class="btn primary" href="https://github.com/sebastian-software/palamedes/issues"
+              >Open an issue</a
+            >
+            <a
+              class="btn secondary"
+              href="https://github.com/sebastian-software/palamedes/blob/main/docs/api/README.md"
+              >Read the docs</a
+            >
+          </div>
         </div>
       </div>
-    </div>
-  </section>
+    </main>
 
-  <div class="cta-band">
-    <div class="wrap">
-      <h2>Stuck? The maintainer reads every issue.</h2>
-      <div class="cta-row">
-        <a class="btn primary" href="https://github.com/sebastian-software/palamedes/issues">Open an issue</a>
-        <a class="btn secondary" href="https://github.com/sebastian-software/palamedes/blob/main/docs/api/README.md">Read the docs</a>
+    <!-- ==================================================== FOOTER -->
+    <footer class="site-footer">
+      <div class="wrap">
+        <div class="footer-cols">
+          <div>
+            <h4>Product</h4>
+            <ul>
+              <li><a href="#/get-started">Get started</a></li>
+              <li><a href="#/frameworks">Framework matrix</a></li>
+              <li><a href="#/proof">Benchmarks &amp; proof</a></li>
+              <li><a href="#" class="dead" title="Not part of this draft">Comparison</a></li>
+            </ul>
+          </div>
+          <div>
+            <h4>Documentation</h4>
+            <ul>
+              <li>
+                <a
+                  href="https://github.com/sebastian-software/palamedes/blob/main/docs/first-working-translation.md"
+                  >5-minute quickstart</a
+                >
+              </li>
+              <li>
+                <a
+                  href="https://github.com/sebastian-software/palamedes/blob/main/docs/api/README.md"
+                  >API reference</a
+                >
+              </li>
+              <li>
+                <a
+                  href="https://github.com/sebastian-software/palamedes/blob/main/docs/configuration.md"
+                  >Configuration</a
+                >
+              </li>
+              <li>
+                <a href="https://github.com/sebastian-software/palamedes/blob/main/docs/cli.md"
+                  >CLI</a
+                >
+              </li>
+              <li>
+                <a
+                  href="https://github.com/sebastian-software/palamedes/blob/main/docs/troubleshooting.md"
+                  >Troubleshooting</a
+                >
+              </li>
+            </ul>
+          </div>
+          <div>
+            <h4>Project</h4>
+            <ul>
+              <li>
+                <a href="https://github.com/sebastian-software/palamedes/tree/main/adr"
+                  >Architecture decisions</a
+                >
+              </li>
+              <li>
+                <a
+                  href="https://github.com/sebastian-software/palamedes/blob/main/docs/stability.md"
+                  >Stability &amp; versioning</a
+                >
+              </li>
+              <li>
+                <a href="https://github.com/sebastian-software/palamedes/blob/main/CHANGELOG.md"
+                  >Changelog</a
+                >
+              </li>
+              <li>
+                <a href="https://github.com/sebastian-software/palamedes/blob/main/SECURITY.md"
+                  >Security</a
+                >
+              </li>
+              <li>
+                <a href="https://github.com/sebastian-software/palamedes/blob/main/LICENSE"
+                  >MIT license</a
+                >
+              </li>
+            </ul>
+          </div>
+          <div>
+            <h4>Company</h4>
+            <ul>
+              <li><a href="https://oss.sebastian-software.com/">Sebastian Software</a></li>
+              <li><a href="https://sebastian-software.de/werner">Sebastian Werner</a></li>
+              <li><a href="#" class="dead" title="Not part of this draft">Blog</a></li>
+            </ul>
+          </div>
+        </div>
+        <div class="legal-strip">
+          MIT © 2026 Sebastian Software GmbH — built in the open, verified in CI.
+        </div>
       </div>
-    </div>
-  </div>
-</main>
+    </footer>
 
-<!-- ==================================================== FOOTER -->
-<footer class="site-footer">
-  <div class="wrap">
-    <div class="footer-cols">
-      <div>
-        <h4>Product</h4>
-        <ul>
-          <li><a href="#/get-started">Get started</a></li>
-          <li><a href="#/frameworks">Framework matrix</a></li>
-          <li><a href="#/proof">Benchmarks &amp; proof</a></li>
-          <li><a href="#" class="dead" title="Not part of this draft">Comparison</a></li>
-        </ul>
-      </div>
-      <div>
-        <h4>Documentation</h4>
-        <ul>
-          <li><a href="https://github.com/sebastian-software/palamedes/blob/main/docs/first-working-translation.md">5-minute quickstart</a></li>
-          <li><a href="https://github.com/sebastian-software/palamedes/blob/main/docs/api/README.md">API reference</a></li>
-          <li><a href="https://github.com/sebastian-software/palamedes/blob/main/docs/configuration.md">Configuration</a></li>
-          <li><a href="https://github.com/sebastian-software/palamedes/blob/main/docs/cli.md">CLI</a></li>
-          <li><a href="https://github.com/sebastian-software/palamedes/blob/main/docs/troubleshooting.md">Troubleshooting</a></li>
-        </ul>
-      </div>
-      <div>
-        <h4>Project</h4>
-        <ul>
-          <li><a href="https://github.com/sebastian-software/palamedes/tree/main/adr">Architecture decisions</a></li>
-          <li><a href="https://github.com/sebastian-software/palamedes/blob/main/docs/stability.md">Stability &amp; versioning</a></li>
-          <li><a href="https://github.com/sebastian-software/palamedes/blob/main/CHANGELOG.md">Changelog</a></li>
-          <li><a href="https://github.com/sebastian-software/palamedes/blob/main/SECURITY.md">Security</a></li>
-          <li><a href="https://github.com/sebastian-software/palamedes/blob/main/LICENSE">MIT license</a></li>
-        </ul>
-      </div>
-      <div>
-        <h4>Company</h4>
-        <ul>
-          <li><a href="https://oss.sebastian-software.com/">Sebastian Software</a></li>
-          <li><a href="https://sebastian-software.de/werner">Sebastian Werner</a></li>
-          <li><a href="#" class="dead" title="Not part of this draft">Blog</a></li>
-        </ul>
-      </div>
-    </div>
-    <div class="legal-strip">MIT © 2026 Sebastian Software GmbH — built in the open, verified in CI.</div>
-  </div>
-</footer>
+    <script>
+      ;(function () {
+        "use strict"
 
-<script>
-(function () {
-  "use strict";
+        /* ------------------------------------------- framework matrix -- */
+        var REPO = "https://github.com/sebastian-software/palamedes"
+        var FRAMEWORKS = [
+          ["Next.js", "nextjs"],
+          ["TanStack Start", "tanstack"],
+          ["SolidStart", "solidstart"],
+          ["Waku", "waku"],
+          ["React Router", "react-router"],
+        ]
+        var STRATEGIES = ["cookie", "route", "subdomain", "tld"]
 
-  /* ------------------------------------------- framework matrix -- */
-  var REPO = "https://github.com/sebastian-software/palamedes";
-  var FRAMEWORKS = [
-    ["Next.js", "nextjs"],
-    ["TanStack Start", "tanstack"],
-    ["SolidStart", "solidstart"],
-    ["Waku", "waku"],
-    ["React Router", "react-router"]
-  ];
-  var STRATEGIES = ["cookie", "route", "subdomain", "tld"];
+        function esc(s) {
+          return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+        }
 
-  function esc(s) {
-    return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-  }
+        function cellHtml(slug, strategy) {
+          var src = REPO + "/tree/main/examples/" + slug + "-" + strategy
+          var html = ""
+          if (strategy === "cookie") {
+            html +=
+              '<span class="led live" title="live"></span><span class="chip-verified">VERIFIED</span>'
+            html += '<div class="cell-links">'
+            html += '<a href="https://' + slug + '-cookie.examples.palamedes.dev">open ↗</a>'
+            html += '<a class="src" href="' + src + '">src</a>'
+            html += "</div>"
+          } else if (strategy === "route") {
+            html +=
+              '<span class="led live" title="live"></span><span class="chip-verified">VERIFIED</span>'
+            html += '<div class="cell-links">'
+            ;["en", "de", "es"].forEach(function (loc) {
+              html +=
+                '<a href="https://' +
+                slug +
+                "-route.examples.palamedes.dev/" +
+                loc +
+                '">' +
+                loc +
+                "</a>"
+            })
+            html += '<a class="src" href="' + src + '">src</a>'
+            html += "</div>"
+          } else {
+            html +=
+              '<span class="led prov" title="provisioning"></span><span class="chip-verified">VERIFIED</span>'
+            html += '<div class="cell-links"><span class="cell-status">provisioning</span>'
+            html += '<a class="src" href="' + src + '">source ↗</a></div>'
+          }
+          return html
+        }
 
-  function cellHtml(slug, strategy) {
-    var src = REPO + "/tree/main/examples/" + slug + "-" + strategy;
-    var html = "";
-    if (strategy === "cookie") {
-      html += '<span class="led live" title="live"></span><span class="chip-verified">VERIFIED</span>';
-      html += '<div class="cell-links">';
-      html += '<a href="https://' + slug + '-cookie.examples.palamedes.dev">open ↗</a>';
-      html += '<a class="src" href="' + src + '">src</a>';
-      html += "</div>";
-    } else if (strategy === "route") {
-      html += '<span class="led live" title="live"></span><span class="chip-verified">VERIFIED</span>';
-      html += '<div class="cell-links">';
-      ["en", "de", "es"].forEach(function (loc) {
-        html += '<a href="https://' + slug + '-route.examples.palamedes.dev/' + loc + '">' + loc + "</a>";
-      });
-      html += '<a class="src" href="' + src + '">src</a>';
-      html += "</div>";
-    } else {
-      html += '<span class="led prov" title="provisioning"></span><span class="chip-verified">VERIFIED</span>';
-      html += '<div class="cell-links"><span class="cell-status">provisioning</span>';
-      html += '<a class="src" href="' + src + '">source ↗</a></div>';
-    }
-    return html;
-  }
+        function buildMatrix(mount) {
+          var labels = (
+            mount.getAttribute("data-strategy-labels") || "Cookie|Route|Subdomain|TLD"
+          ).split("|")
+          var html = '<table class="matrix"><thead><tr><th scope="col">framework \\ strategy</th>'
+          labels.forEach(function (l) {
+            html += '<th scope="col">' + esc(l) + "</th>"
+          })
+          html += "</tr></thead><tbody>"
+          FRAMEWORKS.forEach(function (fw) {
+            html += '<tr><th scope="row">' + esc(fw[0]) + "</th>"
+            STRATEGIES.forEach(function (st) {
+              html += "<td>" + cellHtml(fw[1], st) + "</td>"
+            })
+            html += "</tr>"
+          })
+          html += "</tbody></table>"
+          mount.innerHTML = html
+        }
 
-  function buildMatrix(mount) {
-    var labels = (mount.getAttribute("data-strategy-labels") || "Cookie|Route|Subdomain|TLD").split("|");
-    var html = '<table class="matrix"><thead><tr><th scope="col">framework \\ strategy</th>';
-    labels.forEach(function (l) { html += '<th scope="col">' + esc(l) + "</th>"; });
-    html += "</tr></thead><tbody>";
-    FRAMEWORKS.forEach(function (fw) {
-      html += '<tr><th scope="row">' + esc(fw[0]) + "</th>";
-      STRATEGIES.forEach(function (st) { html += "<td>" + cellHtml(fw[1], st) + "</td>"; });
-      html += "</tr>";
-    });
-    html += "</tbody></table>";
-    mount.innerHTML = html;
-  }
+        Array.prototype.forEach.call(document.querySelectorAll(".matrix-mount"), buildMatrix)
 
-  Array.prototype.forEach.call(document.querySelectorAll(".matrix-mount"), buildMatrix);
+        /* ------------------------------------------------- hash router -- */
+        var ROUTES = {
+          "": "view-home",
+          "#": "view-home",
+          "#/": "view-home",
+          "#/frameworks": "view-frameworks",
+          "#/proof": "view-proof",
+          "#/get-started": "view-get-started",
+        }
+        var views = document.querySelectorAll(".view")
+        var navLinks = document.querySelectorAll(".nav-links a[data-route]")
+        var shown = false
 
-  /* ------------------------------------------------- hash router -- */
-  var ROUTES = {
-    "": "view-home",
-    "#": "view-home",
-    "#/": "view-home",
-    "#/frameworks": "view-frameworks",
-    "#/proof": "view-proof",
-    "#/get-started": "view-get-started"
-  };
-  var views = document.querySelectorAll(".view");
-  var navLinks = document.querySelectorAll(".nav-links a[data-route]");
-  var shown = false;
+        function show(id, hash) {
+          Array.prototype.forEach.call(views, function (v) {
+            v.classList.toggle("active", v.id === id)
+          })
+          Array.prototype.forEach.call(navLinks, function (a) {
+            a.classList.toggle("active", "#/" + a.getAttribute("data-route") === hash)
+          })
+          shown = true
+          window.scrollTo(0, 0)
+        }
 
-  function show(id, hash) {
-    Array.prototype.forEach.call(views, function (v) {
-      v.classList.toggle("active", v.id === id);
-    });
-    Array.prototype.forEach.call(navLinks, function (a) {
-      a.classList.toggle("active", "#/" + a.getAttribute("data-route") === hash);
-    });
-    shown = true;
-    window.scrollTo(0, 0);
-  }
-
-  function route() {
-    var hash = window.location.hash;
-    if (Object.prototype.hasOwnProperty.call(ROUTES, hash)) {
-      show(ROUTES[hash], hash);
-    } else if (!shown) {
-      show("view-home", "#/");
-    }
-    /* unknown hashes (e.g. #install) keep the current view so
+        function route() {
+          var hash = window.location.hash
+          if (Object.prototype.hasOwnProperty.call(ROUTES, hash)) {
+            show(ROUTES[hash], hash)
+          } else if (!shown) {
+            show("view-home", "#/")
+          }
+          /* unknown hashes (e.g. #install) keep the current view so
        in-page anchors work; the browser handles the scroll. */
-  }
+        }
 
-  window.addEventListener("hashchange", route);
-  route();
+        window.addEventListener("hashchange", route)
+        route()
 
-  /* ------------------------------------------------- dead links -- */
-  document.addEventListener("click", function (e) {
-    var el = e.target.closest ? e.target.closest("a.dead") : null;
-    if (el) e.preventDefault();
-  });
+        /* ------------------------------------------------- dead links -- */
+        document.addEventListener("click", function (e) {
+          var el = e.target.closest ? e.target.closest("a.dead") : null
+          if (el) e.preventDefault()
+        })
 
-  /* -------------------------------------------- code showcase tabs -- */
-  var tabButtons = document.querySelectorAll(".tab-btn");
-  Array.prototype.forEach.call(tabButtons, function (btn) {
-    btn.addEventListener("click", function () {
-      var name = btn.getAttribute("data-tab");
-      Array.prototype.forEach.call(tabButtons, function (b) {
-        var on = b === btn;
-        b.classList.toggle("active", on);
-        b.setAttribute("aria-selected", on ? "true" : "false");
-      });
-      Array.prototype.forEach.call(document.querySelectorAll(".tab-panel"), function (p) {
-        p.classList.toggle("active", p.getAttribute("data-panel") === name);
-      });
-    });
-  });
+        /* -------------------------------------------- code showcase tabs -- */
+        var tabButtons = document.querySelectorAll(".tab-btn")
+        Array.prototype.forEach.call(tabButtons, function (btn) {
+          btn.addEventListener("click", function () {
+            var name = btn.getAttribute("data-tab")
+            Array.prototype.forEach.call(tabButtons, function (b) {
+              var on = b === btn
+              b.classList.toggle("active", on)
+              b.setAttribute("aria-selected", on ? "true" : "false")
+            })
+            Array.prototype.forEach.call(document.querySelectorAll(".tab-panel"), function (p) {
+              p.classList.toggle("active", p.getAttribute("data-panel") === name)
+            })
+          })
+        })
 
-  /* ------------------------------------------- stack picker (mock) -- */
-  var chips = document.querySelectorAll(".stack-chip");
-  Array.prototype.forEach.call(chips, function (chip) {
-    chip.addEventListener("click", function () {
-      Array.prototype.forEach.call(chips, function (c) {
-        c.classList.toggle("active", c === chip);
-      });
-    });
-  });
-})();
-</script>
-</body>
+        /* ------------------------------------------- stack picker (mock) -- */
+        var chips = document.querySelectorAll(".stack-chip")
+        Array.prototype.forEach.call(chips, function (chip) {
+          chip.addEventListener("click", function () {
+            Array.prototype.forEach.call(chips, function (c) {
+              c.classList.toggle("active", c === chip)
+            })
+          })
+        })
+      })()
+    </script>
+  </body>
 </html>

--- a/docs/site/structure/drafts/design-c-editorial.html
+++ b/docs/site/structure/drafts/design-c-editorial.html
@@ -1,0 +1,2458 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Palamedes — Design draft C · Editorial</title>
+    <style>
+      /* ================================================================
+   DESIGN DRAFT C — "EDITORIAL CALM"
+   Warm paper, serif long-form, one teal accent, terracotta details.
+   Fully self-contained: no external fonts, scripts, or images.
+   ================================================================ */
+
+      :root {
+        --paper: #f7f3ec;
+        --ink: #221f1a;
+        --ink-soft: #5c5548;
+        --ink-faint: #8a8071;
+        --rule: #e2dbcd;
+        --teal: #0e6b5c;
+        --teal-deep: #0a5347;
+        --terra: #b4552d;
+        --card: #fffdf8;
+        --code-bg: #2a2620;
+        --code-ink: #efe7d8;
+        --serif: Georgia, "Iowan Old Style", "Times New Roman", serif;
+        --sans: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+        --mono:
+          ui-monospace, "SF Mono", SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+        --shadow-ticket: 0 10px 28px rgba(34, 31, 26, 0.09), 0 2px 6px rgba(34, 31, 26, 0.05);
+      }
+
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+
+      html {
+        scroll-behavior: smooth;
+      }
+      @media (prefers-reduced-motion: reduce) {
+        html {
+          scroll-behavior: auto;
+        }
+        *,
+        *::before,
+        *::after {
+          animation: none !important;
+          transition: none !important;
+        }
+      }
+
+      body {
+        background: var(--paper);
+        color: var(--ink);
+        font-family: var(--serif);
+        font-size: 18.5px;
+        line-height: 1.65;
+        -webkit-font-smoothing: antialiased;
+      }
+
+      /* ------------------------------------------------------------ layout -- */
+
+      .wrap {
+        max-width: 1120px;
+        margin-inline: auto;
+        padding-inline: 24px;
+      }
+      .prose {
+        max-width: 68ch;
+        margin-inline: auto;
+      }
+      .section {
+        padding-block: clamp(56px, 8vw, 120px);
+      }
+      .section--tight {
+        padding-block: clamp(40px, 5vw, 72px);
+      }
+
+      /* Asterism divider between major sections */
+      .asterism {
+        text-align: center;
+        color: var(--terra);
+        font-family: var(--serif);
+        font-size: 24px;
+        letter-spacing: 0.6em;
+        padding-left: 0.6em; /* recenters the letterspaced glyphs */
+        user-select: none;
+      }
+      .asterism::before {
+        content: "\2042";
+      } /* ⁂ */
+
+      /* --------------------------------------------------------- typography -- */
+
+      .eyebrow {
+        font-family: var(--sans);
+        font-size: 12px;
+        font-weight: 600;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        color: var(--teal);
+        margin-bottom: 22px;
+      }
+
+      h1.display {
+        font-family: var(--serif);
+        font-weight: 600;
+        font-size: clamp(40px, 6.5vw, 72px);
+        line-height: 1.1;
+        letter-spacing: -0.012em;
+        margin-bottom: 28px;
+        text-wrap: balance;
+      }
+
+      h2 {
+        font-family: var(--serif);
+        font-weight: 600;
+        font-size: clamp(28px, 4vw, 40px);
+        line-height: 1.18;
+        letter-spacing: -0.008em;
+        margin-bottom: 22px;
+        text-wrap: balance;
+      }
+
+      h3 {
+        font-family: var(--serif);
+        font-weight: 600;
+        font-size: 23px;
+        line-height: 1.3;
+        margin-bottom: 10px;
+      }
+
+      p {
+        max-width: 68ch;
+      }
+      p + p {
+        margin-top: 1em;
+      }
+
+      .lede {
+        font-size: clamp(19px, 2.2vw, 21.5px);
+        line-height: 1.6;
+        color: var(--ink-soft);
+        max-width: 62ch;
+      }
+
+      .caption {
+        font-family: var(--serif);
+        font-style: italic;
+        font-size: 15.5px;
+        color: var(--ink-soft);
+        max-width: 68ch;
+      }
+
+      .smallcaps {
+        font-family: var(--sans);
+        font-size: 11.5px;
+        font-weight: 600;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+      }
+
+      a {
+        color: var(--teal);
+        text-decoration: underline;
+        text-decoration-thickness: 1px;
+        text-underline-offset: 3px;
+        text-decoration-color: rgba(14, 107, 92, 0.45);
+      }
+      a:hover {
+        text-decoration-color: var(--teal);
+      }
+      a.dead {
+        color: var(--ink-faint);
+        cursor: not-allowed;
+        text-decoration-style: dotted;
+      }
+
+      code {
+        font-family: var(--mono);
+        font-size: 0.86em;
+        background: rgba(34, 31, 26, 0.06);
+        border-radius: 4px;
+        padding: 0.1em 0.35em;
+      }
+
+      pre {
+        background: var(--code-bg);
+        color: var(--code-ink);
+        font-family: var(--mono);
+        font-size: 14px;
+        line-height: 1.6;
+        border-radius: 6px;
+        padding: 22px 24px;
+        overflow-x: auto;
+        margin-block: 18px;
+      }
+      pre code {
+        background: none;
+        padding: 0;
+        font-size: inherit;
+      }
+
+      /* ------------------------------------------------------------ buttons -- */
+
+      .btn {
+        display: inline-block;
+        font-family: var(--sans);
+        font-size: 15px;
+        font-weight: 600;
+        letter-spacing: 0.01em;
+        text-decoration: none;
+        border-radius: 999px;
+        padding: 13px 28px;
+        border: 1px solid transparent;
+      }
+      .btn-primary {
+        background: var(--teal);
+        color: var(--paper);
+      }
+      .btn-primary:hover {
+        background: var(--teal-deep);
+      }
+      .btn-secondary {
+        border-color: var(--teal);
+        color: var(--teal);
+        background: transparent;
+      }
+      .btn-secondary:hover {
+        background: rgba(14, 107, 92, 0.07);
+      }
+      .btn-row {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 14px;
+        margin-top: 34px;
+      }
+
+      /* ---------------------------------------------------------------- nav -- */
+
+      .site-nav {
+        position: sticky;
+        top: 0;
+        z-index: 50;
+        background: rgba(247, 243, 236, 0.94);
+        backdrop-filter: blur(6px);
+        border-bottom: 1px solid var(--rule);
+      }
+      .site-nav .wrap {
+        display: flex;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 10px 26px;
+        padding-block: 14px;
+      }
+      .wordmark {
+        font-family: var(--serif);
+        font-size: 21px;
+        font-weight: 600;
+        letter-spacing: -0.01em;
+        color: var(--ink);
+        text-decoration: none;
+      }
+      .wordmark::after {
+        content: "\002A";
+        color: var(--terra);
+        margin-left: 2px;
+      } /* small asterisk mark */
+      .nav-links {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px 22px;
+        margin-right: auto;
+      }
+      .nav-links a {
+        font-family: var(--sans);
+        font-size: 12px;
+        font-weight: 600;
+        letter-spacing: 0.13em;
+        text-transform: uppercase;
+        text-decoration: none;
+        color: var(--ink-soft);
+        padding-block: 4px;
+        border-bottom: 2px solid transparent;
+      }
+      .nav-links a:hover {
+        color: var(--teal);
+      }
+      .nav-links a[aria-current="page"] {
+        color: var(--teal);
+        border-bottom-color: var(--teal);
+      }
+      .nav-actions {
+        display: flex;
+        align-items: center;
+        gap: 16px;
+      }
+      .nav-actions .gh {
+        font-family: var(--sans);
+        font-size: 12px;
+        font-weight: 600;
+        letter-spacing: 0.13em;
+        text-transform: uppercase;
+        text-decoration: none;
+        color: var(--ink-soft);
+      }
+      .nav-actions .gh:hover {
+        color: var(--teal);
+      }
+      .nav-actions .btn {
+        padding: 9px 20px;
+        font-size: 13px;
+      }
+
+      @media (max-width: 719px) {
+        .site-nav .wrap {
+          justify-content: space-between;
+        }
+        .nav-links {
+          order: 3;
+          width: 100%;
+          margin-right: 0;
+        }
+      }
+
+      /* ------------------------------------------------------------- ribbon -- */
+
+      .draft-ribbon {
+        position: fixed;
+        right: 14px;
+        bottom: 14px;
+        z-index: 90;
+        font-family: var(--sans);
+        font-size: 10.5px;
+        font-weight: 600;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        color: var(--terra);
+        background: var(--card);
+        border: 1px solid var(--terra);
+        border-radius: 999px;
+        padding: 7px 14px;
+        box-shadow: none;
+      }
+
+      /* --------------------------------------------------------------- hero -- */
+
+      .hero {
+        padding-block: clamp(64px, 9vw, 130px) clamp(40px, 5vw, 64px);
+        text-align: left;
+      }
+
+      /* ------------------------------------------------------------ tickets -- */
+
+      .ticket-row {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+        gap: 22px;
+        margin-top: clamp(36px, 5vw, 64px);
+      }
+      .ticket {
+        background: var(--card);
+        border: 1px solid var(--rule);
+        border-radius: 12px;
+        box-shadow: var(--shadow-ticket);
+        padding: 22px 24px 20px;
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+      }
+      .ticket .locale-tag {
+        font-family: var(--sans);
+        font-size: 10.5px;
+        font-weight: 700;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        color: var(--teal);
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+      .ticket .locale-tag::before {
+        content: "";
+        width: 7px;
+        height: 7px;
+        border-radius: 50%;
+        background: var(--terra);
+        flex: none;
+      }
+      .ticket .trip {
+        font-family: var(--serif);
+        font-weight: 600;
+        font-size: 21px;
+        line-height: 1.25;
+      }
+      .ticket .seats {
+        font-size: 15.5px;
+        color: var(--ink-soft);
+      }
+      .ticket .tear {
+        border-top: 1px dashed var(--rule);
+        margin-top: 8px;
+        padding-top: 12px;
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 10px;
+        flex-wrap: wrap;
+      }
+      .ticket .price {
+        font-family: var(--mono);
+        font-size: 21px;
+        font-weight: 600;
+      }
+      .ticket .date {
+        font-family: var(--serif);
+        font-style: italic;
+        font-size: 14.5px;
+        color: var(--ink-soft);
+      }
+
+      .ticket--mini {
+        padding: 14px 15px 12px;
+        gap: 5px;
+        border-radius: 9px;
+        box-shadow: none;
+      }
+      .ticket--mini .trip {
+        font-size: 15px;
+      }
+      .ticket--mini .seats {
+        font-size: 12.5px;
+      }
+      .ticket--mini .price {
+        font-size: 14px;
+      }
+      .ticket--mini .date {
+        font-size: 11.5px;
+      }
+      .ticket--mini .tear {
+        margin-top: 4px;
+        padding-top: 8px;
+      }
+
+      /* --------------------------------------------------------- proof strip -- */
+
+      .proof-strip {
+        border-top: 1px solid var(--rule);
+        border-bottom: 1px solid var(--rule);
+        padding-block: 30px;
+      }
+      .proof-strip .wrap {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+        gap: 26px;
+      }
+      .stat {
+        text-decoration: none;
+        color: inherit;
+        display: block;
+        padding-left: 18px;
+        border-left: 1px solid var(--rule);
+      }
+      .stat:hover .stat-value {
+        color: var(--teal);
+      }
+      .stat-value {
+        font-family: var(--serif);
+        font-weight: 600;
+        font-size: 42px;
+        line-height: 1.1;
+      }
+      .stat-label {
+        display: block;
+        margin-top: 6px;
+        font-family: var(--sans);
+        font-size: 11.5px;
+        font-weight: 600;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        color: var(--ink-soft);
+        line-height: 1.55;
+      }
+
+      /* ------------------------------------------------------- feature cards -- */
+
+      .card-grid {
+        display: grid;
+        gap: 22px;
+        margin-top: 40px;
+      }
+      .card-grid.cols-3 {
+        grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+      }
+      .card-grid.cols-4 {
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      }
+      .card {
+        border-top: 1px solid var(--rule);
+        padding-top: 20px;
+      }
+      .card .card-mark {
+        color: var(--terra);
+        font-size: 18px;
+        line-height: 1;
+        margin-bottom: 12px;
+        font-family: var(--serif);
+      }
+      .card h3 {
+        font-size: 21px;
+      }
+      .card p {
+        font-size: 16.5px;
+        color: var(--ink-soft);
+      }
+      .card .more {
+        display: inline-block;
+        margin-top: 10px;
+        font-family: var(--sans);
+        font-size: 12px;
+        font-weight: 600;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        text-decoration: none;
+      }
+
+      /* ------------------------------------------------------- code showcase -- */
+
+      .showcase {
+        margin-top: 36px;
+      }
+      .tabs {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        margin-bottom: 14px;
+      }
+      .tab {
+        font-family: var(--sans);
+        font-size: 12px;
+        font-weight: 600;
+        letter-spacing: 0.13em;
+        text-transform: uppercase;
+        color: var(--ink-soft);
+        background: none;
+        border: 1px solid var(--rule);
+        border-radius: 999px;
+        padding: 8px 18px;
+        cursor: pointer;
+      }
+      .tab[aria-selected="true"] {
+        background: var(--teal);
+        border-color: var(--teal);
+        color: var(--paper);
+      }
+      .tab-panel[hidden] {
+        display: none;
+      }
+      .tab-panel .caption {
+        margin-top: 4px;
+      }
+      .rendered {
+        margin-top: 22px;
+        border: 1px solid var(--rule);
+        border-radius: 10px;
+        background: var(--card);
+        padding: 20px 24px;
+      }
+      .rendered .smallcaps {
+        color: var(--teal);
+      }
+      .rendered p {
+        font-style: italic;
+        color: var(--ink-soft);
+        margin-top: 6px;
+      }
+
+      /* --------------------------------------------------------- matrix table -- */
+
+      .matrix-scroll {
+        overflow-x: auto;
+        margin-top: 36px;
+        -webkit-overflow-scrolling: touch;
+      }
+      table.matrix {
+        border-collapse: collapse;
+        width: 100%;
+        min-width: 700px;
+      }
+      table.matrix th {
+        font-family: var(--sans);
+        font-size: 11px;
+        font-weight: 700;
+        letter-spacing: 0.13em;
+        text-transform: uppercase;
+        color: var(--ink-soft);
+        text-align: left;
+        padding: 12px 14px;
+        border-bottom: 1px solid var(--ink);
+      }
+      table.matrix td {
+        padding: 14px;
+        border-bottom: 1px solid var(--rule);
+        vertical-align: top;
+        font-size: 15px;
+      }
+      table.matrix td.fw {
+        font-family: var(--serif);
+        font-weight: 600;
+        font-size: 17px;
+        white-space: nowrap;
+      }
+      .verified {
+        display: block;
+        font-family: var(--sans);
+        font-size: 10.5px;
+        font-weight: 700;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        color: var(--teal);
+        margin-bottom: 5px;
+      }
+      .verified::before {
+        content: "\2713\00A0";
+      } /* ✓ */
+      .cell-links {
+        font-family: var(--sans);
+        font-size: 13px;
+      }
+      .cell-links a {
+        text-decoration: none;
+        border-bottom: 1px solid rgba(14, 107, 92, 0.4);
+      }
+      .provisioning {
+        font-style: italic;
+        color: var(--ink-faint);
+        font-family: var(--serif);
+        font-size: 14px;
+      }
+      .cell-src {
+        font-family: var(--sans);
+        font-size: 12px;
+      }
+
+      /* ------------------------------------------------------------ benchmark -- */
+
+      .bench {
+        margin-top: 40px;
+        border: 1px solid var(--rule);
+        border-radius: 10px;
+        background: var(--card);
+        padding: 26px 28px;
+      }
+      .bench h3 {
+        font-size: 19px;
+        margin-bottom: 20px;
+      }
+      .bench-row {
+        display: grid;
+        grid-template-columns: minmax(110px, 170px) 1fr;
+        gap: 6px 16px;
+        align-items: center;
+        margin-bottom: 14px;
+      }
+      .bench-tool {
+        font-family: var(--sans);
+        font-size: 12px;
+        font-weight: 600;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--ink-soft);
+      }
+      .bench-track {
+        position: relative;
+        height: 16px;
+      }
+      .bench-bar {
+        height: 12px;
+        margin-top: 2px;
+        border-radius: 0 4px 4px 0;
+        background: var(--ink-faint);
+        display: inline-block;
+        vertical-align: top;
+      }
+      .bench-bar.hero-bar {
+        background: var(--teal);
+      }
+      .bench-val {
+        font-family: var(--mono);
+        font-size: 13px;
+        margin-left: 10px;
+        white-space: nowrap;
+      }
+      .bench-note {
+        font-family: var(--serif);
+        font-style: italic;
+        font-size: 14px;
+        color: var(--ink-soft);
+        margin-top: 16px;
+        border-top: 1px dashed var(--rule);
+        padding-top: 14px;
+      }
+      @media (max-width: 560px) {
+        .bench-row {
+          grid-template-columns: 1fr;
+        }
+        .bench {
+          padding: 20px 18px;
+        }
+      }
+
+      /* ------------------------------------------------------ statement band -- */
+
+      .statement {
+        text-align: center;
+        padding-block: clamp(56px, 8vw, 110px);
+      }
+      .statement blockquote {
+        position: relative;
+        max-width: 30ch;
+        margin-inline: auto;
+        font-family: var(--serif);
+        font-size: clamp(26px, 3.6vw, 38px);
+        line-height: 1.35;
+        font-style: italic;
+        letter-spacing: -0.005em;
+      }
+      .statement blockquote::before {
+        content: "\201C";
+        display: block;
+        font-size: clamp(80px, 10vw, 130px);
+        line-height: 0.6;
+        color: var(--terra);
+        font-style: normal;
+        margin-bottom: 18px;
+      }
+
+      /* ------------------------------------------------------- author's note -- */
+
+      .author-note {
+        display: flex;
+        gap: 24px;
+        align-items: flex-start;
+        margin-top: 32px;
+        flex-wrap: wrap;
+      }
+      .portrait {
+        flex: none;
+        width: 68px;
+        height: 68px;
+        border-radius: 50%;
+        background: var(--teal);
+        color: var(--paper);
+        font-family: var(--serif);
+        font-weight: 600;
+        font-size: 24px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        letter-spacing: 0.02em;
+      }
+      .byline {
+        font-family: var(--sans);
+        font-size: 12px;
+        font-weight: 600;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        color: var(--ink-soft);
+        margin-top: 12px;
+      }
+
+      /* ------------------------------------------------------------ callout -- */
+
+      .callout {
+        border-left: 3px solid var(--teal);
+        background: var(--card);
+        border-radius: 0 8px 8px 0;
+        padding: 18px 22px;
+        font-size: 16.5px;
+        max-width: 68ch;
+        margin: 32px auto 0;
+      }
+      .callout .smallcaps {
+        color: var(--teal);
+        display: block;
+        margin-bottom: 6px;
+      }
+
+      /* ------------------------------------------------------------ step flow -- */
+
+      .steps {
+        margin-top: 48px;
+        counter-reset: step;
+        max-width: 760px;
+        margin-inline: auto;
+      }
+      .step {
+        display: grid;
+        grid-template-columns: 64px 1fr;
+        gap: 20px;
+        padding-block: 34px;
+        border-top: 1px solid var(--rule);
+      }
+      .step:first-child {
+        border-top: none;
+        padding-top: 0;
+      }
+      .step-num {
+        counter-increment: step;
+        font-family: var(--serif);
+        font-weight: 600;
+        font-size: 40px;
+        line-height: 1;
+        color: var(--terra);
+      }
+      .step-num::before {
+        content: counter(step);
+      }
+      .step h3 {
+        font-size: 24px;
+      }
+      .step p {
+        font-size: 17px;
+      }
+      .step .aside {
+        border-top: 1px dashed var(--rule);
+        margin-top: 16px;
+        padding-top: 12px;
+        font-style: italic;
+        font-size: 15px;
+        color: var(--ink-soft);
+      }
+      .step .aside::before {
+        content: "\2042\00A0\00A0";
+        color: var(--terra);
+        font-style: normal;
+      }
+      @media (max-width: 520px) {
+        .step {
+          grid-template-columns: 1fr;
+          gap: 8px;
+        }
+      }
+
+      /* -------------------------------------------------------- stack picker -- */
+
+      .stack-picker {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 10px;
+        justify-content: center;
+        margin-top: 40px;
+      }
+      .stack-picker .tab {
+        font-size: 12.5px;
+      }
+
+      /* -------------------------------------------------- framework panels -- */
+
+      .fw-panel {
+        border-top: 1px solid var(--rule);
+        padding-block: 30px;
+      }
+      .fw-panel p {
+        color: var(--ink-soft);
+        font-size: 17px;
+      }
+      .fw-links {
+        margin-top: 14px;
+        font-family: var(--sans);
+        font-size: 13px;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px 20px;
+      }
+      .fw-links .prov {
+        font-family: var(--serif);
+        font-style: italic;
+        color: var(--ink-faint);
+      }
+
+      /* --------------------------------------------------- screenshot frame -- */
+
+      .browser {
+        margin-top: 40px;
+        border: 1px solid var(--rule);
+        border-radius: 12px;
+        background: var(--card);
+        box-shadow: var(--shadow-ticket);
+        overflow: hidden;
+      }
+      .browser-bar {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        border-bottom: 1px solid var(--rule);
+        padding: 10px 16px;
+        background: var(--paper);
+      }
+      .browser-dots {
+        display: flex;
+        gap: 5px;
+        flex: none;
+      }
+      .browser-dots i {
+        width: 9px;
+        height: 9px;
+        border-radius: 50%;
+        background: var(--rule);
+        display: block;
+      }
+      .browser-url {
+        font-family: var(--mono);
+        font-size: 12px;
+        color: var(--ink-soft);
+        background: var(--card);
+        border: 1px solid var(--rule);
+        border-radius: 999px;
+        padding: 3px 14px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .browser-body {
+        padding: 20px;
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+        gap: 14px;
+      }
+
+      /* ------------------------------------------------------------ CTA band -- */
+
+      .cta-band {
+        text-align: center;
+        padding-block: clamp(56px, 8vw, 100px);
+        border-top: 1px solid var(--rule);
+      }
+      .cta-band h2 {
+        max-width: 24ch;
+        margin-inline: auto;
+      }
+      .cta-band .btn-row {
+        justify-content: center;
+      }
+
+      /* -------------------------------------------------------------- footer -- */
+
+      .site-footer {
+        border-top: 1px solid var(--rule);
+        padding-block: 56px 0;
+        margin-top: clamp(40px, 6vw, 80px);
+      }
+      .footer-cols {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+        gap: 32px;
+      }
+      .footer-cols h4 {
+        font-family: var(--sans);
+        font-size: 11px;
+        font-weight: 700;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        color: var(--ink-soft);
+        margin-bottom: 14px;
+      }
+      .footer-cols ul {
+        list-style: none;
+      }
+      .footer-cols li {
+        margin-bottom: 9px;
+      }
+      .footer-cols a {
+        font-size: 15px;
+        text-decoration: none;
+        color: var(--ink);
+      }
+      .footer-cols a:hover {
+        color: var(--teal);
+      }
+      .legal {
+        margin-top: 48px;
+        border-top: 1px solid var(--rule);
+        padding-block: 22px;
+        font-family: var(--sans);
+        font-size: 12.5px;
+        letter-spacing: 0.04em;
+        color: var(--ink-soft);
+        text-align: center;
+      }
+
+      /* -------------------------------------------------------- view routing -- */
+
+      .view[hidden] {
+        display: none;
+      }
+      @media (prefers-reduced-motion: no-preference) {
+        .view:not([hidden]) {
+          animation: viewfade 0.45s ease both;
+        }
+        @keyframes viewfade {
+          from {
+            opacity: 0;
+            transform: translateY(8px);
+          }
+          to {
+            opacity: 1;
+            transform: none;
+          }
+        }
+      }
+
+      .link-list {
+        list-style: none;
+        margin-top: 24px;
+      }
+      .link-list li {
+        margin-bottom: 8px;
+      }
+      .link-list li::before {
+        content: "\2192\00A0\00A0";
+        color: var(--terra);
+      }
+    </style>
+  </head>
+  <body>
+    <div class="draft-ribbon" role="note">Design draft C — Editorial · not final</div>
+
+    <!-- ============================================================ NAV -- -->
+    <nav class="site-nav" aria-label="Site">
+      <div class="wrap">
+        <a class="wordmark" href="#/">Palamedes</a>
+        <div class="nav-links">
+          <a href="#/frameworks" data-route="/frameworks">Frameworks</a>
+          <a href="#/proof" data-route="/proof">Proof</a>
+          <a class="dead" title="Not part of this draft">Compare</a>
+          <a class="dead" title="Not part of this draft">Blog</a>
+          <a href="https://github.com/sebastian-software/palamedes/tree/main/docs">Docs</a>
+        </div>
+        <div class="nav-actions">
+          <a class="gh" href="https://github.com/sebastian-software/palamedes">&#9733; GitHub</a>
+          <a class="btn btn-primary" href="#/get-started" data-route="/get-started">Get started</a>
+        </div>
+      </div>
+    </nav>
+
+    <main>
+      <!-- ============================================================ HOME -- -->
+      <section class="view" id="view-home">
+        <header class="hero">
+          <div class="wrap">
+            <div class="prose">
+              <p class="eyebrow">Open-source i18n tooling for JavaScript &amp; TypeScript</p>
+              <h1 class="display">One translation model. Every&nbsp;framework.</h1>
+              <p class="lede">
+                Write messages where your UI happens. Keep source-string-first .po catalogs your
+                translators can actually read. Ship the same runtime model across Next.js, TanStack
+                Start, SolidStart, Waku, and React Router — with a Rust core that ran the checked
+                small-corpus extract/update benchmark 19.6× faster than Lingui on the recorded
+                machine-local run.
+              </p>
+              <div class="btn-row">
+                <a class="btn btn-primary" href="#/get-started">Get started in 5 minutes</a>
+                <a class="btn btn-secondary" href="https://nextjs-cookie.examples.palamedes.dev"
+                  >See it live</a
+                >
+              </div>
+            </div>
+
+            <!-- Hero visual: the same booking card in three locales — copy,
+           plurals, currency, and dates change together. Full-bleed moment. -->
+            <div
+              class="ticket-row"
+              aria-label="The same booking card rendered in English, German, and Spanish"
+            >
+              <article class="ticket" lang="en">
+                <span class="locale-tag">EN · English</span>
+                <p class="trip">Your trip to Lisbon</p>
+                <p class="seats">3 seats left</p>
+                <div class="tear">
+                  <span class="price">&euro;1,234.00</span>
+                  <span class="date">Jul 12, 2026</span>
+                </div>
+              </article>
+              <article class="ticket" lang="de">
+                <span class="locale-tag">DE · Deutsch</span>
+                <p class="trip">Deine Reise nach Lissabon</p>
+                <p class="seats">3 Plätze frei</p>
+                <div class="tear">
+                  <span class="price">1.234,00&nbsp;&euro;</span>
+                  <span class="date">12. Juli 2026</span>
+                </div>
+              </article>
+              <article class="ticket" lang="es">
+                <span class="locale-tag">ES · Español</span>
+                <p class="trip">Tu viaje a Lisboa</p>
+                <p class="seats">Quedan 3 asientos</p>
+                <div class="tear">
+                  <span class="price">1234,00&nbsp;&euro;</span>
+                  <span class="date">12 jul 2026</span>
+                </div>
+              </article>
+            </div>
+            <p class="caption" style="text-align: center; margin: 18px auto 0">
+              One component, three locales — copy, plurals, currency, and dates change together.
+            </p>
+          </div>
+        </header>
+
+        <!-- Proof strip: hard facts, every number links to evidence. -->
+        <div class="proof-strip">
+          <div class="wrap">
+            <a class="stat" href="#/frameworks">
+              <span class="stat-value">20</span>
+              <span class="stat-label">browser-verified example apps</span>
+            </a>
+            <a class="stat" href="#/frameworks">
+              <span class="stat-value">5&nbsp;&times;&nbsp;4</span>
+              <span class="stat-label">frameworks &times; locale strategies</span>
+            </a>
+            <a class="stat" href="#/proof">
+              <span class="stat-value">19.6&times;</span>
+              <span class="stat-label"
+                >faster than Lingui — checked extract/update benchmark, machine-local run</span
+              >
+            </a>
+            <a class="stat" href="https://github.com/sebastian-software/palamedes/tree/main/adr">
+              <span class="stat-value">16</span>
+              <span class="stat-label">ADRs documenting every tradeoff</span>
+            </a>
+          </div>
+        </div>
+
+        <!-- The core promise -->
+        <section class="section" id="model">
+          <div class="wrap">
+            <div class="prose">
+              <h2>Your i18n setup should not splinter when your framework changes.</h2>
+              <p>
+                Most teams relearn internationalization with every migration: new runtime, new
+                message IDs, new catalog quirks. Palamedes keeps the parts you touch every day
+                stable — and lets the framework be the only thing that changes.
+              </p>
+            </div>
+            <div class="card-grid cols-3">
+              <article class="card">
+                <div class="card-mark">&#10047;</div>
+                <h3>Write messages in place</h3>
+                <p>
+                  Macro-style authoring next to your JSX. No message-ID bookkeeping, no separate
+                  dictionary files to keep in sync.
+                </p>
+                <a class="more" href="#/get-started">Get started &rarr;</a>
+              </article>
+              <article class="card">
+                <div class="card-mark">&#10047;</div>
+                <h3>One identity model</h3>
+                <p>
+                  Messages are identified by message + context — stable across refactors,
+                  frameworks, and years of catalog history.
+                </p>
+                <a
+                  class="more"
+                  href="https://github.com/sebastian-software/palamedes/blob/main/adr/003-source-string-first-message-identity.md"
+                  >The ADR &rarr;</a
+                >
+              </article>
+              <article class="card">
+                <div class="card-mark">&#10047;</div>
+                <h3>One runtime call</h3>
+                <p>
+                  getI18n() resolves the active instance everywhere: server components, client
+                  islands, backend request handlers.
+                </p>
+                <a
+                  class="more"
+                  href="https://github.com/sebastian-software/palamedes/blob/main/adr/005-universal-geti18n-runtime-model.md"
+                  >The ADR &rarr;</a
+                >
+              </article>
+            </div>
+          </div>
+        </section>
+
+        <p class="asterism" aria-hidden="true"></p>
+
+        <!-- Code showcase -->
+        <section class="section" id="code">
+          <div class="wrap">
+            <div class="prose">
+              <h2>The whole workflow, honestly small.</h2>
+            </div>
+            <div class="showcase prose">
+              <div class="tabs" role="tablist" aria-label="Workflow steps">
+                <button class="tab" role="tab" aria-selected="true" data-panel="panel-write">
+                  Write
+                </button>
+                <button class="tab" role="tab" aria-selected="false" data-panel="panel-extract">
+                  Extract
+                </button>
+                <button class="tab" role="tab" aria-selected="false" data-panel="panel-translate">
+                  Translate
+                </button>
+              </div>
+              <div class="tab-panel" id="panel-write" role="tabpanel">
+                <pre><code>import { t, plural } from "@palamedes/core/macro"
+import { Trans } from "@palamedes/react"
+
+export function Booking({ seats }: { seats: number }) {
+  return (
+    &lt;&gt;
+      &lt;h1&gt;{t`Your trip to Lisbon`}&lt;/h1&gt;
+      &lt;p&gt;{plural(seats, { one: "# seat left", other: "# seats left" })}&lt;/p&gt;
+      &lt;Trans&gt;Free cancellation until &lt;b&gt;24 hours&lt;/b&gt; before departure.&lt;/Trans&gt;
+    &lt;/&gt;
+  )
+}</code></pre>
+                <p class="caption">Messages live where the UI happens.</p>
+              </div>
+              <div class="tab-panel" id="panel-extract" role="tabpanel" hidden>
+                <pre><code>$ pmds extract
+
+  en  3 messages  (1 new)
+  de  3 messages  (1 missing translation)
+
+  done in 34 ms</code></pre>
+                <p class="caption">One native command scans, extracts, and updates catalogs.</p>
+              </div>
+              <div class="tab-panel" id="panel-translate" role="tabpanel" hidden>
+                <pre><code>#: src/Booking.tsx:7
+msgid "Your trip to Lisbon"
+msgstr "Deine Reise nach Lissabon"
+
+#: src/Booking.tsx:8
+msgid "{seats, plural, one {# seat left} other {# seats left}}"
+msgstr "{seats, plural, one {# Platz frei} other {# Plätze frei}}"</code></pre>
+                <p class="caption">
+                  Source-string-first .po — readable by translators and every TMS.
+                </p>
+              </div>
+              <div class="rendered">
+                <span class="smallcaps">Rendered</span>
+                <p>The same component, in every locale, in every framework.</p>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <p class="asterism" aria-hidden="true"></p>
+
+        <!-- Proof teaser -->
+        <section class="section" id="proof-teaser">
+          <div class="wrap">
+            <div class="prose">
+              <h2>We don't ask you to trust a slogan. The repo shows the work.</h2>
+              <p>
+                Every framework/strategy combination is a real app, re-verified in CI through the
+                same Playwright flow — with public demos where the hosting is ready. Every benchmark
+                number links to a checked-in, re-runnable report.
+              </p>
+            </div>
+
+            <!-- Full-bleed moment: the 5×4 matrix (shared cell data, built once in JS). -->
+            <div class="matrix-scroll" id="matrix-home"></div>
+
+            <div class="bench" style="max-width: 760px; margin-inline: auto">
+              <h3>End-to-end extract + catalog update <em>(small corpus, median)</em></h3>
+              <div class="bench-row">
+                <span class="bench-tool">Palamedes</span>
+                <span class="bench-track"
+                  ><span class="bench-bar hero-bar" style="width: 22.6%"></span
+                  ><span class="bench-val">33.53&nbsp;ms</span></span
+                >
+              </div>
+              <div class="bench-row">
+                <span class="bench-tool">i18next-parser</span>
+                <span class="bench-track"
+                  ><span class="bench-bar" style="width: 85.3%"></span
+                  ><span class="bench-val">477.58&nbsp;ms</span></span
+                >
+              </div>
+              <div class="bench-row">
+                <span class="bench-tool">Lingui</span>
+                <span class="bench-track"
+                  ><span class="bench-bar" style="width: 100%"></span
+                  ><span class="bench-val">657.00&nbsp;ms</span></span
+                >
+              </div>
+              <p class="bench-note">
+                Bar lengths use a square-root scale so a 19.6&times; gap fits on the page without
+                hiding the fast bar; the labeled milliseconds are the real, linear values.
+                Machine-local numbers from the checked-in report — your hardware will differ.
+                <a
+                  href="https://github.com/sebastian-software/palamedes/blob/main/docs/benchmark-e2e-workflow.md"
+                  >Methodology</a
+                >.
+              </p>
+            </div>
+
+            <div class="btn-row" style="justify-content: center">
+              <a class="btn btn-secondary" href="#/proof"
+                >All benchmarks &amp; the verification story</a
+              >
+            </div>
+          </div>
+        </section>
+
+        <!-- Statement band as a large serif pull-quote -->
+        <section class="statement">
+          <div class="wrap">
+            <blockquote>
+              Palamedes is narrower than some alternatives on purpose: compile-time authoring,
+              source-string-first catalogs, and a local workflow your repo owns — with a Rust core
+              doing the careful work.
+            </blockquote>
+          </div>
+        </section>
+
+        <p class="asterism" aria-hidden="true"></p>
+
+        <!-- Maintainer — reads like an author's note -->
+        <section class="section" id="maintainer">
+          <div class="wrap">
+            <div class="prose">
+              <h2>Built from repeat experience, not a weekend take.</h2>
+              <div class="author-note">
+                <div class="portrait" aria-hidden="true">SW</div>
+                <div>
+                  <p>
+                    Palamedes is maintained by Sebastian Software GmbH. It is the third generation
+                    of source-string-first JavaScript i18n tooling from the same author — from
+                    gettext-style macro systems in qooxdoo to a full enterprise Lingui migration at
+                    Regrello (acquired by Salesforce in 2025). The lessons are written down as 16
+                    ADRs before you depend on the tool.
+                  </p>
+                  <p class="byline">Sebastian Werner · Sebastian Software GmbH</p>
+                  <ul class="link-list">
+                    <li>
+                      <a href="https://github.com/sebastian-software/palamedes/tree/main/adr"
+                        >The decision trail (ADRs)</a
+                      >
+                    </li>
+                    <li><a class="dead" title="Not part of this draft">Why this exists</a></li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section class="cta-band">
+          <div class="wrap">
+            <h2>Your first working translation is 5 minutes away.</h2>
+            <div class="btn-row">
+              <a class="btn btn-primary" href="#/get-started">Get started</a>
+              <a class="btn btn-secondary" href="https://github.com/sebastian-software/palamedes"
+                >Star on GitHub</a
+              >
+            </div>
+          </div>
+        </section>
+      </section>
+
+      <!-- ====================================================== FRAMEWORKS -- -->
+      <section class="view" id="view-frameworks" hidden>
+        <header class="hero">
+          <div class="wrap">
+            <div class="prose">
+              <p class="eyebrow">Framework matrix</p>
+              <h1 class="display">Five frameworks. Four locale strategies. One mental model.</h1>
+              <p class="lede">
+                Every cell below is a real application — the same booking UI, the same catalogs, the
+                same runtime calls — browser-verified in CI. Where public hosting is ready, open the
+                demo, switch the language, and watch copy, plurals, currency, and dates change
+                together.
+              </p>
+              <div class="btn-row">
+                <a class="btn btn-primary" href="https://nextjs-cookie.examples.palamedes.dev"
+                  >Open a live demo</a
+                >
+                <a
+                  class="btn btn-secondary"
+                  href="https://github.com/sebastian-software/palamedes/tree/main/examples"
+                  >Browse the example source</a
+                >
+              </div>
+            </div>
+          </div>
+        </header>
+
+        <!-- The centerpiece: the 5×4 matrix, full-bleed. -->
+        <section class="section--tight" id="matrix">
+          <div class="wrap">
+            <div class="matrix-scroll" id="matrix-frameworks"></div>
+            <p class="caption" style="margin-top: 20px">
+              All 20 apps are verified in CI with the same Playwright-driven browser flow: SSR
+              output, locale switching, localized server actions. Screenshots are versioned in the
+              repo. Cookie and route demos are publicly hosted today; subdomain and TLD hosting is
+              being provisioned — until then those cells link the verified source instead.
+            </p>
+          </div>
+        </section>
+
+        <p class="asterism" aria-hidden="true"></p>
+
+        <!-- Locale strategy guide -->
+        <section class="section" id="strategies">
+          <div class="wrap">
+            <div class="prose">
+              <h2>
+                Pick the locale strategy your product needs — not the one your framework dictates.
+              </h2>
+            </div>
+            <div class="card-grid cols-4">
+              <article class="card">
+                <div class="card-mark">&#10047;</div>
+                <h3>Cookie</h3>
+                <p>
+                  One URL for all locales. Best for apps behind login where SEO is irrelevant and
+                  switching should be instant.
+                </p>
+              </article>
+              <article class="card">
+                <div class="card-mark">&#10047;</div>
+                <h3>Route segment</h3>
+                <p>
+                  /de/checkout-style paths. The SEO-friendly default for public content with
+                  indexable localized pages.
+                </p>
+              </article>
+              <article class="card">
+                <div class="card-mark">&#10047;</div>
+                <h3>Subdomain</h3>
+                <p>
+                  de.example.com. Clean separation per market, works well with regional CDNs and
+                  analytics splits.
+                </p>
+              </article>
+              <article class="card">
+                <div class="card-mark">&#10047;</div>
+                <h3>Top-level domain</h3>
+                <p>
+                  example.de vs example.com. Maximum market trust; Palamedes maps each domain to its
+                  locale.
+                </p>
+              </article>
+            </div>
+            <ul class="link-list">
+              <li>
+                <a
+                  href="https://github.com/sebastian-software/palamedes/blob/main/docs/locale-strategies.md"
+                  >Locale strategies in depth</a
+                >
+              </li>
+            </ul>
+          </div>
+        </section>
+
+        <p class="asterism" aria-hidden="true"></p>
+
+        <!-- Per-framework panels -->
+        <section class="section" id="per-framework">
+          <div class="wrap">
+            <div class="prose">
+              <h2>Your stack, specifically.</h2>
+
+              <div class="fw-panel">
+                <h3>Next.js</h3>
+                <p>
+                  App Router with server components and server actions. The @palamedes/next-plugin
+                  wires the transform into the Next build; everything else is the shared model.
+                </p>
+                <div class="fw-links">
+                  <a href="https://nextjs-cookie.examples.palamedes.dev">Cookie demo &nearr;</a>
+                  <span
+                    >Route demo: <a href="https://nextjs-route.examples.palamedes.dev/en">en</a> ·
+                    <a href="https://nextjs-route.examples.palamedes.dev/de">de</a> ·
+                    <a href="https://nextjs-route.examples.palamedes.dev/es">es</a></span
+                  >
+                  <span class="prov"
+                    >subdomain — provisioning ·
+                    <a
+                      href="https://github.com/sebastian-software/palamedes/tree/main/examples/nextjs-subdomain"
+                      >source</a
+                    ></span
+                  >
+                  <span class="prov"
+                    >TLD — provisioning ·
+                    <a
+                      href="https://github.com/sebastian-software/palamedes/tree/main/examples/nextjs-tld"
+                      >source</a
+                    ></span
+                  >
+                  <a
+                    href="https://github.com/sebastian-software/palamedes/tree/main/examples/nextjs-route"
+                    >Example source</a
+                  >
+                </div>
+              </div>
+
+              <div class="fw-panel">
+                <h3>TanStack Start</h3>
+                <p>
+                  Server functions and file-based routing, integrated through
+                  @palamedes/vite-plugin. Locale resolution runs in a server function; the client
+                  stays island-light.
+                </p>
+                <div class="fw-links">
+                  <a href="https://tanstack-cookie.examples.palamedes.dev">Cookie demo &nearr;</a>
+                  <span
+                    >Route demo: <a href="https://tanstack-route.examples.palamedes.dev/en">en</a> ·
+                    <a href="https://tanstack-route.examples.palamedes.dev/de">de</a> ·
+                    <a href="https://tanstack-route.examples.palamedes.dev/es">es</a></span
+                  >
+                  <span class="prov"
+                    >subdomain — provisioning ·
+                    <a
+                      href="https://github.com/sebastian-software/palamedes/tree/main/examples/tanstack-subdomain"
+                      >source</a
+                    ></span
+                  >
+                  <span class="prov"
+                    >TLD — provisioning ·
+                    <a
+                      href="https://github.com/sebastian-software/palamedes/tree/main/examples/tanstack-tld"
+                      >source</a
+                    ></span
+                  >
+                  <a
+                    href="https://github.com/sebastian-software/palamedes/tree/main/examples/tanstack-route"
+                    >Example source</a
+                  >
+                </div>
+              </div>
+
+              <div class="fw-panel">
+                <h3>SolidStart</h3>
+                <p>
+                  Fine-grained reactivity with @palamedes/solid — the same macro authoring and
+                  catalogs as React, no fork of your i18n strategy for a different renderer.
+                </p>
+                <div class="fw-links">
+                  <a href="https://solidstart-cookie.examples.palamedes.dev">Cookie demo &nearr;</a>
+                  <span
+                    >Route demo:
+                    <a href="https://solidstart-route.examples.palamedes.dev/en">en</a> ·
+                    <a href="https://solidstart-route.examples.palamedes.dev/de">de</a> ·
+                    <a href="https://solidstart-route.examples.palamedes.dev/es">es</a></span
+                  >
+                  <span class="prov"
+                    >subdomain — provisioning ·
+                    <a
+                      href="https://github.com/sebastian-software/palamedes/tree/main/examples/solidstart-subdomain"
+                      >source</a
+                    ></span
+                  >
+                  <span class="prov"
+                    >TLD — provisioning ·
+                    <a
+                      href="https://github.com/sebastian-software/palamedes/tree/main/examples/solidstart-tld"
+                      >source</a
+                    ></span
+                  >
+                  <a
+                    href="https://github.com/sebastian-software/palamedes/tree/main/examples/solidstart-route"
+                    >Example source</a
+                  >
+                </div>
+              </div>
+
+              <div class="fw-panel">
+                <h3>Waku</h3>
+                <p>
+                  Minimal RSC framework. If the model holds here, it holds in your custom setup too
+                  — that's why Waku is in the matrix.
+                </p>
+                <div class="fw-links">
+                  <a href="https://waku-cookie.examples.palamedes.dev">Cookie demo &nearr;</a>
+                  <span
+                    >Route demo: <a href="https://waku-route.examples.palamedes.dev/en">en</a> ·
+                    <a href="https://waku-route.examples.palamedes.dev/de">de</a> ·
+                    <a href="https://waku-route.examples.palamedes.dev/es">es</a></span
+                  >
+                  <span class="prov"
+                    >subdomain — provisioning ·
+                    <a
+                      href="https://github.com/sebastian-software/palamedes/tree/main/examples/waku-subdomain"
+                      >source</a
+                    ></span
+                  >
+                  <span class="prov"
+                    >TLD — provisioning ·
+                    <a
+                      href="https://github.com/sebastian-software/palamedes/tree/main/examples/waku-tld"
+                      >source</a
+                    ></span
+                  >
+                  <a
+                    href="https://github.com/sebastian-software/palamedes/tree/main/examples/waku-route"
+                    >Example source</a
+                  >
+                </div>
+              </div>
+
+              <div class="fw-panel">
+                <h3>React Router</h3>
+                <p>
+                  Framework-mode React Router with loaders and actions. The classic SPA-plus-SSR
+                  shape, same catalogs, same runtime.
+                </p>
+                <div class="fw-links">
+                  <a href="https://react-router-cookie.examples.palamedes.dev"
+                    >Cookie demo &nearr;</a
+                  >
+                  <span
+                    >Route demo:
+                    <a href="https://react-router-route.examples.palamedes.dev/en">en</a> ·
+                    <a href="https://react-router-route.examples.palamedes.dev/de">de</a> ·
+                    <a href="https://react-router-route.examples.palamedes.dev/es">es</a></span
+                  >
+                  <span class="prov"
+                    >subdomain — provisioning ·
+                    <a
+                      href="https://github.com/sebastian-software/palamedes/tree/main/examples/react-router-subdomain"
+                      >source</a
+                    ></span
+                  >
+                  <span class="prov"
+                    >TLD — provisioning ·
+                    <a
+                      href="https://github.com/sebastian-software/palamedes/tree/main/examples/react-router-tld"
+                      >source</a
+                    ></span
+                  >
+                  <a
+                    href="https://github.com/sebastian-software/palamedes/tree/main/examples/react-router-route"
+                    >Example source</a
+                  >
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <p class="asterism" aria-hidden="true"></p>
+
+        <!-- Backend -->
+        <section class="section" id="backend">
+          <div class="wrap">
+            <div class="prose">
+              <h2>And it doesn't stop at the frontend.</h2>
+              <p>
+                The same getI18n() model runs in Hono and Express with request-local locale
+                resolution — transactional emails, API error messages, and PDF generation speak the
+                user's language from the same catalogs.
+              </p>
+              <div class="btn-row">
+                <a
+                  class="btn btn-secondary"
+                  href="https://github.com/sebastian-software/palamedes/blob/main/docs/backend-servers.md"
+                  >Backend servers guide</a
+                >
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section class="cta-band">
+          <div class="wrap">
+            <h2>See your framework speaking three languages — right now.</h2>
+            <div class="btn-row">
+              <a class="btn btn-primary" href="https://nextjs-cookie.examples.palamedes.dev"
+                >Open the live matrix</a
+              >
+              <a class="btn btn-secondary" href="#/get-started">Get started</a>
+            </div>
+          </div>
+        </section>
+      </section>
+
+      <!-- =========================================================== PROOF -- -->
+      <section class="view" id="view-proof" hidden>
+        <header class="hero">
+          <div class="wrap">
+            <div class="prose">
+              <p class="eyebrow">Proof</p>
+              <h1 class="display">Claims you can re-run.</h1>
+              <p class="lede">
+                Every number on this page comes from a checked-in, machine-readable report with
+                fixtures and commands in the repo. If a claim can't be re-run, we don't make it.
+              </p>
+              <div class="btn-row">
+                <a
+                  class="btn btn-primary"
+                  href="https://github.com/sebastian-software/palamedes/blob/main/docs/benchmark-e2e-workflow.md"
+                  >Re-run the benchmarks</a
+                >
+                <a
+                  class="btn btn-secondary"
+                  href="https://github.com/sebastian-software/palamedes/tree/main/benchmarks/e2e-workflow/results"
+                  >Browse checked-in reports</a
+                >
+              </div>
+            </div>
+          </div>
+        </header>
+
+        <!-- Benchmarks -->
+        <section class="section--tight" id="benchmarks">
+          <div class="wrap">
+            <div class="prose">
+              <h2>The workflow you feel every day: extract &amp; update.</h2>
+              <p>
+                The end-to-end benchmark measures what a developer actually waits for: scan sources,
+                extract messages, update catalogs, write files. Same generated message inventory,
+                rendered into each tool's idiomatic source shape, semantically validated after every
+                run.
+              </p>
+            </div>
+
+            <div class="bench" style="max-width: 760px; margin-inline: auto">
+              <h3>Small corpus — 80 files, 640 messages <em>(median of 7 runs)</em></h3>
+              <div class="bench-row">
+                <span class="bench-tool">Palamedes</span>
+                <span class="bench-track"
+                  ><span class="bench-bar hero-bar" style="width: 22.6%"></span
+                  ><span class="bench-val">33.53&nbsp;ms</span></span
+                >
+              </div>
+              <div class="bench-row">
+                <span class="bench-tool">i18next-parser 9.4</span>
+                <span class="bench-track"
+                  ><span class="bench-bar" style="width: 85.3%"></span
+                  ><span class="bench-val">477.58&nbsp;ms</span></span
+                >
+              </div>
+              <div class="bench-row">
+                <span class="bench-tool">Lingui 6.4</span>
+                <span class="bench-track"
+                  ><span class="bench-bar" style="width: 100%"></span
+                  ><span class="bench-val">657.00&nbsp;ms</span></span
+                >
+              </div>
+              <p class="bench-note">
+                Bar lengths use a square-root scale so a 19.6&times; gap fits on the page without
+                hiding the fast bar; the labeled milliseconds are the real, linear values.
+                <a
+                  href="https://github.com/sebastian-software/palamedes/blob/main/docs/benchmark-e2e-workflow.md"
+                  >Methodology</a
+                >.
+              </p>
+            </div>
+
+            <div class="bench" style="max-width: 760px; margin-inline: auto">
+              <h3>Medium corpus <em>(median of 7 runs)</em></h3>
+              <div class="bench-row">
+                <span class="bench-tool">Palamedes</span>
+                <span class="bench-track"
+                  ><span class="bench-bar hero-bar" style="width: 25.6%"></span
+                  ><span class="bench-val">42.92&nbsp;ms</span></span
+                >
+              </div>
+              <p class="bench-note">
+                Comparison rows for this corpus come from the checked-in report — see
+                <a
+                  href="https://github.com/sebastian-software/palamedes/blob/main/benchmarks/e2e-workflow/results/latest.md"
+                  >benchmarks/e2e-workflow/results/latest.md</a
+                >.
+                <a
+                  href="https://github.com/sebastian-software/palamedes/blob/main/docs/benchmark-e2e-workflow.md"
+                  >Methodology</a
+                >.
+              </p>
+            </div>
+
+            <div class="callout">
+              <span class="smallcaps">Honest numbers</span>
+              These are machine-local numbers from the checked-in report, not a marketing average.
+              Your hardware will differ; the ratios are the signal. Commands to reproduce:
+              <code>pnpm benchmark:e2e-workflow</code>.
+            </div>
+          </div>
+        </section>
+
+        <p class="asterism" aria-hidden="true"></p>
+
+        <!-- Verification -->
+        <section class="section" id="verification">
+          <div class="wrap">
+            <div class="prose">
+              <h2>20 apps, verified in a real browser, on every change.</h2>
+              <div class="steps">
+                <div class="step">
+                  <span class="step-num" aria-hidden="true"></span>
+                  <div>
+                    <h3>Build</h3>
+                    <p>
+                      All 20 example apps build against the workspace packages — no mocked
+                      integrations.
+                    </p>
+                  </div>
+                </div>
+                <div class="step">
+                  <span class="step-num" aria-hidden="true"></span>
+                  <div>
+                    <h3>Drive</h3>
+                    <p>
+                      A Playwright flow loads each app, checks SSR output, switches locales, and
+                      exercises localized server actions.
+                    </p>
+                  </div>
+                </div>
+                <div class="step">
+                  <span class="step-num" aria-hidden="true"></span>
+                  <div>
+                    <h3>Capture</h3>
+                    <p>
+                      Screenshots are versioned in the repo, so 'works across frameworks' is a
+                      diffable artifact, not a slide.
+                    </p>
+                  </div>
+                </div>
+              </div>
+
+              <!-- Screenshot stand-in: pure-CSS browser frame around the
+             three-locale booking card (no external images allowed). -->
+              <div
+                class="browser"
+                role="img"
+                aria-label="The same booking UI rendered in English, German, and Spanish"
+              >
+                <div class="browser-bar">
+                  <span class="browser-dots" aria-hidden="true"><i></i><i></i><i></i></span>
+                  <span class="browser-url">nextjs-cookie.examples.palamedes.dev</span>
+                </div>
+                <div class="browser-body">
+                  <article class="ticket ticket--mini" lang="en">
+                    <span class="locale-tag">EN</span>
+                    <p class="trip">Your trip to Lisbon</p>
+                    <p class="seats">3 seats left</p>
+                    <div class="tear">
+                      <span class="price">&euro;1,234.00</span
+                      ><span class="date">Jul 12, 2026</span>
+                    </div>
+                  </article>
+                  <article class="ticket ticket--mini" lang="de">
+                    <span class="locale-tag">DE</span>
+                    <p class="trip">Deine Reise nach Lissabon</p>
+                    <p class="seats">3 Plätze frei</p>
+                    <div class="tear">
+                      <span class="price">1.234,00&nbsp;&euro;</span
+                      ><span class="date">12. Juli 2026</span>
+                    </div>
+                  </article>
+                  <article class="ticket ticket--mini" lang="es">
+                    <span class="locale-tag">ES</span>
+                    <p class="trip">Tu viaje a Lisboa</p>
+                    <p class="seats">Quedan 3 asientos</p>
+                    <div class="tear">
+                      <span class="price">1234,00&nbsp;&euro;</span
+                      ><span class="date">12 jul 2026</span>
+                    </div>
+                  </article>
+                </div>
+              </div>
+              <p class="caption" style="margin-top: 14px">
+                One demo, three locales: copy, plural seat counts, currency, and dates change
+                together.
+                <a
+                  href="https://github.com/sebastian-software/palamedes/blob/main/docs/example-screenshots/README.md"
+                  >Versioned screenshots</a
+                >.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <p class="asterism" aria-hidden="true"></p>
+
+        <!-- Catalog quality -->
+        <section class="section" id="catalog-qa">
+          <div class="wrap">
+            <div class="prose">
+              <h2>Fast would be worthless if the catalogs were wrong.</h2>
+              <p>
+                Catalog semantics live in one dedicated engine (ferrocat): parsing, merging,
+                structured audits, and ICU authoring diagnostics. The benchmark harness validates
+                every tool run semantically — message inventories are compared, not just timed.
+              </p>
+            </div>
+            <div class="card-grid cols-3">
+              <article class="card">
+                <div class="card-mark">&#10047;</div>
+                <h3>Structured audits</h3>
+                <p>
+                  Machine-readable catalog audits catch missing translations, stale entries, and
+                  metadata drift in CI.
+                </p>
+              </article>
+              <article class="card">
+                <div class="card-mark">&#10047;</div>
+                <h3>ICU diagnostics</h3>
+                <p>
+                  Authoring mistakes in plural/select syntax are flagged at extract time, not at
+                  runtime in production.
+                </p>
+              </article>
+              <article class="card">
+                <div class="card-mark">&#10047;</div>
+                <h3>Semantic merging</h3>
+                <p>
+                  A Git merge driver resolves catalog conflicts by meaning, not by line — no more
+                  broken .po files after rebases.
+                </p>
+              </article>
+            </div>
+          </div>
+        </section>
+
+        <p class="asterism" aria-hidden="true"></p>
+
+        <!-- Decision trail -->
+        <section class="section" id="adrs">
+          <div class="wrap">
+            <div class="prose">
+              <h2>16 decisions, written down before you depend on them.</h2>
+              <p>
+                The ADRs cover message identity, the native boundary, adapter architecture — and,
+                just as deliberately, what Palamedes refuses to own. Reading them is the fastest way
+                to know if our tradeoffs match yours.
+              </p>
+              <ul class="link-list">
+                <li>
+                  <a href="https://github.com/sebastian-software/palamedes/tree/main/adr"
+                    >ADR index</a
+                  >
+                </li>
+                <li>
+                  <a
+                    href="https://github.com/sebastian-software/palamedes/blob/main/docs/stability.md"
+                    >Stability &amp; versioning policy</a
+                  >
+                </li>
+                <li>
+                  <a
+                    href="https://github.com/sebastian-software/palamedes/blob/main/docs/principles.md"
+                    >Palamedes principles</a
+                  >
+                </li>
+              </ul>
+            </div>
+          </div>
+        </section>
+
+        <section class="cta-band">
+          <div class="wrap">
+            <h2>Convinced by the receipts? The quickstart takes 5 minutes.</h2>
+            <div class="btn-row">
+              <a class="btn btn-primary" href="#/get-started">Get started</a>
+              <a class="btn btn-secondary dead" title="Not part of this draft"
+                >Compare with your current tool</a
+              >
+            </div>
+          </div>
+        </section>
+      </section>
+
+      <!-- ===================================================== GET STARTED -- -->
+      <section class="view" id="view-get-started" hidden>
+        <header class="hero">
+          <div class="wrap">
+            <div class="prose">
+              <p class="eyebrow">Quickstart</p>
+              <h1 class="display">First working translation in 5&nbsp;minutes.</h1>
+              <p class="lede">
+                One translated component, one extraction run, one .po file, one runtime instance. No
+                message IDs to invent, no dictionary files to maintain.
+              </p>
+              <div class="btn-row">
+                <a class="btn btn-primary" href="#install">Skip to step 1</a>
+                <a
+                  class="btn btn-secondary"
+                  href="https://github.com/sebastian-software/palamedes/blob/main/docs/first-working-translation.md"
+                  >Full written guide</a
+                >
+              </div>
+            </div>
+          </div>
+        </header>
+
+        <div class="wrap">
+          <!-- Stack picker: mock switcher; this draft shows the Vite + React path. -->
+          <div class="stack-picker" role="tablist" aria-label="Stack picker">
+            <button class="tab stack" aria-selected="true">Vite + React</button>
+            <button class="tab stack" aria-selected="false">Vite + Solid</button>
+            <button class="tab stack" aria-selected="false">Next.js</button>
+          </div>
+          <p class="caption" style="text-align: center; margin: 12px auto 0">
+            This draft shows the Vite + React path; the picker switches all code blocks below.
+          </p>
+
+          <div class="callout">
+            <span class="smallcaps">Heads-up</span>
+            Heads-up: install the scoped <code>@palamedes/*</code> packages. The top-level
+            <code>palamedes</code> and <code>create-palamedes</code> names are reserved for a future
+            one-command setup and are not the entry point today.
+          </div>
+
+          <div class="steps" id="install">
+            <div class="step">
+              <span class="step-num" aria-hidden="true"></span>
+              <div>
+                <h3>Install</h3>
+                <p>
+                  Core, runtime, host adapter, and the build plugin — plus the CLI as a dev
+                  dependency.
+                </p>
+                <pre><code>pnpm add @palamedes/core @palamedes/react @palamedes/runtime @palamedes/vite-plugin
+pnpm add -D @palamedes/cli @vitejs/plugin-react</code></pre>
+              </div>
+            </div>
+
+            <div class="step">
+              <span class="step-num" aria-hidden="true"></span>
+              <div>
+                <h3>Configure</h3>
+                <p>One YAML file declares your locales and where catalogs live.</p>
+                <pre><code># palamedes.yaml
+locales: [en, de]
+source-locale: en
+catalogs:
+  - path: src/locales/{locale}
+    include: [src]</code></pre>
+              </div>
+            </div>
+
+            <div class="step">
+              <span class="step-num" aria-hidden="true"></span>
+              <div>
+                <h3>Wire the plugin &amp; runtime</h3>
+                <p>
+                  The Vite plugin handles the macro transform; the runtime holds the active i18n
+                  instance.
+                </p>
+                <pre><code>// vite.config.ts
+import { palamedes } from "@palamedes/vite-plugin"
+export default defineConfig({ plugins: [palamedes(), react()] })
+
+// src/i18n.ts
+import { createI18n } from "@palamedes/core"
+import { setClientI18n } from "@palamedes/runtime"
+
+export const i18n = createI18n()
+setClientI18n(i18n)</code></pre>
+              </div>
+            </div>
+
+            <div class="step">
+              <span class="step-num" aria-hidden="true"></span>
+              <div>
+                <h3>Write &amp; extract</h3>
+                <p>
+                  Author the message in your component, then run one command — it creates
+                  src/locales/en.po and de.po.
+                </p>
+                <pre><code>// src/App.tsx
+import { t } from "@palamedes/core/macro"
+export const App = () =&gt; &lt;h1&gt;{t`Welcome to Palamedes`}&lt;/h1&gt;
+
+$ pmds extract</code></pre>
+              </div>
+            </div>
+
+            <div class="step">
+              <span class="step-num" aria-hidden="true"></span>
+              <div>
+                <h3>Translate</h3>
+                <p>Open the German catalog and fill in the translated string.</p>
+                <pre><code># src/locales/de.po
+msgid "Welcome to Palamedes"
+msgstr "Willkommen bei Palamedes"</code></pre>
+              </div>
+            </div>
+
+            <div class="step">
+              <span class="step-num" aria-hidden="true"></span>
+              <div>
+                <h3>Load &amp; see it render</h3>
+                <p>
+                  Load the catalogs, activate a locale, and run the dev server — the page now
+                  renders &ldquo;Willkommen bei Palamedes&rdquo;. That is the full local loop:
+                  transform, extraction, catalog, runtime.
+                </p>
+                <pre><code>// src/main.tsx
+import { i18n } from "./i18n"
+import { messages as enMessages } from "./locales/en.po"
+import { messages as deMessages } from "./locales/de.po"
+
+i18n.load("en", enMessages)
+i18n.load("de", deMessages)
+i18n.activate("de")
+
+$ pnpm dev</code></pre>
+                <p class="aside">
+                  TypeScript needs an ambient declaration for .po imports — add a src/po.d.ts with
+                  <code>declare module "*.po"</code> (see the
+                  <a
+                    href="https://github.com/sebastian-software/palamedes/blob/main/docs/troubleshooting.md"
+                    >troubleshooting guide</a
+                  >).
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <p class="asterism" aria-hidden="true"></p>
+
+        <!-- Next steps -->
+        <section class="section" id="next">
+          <div class="wrap">
+            <div class="prose">
+              <h2>Where to go from here</h2>
+            </div>
+            <div class="card-grid cols-3">
+              <article class="card">
+                <div class="card-mark">&#10047;</div>
+                <h3>Plurals, dates &amp; currency</h3>
+                <p>
+                  ICU MessageFormat with authoring diagnostics that catch mistakes at extract time.
+                </p>
+                <a
+                  class="more"
+                  href="https://github.com/sebastian-software/palamedes/blob/main/docs/api/core.md"
+                  >Core API &rarr;</a
+                >
+              </article>
+              <article class="card">
+                <div class="card-mark">&#10047;</div>
+                <h3>Pick a locale strategy</h3>
+                <p>
+                  Cookie, route, subdomain, or TLD — with a live demo for each, in your framework.
+                </p>
+                <a class="more" href="#/frameworks">Frameworks &rarr;</a>
+              </article>
+              <article class="card">
+                <div class="card-mark">&#10047;</div>
+                <h3>Localize your backend</h3>
+                <p>Request-local i18n for Hono and Express from the same catalogs.</p>
+                <a
+                  class="more"
+                  href="https://github.com/sebastian-software/palamedes/blob/main/docs/backend-servers.md"
+                  >Backend guide &rarr;</a
+                >
+              </article>
+              <article class="card">
+                <div class="card-mark">&#10047;</div>
+                <h3>Migrating from Lingui?</h3>
+                <p>
+                  A step-by-step playbook. Source-string-first .po catalogs are often reusable after
+                  an extraction pass; explicit-ID setups need cleanup.
+                </p>
+                <a
+                  class="more"
+                  href="https://github.com/sebastian-software/palamedes/blob/main/docs/migrate-from-lingui.md"
+                  >Playbook &rarr;</a
+                >
+              </article>
+              <article class="card">
+                <div class="card-mark">&#10047;</div>
+                <h3>Something broke?</h3>
+                <p>
+                  The troubleshooting guide covers the common setup failures with exact error
+                  messages.
+                </p>
+                <a
+                  class="more"
+                  href="https://github.com/sebastian-software/palamedes/blob/main/docs/troubleshooting.md"
+                  >Troubleshooting &rarr;</a
+                >
+              </article>
+              <article class="card">
+                <div class="card-mark">&#10047;</div>
+                <h3>Using an AI assistant?</h3>
+                <p>Point it at llms.txt — the whole API surface in one machine-readable file.</p>
+                <a
+                  class="more"
+                  href="https://github.com/sebastian-software/palamedes/blob/main/llms.txt"
+                  >llms.txt &rarr;</a
+                >
+              </article>
+            </div>
+          </div>
+        </section>
+
+        <section class="cta-band">
+          <div class="wrap">
+            <h2>Stuck? The maintainer reads every issue.</h2>
+            <div class="btn-row">
+              <a
+                class="btn btn-primary"
+                href="https://github.com/sebastian-software/palamedes/issues"
+                >Open an issue</a
+              >
+              <a
+                class="btn btn-secondary"
+                href="https://github.com/sebastian-software/palamedes/blob/main/docs/api/README.md"
+                >Read the docs</a
+              >
+            </div>
+          </div>
+        </section>
+      </section>
+    </main>
+
+    <!-- ========================================================== FOOTER -- -->
+    <footer class="site-footer">
+      <div class="wrap">
+        <div class="footer-cols">
+          <div>
+            <h4>Product</h4>
+            <ul>
+              <li><a href="#/get-started">Get started</a></li>
+              <li><a href="#/frameworks">Framework matrix</a></li>
+              <li><a href="#/proof">Benchmarks &amp; proof</a></li>
+              <li><a class="dead" title="Not part of this draft">Comparison</a></li>
+            </ul>
+          </div>
+          <div>
+            <h4>Documentation</h4>
+            <ul>
+              <li>
+                <a
+                  href="https://github.com/sebastian-software/palamedes/blob/main/docs/first-working-translation.md"
+                  >5-minute quickstart</a
+                >
+              </li>
+              <li>
+                <a
+                  href="https://github.com/sebastian-software/palamedes/blob/main/docs/api/README.md"
+                  >API reference</a
+                >
+              </li>
+              <li>
+                <a
+                  href="https://github.com/sebastian-software/palamedes/blob/main/docs/configuration.md"
+                  >Configuration</a
+                >
+              </li>
+              <li>
+                <a href="https://github.com/sebastian-software/palamedes/blob/main/docs/cli.md"
+                  >CLI</a
+                >
+              </li>
+              <li>
+                <a
+                  href="https://github.com/sebastian-software/palamedes/blob/main/docs/troubleshooting.md"
+                  >Troubleshooting</a
+                >
+              </li>
+            </ul>
+          </div>
+          <div>
+            <h4>Project</h4>
+            <ul>
+              <li>
+                <a href="https://github.com/sebastian-software/palamedes/tree/main/adr"
+                  >Architecture decisions</a
+                >
+              </li>
+              <li>
+                <a
+                  href="https://github.com/sebastian-software/palamedes/blob/main/docs/stability.md"
+                  >Stability &amp; versioning</a
+                >
+              </li>
+              <li>
+                <a href="https://github.com/sebastian-software/palamedes/blob/main/CHANGELOG.md"
+                  >Changelog</a
+                >
+              </li>
+              <li>
+                <a href="https://github.com/sebastian-software/palamedes/blob/main/SECURITY.md"
+                  >Security</a
+                >
+              </li>
+              <li>
+                <a href="https://github.com/sebastian-software/palamedes/blob/main/LICENSE"
+                  >MIT license</a
+                >
+              </li>
+            </ul>
+          </div>
+          <div>
+            <h4>Company</h4>
+            <ul>
+              <li><a href="https://oss.sebastian-software.com/">Sebastian Software</a></li>
+              <li><a href="https://sebastian-software.de/werner">Sebastian Werner</a></li>
+              <li><a class="dead" title="Not part of this draft">Blog</a></li>
+            </ul>
+          </div>
+        </div>
+        <p class="legal">MIT © 2026 Sebastian Software GmbH — built in the open, verified in CI.</p>
+      </div>
+    </footer>
+
+    <script>
+      /* ------------------------------------------------- tiny hash router -- */
+      ;(function () {
+        "use strict"
+
+        var routes = {
+          "/": "view-home",
+          "/frameworks": "view-frameworks",
+          "/proof": "view-proof",
+          "/get-started": "view-get-started",
+        }
+        var titles = {
+          "/": "Palamedes — i18n that survives your next framework migration",
+          "/frameworks": "Palamedes — one i18n model across five framework families",
+          "/proof": "Palamedes — benchmarks, verification, and the decision trail",
+          "/get-started": "Get started with Palamedes in 5 minutes",
+        }
+        var currentPath = null
+
+        function render() {
+          var hash = window.location.hash.slice(1) // e.g. "/frameworks" or "install"
+          var path = hash === "" ? "/" : hash
+          if (!routes.hasOwnProperty(path)) {
+            // Unknown hash (e.g. in-page anchor "#install"): keep the current
+            // view and let the browser handle the anchor scroll.
+            return
+          }
+          if (path === currentPath) return
+          currentPath = path
+          var id = routes[path]
+          var views = document.querySelectorAll(".view")
+          for (var i = 0; i < views.length; i++) {
+            views[i].hidden = views[i].id !== id
+          }
+          var navLinks = document.querySelectorAll("[data-route]")
+          for (var j = 0; j < navLinks.length; j++) {
+            if (navLinks[j].getAttribute("data-route") === path) {
+              navLinks[j].setAttribute("aria-current", "page")
+            } else {
+              navLinks[j].removeAttribute("aria-current")
+            }
+          }
+          document.title = titles[path] + " · Design draft C"
+          window.scrollTo(0, 0)
+        }
+
+        window.addEventListener("hashchange", render)
+        render()
+
+        /* -------------------------------------- 5×4 matrix (shared data) -- */
+        /* Mirrors FRAMEWORK_MATRIX_CELLS in components.jsx: explicit per-cell
+     links + status, never a generated URL pattern. */
+
+        var REPO = "https://github.com/sebastian-software/palamedes/tree/main/"
+        var FRAMEWORKS = [
+          { name: "Next.js", slug: "nextjs" },
+          { name: "TanStack Start", slug: "tanstack" },
+          { name: "SolidStart", slug: "solidstart" },
+          { name: "Waku", slug: "waku" },
+          { name: "React Router", slug: "react-router" },
+        ]
+        var STRATEGIES = ["cookie", "route", "subdomain", "tld"]
+
+        function cellHtml(fw, strategy) {
+          var src = REPO + "examples/" + fw.slug + "-" + strategy
+          var html = '<span class="verified">verified</span>'
+          if (strategy === "cookie") {
+            html +=
+              '<span class="cell-links"><a href="https://' +
+              fw.slug +
+              '-cookie.examples.palamedes.dev">open &nearr;</a></span>'
+          } else if (strategy === "route") {
+            var locales = ["en", "de", "es"]
+            var links = []
+            for (var i = 0; i < locales.length; i++) {
+              links.push(
+                '<a href="https://' +
+                  fw.slug +
+                  "-route.examples.palamedes.dev/" +
+                  locales[i] +
+                  '">' +
+                  locales[i] +
+                  "</a>"
+              )
+            }
+            html += '<span class="cell-links">' + links.join(" · ") + "</span>"
+          } else {
+            // subdomain / tld: no public hosting yet (#306) — link the verified source.
+            html +=
+              '<span class="provisioning">provisioning</span><br>' +
+              '<span class="cell-src"><a href="' +
+              src +
+              '">source &nearr;</a></span>'
+          }
+          return html
+        }
+
+        function buildMatrix(mountId, strategyLabels) {
+          var mount = document.getElementById(mountId)
+          if (!mount) return
+          var html = '<table class="matrix"><thead><tr><th scope="col">Framework</th>'
+          for (var s = 0; s < STRATEGIES.length; s++) {
+            html += '<th scope="col">' + strategyLabels[s] + "</th>"
+          }
+          html += "</tr></thead><tbody>"
+          for (var f = 0; f < FRAMEWORKS.length; f++) {
+            html += '<tr><td class="fw">' + FRAMEWORKS[f].name + "</td>"
+            for (var t = 0; t < STRATEGIES.length; t++) {
+              html += "<td>" + cellHtml(FRAMEWORKS[f], STRATEGIES[t]) + "</td>"
+            }
+            html += "</tr>"
+          }
+          html += "</tbody></table>"
+          mount.innerHTML = html
+        }
+
+        buildMatrix("matrix-home", ["Cookie", "Route", "Subdomain", "TLD"])
+        buildMatrix("matrix-frameworks", [
+          "Cookie",
+          "Route segment",
+          "Subdomain",
+          "Top-level domain",
+        ])
+
+        /* --------------------------------------------- code showcase tabs -- */
+        var tabs = document.querySelectorAll(".tab[data-panel]")
+        for (var t = 0; t < tabs.length; t++) {
+          tabs[t].addEventListener("click", function () {
+            for (var i = 0; i < tabs.length; i++) {
+              var isMe = tabs[i] === this
+              tabs[i].setAttribute("aria-selected", isMe ? "true" : "false")
+              var panel = document.getElementById(tabs[i].getAttribute("data-panel"))
+              if (panel) panel.hidden = !isMe
+            }
+          })
+        }
+
+        /* ------------------------------------- stack picker (mock toggle) -- */
+        var stacks = document.querySelectorAll(".tab.stack")
+        for (var s = 0; s < stacks.length; s++) {
+          stacks[s].addEventListener("click", function () {
+            for (var i = 0; i < stacks.length; i++) {
+              stacks[i].setAttribute("aria-selected", stacks[i] === this ? "true" : "false")
+            }
+          })
+        }
+      })()
+    </script>
+  </body>
+</html>

--- a/docs/site/structure/pages/BlogIndexPage.jsx
+++ b/docs/site/structure/pages/BlogIndexPage.jsx
@@ -1,0 +1,73 @@
+/**
+ * Route: /blog
+ * Job: founder-led content hub. Sources the existing posts from
+ * docs/site/posts/ and gives the project a voice between releases.
+ * Strategy notes live in docs/founder-led-content.md.
+ */
+
+export function BlogIndexPage() {
+  return (
+    <Page title="Palamedes blog — notes from building i18n tooling in the open">
+      <SiteNav />
+
+      <Hero
+        eyebrow="Blog"
+        headline="Building i18n tooling in the open."
+        subline="Design notes, honest benchmarks, and lessons from the third
+          time around — written by the maintainer, not a content team."
+      />
+
+      <Section id="posts">
+        <PostList>
+          <PostCard
+            post={{
+              title: "The third time I built JavaScript i18n tooling",
+              excerpt:
+                "From qooxdoo's gettext macros to an enterprise Lingui migration to Palamedes — what repeats, what finally changed, and why the third design is source-string-first all the way down.",
+              href: "…/docs/site/posts/the-third-time-i-built-javascript-i18n-tooling.md",
+              readMinutes: 8,
+            }}
+          />
+          <PostCard
+            post={{
+              title: "A calmer path for JavaScript i18n",
+              excerpt:
+                "Why 'calm' is a feature: one runtime model, one identity model, and a catalog workflow that doesn't reopen with every framework decision.",
+              href: "…/docs/site/posts/a-calmer-path-for-javascript-i18n.md",
+              readMinutes: 6,
+            }}
+          />
+          <PostCard
+            post={{
+              title: "Measuring Palamedes honestly",
+              excerpt:
+                "Benchmarks are easy to game and easy to distrust. Here is the methodology: same corpus, semantic validation after every run, checked-in reports anyone can re-run.",
+              href: "…/docs/site/posts/measuring-palamedes-honestly.md",
+              readMinutes: 7,
+            }}
+          />
+          <PostCard
+            post={{
+              title: "Browser-verifying i18n across five frameworks",
+              excerpt:
+                "How 20 example apps get driven by the same Playwright flow in CI — and why versioned screenshots beat compatibility tables.",
+              href: "…/docs/site/posts/browser-verifying-i18n-across-five-frameworks.md",
+              readMinutes: 6,
+            }}
+          />
+        </PostList>
+      </Section>
+
+      <CtaBand
+        headline="Prefer reading code to reading posts?"
+        primary={{
+          label: "Browse the repo",
+          href: "https://github.com/sebastian-software/palamedes",
+        }}
+        secondary={{ label: "Get started", href: "/get-started" }}
+      />
+
+      <SiteFooter />
+    </Page>
+  )
+}

--- a/docs/site/structure/pages/BlogIndexPage.jsx
+++ b/docs/site/structure/pages/BlogIndexPage.jsx
@@ -24,7 +24,7 @@ export function BlogIndexPage() {
               title: "The third time I built JavaScript i18n tooling",
               excerpt:
                 "From qooxdoo's gettext macros to an enterprise Lingui migration to Palamedes — what repeats, what finally changed, and why the third design is source-string-first all the way down.",
-              href: "…/docs/site/posts/the-third-time-i-built-javascript-i18n-tooling.md",
+              href: repoHref("docs/site/posts/the-third-time-i-built-javascript-i18n-tooling.md"),
               readMinutes: 8,
             }}
           />
@@ -33,7 +33,7 @@ export function BlogIndexPage() {
               title: "A calmer path for JavaScript i18n",
               excerpt:
                 "Why 'calm' is a feature: one runtime model, one identity model, and a catalog workflow that doesn't reopen with every framework decision.",
-              href: "…/docs/site/posts/a-calmer-path-for-javascript-i18n.md",
+              href: repoHref("docs/site/posts/a-calmer-path-for-javascript-i18n.md"),
               readMinutes: 6,
             }}
           />
@@ -42,7 +42,7 @@ export function BlogIndexPage() {
               title: "Measuring Palamedes honestly",
               excerpt:
                 "Benchmarks are easy to game and easy to distrust. Here is the methodology: same corpus, semantic validation after every run, checked-in reports anyone can re-run.",
-              href: "…/docs/site/posts/measuring-palamedes-honestly.md",
+              href: repoHref("docs/site/posts/measuring-palamedes-honestly.md"),
               readMinutes: 7,
             }}
           />
@@ -51,7 +51,7 @@ export function BlogIndexPage() {
               title: "Browser-verifying i18n across five frameworks",
               excerpt:
                 "How 20 example apps get driven by the same Playwright flow in CI — and why versioned screenshots beat compatibility tables.",
-              href: "…/docs/site/posts/browser-verifying-i18n-across-five-frameworks.md",
+              href: repoHref("docs/site/posts/browser-verifying-i18n-across-five-frameworks.md"),
               readMinutes: 6,
             }}
           />

--- a/docs/site/structure/pages/ComparisonPage.jsx
+++ b/docs/site/structure/pages/ComparisonPage.jsx
@@ -26,11 +26,10 @@ export function ComparisonPage() {
       <Section id="lingui">
         <h2>Palamedes vs Lingui</h2>
         <p>
-          Lingui is the closest neighbor — same authoring instinct, same
-          source-string-first heart. Palamedes is the stricter end state of
-          that idea: one runtime model instead of several entry points, one
-          native engine for catalogs instead of plugin layers, and adapters
-          that stay thin.
+          Lingui is the closest neighbor — same authoring instinct, same source-string-first heart.
+          Palamedes is the stricter end state of that idea: one runtime model instead of several
+          entry points, one native engine for catalogs instead of plugin layers, and adapters that
+          stay thin.
         </p>
         <CompareTable
           criteria={[
@@ -73,10 +72,9 @@ export function ComparisonPage() {
           ]}
         />
         <Callout tone="honest">
-          Pick Lingui if you need its ecosystem breadth or plugins Palamedes
-          doesn't have yet. If you're starting fresh — or mid-migration
-          anyway — the playbook shows how existing .po catalogs usually carry
-          over unchanged.
+          Pick Lingui if you need its ecosystem breadth or plugins Palamedes doesn't have yet. If
+          you're starting fresh — or mid-migration anyway — the playbook shows how existing .po
+          catalogs usually carry over unchanged.
         </Callout>
         <LinkList
           links={[
@@ -90,9 +88,9 @@ export function ComparisonPage() {
       <Section id="next-intl">
         <h2>Palamedes vs next-intl</h2>
         <p>
-          Different mental model, both valid. next-intl centers on message
-          files with keys and is deeply Next.js-native. Palamedes centers on
-          source strings in your components and stays framework-portable.
+          Different mental model, both valid. next-intl centers on message files with keys and is
+          deeply Next.js-native. Palamedes centers on source strings in your components and stays
+          framework-portable.
         </p>
         <FeatureGrid
           columns={2}
@@ -115,10 +113,9 @@ export function ComparisonPage() {
       <Section id="gt">
         <h2>Palamedes vs General Translation</h2>
         <p>
-          A category difference, not a feature race. GT is a translation
-          platform — hosted workflows, AI translation, delivery. Palamedes is
-          local-first tooling: your repo owns the catalogs, the QA, and the
-          history. The two concerns can even stack: Palamedes as the local
+          A category difference, not a feature race. GT is a translation platform — hosted
+          workflows, AI translation, delivery. Palamedes is local-first tooling: your repo owns the
+          catalogs, the QA, and the history. The two concerns can even stack: Palamedes as the local
           foundation, a service layer on top.
         </p>
       </Section>

--- a/docs/site/structure/pages/ComparisonPage.jsx
+++ b/docs/site/structure/pages/ComparisonPage.jsx
@@ -1,0 +1,142 @@
+/**
+ * Route: /compare
+ * Job: catch the "Palamedes vs X" search intent and answer it honestly.
+ * Follows the messaging rules in docs/site/comparison.mdx: no competitor
+ * bashing, clear "when to pick the other tool" sections — honesty here is
+ * the conversion strategy.
+ */
+
+export function ComparisonPage() {
+  return (
+    <Page title="Palamedes vs Lingui, next-intl, and General Translation — an honest comparison">
+      <SiteNav />
+
+      <Hero
+        eyebrow="Comparison"
+        headline="Narrower than the alternatives. On purpose."
+        subline="Palamedes is for teams that like compile-time authoring and
+          want the stack under it to feel smaller, steadier, and easier to
+          trust. Here is how that compares — including when you should pick
+          something else."
+        primary={{ label: "Compare with Lingui", href: "#lingui" }}
+        secondary={{ label: "See the proof", href: "/proof" }}
+      />
+
+      {/* ---------------------------------------------------------- lingui */}
+      <Section id="lingui">
+        <h2>Palamedes vs Lingui</h2>
+        <p>
+          Lingui is the closest neighbor — same authoring instinct, same
+          source-string-first heart. Palamedes is the stricter end state of
+          that idea: one runtime model instead of several entry points, one
+          native engine for catalogs instead of plugin layers, and adapters
+          that stay thin.
+        </p>
+        <CompareTable
+          criteria={[
+            "Authoring",
+            "Message identity",
+            "Runtime access",
+            "Catalog engine",
+            "Extract + update (small corpus)",
+            "Framework coverage",
+            "Maturity & ecosystem",
+          ]}
+          tools={[
+            {
+              name: "Palamedes",
+              cells: [
+                "Macro-style, JSX-first",
+                "message + context, stable across refactors",
+                "One model: getI18n() everywhere",
+                "Native (Rust/ferrocat), semantic merge & audits",
+                "33.53 ms (checked report¹)",
+                "5 families browser-verified in CI",
+                "New — honest about it; 16 ADRs document the tradeoffs",
+              ],
+            },
+            {
+              name: "Lingui",
+              cells: [
+                "Macro-style, JSX-first",
+                "Configurable ID strategies",
+                "Multiple entry points (i18n, hooks, macros)",
+                "JS-based tooling with plugin ecosystem",
+                "657.00 ms (same harness¹)",
+                "Broad, community-verified",
+                "Mature, large community, years of production use",
+              ],
+            },
+          ]}
+          footnotes={[
+            "¹ Median of 7 runs, same corpus and semantic validation — methodology and raw reports in the repo.",
+          ]}
+        />
+        <Callout tone="honest">
+          Pick Lingui if you need its ecosystem breadth or plugins Palamedes
+          doesn't have yet. If you're starting fresh — or mid-migration
+          anyway — the playbook shows how existing .po catalogs usually carry
+          over unchanged.
+        </Callout>
+        <LinkList
+          links={[
+            { label: "Detailed comparison", href: "…/docs/comparison-with-lingui.md" },
+            { label: "Migration playbook", href: "…/docs/migrate-from-lingui.md" },
+          ]}
+        />
+      </Section>
+
+      {/* ------------------------------------------------------- next-intl */}
+      <Section id="next-intl">
+        <h2>Palamedes vs next-intl</h2>
+        <p>
+          Different mental model, both valid. next-intl centers on message
+          files with keys and is deeply Next.js-native. Palamedes centers on
+          source strings in your components and stays framework-portable.
+        </p>
+        <FeatureGrid
+          columns={2}
+          cards={[
+            {
+              icon: "check",
+              title: "Pick next-intl when…",
+              body: "You are all-in on Next.js, prefer key-based message files as the source of truth, and want the most Next-idiomatic API.",
+            },
+            {
+              icon: "check",
+              title: "Pick Palamedes when…",
+              body: "You write messages in code, want .po catalogs translators already know, or expect to outlive your current framework choice.",
+            },
+          ]}
+        />
+      </Section>
+
+      {/* ---------------------------------------------- general translation */}
+      <Section id="gt">
+        <h2>Palamedes vs General Translation</h2>
+        <p>
+          A category difference, not a feature race. GT is a translation
+          platform — hosted workflows, AI translation, delivery. Palamedes is
+          local-first tooling: your repo owns the catalogs, the QA, and the
+          history. The two concerns can even stack: Palamedes as the local
+          foundation, a service layer on top.
+        </p>
+      </Section>
+
+      {/* -------------------------------------------------- the honest bit */}
+      <StatementBand
+        text="Every tool on this page is good software. The question is which
+          tradeoffs match your team — ours are written down in 16 ADRs, so
+          you can check before you commit."
+      />
+
+      <CtaBand
+        headline="Judge it by the receipts, not the copy."
+        primary={{ label: "See the proof", href: "/proof" }}
+        secondary={{ label: "Try the 5-minute quickstart", href: "/get-started" }}
+      />
+
+      <SiteFooter />
+    </Page>
+  )
+}

--- a/docs/site/structure/pages/ComparisonPage.jsx
+++ b/docs/site/structure/pages/ComparisonPage.jsx
@@ -72,14 +72,14 @@ export function ComparisonPage() {
           ]}
         />
         <Callout tone="honest">
-          Pick Lingui if you need its ecosystem breadth or plugins Palamedes doesn't have yet. If
-          you're starting fresh — or mid-migration anyway — the playbook shows how existing .po
-          catalogs usually carry over unchanged.
+          Pick Lingui if you need its ecosystem breadth or plugins Palamedes doesn't have yet.
+          Migrating anyway? Existing source-string-first .po catalogs are often reusable after an
+          extraction pass; explicit-ID-heavy projects need cleanup — the playbook covers both paths.
         </Callout>
         <LinkList
           links={[
-            { label: "Detailed comparison", href: "…/docs/comparison-with-lingui.md" },
-            { label: "Migration playbook", href: "…/docs/migrate-from-lingui.md" },
+            { label: "Detailed comparison", href: repoHref("docs/comparison-with-lingui.md") },
+            { label: "Migration playbook", href: repoHref("docs/migrate-from-lingui.md") },
           ]}
         />
       </Section>

--- a/docs/site/structure/pages/FrameworksPage.jsx
+++ b/docs/site/structure/pages/FrameworksPage.jsx
@@ -45,9 +45,8 @@ export function FrameworksPage() {
           demoUrl={(f, s) => `https://${f}-${s}.examples.palamedes.dev`}
         />
         <p className="caption">
-          All 20 apps are verified in CI with the same Playwright-driven
-          browser flow: SSR output, locale switching, localized server
-          actions. Screenshots are versioned in the repo.
+          All 20 apps are verified in CI with the same Playwright-driven browser flow: SSR output,
+          locale switching, localized server actions. Screenshots are versioned in the repo.
         </p>
       </Section>
 
@@ -139,14 +138,11 @@ export function FrameworksPage() {
       <Section id="backend">
         <h2>And it doesn't stop at the frontend.</h2>
         <p>
-          The same getI18n() model runs in Hono and Express with request-local
-          locale resolution — transactional emails, API error messages, and
-          PDF generation speak the user's language from the same catalogs.
+          The same getI18n() model runs in Hono and Express with request-local locale resolution —
+          transactional emails, API error messages, and PDF generation speak the user's language
+          from the same catalogs.
         </p>
-        <Button
-          variant="secondary"
-          href="…/docs/backend-servers.md"
-        >
+        <Button variant="secondary" href="…/docs/backend-servers.md">
           Backend servers guide
         </Button>
       </Section>

--- a/docs/site/structure/pages/FrameworksPage.jsx
+++ b/docs/site/structure/pages/FrameworksPage.jsx
@@ -1,0 +1,166 @@
+/**
+ * Route: /frameworks
+ * Job: make the cross-framework claim tangible. Visitors arrive skeptical
+ * ("works with MY stack?") and leave with a live demo open in a second tab.
+ */
+
+export function FrameworksPage() {
+  return (
+    <Page title="Palamedes — one i18n model across five framework families">
+      <SiteNav />
+
+      <Hero
+        eyebrow="Framework matrix"
+        headline="Five frameworks. Four locale strategies. One mental model."
+        subline="Every cell below is a real, deployed application — the same
+          booking UI, the same catalogs, the same runtime calls. Switch the
+          language in any demo and watch copy, plurals, currency, and dates
+          change together."
+        primary={{
+          label: "Open a live demo",
+          href: "https://nextjs-cookie.examples.palamedes.dev",
+        }}
+        secondary={{
+          label: "Browse the example source",
+          href: "https://github.com/sebastian-software/palamedes/tree/main/examples",
+        }}
+      />
+
+      {/* The interactive 5×4 grid is the centerpiece of this page. */}
+      <Section id="matrix">
+        <FrameworkMatrix
+          frameworks={[
+            { name: "Next.js", slug: "nextjs" },
+            { name: "TanStack Start", slug: "tanstack" },
+            { name: "SolidStart", slug: "solidstart" },
+            { name: "Waku", slug: "waku" },
+            { name: "React Router", slug: "react-router" },
+          ]}
+          strategies={[
+            { name: "Cookie", slug: "cookie" },
+            { name: "Route segment", slug: "route" },
+            { name: "Subdomain", slug: "subdomain" },
+            { name: "Top-level domain", slug: "tld" },
+          ]}
+          demoUrl={(f, s) => `https://${f}-${s}.examples.palamedes.dev`}
+        />
+        <p className="caption">
+          All 20 apps are verified in CI with the same Playwright-driven
+          browser flow: SSR output, locale switching, localized server
+          actions. Screenshots are versioned in the repo.
+        </p>
+      </Section>
+
+      {/* ------------------------------------------- locale strategy guide */}
+      <Section id="strategies">
+        <h2>Pick the locale strategy your product needs — not the one your framework dictates.</h2>
+        <FeatureGrid
+          columns={4}
+          cards={[
+            {
+              icon: "cookie",
+              title: "Cookie",
+              body: "One URL for all locales. Best for apps behind login where SEO is irrelevant and switching should be instant.",
+            },
+            {
+              icon: "route",
+              title: "Route segment",
+              body: "/de/checkout-style paths. The SEO-friendly default for public content with indexable localized pages.",
+            },
+            {
+              icon: "globe",
+              title: "Subdomain",
+              body: "de.example.com. Clean separation per market, works well with regional CDNs and analytics splits.",
+            },
+            {
+              icon: "flag",
+              title: "Top-level domain",
+              body: "example.de vs example.com. Maximum market trust; Palamedes maps each domain to its locale.",
+            },
+          ]}
+        />
+        <LinkList
+          links={[
+            {
+              label: "Locale strategies in depth",
+              href: "…/docs/locale-strategies.md",
+            },
+          ]}
+        />
+      </Section>
+
+      {/* --------------------------------------------- per-framework panels */}
+      <Section id="per-framework">
+        <h2>Your stack, specifically.</h2>
+        {/* Accordion or tab panel per framework; each panel: one paragraph on
+            what is framework-specific (and how little that is), a code
+            snippet of the integration point, links to live demos + source. */}
+        <FrameworkPanel
+          name="Next.js"
+          body="App Router with server components and server actions. The
+            @palamedes/next-plugin wires the transform into the Next build;
+            everything else is the shared model."
+          demoLinks={["cookie", "route", "subdomain", "tld"]}
+          sourceHref="…/examples/nextjs-route"
+        />
+        <FrameworkPanel
+          name="TanStack Start"
+          body="Server functions and file-based routing, integrated through
+            @palamedes/vite-plugin. Locale resolution runs in a server
+            function; the client stays island-light."
+          demoLinks={["cookie", "route", "subdomain", "tld"]}
+          sourceHref="…/examples/tanstack-route"
+        />
+        <FrameworkPanel
+          name="SolidStart"
+          body="Fine-grained reactivity with @palamedes/solid — the same
+            macro authoring and catalogs as React, no fork of your i18n
+            strategy for a different renderer."
+          demoLinks={["cookie", "route", "subdomain", "tld"]}
+          sourceHref="…/examples/solidstart-route"
+        />
+        <FrameworkPanel
+          name="Waku"
+          body="Minimal RSC framework. If the model holds here, it holds in
+            your custom setup too — that's why Waku is in the matrix."
+          demoLinks={["cookie", "route", "subdomain", "tld"]}
+          sourceHref="…/examples/waku-route"
+        />
+        <FrameworkPanel
+          name="React Router"
+          body="Framework-mode React Router with loaders and actions. The
+            classic SPA-plus-SSR shape, same catalogs, same runtime."
+          demoLinks={["cookie", "route", "subdomain", "tld"]}
+          sourceHref="…/examples/react-router-route"
+        />
+      </Section>
+
+      {/* --------------------------------------------------------- backend */}
+      <Section id="backend">
+        <h2>And it doesn't stop at the frontend.</h2>
+        <p>
+          The same getI18n() model runs in Hono and Express with request-local
+          locale resolution — transactional emails, API error messages, and
+          PDF generation speak the user's language from the same catalogs.
+        </p>
+        <Button
+          variant="secondary"
+          href="…/docs/backend-servers.md"
+        >
+          Backend servers guide
+        </Button>
+      </Section>
+
+      <CtaBand
+        headline="See your framework speaking three languages — right now."
+        primary={{
+          label: "Open the live matrix",
+          href: "https://nextjs-cookie.examples.palamedes.dev",
+        }}
+        secondary={{ label: "Get started", href: "/get-started" }}
+      />
+
+      <SiteFooter />
+    </Page>
+  )
+}

--- a/docs/site/structure/pages/FrameworksPage.jsx
+++ b/docs/site/structure/pages/FrameworksPage.jsx
@@ -12,10 +12,10 @@ export function FrameworksPage() {
       <Hero
         eyebrow="Framework matrix"
         headline="Five frameworks. Four locale strategies. One mental model."
-        subline="Every cell below is a real, deployed application — the same
-          booking UI, the same catalogs, the same runtime calls. Switch the
-          language in any demo and watch copy, plurals, currency, and dates
-          change together."
+        subline="Every cell below is a real application — the same booking UI,
+          the same catalogs, the same runtime calls — browser-verified in CI.
+          Where public hosting is ready, open the demo, switch the language,
+          and watch copy, plurals, currency, and dates change together."
         primary={{
           label: "Open a live demo",
           href: "https://nextjs-cookie.examples.palamedes.dev",
@@ -26,7 +26,10 @@ export function FrameworksPage() {
         }}
       />
 
-      {/* The interactive 5×4 grid is the centerpiece of this page. */}
+      {/* The interactive 5×4 grid is the centerpiece of this page.
+          Cell data is explicit (per-strategy URL shapes + hosting status),
+          shared with HomePage via FRAMEWORK_MATRIX_CELLS — see
+          components.jsx. No generated URL patterns. */}
       <Section id="matrix">
         <FrameworkMatrix
           frameworks={[
@@ -42,11 +45,13 @@ export function FrameworksPage() {
             { name: "Subdomain", slug: "subdomain" },
             { name: "Top-level domain", slug: "tld" },
           ]}
-          demoUrl={(f, s) => `https://${f}-${s}.examples.palamedes.dev`}
+          cells={FRAMEWORK_MATRIX_CELLS}
         />
         <p className="caption">
           All 20 apps are verified in CI with the same Playwright-driven browser flow: SSR output,
-          locale switching, localized server actions. Screenshots are versioned in the repo.
+          locale switching, localized server actions. Screenshots are versioned in the repo. Cookie
+          and route demos are publicly hosted today; subdomain and TLD hosting is being provisioned
+          — until then those cells link the verified source instead.
         </p>
       </Section>
 
@@ -82,7 +87,7 @@ export function FrameworksPage() {
           links={[
             {
               label: "Locale strategies in depth",
-              href: "…/docs/locale-strategies.md",
+              href: repoHref("docs/locale-strategies.md"),
             },
           ]}
         />
@@ -100,7 +105,7 @@ export function FrameworksPage() {
             @palamedes/next-plugin wires the transform into the Next build;
             everything else is the shared model."
           demoLinks={["cookie", "route", "subdomain", "tld"]}
-          sourceHref="…/examples/nextjs-route"
+          sourceHref={repoHref("examples/nextjs-route")}
         />
         <FrameworkPanel
           name="TanStack Start"
@@ -108,7 +113,7 @@ export function FrameworksPage() {
             @palamedes/vite-plugin. Locale resolution runs in a server
             function; the client stays island-light."
           demoLinks={["cookie", "route", "subdomain", "tld"]}
-          sourceHref="…/examples/tanstack-route"
+          sourceHref={repoHref("examples/tanstack-route")}
         />
         <FrameworkPanel
           name="SolidStart"
@@ -116,21 +121,21 @@ export function FrameworksPage() {
             macro authoring and catalogs as React, no fork of your i18n
             strategy for a different renderer."
           demoLinks={["cookie", "route", "subdomain", "tld"]}
-          sourceHref="…/examples/solidstart-route"
+          sourceHref={repoHref("examples/solidstart-route")}
         />
         <FrameworkPanel
           name="Waku"
           body="Minimal RSC framework. If the model holds here, it holds in
             your custom setup too — that's why Waku is in the matrix."
           demoLinks={["cookie", "route", "subdomain", "tld"]}
-          sourceHref="…/examples/waku-route"
+          sourceHref={repoHref("examples/waku-route")}
         />
         <FrameworkPanel
           name="React Router"
           body="Framework-mode React Router with loaders and actions. The
             classic SPA-plus-SSR shape, same catalogs, same runtime."
           demoLinks={["cookie", "route", "subdomain", "tld"]}
-          sourceHref="…/examples/react-router-route"
+          sourceHref={repoHref("examples/react-router-route")}
         />
       </Section>
 
@@ -142,7 +147,7 @@ export function FrameworksPage() {
           transactional emails, API error messages, and PDF generation speak the user's language
           from the same catalogs.
         </p>
-        <Button variant="secondary" href="…/docs/backend-servers.md">
+        <Button variant="secondary" href={repoHref("docs/backend-servers.md")}>
           Backend servers guide
         </Button>
       </Section>

--- a/docs/site/structure/pages/GetStartedPage.jsx
+++ b/docs/site/structure/pages/GetStartedPage.jsx
@@ -1,0 +1,142 @@
+/**
+ * Route: /get-started
+ * Job: remove every excuse not to try it. Mirrors
+ * docs/first-working-translation.md but web-native: copy buttons, a stack
+ * picker, and honest notes about what doesn't exist yet (no top-level
+ * `palamedes` package). Ends with "where to go next", not a dead end.
+ */
+
+export function GetStartedPage() {
+  return (
+    <Page title="Get started with Palamedes in 5 minutes">
+      <SiteNav />
+
+      <Hero
+        eyebrow="Quickstart"
+        headline="First working translation in 5 minutes."
+        subline="One translated component, one extraction run, one .po file,
+          one runtime instance. No message IDs to invent, no dictionary files
+          to maintain."
+        primary={{ label: "Skip to step 1", href: "#install" }}
+        secondary={{
+          label: "Full written guide",
+          href: "…/docs/first-working-translation.md",
+        }}
+      />
+
+      {/* Stack picker switches all code blocks below between React and
+          Solid via tabs — one page, no duplicated flow. */}
+      <StackPicker options={["Vite + React", "Vite + Solid", "Next.js"]} />
+
+      <Callout tone="honest">
+        Heads-up: install the scoped <code>@palamedes/*</code> packages. The
+        top-level <code>palamedes</code> and <code>create-palamedes</code>{" "}
+        names are reserved for a future one-command setup and are not the
+        entry point today.
+      </Callout>
+
+      <StepFlow
+        steps={[
+          {
+            title: "Install",
+            body: "Core, runtime, host adapter, and the build plugin — plus the CLI as a dev dependency.",
+            code: `
+pnpm add @palamedes/core @palamedes/react @palamedes/runtime @palamedes/vite-plugin
+pnpm add -D @palamedes/cli @vitejs/plugin-react`,
+          },
+          {
+            title: "Configure",
+            body: "One YAML file declares your locales and where catalogs live.",
+            code: `
+# palamedes.yaml
+locales: [en, de]
+source-locale: en
+catalogs:
+  - path: src/locales/{locale}
+    include: [src]`,
+          },
+          {
+            title: "Wire the plugin & runtime",
+            body: "The Vite plugin handles the macro transform; the runtime holds the active i18n instance.",
+            code: `
+// vite.config.ts
+import { palamedes } from "@palamedes/vite-plugin"
+export default defineConfig({ plugins: [palamedes(), react()] })
+
+// src/i18n.ts
+import { createI18n } from "@palamedes/core"
+import { setClientI18n } from "@palamedes/runtime"
+setClientI18n(createI18n())`,
+          },
+          {
+            title: "Write, extract, translate",
+            body: "Author the message in your component, run one command, fill in the German string.",
+            code: `
+// src/App.tsx
+import { t } from "@palamedes/core/macro"
+export const App = () => <h1>{t\`Welcome to Palamedes\`}</h1>
+
+$ pmds extract`,
+          },
+        ]}
+      />
+
+      {/* ------------------------------------------------------ next steps */}
+      <Section id="next">
+        <h2>Where to go from here</h2>
+        <FeatureGrid
+          columns={3}
+          cards={[
+            {
+              icon: "book",
+              title: "Plurals, dates & currency",
+              body: "ICU MessageFormat with authoring diagnostics that catch mistakes at extract time.",
+              href: "…/docs/api/core.md",
+            },
+            {
+              icon: "compass",
+              title: "Pick a locale strategy",
+              body: "Cookie, route, subdomain, or TLD — with a live demo for each, in your framework.",
+              href: "/frameworks",
+            },
+            {
+              icon: "server",
+              title: "Localize your backend",
+              body: "Request-local i18n for Hono and Express from the same catalogs.",
+              href: "…/docs/backend-servers.md",
+            },
+            {
+              icon: "arrows",
+              title: "Migrating from Lingui?",
+              body: "A step-by-step playbook — most teams keep their .po files as-is.",
+              href: "…/docs/migrate-from-lingui.md",
+            },
+            {
+              icon: "wrench",
+              title: "Something broke?",
+              body: "The troubleshooting guide covers the common setup failures with exact error messages.",
+              href: "…/docs/troubleshooting.md",
+            },
+            {
+              icon: "robot",
+              title: "Using an AI assistant?",
+              body: "Point it at llms.txt — the whole API surface in one machine-readable file.",
+              href: "…/llms.txt",
+            },
+          ]}
+        />
+      </Section>
+
+      <CtaBand
+        headline="Stuck? The maintainer reads every issue."
+        primary={{
+          label: "Open an issue",
+          href: "https://github.com/sebastian-software/palamedes/issues",
+        }}
+        secondary={{ label: "Read the docs", href: "…/docs/api/README.md" }}
+      />
+
+      <SiteFooter />
+    </Page>
+  )
+}

--- a/docs/site/structure/pages/GetStartedPage.jsx
+++ b/docs/site/structure/pages/GetStartedPage.jsx
@@ -29,10 +29,9 @@ export function GetStartedPage() {
       <StackPicker options={["Vite + React", "Vite + Solid", "Next.js"]} />
 
       <Callout tone="honest">
-        Heads-up: install the scoped <code>@palamedes/*</code> packages. The
-        top-level <code>palamedes</code> and <code>create-palamedes</code>{" "}
-        names are reserved for a future one-command setup and are not the
-        entry point today.
+        Heads-up: install the scoped <code>@palamedes/*</code> packages. The top-level{" "}
+        <code>palamedes</code> and <code>create-palamedes</code> names are reserved for a future
+        one-command setup and are not the entry point today.
       </Callout>
 
       <StepFlow

--- a/docs/site/structure/pages/GetStartedPage.jsx
+++ b/docs/site/structure/pages/GetStartedPage.jsx
@@ -20,7 +20,7 @@ export function GetStartedPage() {
         primary={{ label: "Skip to step 1", href: "#install" }}
         secondary={{
           label: "Full written guide",
-          href: "…/docs/first-working-translation.md",
+          href: repoHref("docs/first-working-translation.md"),
         }}
       />
 
@@ -65,17 +65,44 @@ export default defineConfig({ plugins: [palamedes(), react()] })
 // src/i18n.ts
 import { createI18n } from "@palamedes/core"
 import { setClientI18n } from "@palamedes/runtime"
-setClientI18n(createI18n())`,
+
+export const i18n = createI18n()
+setClientI18n(i18n)`,
           },
           {
-            title: "Write, extract, translate",
-            body: "Author the message in your component, run one command, fill in the German string.",
+            title: "Write & extract",
+            body: "Author the message in your component, then run one command — it creates src/locales/en.po and de.po.",
             code: `
 // src/App.tsx
 import { t } from "@palamedes/core/macro"
 export const App = () => <h1>{t\`Welcome to Palamedes\`}</h1>
 
 $ pmds extract`,
+          },
+          {
+            title: "Translate",
+            body: "Open the German catalog and fill in the translated string.",
+            code: `
+# src/locales/de.po
+msgid "Welcome to Palamedes"
+msgstr "Willkommen bei Palamedes"`,
+          },
+          {
+            title: "Load & see it render",
+            body: "Load the catalogs, activate a locale, and run the dev server — the page now renders “Willkommen bei Palamedes”. That is the full local loop: transform, extraction, catalog, runtime.",
+            aside:
+              'TypeScript needs an ambient declaration for .po imports — add a src/po.d.ts with `declare module "*.po"` (see the troubleshooting guide).',
+            code: `
+// src/main.tsx
+import { i18n } from "./i18n"
+import { messages as enMessages } from "./locales/en.po"
+import { messages as deMessages } from "./locales/de.po"
+
+i18n.load("en", enMessages)
+i18n.load("de", deMessages)
+i18n.activate("de")
+
+$ pnpm dev`,
           },
         ]}
       />
@@ -90,7 +117,7 @@ $ pmds extract`,
               icon: "book",
               title: "Plurals, dates & currency",
               body: "ICU MessageFormat with authoring diagnostics that catch mistakes at extract time.",
-              href: "…/docs/api/core.md",
+              href: repoHref("docs/api/core.md"),
             },
             {
               icon: "compass",
@@ -102,25 +129,25 @@ $ pmds extract`,
               icon: "server",
               title: "Localize your backend",
               body: "Request-local i18n for Hono and Express from the same catalogs.",
-              href: "…/docs/backend-servers.md",
+              href: repoHref("docs/backend-servers.md"),
             },
             {
               icon: "arrows",
               title: "Migrating from Lingui?",
-              body: "A step-by-step playbook — most teams keep their .po files as-is.",
-              href: "…/docs/migrate-from-lingui.md",
+              body: "A step-by-step playbook. Source-string-first .po catalogs are often reusable after an extraction pass; explicit-ID setups need cleanup.",
+              href: repoHref("docs/migrate-from-lingui.md"),
             },
             {
               icon: "wrench",
               title: "Something broke?",
               body: "The troubleshooting guide covers the common setup failures with exact error messages.",
-              href: "…/docs/troubleshooting.md",
+              href: repoHref("docs/troubleshooting.md"),
             },
             {
               icon: "robot",
               title: "Using an AI assistant?",
               body: "Point it at llms.txt — the whole API surface in one machine-readable file.",
-              href: "…/llms.txt",
+              href: repoHref("llms.txt"),
             },
           ]}
         />
@@ -132,7 +159,7 @@ $ pmds extract`,
           label: "Open an issue",
           href: "https://github.com/sebastian-software/palamedes/issues",
         }}
-        secondary={{ label: "Read the docs", href: "…/docs/api/README.md" }}
+        secondary={{ label: "Read the docs", href: repoHref("docs/api/README.md") }}
       />
 
       <SiteFooter />

--- a/docs/site/structure/pages/HomePage.jsx
+++ b/docs/site/structure/pages/HomePage.jsx
@@ -1,0 +1,223 @@
+/**
+ * Route: /
+ * Job: convert a skeptical JavaScript developer in under 60 seconds of
+ * scrolling — promise, proof, code, path. Every number links to evidence.
+ */
+
+export function HomePage() {
+  return (
+    <Page title="Palamedes — i18n that survives your next framework migration">
+      <SiteNav />
+
+      <Hero
+        eyebrow="Open-source i18n tooling for JavaScript & TypeScript"
+        headline="One translation model. Every framework."
+        subline="Write messages where your UI happens. Keep source-string-first
+          .po catalogs your translators can actually read. Ship the same
+          runtime model across Next.js, TanStack Start, SolidStart, Waku, and
+          React Router — powered by a Rust core that finishes extraction
+          before other tools finish starting."
+        primary={{ label: "Get started in 5 minutes", href: "/get-started" }}
+        secondary={{
+          label: "See it live",
+          href: "https://nextjs-cookie.examples.palamedes.dev",
+        }}
+        visual={
+          <LocaleMatrixAnimation
+            fallbackSrc="…/docs/site/assets/palamedes-localized-matrix.png"
+          />
+        }
+      />
+
+      <ProofStrip
+        stats={[
+          {
+            value: "20",
+            label: "browser-verified example apps",
+            href: "/frameworks",
+          },
+          {
+            value: "5 × 4",
+            label: "frameworks × locale strategies",
+            href: "/frameworks",
+          },
+          {
+            value: "19.6×",
+            label: "faster extract/update than Lingui",
+            href: "/proof",
+          },
+          {
+            value: "16",
+            label: "ADRs documenting every tradeoff",
+            href: "…/adr/",
+          },
+        ]}
+      />
+
+      {/* ------------------------------------------------ the core promise */}
+      <Section id="model">
+        <h2>Your i18n setup should not splinter when your framework changes.</h2>
+        <p>
+          Most teams relearn internationalization with every migration: new
+          runtime, new message IDs, new catalog quirks. Palamedes keeps the
+          parts you touch every day stable — and lets the framework be the
+          only thing that changes.
+        </p>
+        <FeatureGrid
+          columns={3}
+          cards={[
+            {
+              icon: "pen",
+              title: "Write messages in place",
+              body: "Macro-style authoring next to your JSX. No message-ID bookkeeping, no separate dictionary files to keep in sync.",
+              href: "/get-started",
+            },
+            {
+              icon: "fingerprint",
+              title: "One identity model",
+              body: "Messages are identified by message + context — stable across refactors, frameworks, and years of catalog history.",
+              href: "…/adr/003-source-string-first-message-identity.md",
+            },
+            {
+              icon: "plug",
+              title: "One runtime call",
+              body: "getI18n() resolves the active instance everywhere: server components, client islands, backend request handlers.",
+              href: "…/adr/005-universal-geti18n-runtime-model.md",
+            },
+          ]}
+        />
+      </Section>
+
+      {/* --------------------------------------------------- code showcase */}
+      <Section id="code" theme="dark">
+        <h2>The whole workflow, honestly small.</h2>
+        <CodeShowcase
+          tabs={[
+            {
+              label: "Write",
+              language: "tsx",
+              caption: "Messages live where the UI happens.",
+              code: `
+import { t, plural } from "@palamedes/core/macro"
+import { Trans } from "@palamedes/react"
+
+export function Booking({ seats }: { seats: number }) {
+  return (
+    <>
+      <h1>{t\`Your trip to Lisbon\`}</h1>
+      <p>{plural(seats, { one: "# seat left", other: "# seats left" })}</p>
+      <Trans>Free cancellation until <b>24 hours</b> before departure.</Trans>
+    </>
+  )
+}`,
+            },
+            {
+              label: "Extract",
+              language: "bash",
+              caption: "One native command scans, extracts, and updates catalogs.",
+              code: `
+$ pmds extract
+
+  en  3 messages  (1 new)
+  de  3 messages  (1 missing translation)
+
+  done in 34 ms`,
+            },
+            {
+              label: "Translate",
+              language: "po",
+              caption: "Source-string-first .po — readable by translators and every TMS.",
+              code: `
+#: src/Booking.tsx:7
+msgid "Your trip to Lisbon"
+msgstr "Deine Reise nach Lissabon"
+
+#: src/Booking.tsx:8
+msgid "{seats, plural, one {# seat left} other {# seats left}}"
+msgstr "{seats, plural, one {# Platz frei} other {# Plätze frei}}"`,
+            },
+          ]}
+          result={{
+            title: "Rendered",
+            content: "The same component, in every locale, in every framework.",
+          }}
+        />
+      </Section>
+
+      {/* ---------------------------------------------------- proof teaser */}
+      <Section id="proof">
+        <h2>We don't ask you to trust a slogan. The repo shows the work.</h2>
+        <p>
+          Every framework/strategy combination is a real app, deployed live and
+          re-verified in CI through the same Playwright flow. Every benchmark
+          number links to a checked-in, re-runnable report.
+        </p>
+        <FrameworkMatrix
+          frameworks={[
+            { name: "Next.js", slug: "nextjs" },
+            { name: "TanStack Start", slug: "tanstack" },
+            { name: "SolidStart", slug: "solidstart" },
+            { name: "Waku", slug: "waku" },
+            { name: "React Router", slug: "react-router" },
+          ]}
+          strategies={[
+            { name: "Cookie", slug: "cookie" },
+            { name: "Route", slug: "route" },
+            { name: "Subdomain", slug: "subdomain" },
+            { name: "TLD", slug: "tld" },
+          ]}
+          demoUrl={(f, s) => `https://${f}-${s}.examples.palamedes.dev`}
+        />
+        <BenchmarkChart
+          title="End-to-end extract + catalog update (small corpus, median)"
+          rows={[
+            { tool: "Palamedes", median: "33.53 ms" },
+            { tool: "i18next-parser", median: "477.58 ms" },
+            { tool: "Lingui", median: "657.00 ms" },
+          ]}
+          methodologyHref="…/docs/benchmark-e2e-workflow.md"
+        />
+        <Button variant="secondary" href="/proof">
+          All benchmarks & the verification story
+        </Button>
+      </Section>
+
+      {/* ------------------------------------------------------ positioning */}
+      <StatementBand
+        text="Palamedes is narrower than some alternatives on purpose:
+          compile-time authoring, source-string-first catalogs, and a local
+          workflow your repo owns — with a Rust core doing the careful work."
+      />
+
+      {/* ------------------------------------------------------- who builds */}
+      <Section id="maintainer" layout="two-column">
+        <h2>Built from repeat experience, not a weekend take.</h2>
+        <p>
+          Palamedes is maintained by Sebastian Software GmbH. It is the third
+          generation of source-string-first JavaScript i18n tooling from the
+          same author — from gettext-style macro systems in qooxdoo to a
+          full enterprise Lingui migration at Regrello (acquired by
+          Salesforce in 2025). The lessons are written down as 16 ADRs before
+          you depend on the tool.
+        </p>
+        <LinkList
+          links={[
+            { label: "The decision trail (ADRs)", href: "…/adr/" },
+            { label: "Why this exists", href: "/blog" },
+          ]}
+        />
+      </Section>
+
+      <CtaBand
+        headline="Your first working translation is 5 minutes away."
+        primary={{ label: "Get started", href: "/get-started" }}
+        secondary={{
+          label: "Star on GitHub",
+          href: "https://github.com/sebastian-software/palamedes",
+        }}
+      />
+
+      <SiteFooter />
+    </Page>
+  )
+}

--- a/docs/site/structure/pages/HomePage.jsx
+++ b/docs/site/structure/pages/HomePage.jsx
@@ -23,9 +23,7 @@ export function HomePage() {
           href: "https://nextjs-cookie.examples.palamedes.dev",
         }}
         visual={
-          <LocaleMatrixAnimation
-            fallbackSrc="…/docs/site/assets/palamedes-localized-matrix.png"
-          />
+          <LocaleMatrixAnimation fallbackSrc="…/docs/site/assets/palamedes-localized-matrix.png" />
         }
       />
 
@@ -58,10 +56,9 @@ export function HomePage() {
       <Section id="model">
         <h2>Your i18n setup should not splinter when your framework changes.</h2>
         <p>
-          Most teams relearn internationalization with every migration: new
-          runtime, new message IDs, new catalog quirks. Palamedes keeps the
-          parts you touch every day stable — and lets the framework be the
-          only thing that changes.
+          Most teams relearn internationalization with every migration: new runtime, new message
+          IDs, new catalog quirks. Palamedes keeps the parts you touch every day stable — and lets
+          the framework be the only thing that changes.
         </p>
         <FeatureGrid
           columns={3}
@@ -148,9 +145,9 @@ msgstr "{seats, plural, one {# Platz frei} other {# Plätze frei}}"`,
       <Section id="proof">
         <h2>We don't ask you to trust a slogan. The repo shows the work.</h2>
         <p>
-          Every framework/strategy combination is a real app, deployed live and
-          re-verified in CI through the same Playwright flow. Every benchmark
-          number links to a checked-in, re-runnable report.
+          Every framework/strategy combination is a real app, deployed live and re-verified in CI
+          through the same Playwright flow. Every benchmark number links to a checked-in,
+          re-runnable report.
         </p>
         <FrameworkMatrix
           frameworks={[
@@ -193,12 +190,11 @@ msgstr "{seats, plural, one {# Platz frei} other {# Plätze frei}}"`,
       <Section id="maintainer" layout="two-column">
         <h2>Built from repeat experience, not a weekend take.</h2>
         <p>
-          Palamedes is maintained by Sebastian Software GmbH. It is the third
-          generation of source-string-first JavaScript i18n tooling from the
-          same author — from gettext-style macro systems in qooxdoo to a
-          full enterprise Lingui migration at Regrello (acquired by
-          Salesforce in 2025). The lessons are written down as 16 ADRs before
-          you depend on the tool.
+          Palamedes is maintained by Sebastian Software GmbH. It is the third generation of
+          source-string-first JavaScript i18n tooling from the same author — from gettext-style
+          macro systems in qooxdoo to a full enterprise Lingui migration at Regrello (acquired by
+          Salesforce in 2025). The lessons are written down as 16 ADRs before you depend on the
+          tool.
         </p>
         <LinkList
           links={[

--- a/docs/site/structure/pages/HomePage.jsx
+++ b/docs/site/structure/pages/HomePage.jsx
@@ -15,15 +15,18 @@ export function HomePage() {
         subline="Write messages where your UI happens. Keep source-string-first
           .po catalogs your translators can actually read. Ship the same
           runtime model across Next.js, TanStack Start, SolidStart, Waku, and
-          React Router — powered by a Rust core that finishes extraction
-          before other tools finish starting."
+          React Router — with a Rust core that ran the checked small-corpus
+          extract/update benchmark 19.6× faster than Lingui on the recorded
+          machine-local run."
         primary={{ label: "Get started in 5 minutes", href: "/get-started" }}
         secondary={{
           label: "See it live",
           href: "https://nextjs-cookie.examples.palamedes.dev",
         }}
         visual={
-          <LocaleMatrixAnimation fallbackSrc="…/docs/site/assets/palamedes-localized-matrix.png" />
+          <LocaleMatrixAnimation
+            fallbackSrc={repoHref("docs/site/assets/palamedes-localized-matrix.png")}
+          />
         }
       />
 
@@ -41,13 +44,13 @@ export function HomePage() {
           },
           {
             value: "19.6×",
-            label: "faster extract/update than Lingui",
+            label: "faster than Lingui — checked extract/update benchmark, machine-local run",
             href: "/proof",
           },
           {
             value: "16",
             label: "ADRs documenting every tradeoff",
-            href: "…/adr/",
+            href: repoHref("adr"),
           },
         ]}
       />
@@ -73,13 +76,13 @@ export function HomePage() {
               icon: "fingerprint",
               title: "One identity model",
               body: "Messages are identified by message + context — stable across refactors, frameworks, and years of catalog history.",
-              href: "…/adr/003-source-string-first-message-identity.md",
+              href: repoHref("adr/003-source-string-first-message-identity.md"),
             },
             {
               icon: "plug",
               title: "One runtime call",
               body: "getI18n() resolves the active instance everywhere: server components, client islands, backend request handlers.",
-              href: "…/adr/005-universal-geti18n-runtime-model.md",
+              href: repoHref("adr/005-universal-geti18n-runtime-model.md"),
             },
           ]}
         />
@@ -145,10 +148,12 @@ msgstr "{seats, plural, one {# Platz frei} other {# Plätze frei}}"`,
       <Section id="proof">
         <h2>We don't ask you to trust a slogan. The repo shows the work.</h2>
         <p>
-          Every framework/strategy combination is a real app, deployed live and re-verified in CI
-          through the same Playwright flow. Every benchmark number links to a checked-in,
-          re-runnable report.
+          Every framework/strategy combination is a real app, re-verified in CI through the same
+          Playwright flow — with public demos where the hosting is ready. Every benchmark number
+          links to a checked-in, re-runnable report.
         </p>
+        {/* Explicit per-cell links + status shared with /frameworks — see
+            FRAMEWORK_MATRIX_CELLS in components.jsx. No generated URLs. */}
         <FrameworkMatrix
           frameworks={[
             { name: "Next.js", slug: "nextjs" },
@@ -163,7 +168,7 @@ msgstr "{seats, plural, one {# Platz frei} other {# Plätze frei}}"`,
             { name: "Subdomain", slug: "subdomain" },
             { name: "TLD", slug: "tld" },
           ]}
-          demoUrl={(f, s) => `https://${f}-${s}.examples.palamedes.dev`}
+          cells={FRAMEWORK_MATRIX_CELLS}
         />
         <BenchmarkChart
           title="End-to-end extract + catalog update (small corpus, median)"
@@ -172,7 +177,7 @@ msgstr "{seats, plural, one {# Platz frei} other {# Plätze frei}}"`,
             { tool: "i18next-parser", median: "477.58 ms" },
             { tool: "Lingui", median: "657.00 ms" },
           ]}
-          methodologyHref="…/docs/benchmark-e2e-workflow.md"
+          methodologyHref={repoHref("docs/benchmark-e2e-workflow.md")}
         />
         <Button variant="secondary" href="/proof">
           All benchmarks & the verification story
@@ -198,7 +203,7 @@ msgstr "{seats, plural, one {# Platz frei} other {# Plätze frei}}"`,
         </p>
         <LinkList
           links={[
-            { label: "The decision trail (ADRs)", href: "…/adr/" },
+            { label: "The decision trail (ADRs)", href: repoHref("adr") },
             { label: "Why this exists", href: "/blog" },
           ]}
         />

--- a/docs/site/structure/pages/ProofPage.jsx
+++ b/docs/site/structure/pages/ProofPage.jsx
@@ -1,0 +1,147 @@
+/**
+ * Route: /proof
+ * Job: the evidence page. For the visitor who liked the promise but wants
+ * receipts: benchmarks with methodology, the CI verification story, and the
+ * architectural decision trail. Tone: disciplined, zero hype.
+ */
+
+export function ProofPage() {
+  return (
+    <Page title="Palamedes — benchmarks, verification, and the decision trail">
+      <SiteNav />
+
+      <Hero
+        eyebrow="Proof"
+        headline="Claims you can re-run."
+        subline="Every number on this page comes from a checked-in,
+          machine-readable report with fixtures and commands in the repo.
+          If a claim can't be re-run, we don't make it."
+        primary={{
+          label: "Re-run the benchmarks",
+          href: "…/docs/benchmark-e2e-workflow.md",
+        }}
+        secondary={{
+          label: "Browse checked-in reports",
+          href: "…/benchmarks/e2e-workflow/results/",
+        }}
+      />
+
+      {/* ------------------------------------------------------ benchmarks */}
+      <Section id="benchmarks">
+        <h2>The workflow you feel every day: extract & update.</h2>
+        <p>
+          The end-to-end benchmark measures what a developer actually waits
+          for: scan sources, extract messages, update catalogs, write files.
+          Same generated message inventory, rendered into each tool's
+          idiomatic source shape, semantically validated after every run.
+        </p>
+        <BenchmarkChart
+          title="Small corpus — 80 files, 640 messages (median of 7 runs)"
+          rows={[
+            { tool: "Palamedes", median: "33.53 ms" },
+            { tool: "i18next-parser 9.4", median: "477.58 ms" },
+            { tool: "Lingui 6.4", median: "657.00 ms" },
+          ]}
+          methodologyHref="…/docs/benchmark-e2e-workflow.md"
+        />
+        <BenchmarkChart
+          title="Medium corpus (median of 7 runs)"
+          rows={[
+            { tool: "Palamedes", median: "42.92 ms" },
+            /* fill from benchmarks/e2e-workflow/results/latest.md */
+          ]}
+          methodologyHref="…/docs/benchmark-e2e-workflow.md"
+        />
+        <Callout tone="honest">
+          These are machine-local numbers from the checked-in report, not a
+          marketing average. Your hardware will differ; the ratios are the
+          signal. Commands to reproduce: <code>pnpm benchmark:e2e-workflow</code>.
+        </Callout>
+      </Section>
+
+      {/* ----------------------------------------------------- verification */}
+      <Section id="verification">
+        <h2>20 apps, verified in a real browser, on every change.</h2>
+        <StepFlow
+          steps={[
+            {
+              title: "Build",
+              body: "All 20 example apps build against the workspace packages — no mocked integrations.",
+            },
+            {
+              title: "Drive",
+              body: "A Playwright flow loads each app, checks SSR output, switches locales, and exercises localized server actions.",
+            },
+            {
+              title: "Capture",
+              body: "Screenshots are versioned in the repo, so 'works across frameworks' is a diffable artifact, not a slide.",
+            },
+          ]}
+        />
+        <Screenshot
+          src="…/docs/site/assets/palamedes-localized-matrix.png"
+          alt="The same booking UI rendered in English, German, and Spanish"
+          caption="One demo, three locales: copy, plural seat counts, currency, and dates change together."
+          href="…/docs/example-screenshots/README.md"
+        />
+      </Section>
+
+      {/* ------------------------------------------------- catalog quality */}
+      <Section id="catalog-qa">
+        <h2>Fast would be worthless if the catalogs were wrong.</h2>
+        <p>
+          Catalog semantics live in one dedicated engine (ferrocat): parsing,
+          merging, structured audits, and ICU authoring diagnostics. The
+          benchmark harness validates every tool run semantically — message
+          inventories are compared, not just timed.
+        </p>
+        <FeatureGrid
+          columns={3}
+          cards={[
+            {
+              icon: "shield",
+              title: "Structured audits",
+              body: "Machine-readable catalog audits catch missing translations, stale entries, and metadata drift in CI.",
+            },
+            {
+              icon: "brackets",
+              title: "ICU diagnostics",
+              body: "Authoring mistakes in plural/select syntax are flagged at extract time, not at runtime in production.",
+            },
+            {
+              icon: "merge",
+              title: "Semantic merging",
+              body: "A Git merge driver resolves catalog conflicts by meaning, not by line — no more broken .po files after rebases.",
+            },
+          ]}
+        />
+      </Section>
+
+      {/* --------------------------------------------------- decision trail */}
+      <Section id="adrs">
+        <h2>16 decisions, written down before you depend on them.</h2>
+        <p>
+          The ADRs cover message identity, the native boundary, adapter
+          architecture — and, just as deliberately, what Palamedes refuses to
+          own. Reading them is the fastest way to know if our tradeoffs match
+          yours.
+        </p>
+        <LinkList
+          links={[
+            { label: "ADR index", href: "…/adr/" },
+            { label: "Stability & versioning policy", href: "…/docs/stability.md" },
+            { label: "Palamedes principles", href: "…/docs/principles.md" },
+          ]}
+        />
+      </Section>
+
+      <CtaBand
+        headline="Convinced by the receipts? The quickstart takes 5 minutes."
+        primary={{ label: "Get started", href: "/get-started" }}
+        secondary={{ label: "Compare with your current tool", href: "/compare" }}
+      />
+
+      <SiteFooter />
+    </Page>
+  )
+}

--- a/docs/site/structure/pages/ProofPage.jsx
+++ b/docs/site/structure/pages/ProofPage.jsx
@@ -18,11 +18,11 @@ export function ProofPage() {
           If a claim can't be re-run, we don't make it."
         primary={{
           label: "Re-run the benchmarks",
-          href: "…/docs/benchmark-e2e-workflow.md",
+          href: repoHref("docs/benchmark-e2e-workflow.md"),
         }}
         secondary={{
           label: "Browse checked-in reports",
-          href: "…/benchmarks/e2e-workflow/results/",
+          href: repoHref("benchmarks/e2e-workflow/results"),
         }}
       />
 
@@ -41,7 +41,7 @@ export function ProofPage() {
             { tool: "i18next-parser 9.4", median: "477.58 ms" },
             { tool: "Lingui 6.4", median: "657.00 ms" },
           ]}
-          methodologyHref="…/docs/benchmark-e2e-workflow.md"
+          methodologyHref={repoHref("docs/benchmark-e2e-workflow.md")}
         />
         <BenchmarkChart
           title="Medium corpus (median of 7 runs)"
@@ -49,7 +49,7 @@ export function ProofPage() {
             { tool: "Palamedes", median: "42.92 ms" },
             /* fill from benchmarks/e2e-workflow/results/latest.md */
           ]}
-          methodologyHref="…/docs/benchmark-e2e-workflow.md"
+          methodologyHref={repoHref("docs/benchmark-e2e-workflow.md")}
         />
         <Callout tone="honest">
           These are machine-local numbers from the checked-in report, not a marketing average. Your
@@ -78,10 +78,10 @@ export function ProofPage() {
           ]}
         />
         <Screenshot
-          src="…/docs/site/assets/palamedes-localized-matrix.png"
+          src={repoHref("docs/site/assets/palamedes-localized-matrix.png")}
           alt="The same booking UI rendered in English, German, and Spanish"
           caption="One demo, three locales: copy, plural seat counts, currency, and dates change together."
-          href="…/docs/example-screenshots/README.md"
+          href={repoHref("docs/example-screenshots/README.md")}
         />
       </Section>
 
@@ -125,9 +125,9 @@ export function ProofPage() {
         </p>
         <LinkList
           links={[
-            { label: "ADR index", href: "…/adr/" },
-            { label: "Stability & versioning policy", href: "…/docs/stability.md" },
-            { label: "Palamedes principles", href: "…/docs/principles.md" },
+            { label: "ADR index", href: repoHref("adr") },
+            { label: "Stability & versioning policy", href: repoHref("docs/stability.md") },
+            { label: "Palamedes principles", href: repoHref("docs/principles.md") },
           ]}
         />
       </Section>

--- a/docs/site/structure/pages/ProofPage.jsx
+++ b/docs/site/structure/pages/ProofPage.jsx
@@ -30,10 +30,9 @@ export function ProofPage() {
       <Section id="benchmarks">
         <h2>The workflow you feel every day: extract & update.</h2>
         <p>
-          The end-to-end benchmark measures what a developer actually waits
-          for: scan sources, extract messages, update catalogs, write files.
-          Same generated message inventory, rendered into each tool's
-          idiomatic source shape, semantically validated after every run.
+          The end-to-end benchmark measures what a developer actually waits for: scan sources,
+          extract messages, update catalogs, write files. Same generated message inventory, rendered
+          into each tool's idiomatic source shape, semantically validated after every run.
         </p>
         <BenchmarkChart
           title="Small corpus — 80 files, 640 messages (median of 7 runs)"
@@ -53,9 +52,9 @@ export function ProofPage() {
           methodologyHref="…/docs/benchmark-e2e-workflow.md"
         />
         <Callout tone="honest">
-          These are machine-local numbers from the checked-in report, not a
-          marketing average. Your hardware will differ; the ratios are the
-          signal. Commands to reproduce: <code>pnpm benchmark:e2e-workflow</code>.
+          These are machine-local numbers from the checked-in report, not a marketing average. Your
+          hardware will differ; the ratios are the signal. Commands to reproduce:{" "}
+          <code>pnpm benchmark:e2e-workflow</code>.
         </Callout>
       </Section>
 
@@ -90,10 +89,9 @@ export function ProofPage() {
       <Section id="catalog-qa">
         <h2>Fast would be worthless if the catalogs were wrong.</h2>
         <p>
-          Catalog semantics live in one dedicated engine (ferrocat): parsing,
-          merging, structured audits, and ICU authoring diagnostics. The
-          benchmark harness validates every tool run semantically — message
-          inventories are compared, not just timed.
+          Catalog semantics live in one dedicated engine (ferrocat): parsing, merging, structured
+          audits, and ICU authoring diagnostics. The benchmark harness validates every tool run
+          semantically — message inventories are compared, not just timed.
         </p>
         <FeatureGrid
           columns={3}
@@ -121,10 +119,9 @@ export function ProofPage() {
       <Section id="adrs">
         <h2>16 decisions, written down before you depend on them.</h2>
         <p>
-          The ADRs cover message identity, the native boundary, adapter
-          architecture — and, just as deliberately, what Palamedes refuses to
-          own. Reading them is the fastest way to know if our tradeoffs match
-          yours.
+          The ADRs cover message identity, the native boundary, adapter architecture — and, just as
+          deliberately, what Palamedes refuses to own. Reading them is the fastest way to know if
+          our tradeoffs match yours.
         </p>
         <LinkList
           links={[


### PR DESCRIPTION
## Summary

Adds `docs/site/structure/` — the design source for the public Palamedes site, expressed as pseudo-JSX page specs rather than runnable code:

- `README.md` — sitemap, how to read the specs, messaging rules (proof-first, no unbacked numbers, honest competitor framing), the relationship to the direction decision in #290, and the facts the copy relies on (with a flagged caveat on the demo-URL story, see #306)
- `components.jsx` — shared component inventory with layout anatomy and props (`SiteNav`, `Hero`, `ProofStrip`, `FrameworkMatrix`, `BenchmarkChart`, `CodeShowcase`, `CompareTable`, `StepFlow`, `CtaBand`, …)
- Six page specs with final-draft marketing copy: `HomePage`, `FrameworksPage` (5×4 matrix + locale-strategy guide), `ProofPage` (benchmarks with methodology links), `GetStartedPage` (web-native quickstart incl. the reserved-package honesty note), `ComparisonPage` (Lingui / next-intl / GT, incl. "when to pick the other tool"), `BlogIndexPage` (sources docs/site/posts/)

The structure is deliberately visual-direction-agnostic so any of the ten directions explored in #290 can skin it.

## Issue

Refs #290, #321, #323 (docs-audit epic — created alongside this PR, together with issues #302–#322 from the six-pass documentation audit).

## Validation

Docs-only change: no build surface. All quantitative claims in the copy were verified against the repo (20 examples in `examples/`, 16 ADRs, benchmark medians/speedups against `benchmarks/e2e-workflow/results/latest.md`); known-unreliable claims (live-demo URLs) are explicitly flagged in the structure README instead of asserted.

## Follow-up

- Direction decision in #290 (Core-led vs. Plus-led hero; possible `/plus` route)
- Demo-URL reconciliation (#306) before the site links live demos
- Actual site implementation tracked in #321

---
_Generated by [Claude Code](https://claude.ai/code/session_01CVHqC6HnkVsTeFp5HMJcbS)_