### PR TITLE
feat(site): live smoke-test after Pages deploys and canonical palamedes.dev metadata

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -69,3 +69,58 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v5
+
+  verify:
+    needs: deploy
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Smoke-test the live site
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          base="https://palamedes.dev"
+
+          fetch() {
+            local path="$1"
+            local attempt
+            for attempt in 1 2 3; do
+              if body=$(curl -sS --max-time 20 -w '\n%{http_code}' "$base$path"); then
+                status="${body##*$'\n'}"
+                content="${body%$'\n'*}"
+                return 0
+              fi
+              echo "attempt $attempt for $path failed; retrying in 20s"
+              sleep 20
+            done
+            echo "could not reach $base$path"
+            return 1
+          }
+
+          check() {
+            local path="$1" expected_status="$2" needle="${3:-}"
+            fetch "$path"
+            if [ "$status" != "$expected_status" ]; then
+              echo "FAIL $path: expected HTTP $expected_status, got $status"
+              exit 1
+            fi
+            if [ -n "$needle" ] && ! grep -qF "$needle" <<<"$content"; then
+              echo "FAIL $path: body does not contain '$needle'"
+              exit 1
+            fi
+            echo "ok $path ($status)"
+          }
+
+          check "/" 200 "One translation model."
+          check "/frameworks" 200 "Five frameworks."
+          check "/proof" 200 "Claims you can re-run."
+          check "/get-started" 200 "First working translation"
+          check "/compare" 200 "Narrower than the alternatives."
+          check "/blog" 200 "Building i18n tooling"
+          check "/llms.txt" 200 "palamedes.yaml"
+          check "/llms-full.txt" 200 "palamedes.yaml"
+          check "/sitemap.xml" 200 "https://palamedes.dev/proof"
+          check "/robots.txt" 200 "Sitemap:"
+          check "/does-not-exist" 404 "<html"
+
+          echo "live site verified at $base"

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 [![Sponsored by Sebastian Software](https://img.shields.io/badge/Sponsored%20by-Sebastian%20Software-0f172a.svg)](https://oss.sebastian-software.com/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-0f172a.svg)](https://github.com/sebastian-software/palamedes/blob/main/LICENSE)
 
+**Website: [palamedes.dev](https://palamedes.dev)**
+
 Palamedes is i18n tooling for JavaScript and TypeScript teams that want one
 translation model to survive framework changes.
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "palamedes",
   "private": true,
   "description": "Rust-powered i18n tooling for JavaScript and TypeScript with a cleaner Lingui-style architecture",
-  "homepage": "https://github.com/sebastian-software/palamedes",
+  "homepage": "https://palamedes.dev",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/sebastian-software/palamedes.git"

--- a/site/README.md
+++ b/site/README.md
@@ -1,6 +1,6 @@
 # @palamedes/site
 
-The public Palamedes website — React Router 8 (framework mode) with full
+The public Palamedes website, live at <https://palamedes.dev> — React Router 8 (framework mode) with full
 prerendering, Tailwind v4, and the Swiss-spec-grid design system from
 [`docs/site/structure/`](../docs/site/structure/README.md). Private
 workspace, never published to npm.

--- a/site/app/data/links.ts
+++ b/site/app/data/links.ts
@@ -1,3 +1,5 @@
+export const SITE_ORIGIN = "https://palamedes.dev"
+
 export const REPO = "https://github.com/sebastian-software/palamedes"
 
 /*

--- a/site/app/lib/meta.ts
+++ b/site/app/lib/meta.ts
@@ -1,0 +1,28 @@
+import { SITE_ORIGIN } from "~/data/links"
+
+/*
+ * Shared per-route meta: title/description plus canonical link and Open
+ * Graph tags on the canonical https://palamedes.dev origin. `path` is the
+ * site-relative route ("/", "/proof", …).
+ */
+export function pageMeta({
+  title,
+  description,
+  path,
+}: {
+  title: string
+  description: string
+  path: string
+}) {
+  const url = path === "/" ? `${SITE_ORIGIN}/` : `${SITE_ORIGIN}${path}`
+  return [
+    { title },
+    { name: "description", content: description },
+    { tagName: "link", rel: "canonical", href: url },
+    { property: "og:type", content: "website" },
+    { property: "og:site_name", content: "Palamedes" },
+    { property: "og:url", content: url },
+    { property: "og:title", content: title },
+    { property: "og:description", content: description },
+  ]
+}

--- a/site/app/routes/blog.tsx
+++ b/site/app/routes/blog.tsx
@@ -1,18 +1,17 @@
 import { Page } from "~/components/chrome/Page"
+import { pageMeta } from "~/lib/meta"
 import { Section } from "~/components/chrome/Section"
 import { CtaBand } from "~/components/home/CtaBand"
 import { REPO } from "~/data/links"
 import { POSTS } from "~/data/posts"
 
 export function meta() {
-  return [
-    { title: "Palamedes blog — notes from building i18n tooling in the open" },
-    {
-      name: "description",
-      content:
-        "Design notes, honest benchmarks, and lessons from the third time around — written by the maintainer, not a content team.",
-    },
-  ]
+  return pageMeta({
+    title: "Palamedes blog — notes from building i18n tooling in the open",
+    description:
+      "Design notes, honest benchmarks, and lessons from the third time around — written by the maintainer, not a content team.",
+    path: "/blog",
+  })
 }
 
 export default function Blog() {

--- a/site/app/routes/compare.tsx
+++ b/site/app/routes/compare.tsx
@@ -1,5 +1,6 @@
 import { ButtonLink } from "~/components/chrome/Button"
 import { Page } from "~/components/chrome/Page"
+import { pageMeta } from "~/lib/meta"
 import { Section } from "~/components/chrome/Section"
 import { CtaBand } from "~/components/home/CtaBand"
 import { StatementBand } from "~/components/home/StatementBand"
@@ -7,16 +8,12 @@ import { COMPARE_CRITERIA, COMPARE_FOOTNOTES, COMPARE_TOOLS } from "~/data/compa
 import { repoHref } from "~/data/links"
 
 export function meta() {
-  return [
-    {
-      title: "Palamedes vs Lingui, next-intl, and General Translation — an honest comparison",
-    },
-    {
-      name: "description",
-      content:
-        "How Palamedes compares with Lingui, next-intl, and General Translation — including when you should pick the other tool.",
-    },
-  ]
+  return pageMeta({
+    title: "Palamedes vs Lingui, next-intl, and General Translation — an honest comparison",
+    description:
+      "How Palamedes compares with Lingui, next-intl, and General Translation — including when you should pick the other tool.",
+    path: "/compare",
+  })
 }
 
 function CompareTable() {

--- a/site/app/routes/frameworks.tsx
+++ b/site/app/routes/frameworks.tsx
@@ -1,5 +1,6 @@
 import { ButtonLink } from "~/components/chrome/Button"
 import { Page } from "~/components/chrome/Page"
+import { pageMeta } from "~/lib/meta"
 import { Section } from "~/components/chrome/Section"
 import { FrameworkMatrix } from "~/components/frameworks/FrameworkMatrix"
 import { FwPanels } from "~/components/frameworks/FwPanels"
@@ -9,14 +10,12 @@ import { STRATEGY_CARDS } from "~/data/features"
 import { DEMO_NEXTJS_COOKIE, repoHref } from "~/data/links"
 
 export function meta() {
-  return [
-    { title: "Palamedes — one i18n model across five framework families" },
-    {
-      name: "description",
-      content:
-        "Five frameworks, four locale strategies, one mental model: the browser-verified Palamedes example matrix across Next.js, TanStack Start, SolidStart, Waku, and React Router.",
-    },
-  ]
+  return pageMeta({
+    title: "Palamedes — one i18n model across five framework families",
+    description:
+      "Five frameworks, four locale strategies, one mental model: the browser-verified Palamedes example matrix across Next.js, TanStack Start, SolidStart, Waku, and React Router.",
+    path: "/frameworks",
+  })
 }
 
 export default function Frameworks() {

--- a/site/app/routes/get-started.tsx
+++ b/site/app/routes/get-started.tsx
@@ -1,5 +1,6 @@
 import { ButtonLink } from "~/components/chrome/Button"
 import { Page } from "~/components/chrome/Page"
+import { pageMeta } from "~/lib/meta"
 import { Section } from "~/components/chrome/Section"
 import { PipelineDiagram } from "~/components/get-started/PipelineDiagram"
 import { StackPicker } from "~/components/get-started/StackPicker"
@@ -11,14 +12,12 @@ import { repoHref } from "~/data/links"
 import { QUICKSTART_STEPS } from "~/data/steps"
 
 export function meta() {
-  return [
-    { title: "Get started with Palamedes in 5 minutes" },
-    {
-      name: "description",
-      content:
-        "First working translation in 5 minutes: install the scoped @palamedes packages, configure palamedes.yaml, extract with pmds, translate the .po catalog, and see it render.",
-    },
-  ]
+  return pageMeta({
+    title: "Get started with Palamedes in 5 minutes",
+    description:
+      "First working translation in 5 minutes: install the scoped @palamedes packages, configure palamedes.yaml, extract with pmds, translate the .po catalog, and see it render.",
+    path: "/get-started",
+  })
 }
 
 export default function GetStarted() {

--- a/site/app/routes/home.tsx
+++ b/site/app/routes/home.tsx
@@ -1,5 +1,6 @@
 import { ButtonLink } from "~/components/chrome/Button"
 import { Page } from "~/components/chrome/Page"
+import { pageMeta } from "~/lib/meta"
 import { Reveal } from "~/components/chrome/Reveal"
 import { Section } from "~/components/chrome/Section"
 import { FrameworkMatrix } from "~/components/frameworks/FrameworkMatrix"
@@ -17,14 +18,12 @@ import { HOME_MODEL_CARDS } from "~/data/features"
 import { DEMO_NEXTJS_COOKIE, REPO, repoHref } from "~/data/links"
 
 export function meta() {
-  return [
-    { title: "Palamedes — i18n that survives your next framework migration" },
-    {
-      name: "description",
-      content:
-        "Open-source i18n tooling for JavaScript & TypeScript: one translation model across Next.js, TanStack Start, SolidStart, Waku, and React Router, with a Rust core and source-string-first .po catalogs.",
-    },
-  ]
+  return pageMeta({
+    title: "Palamedes — i18n that survives your next framework migration",
+    description:
+      "Open-source i18n tooling for JavaScript & TypeScript: one translation model across Next.js, TanStack Start, SolidStart, Waku, and React Router, with a Rust core and source-string-first .po catalogs.",
+    path: "/",
+  })
 }
 
 export default function Home() {

--- a/site/app/routes/proof.tsx
+++ b/site/app/routes/proof.tsx
@@ -1,5 +1,6 @@
 import { ButtonLink } from "~/components/chrome/Button"
 import { Page } from "~/components/chrome/Page"
+import { pageMeta } from "~/lib/meta"
 import { Section } from "~/components/chrome/Section"
 import { CtaBand } from "~/components/home/CtaBand"
 import { FeatureGrid } from "~/components/home/FeatureGrid"
@@ -10,14 +11,12 @@ import { CATALOG_QA_CARDS } from "~/data/features"
 import { repoHref } from "~/data/links"
 
 export function meta() {
-  return [
-    { title: "Palamedes — benchmarks, verification, and the decision trail" },
-    {
-      name: "description",
-      content:
-        "Claims you can re-run: checked-in extract/update benchmarks against Lingui and i18next-parser, 20 browser-verified example apps, and 16 architecture decision records.",
-    },
-  ]
+  return pageMeta({
+    title: "Palamedes — benchmarks, verification, and the decision trail",
+    description:
+      "Claims you can re-run: checked-in extract/update benchmarks against Lingui and i18next-parser, 20 browser-verified example apps, and 16 architecture decision records.",
+    path: "/proof",
+  })
 }
 
 const VERIFICATION_STEPS = [


### PR DESCRIPTION
## Summary

Follow-up now that palamedes.dev is live on GitHub Pages:

- **Live verification built into the pipeline**: `deploy-site.yml` gains a `verify` job after `deploy` — curl checks with retry/backoff against `https://palamedes.dev` covering all six routes (status + h1 content), `/llms.txt` + `/llms-full.txt` content (`palamedes.yaml` present), `sitemap.xml`/`robots.txt`, and the 404 fallback. A broken deploy now turns the workflow red instead of drifting silently. (Background: the CCR sandbox network policy can't reach the live domain, so the check runs where it belongs — in the deploy itself.)
- **Canonical metadata**: every route's `meta()` goes through a shared `pageMeta` helper (`site/app/lib/meta.ts`) emitting `<link rel="canonical">` plus `og:url`/`og:title`/`og:description`/`og:site_name` on the canonical `https://palamedes.dev` origin (`SITE_ORIGIN` in `site/app/data/links.ts`).
- **Repo pointers**: root `package.json` `homepage` → `https://palamedes.dev`; website link at the top of the README; live URL noted in `site/README.md`.

## Issue

Refs #321, #323. Completes the deployment story from #327 (merged) after DNS went live.

## Validation

- `pnpm build:site`: prerendered HTML contains the canonical link and `og:url` for each route (grep-verified on `/` and `/proof`)
- `node scripts/verify-site-routes.mjs`: three-pass headless click-through still green
- Root `pnpm format:check`, `pnpm lint`, `pnpm --filter @palamedes/site typecheck`: clean
- The new `verify` job runs on the first main push after merge and delivers the actual live proof

## Follow-up

- None — the live smoke test replaces manual post-deploy checks going forward

---
_Generated by [Claude Code](https://claude.ai/code/session_01CVHqC6HnkVsTeFp5HMJcbS)_