### PR TITLE
fix: render and compile-validate self-closing component placeholders

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -334,9 +334,9 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ferrocat"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47da07e9a7d8c9322abbc33f8a0b73ffc50c88ceb42a91b5fcd55e930245299a"
+checksum = "38fb9e56b5e9541047f84fb1e1b64829bf7ee15b8cb7d1df62aee4d2e075dc26"
 dependencies = [
  "ferrocat-icu",
  "ferrocat-po",
@@ -344,9 +344,9 @@ dependencies = [
 
 [[package]]
 name = "ferrocat-icu"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdf8833bc32377ed7d6bc08752da0ace1551a8882ee89c45302ae126b5a16844"
+checksum = "6302377ad853d3406b2d38a0733fd3f1cbd57137c019e1f71646a3398e60a538"
 dependencies = [
  "memchr",
  "serde",
@@ -354,9 +354,9 @@ dependencies = [
 
 [[package]]
 name = "ferrocat-po"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99fb40ecaa52518cac25f454043b0001781118c17f9995486f8aebf3ad6fa7a4"
+checksum = "fce65d78fff1838a19227e32b56caca2d25fa4b451d6ff0f922deae436a02cf0"
 dependencies = [
  "ferrocat-icu",
  "icu_locale",

--- a/crates/palamedes/Cargo.toml
+++ b/crates/palamedes/Cargo.toml
@@ -8,9 +8,9 @@ rust-version.workspace = true
 description = "Rust core for Palamedes."
 
 [dependencies]
-ferrocat = "=2.1.1"
-ferrocat-icu = "=2.1.1"
-ferrocat-po = "=2.1.1"
+ferrocat = "=2.2.0"
+ferrocat-icu = "=2.2.0"
+ferrocat-po = "=2.2.0"
 oxc_allocator = "0.133.0"
 oxc_ast = "0.133.0"
 oxc_ast_visit = "0.133.0"

--- a/crates/palamedes/src/catalog_artifact/tests.rs
+++ b/crates/palamedes/src/catalog_artifact/tests.rs
@@ -198,6 +198,46 @@ msgstr ""
 }
 
 #[test]
+fn compile_catalog_artifact_accepts_self_closing_component_placeholders() {
+    let fixture = create_fixture_dir("catalog-artifact-self-closing");
+    let locale_dir = fixture.join("src/locales");
+    fs::create_dir_all(&locale_dir).expect("locale dir");
+
+    let message = "Line one<0/>Line two";
+    write_test_catalog(&locale_dir, "en", &[(message, "")]);
+    write_test_catalog(&locale_dir, "de", &[(message, message)]);
+
+    let request = CatalogArtifactRequest {
+        config: CatalogArtifactConfig {
+            root_dir: fixture.to_string_lossy().into_owned(),
+            locales: vec!["en".to_owned(), "de".to_owned()],
+            source_locale: "en".to_owned(),
+            fallback_locales: None,
+            pseudo_locale: None,
+            catalogs: vec![CatalogConfig {
+                path: "src/locales/{locale}".to_owned(),
+                format: PalamedesCatalogFormat::Po,
+            }],
+        },
+        resource_path: locale_dir.join("de.po").to_string_lossy().into_owned(),
+    };
+    let result = compile_catalog_artifact(&request).expect("catalog artifact");
+
+    assert!(
+        result.diagnostics.is_empty(),
+        "self-closing component placeholder should compile without diagnostics: {:?}",
+        result.diagnostics
+    );
+    assert_eq!(
+        result
+            .messages
+            .get(&compiled_key(message, None))
+            .map(String::as_str),
+        Some(message)
+    );
+}
+
+#[test]
 fn compile_catalog_artifact_pseudolocalizes_with_ferrocat_runtime_syntax_policy() {
     let fixture = create_fixture_dir("catalog-artifact-pseudo-ferrocat");
     let locale_dir = fixture.join("src/locales");

--- a/crates/palamedes/src/lib.rs
+++ b/crates/palamedes/src/lib.rs
@@ -72,7 +72,7 @@ pub use transform::{
 };
 
 /// Published `ferrocat` version used by the Rust core.
-pub const FERROCAT_VERSION: &str = "2.1.1";
+pub const FERROCAT_VERSION: &str = "2.2.0";
 
 /// Version metadata for the loaded native core.
 #[derive(Debug, Serialize)]

--- a/packages/core/src/messageFormat.test.ts
+++ b/packages/core/src/messageFormat.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest"
+
+import { formatMessagePattern, parseMessagePattern } from "./messageFormat"
+
+describe("parseMessagePattern", () => {
+  it("parses a self-closing placeholder as a tag with no children", () => {
+    expect(parseMessagePattern("Line one<0/>Line two")).toStrictEqual([
+      { type: "text", value: "Line one" },
+      { type: "tag", name: "0", children: [] },
+      { type: "text", value: "Line two" },
+    ])
+  })
+
+  it("still parses paired tags with children", () => {
+    expect(parseMessagePattern("Powered by <0>Palamedes</0>")).toStrictEqual([
+      { type: "text", value: "Powered by " },
+      { type: "tag", name: "0", children: [{ type: "text", value: "Palamedes" }] },
+    ])
+  })
+
+  it("parses a self-closing placeholder inside plural options", () => {
+    expect(parseMessagePattern("{count, plural, other {Line<0/>break}}")).toStrictEqual([
+      {
+        type: "choice",
+        variable: "count",
+        kind: "plural",
+        options: {
+          other: [
+            { type: "text", value: "Line" },
+            { type: "tag", name: "0", children: [] },
+            { type: "text", value: "break" },
+          ],
+        },
+      },
+    ])
+  })
+})
+
+describe("formatMessagePattern", () => {
+  it("renders a self-closing placeholder as empty text", () => {
+    expect(formatMessagePattern("Line one<0/>Line two")).toBe("Line oneLine two")
+  })
+})

--- a/packages/core/src/messageFormat.ts
+++ b/packages/core/src/messageFormat.ts
@@ -237,7 +237,22 @@ function parseTextUntilBrace(state: ParserState): MessageTextNode {
 
 function parseTag(state: ParserState): MessageTagNode {
   expectChar(state, "<")
-  const name = readUntil(state, [">"]).trim()
+  const name = readUntil(state, ["/", ">"]).trim()
+
+  // Self-closing placeholder `<name/>` (e.g. `<br/>`): the emitter produces this
+  // compact form for component placeholders with no children. Consume `/>` and
+  // yield a tag node with an empty child list.
+  if (state.input[state.index] === "/") {
+    state.index += 1
+    expectChar(state, ">")
+
+    return {
+      type: "tag",
+      name,
+      children: [],
+    }
+  }
+
   expectChar(state, ">")
   const children = parseNodes(state, name)
 
@@ -250,7 +265,7 @@ function parseTag(state: ParserState): MessageTagNode {
 
 function isTagStart(state: ParserState): boolean {
   const slice = state.input.slice(state.index)
-  return /^<([A-Za-z0-9_]+)>/.test(slice)
+  return /^<([A-Za-z0-9_]+)\/?>/.test(slice)
 }
 
 function readUntil(state: ParserState, delimiters: string[]): string {

--- a/packages/react/src/index.test.tsx
+++ b/packages/react/src/index.test.tsx
@@ -29,6 +29,18 @@ describe("@palamedes/react", () => {
     expect(html).toBe("Bereitgestellt von <strong>Palamedes</strong>")
   })
 
+  it("renders a self-closing placeholder as a void component", () => {
+    const i18n = createI18n()
+    i18n.activate("en")
+    setClientI18n(i18n)
+
+    const html = renderToStaticMarkup(
+      <Trans id="imprint" message="Line one<0/>Line two" components={{ 0: <br /> }} />
+    )
+
+    expect(html).toBe("Line one<br/>Line two")
+  })
+
   it("renders plural output through the active runtime instance", () => {
     const i18n = createI18n()
     setClientI18n(i18n)


### PR DESCRIPTION
## Summary

Fixes #328: self-closing component placeholders (`<n/>`) are emitted by the extractor (since #237) but were rejected by the two consumers — the runtime renderer showed them as literal text, and the compile-time catalog validator failed with `invalid_icu_message` (`Expected '>'`).

The common pattern `<Trans>line one<br/>line two</Trans>` extracts to `line one<0/>line two`, which previously broke catalog compilation and rendered `&lt;0/&gt;` as literal text in every locale.

## Changes

- **core** (`packages/core/src/messageFormat.ts`): extend `isTagStart` and `parseTag` to accept the self-closing `<name/>` form and emit a tag node with empty children. The React renderer already renders empty-children tags as void components (e.g. `<br/>`), so no renderer change was needed.
- **rust**: bump `ferrocat` / `ferrocat-icu` / `ferrocat-po` from `=2.1.1` to `=2.2.0`. ferrocat-icu 2.2.0 (sebastian-software/ferrocat#227) teaches its ICU-with-tags parser the self-closing form without an API change, so `catalog_artifact/compile.rs` now validates `<n/>` cleanly. `FERROCAT_VERSION` bumped accordingly.
- **tests**: parse/format tests in core, a `<br/>` render test in react, and a compile-validation test proving `<n/>` compiles without diagnostics and round-trips into the artifact.

## Validation

`pnpm agent:check` passes green (build, format, lint, vitest, check-types, cargo fmt, clippy, cargo test).

## Notes

The upstream half of #328 (the ICU-with-tags parser) lived in the external `ferrocat` crate and was fixed there first — see sebastian-software/ferrocat#227 — then consumed here via the `2.2.0` bump.

Closes #328

🤖 Generated with [Claude Code](https://claude.com/claude-code)