### PR TITLE
fix: extract interpolated plural branches

### DIFF
--- a/crates/palamedes/src/extract.rs
+++ b/crates/palamedes/src/extract.rs
@@ -377,6 +377,7 @@ impl<'a> Visit<'a> for ExtractionVisitor<'a> {
                         macro_name,
                         self.origin(it.span.start as usize),
                         self.current_scope(),
+                        self.source,
                     ),
                     _ => extract_from_descriptor_call(
                         it,
@@ -533,8 +534,13 @@ fn extract_object_properties(object: &ObjectExpression<'_>) -> BTreeMap<String, 
     properties
 }
 
-fn extract_choice_options_from_object(object: &ObjectExpression<'_>) -> ChoiceOptions {
+fn extract_choice_options_from_object(
+    object: &ObjectExpression<'_>,
+    source: &str,
+    used_value_names: &mut HashMap<String, String>,
+) -> PalamedesResult<(ChoiceOptions, BTreeMap<String, String>)> {
     let mut options = Vec::new();
+    let mut placeholders = BTreeMap::new();
 
     for property in &object.properties {
         let ObjectPropertyKind::ObjectProperty(property) = property else {
@@ -543,8 +549,15 @@ fn extract_choice_options_from_object(object: &ObjectExpression<'_>) -> ChoiceOp
         let Some(key) = property.key.static_name() else {
             continue;
         };
-        let Some(value) = string_value(&property.value) else {
-            continue;
+        let (value, option_placeholders) = match property.value.without_parentheses() {
+            Expression::StringLiteral(literal) => (literal.value.to_string(), BTreeMap::new()),
+            Expression::TemplateLiteral(template) => template_to_message_with_state(
+                template,
+                source,
+                "choice option template expression",
+                used_value_names,
+            )?,
+            _ => continue,
         };
 
         let key = key.into_owned();
@@ -553,9 +566,10 @@ fn extract_choice_options_from_object(object: &ObjectExpression<'_>) -> ChoiceOp
         } else {
             options.push((key, value));
         }
+        placeholders.extend(option_placeholders);
     }
 
-    options
+    Ok((options, placeholders))
 }
 
 fn extract_from_jsx_element(
@@ -599,10 +613,17 @@ fn extract_from_jsx_element(
         if attrs.contains_key("id") {
             return Err(PalamedesError::ExplicitMessageIdsUnsupported);
         }
-        let Some(value_name) = extract_jsx_value_name(&element.opening_element)? else {
+        let Some((value_name, value_expression)) =
+            extract_jsx_choice_value(&element.opening_element, source)?
+        else {
             return Ok(None);
         };
-        let options = extract_choice_options_from_jsx(&element.opening_element);
+        let mut used_value_names = HashMap::from([(value_name.clone(), value_expression)]);
+        let (options, placeholders) = extract_choice_options_from_jsx(
+            &element.opening_element,
+            source,
+            &mut used_value_names,
+        )?;
         if options.is_empty() {
             return Ok(None);
         }
@@ -626,7 +647,7 @@ fn extract_from_jsx_element(
             message,
             comment: attrs.get("comment").cloned(),
             context,
-            placeholders: None,
+            placeholders: (!placeholders.is_empty()).then_some(placeholders),
             origin,
             scope,
         }));
@@ -703,6 +724,7 @@ fn extract_from_choice_call(
     macro_name: &str,
     origin: (String, usize, Option<usize>),
     scope: Option<String>,
+    source: &str,
 ) -> PalamedesResult<Option<ExtractedMessageRecord>> {
     let Some(value_arg) = call.arguments.first() else {
         return Ok(None);
@@ -714,12 +736,18 @@ fn extract_from_choice_call(
         return Ok(None);
     };
 
-    let options = extract_choice_options_from_object(object);
+    let value_name = argument_expression_name(value_arg)
+        .unwrap_or_else(|| CHOICE_VALUE_FALLBACK_NAME.to_string());
+    let value_expression = value_arg
+        .as_expression()
+        .and_then(|expression| expression_source(expression, source))
+        .unwrap_or_else(|| value_name.clone());
+    let mut used_value_names = HashMap::from([(value_name.clone(), value_expression)]);
+    let (options, placeholders) =
+        extract_choice_options_from_object(object, source, &mut used_value_names)?;
     if options.is_empty() {
         return Ok(None);
     }
-    let value_name = argument_expression_name(value_arg)
-        .unwrap_or_else(|| CHOICE_VALUE_FALLBACK_NAME.to_string());
 
     let format = match macro_name {
         "plural" => "plural",
@@ -734,7 +762,7 @@ fn extract_from_choice_call(
         message,
         comment: None,
         context: None,
-        placeholders: None,
+        placeholders: (!placeholders.is_empty()).then_some(placeholders),
         origin,
         scope,
     }))
@@ -854,6 +882,21 @@ fn template_to_message(
     template: &TemplateLiteral<'_>,
     source: &str,
 ) -> PalamedesResult<(String, BTreeMap<String, String>)> {
+    let mut used_value_names = HashMap::new();
+    template_to_message_with_state(
+        template,
+        source,
+        "template expression",
+        &mut used_value_names,
+    )
+}
+
+fn template_to_message_with_state(
+    template: &TemplateLiteral<'_>,
+    source: &str,
+    syntax: &'static str,
+    used_value_names: &mut HashMap<String, String>,
+) -> PalamedesResult<(String, BTreeMap<String, String>)> {
     let mut message = String::new();
     let mut placeholders = BTreeMap::new();
 
@@ -865,12 +908,13 @@ fn template_to_message(
         }
 
         if let Some(expr) = template.expressions.get(index) {
-            let Some(placeholder) = expression_name(expr) else {
-                return Err(PalamedesError::UnnamedPlaceholder {
-                    syntax: "template expression",
-                });
+            let Some(preferred_name) = expression_name(expr) else {
+                return Err(PalamedesError::UnnamedPlaceholder { syntax });
             };
-            let expression = expression_source(expr, source).unwrap_or_else(|| placeholder.clone());
+            let expression =
+                expression_source(expr, source).unwrap_or_else(|| preferred_name.clone());
+            let placeholder =
+                make_unique_placeholder_name(preferred_name, &expression, used_value_names);
             message.push('{');
             message.push_str(&placeholder);
             message.push('}');
@@ -879,6 +923,33 @@ fn template_to_message(
     }
 
     Ok((message, placeholders))
+}
+
+fn make_unique_placeholder_name(
+    preferred_name: String,
+    expression: &str,
+    used_value_names: &mut HashMap<String, String>,
+) -> String {
+    if let Some(existing_expression) = used_value_names.get(&preferred_name) {
+        if existing_expression == expression {
+            return preferred_name;
+        }
+    } else {
+        used_value_names.insert(preferred_name.clone(), expression.to_string());
+        return preferred_name;
+    }
+
+    let mut suffix = 1usize;
+    loop {
+        let candidate = format!("{preferred_name}_{suffix}");
+        match used_value_names.get(&candidate) {
+            Some(existing_expression) if existing_expression != expression => suffix += 1,
+            _ => {
+                used_value_names.insert(candidate.clone(), expression.to_string());
+                return candidate;
+            }
+        }
+    }
 }
 
 fn expression_source(expr: &Expression<'_>, source: &str) -> Option<String> {
@@ -929,9 +1000,10 @@ fn jsx_expression_string_value(expr: &JSXExpression<'_>) -> Option<String> {
     }
 }
 
-fn extract_jsx_value_name(
+fn extract_jsx_choice_value(
     opening_element: &JSXOpeningElement<'_>,
-) -> PalamedesResult<Option<String>> {
+    source: &str,
+) -> PalamedesResult<Option<(String, String)>> {
     for attr in &opening_element.attributes {
         let Some(attr) = attr.as_attribute() else {
             continue;
@@ -943,10 +1015,17 @@ fn extract_jsx_value_name(
             continue;
         };
 
-        return Ok(Some(
-            jsx_expression_name(&container.expression)
-                .unwrap_or_else(|| CHOICE_VALUE_FALLBACK_NAME.to_string()),
-        ));
+        let name = jsx_expression_name(&container.expression)
+            .unwrap_or_else(|| CHOICE_VALUE_FALLBACK_NAME.to_string());
+        let span = container.expression.span();
+        let expression = source
+            .get(span.start as usize..span.end as usize)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .unwrap_or(name.as_str())
+            .to_string();
+
+        return Ok(Some((name, expression)));
     }
 
     Ok(None)
@@ -1046,8 +1125,13 @@ fn extract_jsx_children_as_message_with_state(
     Ok(join_jsx_message_parts(&parts))
 }
 
-fn extract_choice_options_from_jsx(opening_element: &JSXOpeningElement<'_>) -> ChoiceOptions {
+fn extract_choice_options_from_jsx(
+    opening_element: &JSXOpeningElement<'_>,
+    source: &str,
+    used_value_names: &mut HashMap<String, String>,
+) -> PalamedesResult<(ChoiceOptions, BTreeMap<String, String>)> {
     let mut options = Vec::new();
+    let mut placeholders = BTreeMap::new();
 
     for attr in &opening_element.attributes {
         let Some(attr) = attr.as_attribute() else {
@@ -1060,8 +1144,26 @@ fn extract_choice_options_from_jsx(opening_element: &JSXOpeningElement<'_>) -> C
         ) {
             continue;
         }
-        let Some(value) = attr.value.as_ref().and_then(jsx_attribute_string_value) else {
+        let Some(attr_value) = attr.value.as_ref() else {
             continue;
+        };
+        let (value, option_placeholders) = match attr_value {
+            JSXAttributeValue::StringLiteral(literal) => {
+                (decode_jsx_entities(literal.value.as_str()), BTreeMap::new())
+            }
+            JSXAttributeValue::ExpressionContainer(container) => match &container.expression {
+                JSXExpression::StringLiteral(literal) => {
+                    (literal.value.to_string(), BTreeMap::new())
+                }
+                JSXExpression::TemplateLiteral(template) => template_to_message_with_state(
+                    template,
+                    source,
+                    "choice option template expression",
+                    used_value_names,
+                )?,
+                _ => continue,
+            },
+            _ => continue,
         };
 
         if let Some(exact) = key.strip_prefix('_') {
@@ -1069,9 +1171,10 @@ fn extract_choice_options_from_jsx(opening_element: &JSXOpeningElement<'_>) -> C
         } else {
             options.push((key, value));
         }
+        placeholders.extend(option_placeholders);
     }
 
-    options
+    Ok((options, placeholders))
 }
 
 fn build_icu_message(
@@ -1414,6 +1517,7 @@ impl From<AggregatedCatalogEntry> for CatalogUpdateMessage {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
     use std::fs;
     use std::path::PathBuf;
     use std::sync::atomic::{AtomicUsize, Ordering};
@@ -1602,6 +1706,61 @@ mod tests {
                 "{count, plural, one {# queue detail 00042-now} other {# queue details 00042-now}}",
                 "x",
             ]
+        );
+    }
+
+    #[test]
+    fn extracts_plural_choice_branch_interpolations() {
+        let messages = extract_messages(
+            r##"
+              import { plural } from "@palamedes/core/macro"
+              const message = plural(count, {
+                one: `# item will be archived because ${planLabel} allows a maximum of ${max}`,
+                other: `# items will be archived because ${planLabel} allows a maximum of ${max}`,
+              })
+            "##,
+            "test.tsx",
+        )
+        .expect("messages should extract");
+
+        assert_eq!(
+            messages[0].message,
+            "{count, plural, one {# item will be archived because {planLabel} allows a maximum of {max}} other {# items will be archived because {planLabel} allows a maximum of {max}}}"
+        );
+        assert_eq!(
+            messages[0].placeholders,
+            Some(BTreeMap::from([
+                ("max".to_string(), "max".to_string()),
+                ("planLabel".to_string(), "planLabel".to_string()),
+            ]))
+        );
+    }
+
+    #[test]
+    fn extracts_plural_jsx_branch_interpolations() {
+        let messages = extract_messages(
+            r##"
+              import { Plural } from "@palamedes/react/macro"
+              const message = <Plural
+                value={count}
+                one={`# item will be archived because ${planLabel} allows a maximum of ${max}`}
+                other={`# items will be archived because ${planLabel} allows a maximum of ${max}`}
+              />
+            "##,
+            "test.tsx",
+        )
+        .expect("messages should extract");
+
+        assert_eq!(
+            messages[0].message,
+            "{count, plural, one {# item will be archived because {planLabel} allows a maximum of {max}} other {# items will be archived because {planLabel} allows a maximum of {max}}}"
+        );
+        assert_eq!(
+            messages[0].placeholders,
+            Some(BTreeMap::from([
+                ("max".to_string(), "max".to_string()),
+                ("planLabel".to_string(), "planLabel".to_string()),
+            ]))
         );
     }
 

--- a/crates/palamedes/src/transform/messages.rs
+++ b/crates/palamedes/src/transform/messages.rs
@@ -18,6 +18,11 @@ pub(super) struct ValueBinding {
     pub name: String,
 }
 
+pub(super) struct ExtractedChoiceOptions {
+    pub options: Vec<(String, String)>,
+    pub values: Vec<ValueBinding>,
+}
+
 const CHOICE_VALUE_FALLBACK_NAME: &str = "value";
 
 pub(super) fn identifier_name<'a>(expr: &'a Expression<'a>) -> Option<&'a str> {
@@ -56,8 +61,13 @@ pub(super) fn extract_object_properties(object: &ObjectExpression<'_>) -> HashMa
     properties
 }
 
-pub(super) fn extract_choice_options(object: &ObjectExpression<'_>) -> Vec<(String, String)> {
+pub(super) fn extract_choice_options(
+    object: &ObjectExpression<'_>,
+    source: &str,
+    used_value_names: &mut HashMap<String, String>,
+) -> PalamedesResult<ExtractedChoiceOptions> {
     let mut options = Vec::new();
+    let mut values = Vec::new();
 
     for property in &object.properties {
         let ObjectPropertyKind::ObjectProperty(property) = property else {
@@ -66,8 +76,15 @@ pub(super) fn extract_choice_options(object: &ObjectExpression<'_>) -> Vec<(Stri
         let Some(key) = property.key.static_name() else {
             continue;
         };
-        let Some(value) = string_value(&property.value) else {
-            continue;
+        let (value, option_values) = match property.value.without_parentheses() {
+            Expression::StringLiteral(literal) => (literal.value.to_string(), Vec::new()),
+            Expression::TemplateLiteral(template) => template_to_message_with_state(
+                template,
+                source,
+                "choice option template expression",
+                used_value_names,
+            )?,
+            _ => continue,
         };
 
         let normalized_key = if let Some(exact) = key.strip_prefix('_') {
@@ -76,9 +93,10 @@ pub(super) fn extract_choice_options(object: &ObjectExpression<'_>) -> Vec<(Stri
             key.into_owned()
         };
         options.push((normalized_key, value));
+        append_unique_bindings(&mut values, option_values);
     }
 
-    options
+    Ok(ExtractedChoiceOptions { options, values })
 }
 
 pub(super) fn jsx_attribute_string_value(value: &JSXAttributeValue<'_>) -> Option<String> {
@@ -123,6 +141,7 @@ pub(super) fn jsx_attributes(opening_element: &JSXOpeningElement<'_>) -> HashMap
 pub(super) fn extract_jsx_value_binding(
     opening_element: &JSXOpeningElement<'_>,
     source: &str,
+    used_value_names: &mut HashMap<String, String>,
 ) -> PalamedesResult<Option<ValueBinding>> {
     for attr in &opening_element.attributes {
         let Some(attr) = attr.as_attribute() else {
@@ -135,11 +154,10 @@ pub(super) fn extract_jsx_value_binding(
             continue;
         };
 
-        let mut used_value_names = HashMap::<String, String>::new();
         return Ok(Some(choice_jsx_value_binding(
             &container.expression,
             source,
-            &mut used_value_names,
+            used_value_names,
         )));
     }
 
@@ -190,8 +208,11 @@ fn call_expression_name(call: &CallExpression<'_>) -> Option<String> {
 
 pub(super) fn extract_choice_options_from_jsx(
     opening_element: &JSXOpeningElement<'_>,
-) -> Vec<(String, String)> {
+    source: &str,
+    used_value_names: &mut HashMap<String, String>,
+) -> PalamedesResult<ExtractedChoiceOptions> {
     let mut options = Vec::new();
+    let mut values = Vec::new();
 
     for attr in &opening_element.attributes {
         let Some(attr) = attr.as_attribute() else {
@@ -204,8 +225,24 @@ pub(super) fn extract_choice_options_from_jsx(
         ) {
             continue;
         }
-        let Some(value) = attr.value.as_ref().and_then(jsx_attribute_string_value) else {
+        let Some(attr_value) = attr.value.as_ref() else {
             continue;
+        };
+        let (value, option_values) = match attr_value {
+            JSXAttributeValue::StringLiteral(literal) => {
+                (decode_jsx_entities(literal.value.as_str()), Vec::new())
+            }
+            JSXAttributeValue::ExpressionContainer(container) => match &container.expression {
+                JSXExpression::StringLiteral(literal) => (literal.value.to_string(), Vec::new()),
+                JSXExpression::TemplateLiteral(template) => template_to_message_with_state(
+                    template,
+                    source,
+                    "choice option template expression",
+                    used_value_names,
+                )?,
+                _ => continue,
+            },
+            _ => continue,
         };
 
         if let Some(exact) = key.strip_prefix('_') {
@@ -213,9 +250,10 @@ pub(super) fn extract_choice_options_from_jsx(
         } else {
             options.push((key, value));
         }
+        append_unique_bindings(&mut values, option_values);
     }
 
-    options
+    Ok(ExtractedChoiceOptions { options, values })
 }
 
 pub(super) fn opening_element_to_component(
@@ -384,7 +422,10 @@ fn push_unique_binding(bindings: &mut Vec<ValueBinding>, binding: ValueBinding) 
     bindings.push(binding);
 }
 
-fn append_unique_bindings(bindings: &mut Vec<ValueBinding>, incoming: Vec<ValueBinding>) {
+pub(super) fn append_unique_bindings(
+    bindings: &mut Vec<ValueBinding>,
+    incoming: Vec<ValueBinding>,
+) {
     for binding in incoming {
         push_unique_binding(bindings, binding);
     }
@@ -515,26 +556,13 @@ pub(super) fn template_to_message(
     template: &TemplateLiteral<'_>,
     source: &str,
 ) -> PalamedesResult<(String, Option<Vec<ValueBinding>>)> {
-    let mut message = String::new();
-    let mut values = Vec::new();
     let mut used_value_names = HashMap::<String, String>::new();
-
-    for (index, quasi) in template.quasis.iter().enumerate() {
-        if let Some(value) = quasi.value.cooked {
-            message.push_str(value.as_str());
-        } else {
-            message.push_str(quasi.value.raw.as_str());
-        }
-
-        if let Some(expr) = template.expressions.get(index) {
-            let binding =
-                expression_binding(expr, source, "template expression", &mut used_value_names)?;
-            message.push('{');
-            message.push_str(&binding.name);
-            message.push('}');
-            values.push(binding);
-        }
-    }
+    let (message, values) = template_to_message_with_state(
+        template,
+        source,
+        "template expression",
+        &mut used_value_names,
+    )?;
 
     Ok((
         message,
@@ -544,6 +572,34 @@ pub(super) fn template_to_message(
             Some(values)
         },
     ))
+}
+
+fn template_to_message_with_state(
+    template: &TemplateLiteral<'_>,
+    source: &str,
+    syntax: &'static str,
+    used_value_names: &mut HashMap<String, String>,
+) -> PalamedesResult<(String, Vec<ValueBinding>)> {
+    let mut message = String::new();
+    let mut values = Vec::new();
+
+    for (index, quasi) in template.quasis.iter().enumerate() {
+        if let Some(value) = quasi.value.cooked {
+            message.push_str(value.as_str());
+        } else {
+            message.push_str(quasi.value.raw.as_str());
+        }
+
+        if let Some(expr) = template.expressions.get(index) {
+            let binding = expression_binding(expr, source, syntax, used_value_names)?;
+            message.push('{');
+            message.push_str(&binding.name);
+            message.push('}');
+            push_unique_binding(&mut values, binding);
+        }
+    }
+
+    Ok((message, values))
 }
 
 pub(super) fn build_icu_message(

--- a/crates/palamedes/src/transform/runtime.rs
+++ b/crates/palamedes/src/transform/runtime.rs
@@ -9,10 +9,10 @@ use oxc_span::GetSpan;
 use crate::error::{PalamedesError, PalamedesResult};
 
 use super::messages::{
-    build_icu_message, choice_expression_binding, escape_string, expression_source,
-    extract_choice_options, extract_choice_options_from_jsx, extract_jsx_children_parts,
-    extract_jsx_value_binding, extract_object_properties, first_argument_object, jsx_attributes,
-    template_to_message, ValueBinding,
+    append_unique_bindings, build_icu_message, choice_expression_binding, escape_string,
+    expression_source, extract_choice_options, extract_choice_options_from_jsx,
+    extract_jsx_children_parts, extract_jsx_value_binding, extract_object_properties,
+    first_argument_object, jsx_attributes, template_to_message, ValueBinding,
 };
 use super::NativeTransformOptions;
 
@@ -257,9 +257,9 @@ pub(super) fn transform_choice_call(
     let mut used_value_names = std::collections::HashMap::new();
     let value_binding = choice_expression_binding(value_expr, source, &mut used_value_names);
     let value_name = value_binding.name.clone();
-    let choice_options = extract_choice_options(choice_object);
+    let extracted_options = extract_choice_options(choice_object, source, &mut used_value_names)?;
 
-    if choice_options.is_empty() {
+    if extracted_options.options.is_empty() {
         return Ok(None);
     }
 
@@ -268,14 +268,15 @@ pub(super) fn transform_choice_call(
     } else {
         macro_name
     };
-    let message = build_icu_message(format, &value_name, &choice_options, None);
+    let message = build_icu_message(format, &value_name, &extracted_options.options, None);
     let lookup_key = compiled_key(&message, None);
-    let values = [value_binding];
+    let mut values = vec![value_binding];
+    append_unique_bindings(&mut values, extracted_options.values);
     Ok(Some((
         build_runtime_call(
             &lookup_key,
             Some(&message),
-            Some(&values),
+            Some(values.as_slice()),
             None,
             None,
             options,
@@ -339,13 +340,17 @@ pub(super) fn transform_choice_jsx_element(
     }
     let context = attrs.get("context").cloned();
     let comment = attrs.get("comment").cloned();
-    let Some(value_binding) = extract_jsx_value_binding(&element.opening_element, source)? else {
+    let mut used_value_names = std::collections::HashMap::new();
+    let Some(value_binding) =
+        extract_jsx_value_binding(&element.opening_element, source, &mut used_value_names)?
+    else {
         return Ok(None);
     };
     let value_name = value_binding.name.clone();
-    let choice_options = extract_choice_options_from_jsx(&element.opening_element);
+    let extracted_options =
+        extract_choice_options_from_jsx(&element.opening_element, source, &mut used_value_names)?;
 
-    if choice_options.is_empty() {
+    if extracted_options.options.is_empty() {
         return Ok(None);
     }
 
@@ -358,16 +363,17 @@ pub(super) fn transform_choice_jsx_element(
     let message = build_icu_message(
         format,
         &value_name,
-        &choice_options,
+        &extracted_options.options,
         attrs.get("offset").map(String::as_str),
     );
     let lookup_key = compiled_key(&message, context.as_deref());
-    let values = [value_binding];
+    let mut values = vec![value_binding];
+    append_unique_bindings(&mut values, extracted_options.values);
     Ok(Some((
         build_runtime_call(
             &lookup_key,
             Some(&message),
-            Some(&values),
+            Some(values.as_slice()),
             context.as_deref(),
             comment.as_deref(),
             options,

--- a/crates/palamedes/src/transform/tests.rs
+++ b/crates/palamedes/src/transform/tests.rs
@@ -109,6 +109,26 @@ fn transforms_plural_choice_macros() {
 }
 
 #[test]
+fn transforms_plural_choice_branch_interpolations() {
+    let result = transform_macros(
+        r##"import { plural } from "@palamedes/core/macro";
+const msg = plural(count, {
+  one: `# item will be archived because ${planLabel} allows a maximum of ${max}`,
+  other: `# items will be archived because ${planLabel} allows a maximum of ${max}`,
+});
+"##,
+        "test.ts",
+        None,
+    )
+    .expect("transform should succeed");
+
+    assert!(result.code.contains(
+        "message: \"{count, plural, one {# item will be archived because {planLabel} allows a maximum of {max}} other {# items will be archived because {planLabel} allows a maximum of {max}}}\""
+    ));
+    assert!(result.code.contains("{ count, planLabel, max }"));
+}
+
+#[test]
 fn transforms_plural_choice_with_signal_accessor() {
     let result = transform_macros(
         "import { plural } from \"@palamedes/core/macro\";\nconst msg = plural(count(), { one: \"# item\", other: \"# items\" });\n",
@@ -323,6 +343,27 @@ fn transforms_plural_jsx_macro() {
         .code
         .contains("message: \"{count, plural, one {# item} other {# items}}\""));
     assert!(result.code.contains("{ count }"));
+}
+
+#[test]
+fn transforms_plural_jsx_branch_interpolations() {
+    let result = transform_macros(
+        r##"import { Plural } from "@palamedes/react/macro";
+const el = <Plural
+  value={count}
+  one={`# item will be archived because ${planLabel} allows a maximum of ${max}`}
+  other={`# items will be archived because ${planLabel} allows a maximum of ${max}`}
+/>;
+"##,
+        "test.tsx",
+        None,
+    )
+    .expect("transform should succeed");
+
+    assert!(result.code.contains(
+        "message: \"{count, plural, one {# item will be archived because {planLabel} allows a maximum of {max}} other {# items will be archived because {planLabel} allows a maximum of {max}}}\""
+    ));
+    assert!(result.code.contains("{ count, planLabel, max }"));
 }
 
 #[test]

--- a/packages/extractor/src/extractMessages.test.ts
+++ b/packages/extractor/src/extractMessages.test.ts
@@ -158,6 +158,31 @@ describe("extractMessages", () => {
       expect(messages[0].message).toBe("{count, plural, one {# item} other {# items}}")
       expect(messages[1].message).toBe("{gender, select, male {He} female {She} other {They}}")
     })
+
+    it("extracts interpolated plural branches with placeholder metadata", () => {
+      const code = `
+        import { plural } from "@palamedes/core/macro"
+        import { Plural } from "@palamedes/react/macro"
+        const call = plural(count, {
+          one: \`# item will be archived because \${planLabel} allows a maximum of \${max}\`,
+          other: \`# items will be archived because \${planLabel} allows a maximum of \${max}\`,
+        })
+        const jsx = <Plural
+          value={count}
+          one={\`# item will be archived because \${planLabel} allows a maximum of \${max}\`}
+          other={\`# items will be archived because \${planLabel} allows a maximum of \${max}\`}
+        />
+      `
+      const messages = extract(code)
+      const expected =
+        "{count, plural, one {# item will be archived because {planLabel} allows a maximum of {max}} other {# items will be archived because {planLabel} allows a maximum of {max}}}"
+
+      expect(messages.map((message) => message.message)).toStrictEqual([expected, expected])
+      expect(messages.map((message) => message.placeholders)).toStrictEqual([
+        { max: "max", planLabel: "planLabel" },
+        { max: "max", planLabel: "planLabel" },
+      ])
+    })
   })
 
   describe("runtime calls", () => {

--- a/packages/transform/src/transform.test.ts
+++ b/packages/transform/src/transform.test.ts
@@ -476,6 +476,28 @@ const literal = plural(21, { one: "# month", other: "# months" });
     expect(result.code).toContain("{ value: 21 }")
   })
 
+  it("transforms interpolated plural branches and forwards their values", () => {
+    const code = `
+import { plural } from "@palamedes/core/macro";
+import { Plural } from "@palamedes/react/macro";
+const call = plural(count, {
+  one: \`# item will be archived because \${planLabel} allows a maximum of \${max}\`,
+  other: \`# items will be archived because \${planLabel} allows a maximum of \${max}\`,
+});
+const jsx = <Plural
+  value={count}
+  one={\`# item will be archived because \${planLabel} allows a maximum of \${max}\`}
+  other={\`# items will be archived because \${planLabel} allows a maximum of \${max}\`}
+/>;
+`
+    const result = transformPalamedesMacros(code, "test.tsx")
+    const expected =
+      "{count, plural, one {# item will be archived because {planLabel} allows a maximum of {max}} other {# items will be archived because {planLabel} allows a maximum of {max}}}"
+
+    expect(result.code.split(`message: "${expected}"`)).toHaveLength(3)
+    expect(result.code.split("{ count, planLabel, max }")).toHaveLength(3)
+  })
+
   it("accepts defaulted JSX choice values", () => {
     const code = `
 import { Plural } from "@palamedes/react/macro";


### PR DESCRIPTION
## Summary

- extract template-literal placeholders inside `plural()` / `select()` / `selectOrdinal()` branches
- support the same interpolation semantics in JSX `<Plural>` / `<Select>` / `<SelectOrdinal>` branch attributes
- forward branch expressions in generated runtime `values` objects and preserve placeholder metadata for catalog comments
- deduplicate repeated expressions and disambiguate colliding placeholder names across the selector and all branches

## Root cause

Choice option extraction only accepted string literals and expression-free template literals via `single_quasi()`. A template with `${…}` was skipped, so calls whose branches were all interpolated produced no extracted message and no diagnostic.

## Impact

Interpolated choice messages now enter catalogs as ICU placeholders and receive the runtime values required to render them. Unsupported unnamed expressions fail with the existing stable-placeholder diagnostic instead of disappearing silently.

## Validation

- `pnpm build`
- `pnpm format:check`
- ESLint and Oxlint on the changed sources
- `pnpm check-types`
- `pnpm test`
- `cargo clippy -p palamedes --all-targets --locked -- -D warnings`
- `cargo test -p palamedes`

Closes #363