### PR TITLE
fix(release): build musl core-node cdylib with a musl-native toolchain

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,11 @@ on:
         required: false
         type: boolean
         default: false
+      dry_run:
+        description: "Build and smoke-test the native packages without publishing anything"
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: publish-${{ github.ref }}
@@ -36,7 +41,7 @@ jobs:
         id: release
         shell: bash
         env:
-          FORCE_PUBLISH: ${{ github.event_name == 'workflow_dispatch' && inputs.force_publish && 'true' || 'false' }}
+          FORCE_PUBLISH: ${{ github.event_name == 'workflow_dispatch' && (inputs.force_publish || inputs.dry_run) && 'true' || 'false' }}
         run: |
           set -euo pipefail
 
@@ -174,7 +179,27 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build native package
+        if: matrix.package_name != '@palamedes/core-node-linux-x64-musl'
         run: pnpm --filter "${{ matrix.package_name }}" build
+
+      # The core-node musl addon is a `cdylib`, so it cannot use musl's default
+      # `+crt-static` (cargo refuses a statically linked cdylib) and must link
+      # dynamically. Cross-linking that dynamic cdylib from the glibc host makes
+      # the linker emit a glibc program interpreter (`ld-linux-x86-64.so.2`),
+      # which then fails to load inside a musl runtime. Building it in a
+      # musl-native environment instead makes the toolchain resolve the correct
+      # `ld-musl-x86-64.so.1` loader. (The static-musl CLI binary has no such
+      # problem, so it keeps building on the host above.)
+      - name: Build musl core-node addon (native musl toolchain)
+        if: matrix.package_name == '@palamedes/core-node-linux-x64-musl'
+        run: >
+          docker run --rm
+          -v "$PWD:/workspace"
+          -w /workspace/packages/core-node-linux-x64-musl
+          -e PALAMEDES_RUST_PROFILE=release
+          rust:alpine
+          sh -c "apk add --no-cache nodejs build-base &&
+          node ../core-node/scripts/build-native.mjs"
 
       - name: Smoke-test native Node package
         if: startsWith(matrix.package_name, '@palamedes/core-node-') && matrix.rust_target == ''
@@ -215,13 +240,14 @@ jobs:
           if (!out.includes('pmds (Palamedes)')) process.exit(1)"
 
       - name: Publish native package
+        if: ${{ github.event_name != 'workflow_dispatch' || !inputs.dry_run }}
         run: node ./scripts/publish-package-if-needed.mjs "${{ matrix.package_name }}"
 
   publish-js:
     needs:
       - determine-release
       - publish-native
-    if: needs.determine-release.outputs.should_publish == 'true'
+    if: ${{ needs.determine-release.outputs.should_publish == 'true' && (github.event_name != 'workflow_dispatch' || !inputs.dry_run) }}
     runs-on: ubuntu-24.04
     permissions:
       contents: read

--- a/packages/core-node/scripts/build-native.mjs
+++ b/packages/core-node/scripts/build-native.mjs
@@ -104,12 +104,18 @@ if (muslNodeAddon) {
   // only reach the final crate too late for that check.
   //
   // The override is scoped to the musl *target* (not the global RUSTFLAGS), so
-  // host build scripts and proc-macros stay untouched. With crt-static off, the
-  // musl target's default self-contained linking (rust-lld plus the bundled musl
-  // objects and unwinder) links the cdylib on its own — the same path the
-  // static-musl CLI addon already uses — so no external `musl-gcc` linker and no
-  // `link-self-contained` component flag are needed. (The unstable
-  // `link-self-contained=+unwind` form is rejected on stable Rust anyway.)
+  // host build scripts and proc-macros stay untouched.
+  //
+  // IMPORTANT: with crt-static off the cdylib links *dynamically*, so this build
+  // must run in a musl-native toolchain (see the "Build musl core-node addon"
+  // step in .github/workflows/publish.yml, which runs it inside `rust:alpine`).
+  // Cross-linking the dynamic cdylib from a glibc host makes the linker emit a
+  // glibc program interpreter (`ld-linux-x86-64.so.2`), and the resulting
+  // `.node` then fails to load inside a musl runtime with `ERR_DLOPEN_FAILED`.
+  // A musl-native `cc` instead resolves the correct `ld-musl-x86-64.so.1`
+  // loader, so no external `musl-gcc` linker or `link-self-contained` flag is
+  // needed. (The static-musl CLI *binary* keeps `+crt-static` and links fully
+  // statically, which is why it builds fine on the glibc host.)
   //
   // `panic=abort` is intentionally not forced here. napi-rs (`#[napi]`) wraps
   // every `extern "C"` entry point in a panic guard, so panics are converted to


### PR DESCRIPTION
## Problem

The 1.1.x Publish repeatedly failed on `publish-native (@palamedes/core-node-linux-x64-musl)`, which skipped `publish-js` and left the user-facing packages (`palamedes`, `@palamedes/core`, `@palamedes/cli`) stuck on npm at **0.8.0** while the native packages advanced to 1.1.1.

Two prior fixes (#296, #300) got the build to compile but the resulting `.node` failed the Alpine smoke test at runtime:

```
Error: Error loading shared library ld-linux-x86-64.so.2: No such file or directory
       (needed by .../core-node-linux-x64-musl/palamedes-node.node)  [ERR_DLOPEN_FAILED]
```

## Root cause

`@palamedes/core-node-linux-x64-musl` is a `cdylib`, so it cannot use musl's default `+crt-static` (cargo refuses a statically linked cdylib) and must link **dynamically**. Cross-linking that dynamic cdylib from the **glibc** CI host makes the linker emit a **glibc** program interpreter (`ld-linux-x86-64.so.2`), which does not exist in a musl runtime.

The static-musl **CLI binary** is unaffected: it keeps `+crt-static` and links fully statically, so it has no loader dependency.

## Fix

Build just this one addon inside `rust:alpine` (native musl `cc`), so the dynamic cdylib resolves the correct `ld-musl-x86-64.so.1` loader. The `-C target-feature=-crt-static` flag in `build-native.mjs` was already correct — it only needed a musl-native link environment. The CLI musl binary keeps building on the host.

Also adds a `dry_run` `workflow_dispatch` input so the native build + smoke tests can be validated without publishing.

## Verification

Dispatched `Publish` with `dry_run=true` on this branch ([run 28739662830](https://github.com/sebastian-software/palamedes/actions/runs/28739662830)) — green:

- `Build musl core-node addon (native musl toolchain)` → **success**
- `Smoke-test musl native Node package` (node:24-alpine) → **success** (previously the failing step)
- All publish steps correctly skipped under dry-run.

## Follow-up to actually ship to npm

Merging this is a plain fix commit and does **not** publish. Release Please will open a `1.1.2` release PR; merging *that* triggers a full Publish that will land the user-facing packages on npm at 1.1.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)