### PR TITLE
fix(benchmarks): read multiline PO msgids

### DIFF
--- a/benchmarks/e2e-workflow/package.json
+++ b/benchmarks/e2e-workflow/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "benchmark": "node ./src/run.mjs",
     "benchmark:quick": "node ./src/run.mjs --warmup 1 --runs 3 --profile small",
+    "test": "node --test ./src/run.test.mjs",
     "validate": "node ./src/run.mjs --validate-only --profile small"
   },
   "dependencies": {

--- a/benchmarks/e2e-workflow/src/po.mjs
+++ b/benchmarks/e2e-workflow/src/po.mjs
@@ -1,0 +1,39 @@
+export function parsePoMsgids(source) {
+  const messages = []
+  let currentMsgid = null
+
+  function finishMsgid() {
+    if (currentMsgid !== null && currentMsgid !== "") {
+      messages.push(currentMsgid)
+    }
+    currentMsgid = null
+  }
+
+  for (const line of source.split(/\r?\n/)) {
+    if (line.startsWith("#~")) {
+      finishMsgid()
+      continue
+    }
+    if (line.trim() === "") {
+      finishMsgid()
+      continue
+    }
+    if (line.startsWith("msgid ")) {
+      finishMsgid()
+      currentMsgid = unquotePo(line.slice("msgid ".length))
+      continue
+    }
+    if (currentMsgid !== null && line.startsWith('"')) {
+      currentMsgid += unquotePo(line)
+      continue
+    }
+    finishMsgid()
+  }
+
+  finishMsgid()
+  return messages
+}
+
+function unquotePo(value) {
+  return JSON.parse(value)
+}

--- a/benchmarks/e2e-workflow/src/run.mjs
+++ b/benchmarks/e2e-workflow/src/run.mjs
@@ -2,8 +2,10 @@ import { cp, mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promi
 import os from "node:os"
 import path from "node:path"
 import { spawn } from "node:child_process"
+import { fileURLToPath } from "node:url"
 
 import { DEFAULT_SEED, PROFILE_DEFINITIONS, createWorkflowCorpus } from "./corpus.mjs"
+import { parsePoMsgids } from "./po.mjs"
 
 const __dirname = import.meta.dirname
 const benchmarkRoot = path.resolve(__dirname, "..")
@@ -341,34 +343,6 @@ async function readActiveMessages(tool, rootDir, locale) {
   return parsePoMsgids(source).sort()
 }
 
-function parsePoMsgids(source) {
-  const messages = []
-  let obsolete = false
-
-  for (const line of source.split(/\r?\n/)) {
-    if (line.startsWith("#~")) {
-      obsolete = true
-      continue
-    }
-    if (line.trim() === "") {
-      obsolete = false
-      continue
-    }
-    if (line.startsWith("msgid ") && !obsolete) {
-      const value = unquotePo(line.slice("msgid ".length))
-      if (value !== "") {
-        messages.push(value)
-      }
-    }
-  }
-
-  return messages
-}
-
-function unquotePo(value) {
-  return JSON.parse(value)
-}
-
 function assertMessageSet(label, expectedInput, actualInput) {
   const expected = [...expectedInput].sort()
   const actual = [...actualInput].sort()
@@ -623,7 +597,9 @@ async function readCommandVersion(command, args) {
   return result.stdout
 }
 
-main().catch((error) => {
-  console.error(error)
-  process.exitCode = 1
-})
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error)
+    process.exitCode = 1
+  })
+}

--- a/benchmarks/e2e-workflow/src/run.test.mjs
+++ b/benchmarks/e2e-workflow/src/run.test.mjs
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import { parsePoMsgids } from "./po.mjs"
+
+test("parsePoMsgids reads multiline ICU msgids", () => {
+  const source = [
+    'msgid ""',
+    'msgstr ""',
+    '"Language: en\\n"',
+    "",
+    'msgid "x"',
+    'msgstr "x"',
+    "",
+    'msgid ""',
+    '"{count, plural, one {# queue detail 00042-now} other {# queue details "',
+    '"00042-now}}"',
+    'msgstr ""',
+    '"{count, plural, one {# queue detail 00042-now} other {# queue details "',
+    '"00042-now}}"',
+    "",
+    '#~ msgid "obsolete"',
+    '#~ msgstr "obsolete"',
+    "",
+  ].join("\n")
+
+  assert.deepEqual(parsePoMsgids(source), [
+    "x",
+    "{count, plural, one {# queue detail 00042-now} other {# queue details 00042-now}}",
+  ])
+})

--- a/crates/palamedes/src/catalog_update.rs
+++ b/crates/palamedes/src/catalog_update.rs
@@ -688,6 +688,34 @@ mod tests {
     }
 
     #[test]
+    fn projects_plural_messages_with_numeric_hyphenated_text() {
+        let path = temp_file("plural-text");
+        let message =
+            "{count, plural, one {# queue detail 00042-now} other {# queue details 00042-now}}";
+
+        update_catalog_file(CatalogUpdateRequest {
+            target_path: path.clone(),
+            locale: "en".to_owned(),
+            source_locale: "en".to_owned(),
+            clean: false,
+            force_clean: false,
+            format: crate::PalamedesCatalogFormat::Po,
+            messages: vec![CatalogUpdateMessage {
+                message: message.to_owned(),
+                context: None,
+                placeholders: BTreeMap::new(),
+                extracted_comments: vec![],
+                origins: vec![],
+            }],
+        })
+        .expect("update");
+
+        let po = parse_po(&std::fs::read_to_string(&path).expect("read output")).expect("parse po");
+        assert_eq!(po.items.len(), 1);
+        assert_eq!(po.items[0].msgid, message);
+    }
+
+    #[test]
     fn forwards_extracted_placeholders_to_ferrocat_update() {
         let path = temp_file("placeholders");
 

--- a/crates/palamedes/src/extract.rs
+++ b/crates/palamedes/src/extract.rs
@@ -1577,6 +1577,35 @@ mod tests {
     }
 
     #[test]
+    fn extracts_plural_messages_with_numeric_hyphenated_text() {
+        let messages = extract_messages(
+            r##"
+              import { plural, t } from "@palamedes/core/macro"
+
+              export function Demo(count) {
+                const a = plural(count, { one: "# queue detail 003", other: "# queue details 003" })
+                const b = plural(count, { one: "# queue detail 00042-now", other: "# queue details 00042-now" })
+                return [t({ message: "x" }), a, b]
+              }
+            "##,
+            "test.tsx",
+        )
+        .expect("messages should extract");
+
+        assert_eq!(
+            messages
+                .iter()
+                .map(|message| message.message.as_str())
+                .collect::<Vec<_>>(),
+            vec![
+                "{count, plural, one {# queue detail 003} other {# queue details 003}}",
+                "{count, plural, one {# queue detail 00042-now} other {# queue details 00042-now}}",
+                "x",
+            ]
+        );
+    }
+
+    #[test]
     fn extracts_defaulted_jsx_choice_values() {
         let messages = extract_messages(
             r##"


### PR DESCRIPTION
## Summary
- Fix the e2e workflow benchmark PO reader so multiline msgid entries are reconstructed instead of treated as empty.
- Add a focused parser test using the issue #355 plural shape that renders as msgid "" plus continuation lines.
- Add Rust regressions proving the native extractor and catalog updater preserve the numeric/hyphenated plural message.

## Validation
- node --test benchmarks/e2e-workflow/src/run.test.mjs
- cargo test -p palamedes --locked
- cargo fmt --all --check

## Notes
The release CLI output for the reported plural is valid multiline PO syntax, not an empty gettext message. The benchmark validation was only reading one-line msgid entries, which made wrapped ICU messages disappear from the counted active message set.

Closes #355