### PR TITLE
feat(cli): add explicit namespaced plugin commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ target/
 packages/core-node/palamedes-node.node
 packages/core-node-*/palamedes-node.node
 packages/cli-*/bin/
+packages/cli/bin/pmds-native*
 .vercel/
 examples/**/.vercel/
 

--- a/crates/palamedes-cli/src/config.rs
+++ b/crates/palamedes-cli/src/config.rs
@@ -339,6 +339,30 @@ include = ["src"]
         assert_eq!(config.source_reference_root, app);
     }
 
+    #[test]
+    fn ignores_explicit_plugin_declarations_for_native_commands() {
+        let app = temp_dir("plugin-config");
+        fs::write(
+            app.join(CONFIG_FILENAME),
+            r#"
+locales: [en, de]
+source-locale: en
+catalogs:
+  - path: src/locales/{locale}
+    include: [src]
+plugins:
+  - "@acme/palamedes-workflows"
+  - ["./local-plugin.mjs", { mode: strict }]
+"#,
+        )
+        .expect("write config");
+
+        let config = load_config(&app, None).expect("load native config with plugins");
+
+        assert_eq!(config.locales, ["en", "de"]);
+        assert_eq!(config.catalogs.len(), 1);
+    }
+
     fn temp_dir(name: &str) -> std::path::PathBuf {
         let id = SystemTime::now()
             .duration_since(UNIX_EPOCH)

--- a/docs/adr/001-cli-plugin-execution-boundary.md
+++ b/docs/adr/001-cli-plugin-execution-boundary.md
@@ -1,0 +1,78 @@
+# 001 — Host Explicit CLI Plugins In The npm Wrapper
+
+- Status: Accepted
+- Date: 2026-07-22
+- Issue: [#365](https://github.com/sebastian-software/palamedes/issues/365)
+
+## Context
+
+The Rust `pmds` binary owns extraction, audits, reports, and catalog operations.
+Third-party workflows need resolved project configuration and semantic catalog
+discovery, but linking independently shipped extensions into the Rust binary or
+exposing N-API internals would couple the extension contract to implementation
+details. An unrestricted lifecycle-hook system would also make ordinary built-in
+commands execute third-party code implicitly.
+
+## Decision
+
+Use a hybrid boundary:
+
+1. The npm package keeps a small Node.js `pmds` wrapper as the public executable
+   and installs the Rust program as a private `pmds-native` sidecar.
+2. Built-in namespaces (`extract`, `audit`, `report`, `catalog`, and `version`)
+   are delegated directly to the sidecar before configuration or plugin modules
+   are loaded.
+3. Plugins are loaded only for a non-built-in namespace and only when explicitly
+   listed in `plugins` in the resolved Palamedes configuration.
+4. A plugin declares a lowercase kebab-case namespace, plugin API major version,
+   and a record of namespaced commands. API version `1` must match exactly.
+5. Package resolution is deterministic and relative to the config file. Installed
+   packages are never discovered or executed merely because they are present.
+6. Commands receive a versioned capability host: resolved configuration, semantic
+   catalog enumeration, structured diagnostics, cancellation, and a guarded way
+   to invoke documented built-in commands. Rust and N-API internals are not part
+   of the contract.
+7. Text output and a single JSON envelope share explicit exit-code semantics.
+   `SIGINT` and `SIGTERM` are exposed through `AbortSignal`; cooperative
+   cancellation maps to exit codes 130 and 143.
+8. The host never prompts. Commands receive an `interactive` capability that is
+   false for JSON, CI, and non-TTY execution.
+
+The plugin API major is independent of the package version. Additive API-1
+capabilities may ship in compatible Palamedes minor releases. Removing or
+changing API-1 behavior requires a Palamedes major release or a parallel newer
+plugin API major with a migration window.
+
+## Trust Model
+
+Configured plugins are trusted local code with the same filesystem, environment,
+and network permissions as `pmds`. The host is an API boundary, not a sandbox.
+Projects must review and pin plugin packages as they would build scripts. CI
+must not inject untrusted plugin configuration. A missing, incompatible, or
+failing plugin prevents only plugin-command dispatch; built-in commands bypass
+plugin loading entirely.
+
+## Alternatives Considered
+
+- **Rust compile-time extensions:** strongly typed but unsuitable for independent
+  npm delivery and would require rebuilding the CLI.
+- **Language-neutral subprocess protocol:** useful for a future multi-language
+  ecosystem, but adds process lifecycle, discovery, and protocol complexity before
+  the first command API has stabilized.
+- **WASI/WASM sandbox:** a potentially stronger isolation boundary, but current
+  workflows need ordinary package resolution and controlled access to project files.
+- **Unrestricted Node lifecycle hooks:** easy to add but would execute third-party
+  code during built-ins and make ordering/failure behavior part of every core command.
+- **External wrapper CLIs:** avoid changes here but duplicate config discovery,
+  catalogs, output envelopes, diagnostics, and version negotiation.
+
+## Consequences
+
+- Existing built-in behavior remains owned and parsed by Rust.
+- The npm wrapper becomes a small runtime component rather than only a binary
+  installer.
+- Plugin authors can ship ordinary ESM/CJS npm packages without depending on
+  internal native bindings.
+- Hooks such as `beforeExtract` and `afterAudit` remain intentionally out of
+  scope. They can be evaluated later without weakening the explicit-command
+  execution rule.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,7 @@
+# Architecture Decision Records
+
+Durable Palamedes architecture decisions live here. Active implementation
+plans belong in [`docs/plans`](../plans) and should be removed once the decision
+is implemented or abandoned.
+
+- [001 — Host explicit CLI plugins in the npm wrapper](./001-cli-plugin-execution-boundary.md)

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -10,6 +10,7 @@ expected to use directly.
 - [`@palamedes/remix`](./remix.md)
 - [`@palamedes/config`](./config.md)
 - [`@palamedes/cli`](./cli.md)
+- [`@palamedes/cli/plugin`](./cli-plugin.md)
 - [`@palamedes/vite-plugin`](./vite-plugin.md)
 - [`@palamedes/next-plugin`](./next-plugin.md)
 - [`@palamedes/core-node`](./core-node.md)

--- a/docs/api/cli-plugin.md
+++ b/docs/api/cli-plugin.md
@@ -58,7 +58,9 @@ an ordinary command argument.
 - `host.catalogs()` returns format, source patterns, and absolute per-locale
   catalog paths without exposing native implementation details.
 - `host.runBuiltIn(args)` accepts only documented built-in namespaces and
-  returns `{exitCode}`.
+  returns `{exitCode}`. During a JSON plugin invocation, native stdout and stderr
+  are captured as optional `stdout` and `stderr` fields so the CLI still emits
+  exactly one JSON envelope.
 - `host.reportDiagnostic()` records `info`, `warning`, or `error` diagnostics.
 - `signal` is aborted on `SIGINT`/`SIGTERM`; commands should stop cooperatively.
 

--- a/docs/api/cli-plugin.md
+++ b/docs/api/cli-plugin.md
@@ -1,0 +1,101 @@
+# `@palamedes/cli/plugin`
+
+The versioned CLI plugin API defines explicit, namespaced workflow commands. It
+does not provide lifecycle hooks and does not expose Rust or N-API internals.
+
+## Define A Plugin
+
+```js
+import { definePlugin } from "@palamedes/cli/plugin"
+
+export default definePlugin({
+  name: "acme",
+  apiVersion: 1,
+  commands: {
+    inspect: {
+      description: "Inspect configured catalogs.",
+      run({ args, options, host, signal }) {
+        signal.throwIfAborted()
+        host.reportDiagnostic({
+          severity: "info",
+          code: "ACME_INSPECTED",
+          message: `Inspected ${host.catalogs().length} catalog definitions.`,
+        })
+        return {
+          text: `Inspected ${args.length} arguments`,
+          data: { catalogs: host.catalogs(), options },
+        }
+      },
+    },
+  },
+})
+```
+
+Configure and invoke it:
+
+```yaml
+plugins:
+  - ["@acme/palamedes-workflows", { policy: strict }]
+```
+
+```bash
+pmds acme inspect one two
+pmds acme inspect --json one two
+pmds acme inspect --config ./palamedes.yaml --json
+```
+
+Use `--` when a plugin needs the reserved `--json`, `--config`, or `-c` token as
+an ordinary command argument.
+
+## Contract
+
+- `name` and command names use lowercase kebab-case.
+- `apiVersion` is currently `1` and must match the host exactly.
+- `options` is the value from the config tuple.
+- `interactive` is false for JSON output, CI, or non-TTY execution. The host
+  never prompts; plugins should only prompt when this value is true.
+- `host.config` is the resolved `LoadedPalamedesConfig`.
+- `host.catalogs()` returns format, source patterns, and absolute per-locale
+  catalog paths without exposing native implementation details.
+- `host.runBuiltIn(args)` accepts only documented built-in namespaces and
+  returns `{exitCode}`.
+- `host.reportDiagnostic()` records `info`, `warning`, or `error` diagnostics.
+- `signal` is aborted on `SIGINT`/`SIGTERM`; commands should stop cooperatively.
+
+A command may return text or `{text, data, diagnostics, exitCode}`. Without an
+explicit exit code, error diagnostics produce `1` and other results produce `0`.
+Exit codes must be integers from 0 through 255.
+
+With `--json`, stdout contains exactly one host envelope:
+
+```json
+{
+  "ok": true,
+  "plugin": "acme",
+  "command": "inspect",
+  "exitCode": 0,
+  "result": { "catalogs": [] },
+  "diagnostics": []
+}
+```
+
+Plugins should not write directly to stdout when `json` is true, because doing
+so would corrupt the machine-readable stream.
+
+## Resolution And Trust
+
+Plugins are resolved in config order relative to the config file. Duplicate or
+built-in namespaces, missing packages, incompatible API versions, invalid
+commands, and thrown errors fail with structured diagnostics. Installed packages
+that are absent from `plugins` are never loaded.
+
+ESM plugins normally use a default export as shown above. CommonJS packages may
+assign the plugin object to `module.exports`; both shapes use Node's package
+resolution from the config location.
+
+Configured plugins are trusted code with the same filesystem, environment, and
+network permissions as the CLI. The API is a compatibility boundary, not a
+sandbox. Built-in commands bypass config and plugin loading, so a broken plugin
+does not change `pmds extract`, `audit`, `report`, `catalog`, or `version`.
+
+See [ADR 001](../adr/001-cli-plugin-execution-boundary.md) for the execution-boundary decision.

--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -1,9 +1,8 @@
 # `@palamedes/cli`
 
-`@palamedes/cli` publishes the `pmds` command.
-
-It is a native Rust binary distributed through npm. The package has no
-programmatic JavaScript API, `main`, or `exports` surface.
+`@palamedes/cli` publishes the `pmds` command. A small Node.js wrapper delegates
+built-in commands to the native Rust sidecar and hosts explicitly configured
+third-party command plugins.
 
 ## Commands
 
@@ -18,6 +17,9 @@ See the [CLI reference](../cli.md) for flags and examples.
 
 ## Programmatic Exports
 
-None. Use `pmds` for extraction, audits, completeness reports, catalog merge
-workflows, and catalog conversion. For custom JavaScript tooling, use
-`@palamedes/core-node` directly.
+- `@palamedes/cli/plugin`: `definePlugin()` and
+  `PALAMEDES_PLUGIN_API_VERSION`, plus TypeScript types for the versioned command
+  host.
+
+See [CLI plugin API](./cli-plugin.md). For lower-level custom JavaScript tooling,
+use `@palamedes/core-node` directly.

--- a/docs/api/config.md
+++ b/docs/api/config.md
@@ -17,6 +17,7 @@
 - `PalamedesCatalogConfig`
 - `PalamedesFallbackLocales`
 - `PalamedesSourceReferenceRoot`
+- `PalamedesPluginDeclaration`
 
 ## Config Files
 
@@ -45,6 +46,7 @@ export default defineConfig({
   locales: ["en", "de"],
   sourceLocale: "en",
   catalogs: [{ path: "src/locales/{locale}", include: ["src"] }],
+  plugins: [["@acme/palamedes-workflows", { policy: "strict" }]],
 })
 ```
 
@@ -71,3 +73,7 @@ const config = await loadPalamedesConfig({ cwd: process.cwd() })
 Options include `cwd`, `configPath`, and `skipValidation`. Use
 `skipValidation` only for tooling that needs to inspect partially-authored
 config files.
+
+`plugins` is returned in declaration order. Each entry is a package specifier
+or `[specifier, options]`; the CLI plugin host resolves it relative to
+`configPath`.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,7 +1,26 @@
 # CLI Reference
 
 The `@palamedes/cli` package publishes `pmds`.
-It is a native Rust binary; npm is only a distribution mechanism.
+Built-in commands execute in the native Rust sidecar. The npm wrapper also hosts
+explicitly configured third-party command plugins.
+
+## Plugin Commands
+
+Plugins register a namespace plus commands. They are invoked as:
+
+```bash
+pmds <plugin> <command> [...args]
+pmds <plugin> <command> --json [...args]
+pmds <plugin> <command> --config ./palamedes.yaml [...args]
+```
+
+`--json`, `--config`, and `-c` are reserved host options after the command; put
+`--` before them to pass them through as plugin arguments. Unknown namespaces
+fall back to the native CLI's normal unknown-command diagnostic.
+
+Plugin loading is explicit and applies only to non-built-in namespaces. See the
+[configuration field](./configuration.md#cli-plugins) and
+[`@palamedes/cli/plugin` API](./api/cli-plugin.md).
 
 ## `pmds extract`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,6 +39,7 @@ catalogs:
 | `fallback-locales`      | No       | `string[] \| Record<string, string[]>` | Shared or per-locale fallback chain.                                                |
 | `pseudo-locale`         | No       | `string`                               | Locale code used for pseudo-localized UI testing.                                   |
 | `source-reference-root` | No       | `git \| config \| lingui \| path`      | Root used for catalog source references. Defaults to nearest Git root, then config. |
+| `plugins`               | No       | `(string \| [string, options])[]`      | Explicit CLI plugin packages. Never auto-discovered.                                |
 
 The native CLI and JS config loader also accept snake_case aliases for
 hyphenated config keys: `source_locale`, `fallback_locales`, `pseudo_locale`,
@@ -116,6 +117,26 @@ catalogs:
 
 Plugin integrations pass `pseudo-locale` through to catalog compilation and skip
 `failOnMissing` failures for that locale.
+
+## CLI Plugins
+
+CLI plugins are opt-in and register namespaced commands. A declaration is either
+a package specifier or a `[specifier, options]` pair:
+
+```yaml
+plugins:
+  - "@acme/palamedes-workflows"
+  - ["./local-workflows.mjs", { policy: strict }]
+```
+
+The npm CLI resolves each specifier relative to this config file. Built-in
+commands do not load plugin code. Configuring a plugin grants it the same local
+permissions as another project build script; the plugin host is not a sandbox.
+Plugin-command dispatch uses `@palamedes/config`, so legacy
+`palamedes.config.ts/js/mjs/cjs` files remain available there even though native
+built-in commands intentionally accept only data config files.
+
+See [CLI plugins](./api/cli-plugin.md) for the command and author API.
 
 ## Other Data Formats
 

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -5,7 +5,7 @@
 Rules:
 
 - keep only documents that are still under active discussion or implementation
-- move durable architectural decisions into ADRs under [adr/](adr)
+- move durable architectural decisions into [Architecture Decision Records](../adr)
 - once a plan is implemented or abandoned, delete it instead of keeping it as stale reference material
 
 Current state:

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -41,6 +41,7 @@ may change faster than Stable surfaces.
 | `@palamedes/vite-plugin` and `@palamedes/next-plugin` | Stable   | Plugin options and `.po` loading behavior are public integration APIs.                                                        |
 | `@palamedes/config`                                   | Stable   | Config file names, `defineConfig`, and the config schema are public.                                                          |
 | `@palamedes/cli`                                      | Stable   | Documented commands and flags are public. New commands may appear in minors.                                                  |
+| `@palamedes/cli/plugin`                               | Stable   | Plugin API v1 is version-negotiated; compatible capabilities may be added in minor releases.                                  |
 | Source-string-first PO catalogs                       | Stable   | Message identity is `message + context`. Catalog files remain user-owned.                                                     |
 | FCL catalog storage                                   | Preview  | Supported through config, CLI, and native catalog APIs; app-facing framework imports remain PO-loader based for now.          |
 | Macro syntax                                          | Stable   | Supported macros remain the authoring model. Unsupported explicit IDs are not a compatibility target.                         |
@@ -81,6 +82,7 @@ adoption:
 - benchmark fixture shape and reporting fields
 - internal package boundaries between plugins and transform/core-node helpers
 - future managed translation workflow bridges
+- CLI plugin host capabilities beyond API v1
 
 ## Deprecation Policy
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -5,11 +5,12 @@
 [![Sponsored by Sebastian Software](https://img.shields.io/badge/Sponsored%20by-Sebastian%20Software-0f172a.svg)](https://oss.sebastian-software.com/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-0f172a.svg)](https://github.com/sebastian-software/palamedes/blob/main/LICENSE)
 
-The native Palamedes command-line interface for keeping local catalogs healthy.
+The Palamedes command-line interface for keeping local catalogs healthy and
+hosting explicitly configured workflow commands.
 
-This is the npm distribution package behind the Rust `pmds` binary. Use it when
-you want extraction, catalog updates, and catalog QA in local development or CI
-without wiring the lower-level APIs yourself.
+The npm package keeps a small Node.js dispatcher in front of the Rust `pmds`
+sidecar. Built-in commands go directly to Rust; namespaced plugin commands use a
+versioned JavaScript host API.
 
 ## When To Use This Package
 
@@ -20,6 +21,7 @@ Use `@palamedes/cli` when you want:
 - watch mode during development
 - a clean way to update `.po` catalogs in CI, with opt-in `.fcl` storage
 - a semantic catalog merge command for Git merge drivers
+- explicit third-party workflow commands without wrapping or forking `pmds`
 
 If you are building your own extraction workflow inside your i18n config or custom tooling, look at [`@palamedes/extractor`](https://www.npmjs.com/package/@palamedes/extractor) instead.
 
@@ -72,6 +74,51 @@ and catalog-write timings.
 
 See [Catalog formats](https://github.com/sebastian-software/palamedes/blob/main/docs/catalog-formats.md)
 for when to keep PO storage and when to opt into FCL.
+
+### CLI Plugins
+
+Plugins are loaded only when they are explicitly declared and a non-built-in
+namespace is invoked:
+
+```yaml
+plugins:
+  - ["@acme/palamedes-workflows", { policy: strict }]
+```
+
+```bash
+pnpm exec pmds acme sync
+pnpm exec pmds acme sync --json
+pnpm exec pmds acme sync --config ./palamedes.yaml
+```
+
+A minimal plugin exports `@palamedes/cli/plugin` API version 1:
+
+```js
+import { definePlugin } from "@palamedes/cli/plugin"
+
+export default definePlugin({
+  name: "acme",
+  apiVersion: 1,
+  commands: {
+    inspect: {
+      run({ host, options }) {
+        return {
+          text: `Found ${host.catalogs().length} catalog definitions`,
+          data: { catalogs: host.catalogs(), options },
+        }
+      },
+    },
+  },
+})
+```
+
+The host exposes resolved config, catalog discovery, structured diagnostics,
+cooperative cancellation, and guarded built-in command execution. It does not
+expose native internals or sandbox plugin code. A configured plugin has the same
+local permissions as a build script, so review and pin plugin dependencies.
+
+See the [CLI plugin API](https://github.com/sebastian-software/palamedes/blob/main/docs/api/cli-plugin.md)
+for output envelopes, exit codes, collision rules, and author types.
 
 ### Completeness Report
 

--- a/packages/cli/bin/pmds
+++ b/packages/cli/bin/pmds
@@ -1,24 +1,4 @@
 #!/usr/bin/env node
-import { existsSync } from "node:fs"
-import { spawnSync } from "node:child_process"
-import path from "node:path"
-import { fileURLToPath } from "node:url"
+import { runCli } from "../scripts/run.mjs"
 
-const binDir = path.dirname(fileURLToPath(import.meta.url))
-const executable = path.join(binDir, "pmds.exe")
-
-if (process.platform === "win32" && existsSync(executable)) {
-  const result = spawnSync(executable, process.argv.slice(2), { stdio: "inherit" })
-  if (result.error) {
-    console.error(result.error.message)
-    process.exit(1)
-  }
-  if (result.signal) {
-    console.error(`pmds exited with signal ${result.signal}`)
-    process.exit(1)
-  }
-  process.exit(result.status ?? 0)
-}
-
-console.error("Palamedes CLI native binary was not installed for this platform.")
-process.exit(1)
+process.exitCode = await runCli(process.argv.slice(2))

--- a/packages/cli/fixtures/plugin-project/commonjs-plugin.cjs
+++ b/packages/cli/fixtures/plugin-project/commonjs-plugin.cjs
@@ -1,0 +1,11 @@
+module.exports = {
+  name: "commonjs",
+  apiVersion: 1,
+  commands: {
+    ping: {
+      run() {
+        return "pong"
+      },
+    },
+  },
+}

--- a/packages/cli/fixtures/plugin-project/example-plugin.mjs
+++ b/packages/cli/fixtures/plugin-project/example-plugin.mjs
@@ -1,0 +1,20 @@
+import { definePlugin } from "../../plugin-api.mjs"
+
+export default definePlugin({
+  name: "example",
+  apiVersion: 1,
+  commands: {
+    inspect: {
+      description: "Inspect the resolved Palamedes project.",
+      run({ args, options, host }) {
+        return {
+          text: `${options.greeting} from ${host.config.rootDir}`,
+          data: {
+            args,
+            catalogs: host.catalogs(),
+          },
+        }
+      },
+    },
+  },
+})

--- a/packages/cli/fixtures/plugin-project/import-only-plugin.mjs
+++ b/packages/cli/fixtures/plugin-project/import-only-plugin.mjs
@@ -1,0 +1,13 @@
+import { definePlugin } from "../../plugin-api.mjs"
+
+export default definePlugin({
+  name: "import-only",
+  apiVersion: 1,
+  commands: {
+    ping: {
+      run() {
+        return "esm pong"
+      },
+    },
+  },
+})

--- a/packages/cli/fixtures/plugin-project/package.json
+++ b/packages/cli/fixtures/plugin-project/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "palamedes-import-only-plugin-fixture",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./import-only-plugin.mjs"
+    }
+  }
+}

--- a/packages/cli/fixtures/plugin-project/palamedes.config.mjs
+++ b/packages/cli/fixtures/plugin-project/palamedes.config.mjs
@@ -1,0 +1,6 @@
+export default {
+  locales: ["en", "de"],
+  sourceLocale: "en",
+  catalogs: [{ path: "locales/{locale}/messages", include: ["src"] }],
+  plugins: [["./example-plugin.mjs", { greeting: "hello" }]],
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@palamedes/cli",
   "version": "1.3.0",
-  "description": "Palamedes CLI for extraction, audits, reports, and catalog workflows",
+  "description": "Palamedes CLI for extraction, audits, reports, catalog workflows, and explicit command plugins",
   "keywords": [
     "i18n",
     "internationalization",
@@ -23,19 +23,31 @@
   "files": [
     "LICENSE",
     "README.md",
-    "bin/",
-    "scripts/"
+    "bin/pmds",
+    "scripts/",
+    "fixtures/",
+    "plugin-api.mjs",
+    "plugin-api.d.ts"
   ],
+  "exports": {
+    "./plugin": {
+      "types": "./plugin-api.d.ts",
+      "import": "./plugin-api.mjs"
+    }
+  },
   "scripts": {
     "build": "node ./scripts/build.mjs",
     "postinstall": "node ./scripts/install.mjs",
-    "test": "node ./scripts/smoke.mjs"
+    "test": "node --test ./scripts/plugin-host.test.mjs && node ./scripts/smoke.mjs"
   },
   "engines": {
     "node": ">=22.0.0"
   },
   "publishConfig": {
     "access": "public"
+  },
+  "dependencies": {
+    "@palamedes/config": "workspace:^"
   },
   "optionalDependencies": {
     "@palamedes/cli-darwin-arm64": "workspace:^",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -47,7 +47,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@palamedes/config": "workspace:^"
+    "@palamedes/config": "workspace:^",
+    "import-meta-resolve": "^4.2.0"
   },
   "optionalDependencies": {
     "@palamedes/cli-darwin-arm64": "workspace:^",

--- a/packages/cli/plugin-api.d.ts
+++ b/packages/cli/plugin-api.d.ts
@@ -1,0 +1,69 @@
+import type { LoadedPalamedesConfig } from "@palamedes/config"
+
+export declare const PALAMEDES_PLUGIN_API_VERSION: 1
+
+export type PalamedesPluginDiagnostic = {
+  severity: "info" | "warning" | "error"
+  message: string
+  code?: string
+  details?: unknown
+}
+
+export type PalamedesPluginCatalog = {
+  path: string
+  format: "po" | "fcl"
+  include: readonly string[]
+  exclude: readonly string[]
+  locales: readonly {
+    locale: string
+    path: string
+  }[]
+}
+
+export type PalamedesBuiltInResult = {
+  exitCode: number
+}
+
+export type PalamedesPluginHost = {
+  readonly apiVersion: 1
+  readonly config: LoadedPalamedesConfig
+  catalogs(): readonly PalamedesPluginCatalog[]
+  runBuiltIn(args: readonly string[]): Promise<PalamedesBuiltInResult>
+  reportDiagnostic(diagnostic: PalamedesPluginDiagnostic): void
+}
+
+export type PalamedesPluginCommandContext<Options = unknown> = {
+  readonly args: readonly string[]
+  readonly options: Options
+  readonly json: boolean
+  readonly interactive: boolean
+  readonly signal: AbortSignal
+  readonly host: PalamedesPluginHost
+}
+
+export type PalamedesPluginCommandResult =
+  | void
+  | string
+  | {
+      exitCode?: number
+      text?: string
+      data?: unknown
+      diagnostics?: readonly PalamedesPluginDiagnostic[]
+    }
+
+export type PalamedesPluginCommand<Options = unknown> = {
+  description?: string
+  run(
+    context: PalamedesPluginCommandContext<Options>
+  ): PalamedesPluginCommandResult | Promise<PalamedesPluginCommandResult>
+}
+
+export type PalamedesCliPlugin<Options = unknown> = {
+  name: string
+  apiVersion: 1
+  commands: Record<string, PalamedesPluginCommand<Options>>
+}
+
+export declare function definePlugin<Options = unknown>(
+  plugin: PalamedesCliPlugin<Options>
+): PalamedesCliPlugin<Options>

--- a/packages/cli/plugin-api.d.ts
+++ b/packages/cli/plugin-api.d.ts
@@ -22,6 +22,8 @@ export type PalamedesPluginCatalog = {
 
 export type PalamedesBuiltInResult = {
   exitCode: number
+  stdout?: string
+  stderr?: string
 }
 
 export type PalamedesPluginHost = {

--- a/packages/cli/plugin-api.mjs
+++ b/packages/cli/plugin-api.mjs
@@ -1,0 +1,5 @@
+export const PALAMEDES_PLUGIN_API_VERSION = 1
+
+export function definePlugin(plugin) {
+  return plugin
+}

--- a/packages/cli/scripts/build.mjs
+++ b/packages/cli/scripts/build.mjs
@@ -1,38 +1,21 @@
-import { mkdirSync, rmSync, writeFileSync } from "node:fs"
+import { chmodSync, mkdirSync, rmSync, writeFileSync } from "node:fs"
 import path from "node:path"
 
 const packageDir = path.resolve(import.meta.dirname, "..")
 const binDir = path.join(packageDir, "bin")
 
 mkdirSync(binDir, { recursive: true })
-rmSync(path.join(binDir, "pmds.exe"), { force: true })
-writeFileSync(path.join(binDir, "pmds"), fallbackScript())
+rmSync(path.join(binDir, "pmds-native"), { force: true })
+rmSync(path.join(binDir, "pmds-native.exe"), { force: true })
+const wrapperPath = path.join(binDir, "pmds")
+writeFileSync(wrapperPath, wrapperScript())
+chmodSync(wrapperPath, 0o755)
 console.log("@palamedes/cli ships platform binaries through optional packages.")
 
-function fallbackScript() {
+function wrapperScript() {
   return `#!/usr/bin/env node
-import { existsSync } from "node:fs"
-import { spawnSync } from "node:child_process"
-import path from "node:path"
-import { fileURLToPath } from "node:url"
+import { runCli } from "../scripts/run.mjs"
 
-const binDir = path.dirname(fileURLToPath(import.meta.url))
-const executable = path.join(binDir, "pmds.exe")
-
-if (process.platform === "win32" && existsSync(executable)) {
-  const result = spawnSync(executable, process.argv.slice(2), { stdio: "inherit" })
-  if (result.error) {
-    console.error(result.error.message)
-    process.exit(1)
-  }
-  if (result.signal) {
-    console.error(\`pmds exited with signal \${result.signal}\`)
-    process.exit(1)
-  }
-  process.exit(result.status ?? 0)
-}
-
-console.error("Palamedes CLI native binary was not installed for this platform.")
-process.exit(1)
+process.exitCode = await runCli(process.argv.slice(2))
 `
 }

--- a/packages/cli/scripts/install.mjs
+++ b/packages/cli/scripts/install.mjs
@@ -1,17 +1,20 @@
-import { chmodSync, copyFileSync, existsSync, mkdirSync } from "node:fs"
+import { chmodSync, copyFileSync, existsSync, mkdirSync, rmSync } from "node:fs"
 import { createRequire } from "node:module"
 import path from "node:path"
 
 const packageDir = path.resolve(import.meta.dirname, "..")
 const binDir = path.join(packageDir, "bin")
 const require = createRequire(import.meta.url)
-const binaryName = process.platform === "win32" ? "pmds.exe" : "pmds"
-const targetPath = path.join(binDir, binaryName)
+const sourceBinaryName = process.platform === "win32" ? "pmds.exe" : "pmds"
+const targetBinaryName = process.platform === "win32" ? "pmds-native.exe" : "pmds-native"
+const targetPath = path.join(binDir, targetBinaryName)
 const packageName = resolvePlatformPackage()
+
+rmSync(targetPath, { force: true })
 
 try {
   const nativePackageDir = resolvePackageDir(packageName)
-  const sourcePath = path.join(nativePackageDir, "bin", binaryName)
+  const sourcePath = path.join(nativePackageDir, "bin", sourceBinaryName)
   if (!existsSync(sourcePath)) {
     console.warn(
       `Palamedes CLI optional package ${packageName} is installed but has no binary yet.`

--- a/packages/cli/scripts/native.mjs
+++ b/packages/cli/scripts/native.mjs
@@ -5,22 +5,49 @@ export async function spawnNative(args, options = {}) {
   if (!executable) {
     throw new Error("Palamedes native CLI executable is not configured.")
   }
+  if (options.signal?.aborted) {
+    return abortExitCode(options.signal.reason)
+  }
 
   return new Promise((resolve, reject) => {
+    const captureOutput = options.captureOutput === true
     const child = spawn(executable, args, {
       cwd: options.cwd,
-      stdio: "inherit",
+      stdio: captureOutput ? ["inherit", "pipe", "pipe"] : "inherit",
+    })
+    let stdout = ""
+    let stderr = ""
+    child.stdout?.setEncoding("utf8")
+    child.stderr?.setEncoding("utf8")
+    child.stdout?.on("data", (chunk) => {
+      stdout += chunk
+    })
+    child.stderr?.on("data", (chunk) => {
+      stderr += chunk
     })
     const onAbort = () => child.kill(options.signal?.reason?.signal ?? "SIGTERM")
+    const cleanup = () => options.signal?.removeEventListener("abort", onAbort)
     options.signal?.addEventListener("abort", onAbort, { once: true })
-    child.once("error", reject)
+    if (options.signal?.aborted) onAbort()
+    child.once("error", (error) => {
+      cleanup()
+      reject(error)
+    })
     child.once("exit", (code, signal) => {
-      options.signal?.removeEventListener("abort", onAbort)
-      if (signal) {
-        resolve(signal === "SIGINT" ? 130 : signal === "SIGTERM" ? 143 : 1)
-      } else {
-        resolve(code ?? 1)
-      }
+      cleanup()
+      const exitCode = signal
+        ? signal === "SIGINT"
+          ? 130
+          : signal === "SIGTERM"
+            ? 143
+            : 1
+        : (code ?? 1)
+      resolve(captureOutput ? { exitCode, stdout, stderr } : exitCode)
     })
   })
+}
+
+function abortExitCode(reason) {
+  if (Number.isInteger(reason?.exitCode)) return reason.exitCode
+  return reason?.signal === "SIGTERM" ? 143 : 130
 }

--- a/packages/cli/scripts/native.mjs
+++ b/packages/cli/scripts/native.mjs
@@ -1,0 +1,26 @@
+import { spawn } from "node:child_process"
+
+export async function spawnNative(args, options = {}) {
+  const executable = options.nativeExecutable
+  if (!executable) {
+    throw new Error("Palamedes native CLI executable is not configured.")
+  }
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(executable, args, {
+      cwd: options.cwd,
+      stdio: "inherit",
+    })
+    const onAbort = () => child.kill(options.signal?.reason?.signal ?? "SIGTERM")
+    options.signal?.addEventListener("abort", onAbort, { once: true })
+    child.once("error", reject)
+    child.once("exit", (code, signal) => {
+      options.signal?.removeEventListener("abort", onAbort)
+      if (signal) {
+        resolve(signal === "SIGINT" ? 130 : signal === "SIGTERM" ? 143 : 1)
+      } else {
+        resolve(code ?? 1)
+      }
+    })
+  })
+}

--- a/packages/cli/scripts/plugin-host.mjs
+++ b/packages/cli/scripts/plugin-host.mjs
@@ -1,6 +1,7 @@
-import { createRequire } from "node:module"
 import path from "node:path"
 import { pathToFileURL } from "node:url"
+
+import { resolve as resolveImport } from "import-meta-resolve"
 
 import { PALAMEDES_PLUGIN_API_VERSION } from "../plugin-api.mjs"
 import { spawnNative } from "./native.mjs"
@@ -91,6 +92,7 @@ export async function tryRunPluginCommand(argv, options = {}) {
     runNative,
     nativeExecutable,
     cwd: options.cwd ?? process.cwd(),
+    json: invocation.json,
   })
 
   try {
@@ -210,7 +212,15 @@ function parseInvocation(argv) {
   }
 }
 
-function createHost({ config, diagnostics, abortController, runNative, nativeExecutable, cwd }) {
+function createHost({
+  config,
+  diagnostics,
+  abortController,
+  runNative,
+  nativeExecutable,
+  cwd,
+  json,
+}) {
   return Object.freeze({
     apiVersion: PALAMEDES_PLUGIN_API_VERSION,
     config,
@@ -232,12 +242,20 @@ function createHost({ config, diagnostics, abortController, runNative, nativeExe
           `runBuiltIn requires a built-in command (${[...BUILT_IN_NAMESPACES].join(", ")}).`
         )
       }
-      const exitCode = await runNative(args, {
+      const nativeResult = await runNative(args, {
         cwd,
         signal: abortController.signal,
         nativeExecutable,
+        captureOutput: json,
       })
-      return { exitCode }
+      if (typeof nativeResult === "number") {
+        return { exitCode: nativeResult }
+      }
+      return {
+        exitCode: nativeResult.exitCode,
+        ...(nativeResult.stdout !== undefined ? { stdout: nativeResult.stdout } : {}),
+        ...(nativeResult.stderr !== undefined ? { stderr: nativeResult.stderr } : {}),
+      }
     },
     reportDiagnostic(diagnostic) {
       diagnostics.push(normalizeDiagnostic(diagnostic))
@@ -284,9 +302,8 @@ function validatePlugin(plugin, specifier) {
 }
 
 async function importPluginFromConfig(specifier, configPath) {
-  const require = createRequire(configPath)
-  const resolved = require.resolve(specifier)
-  return import(pathToFileURL(resolved).href)
+  const resolved = resolveImport(specifier, pathToFileURL(configPath).href)
+  return import(resolved)
 }
 
 function normalizeDeclaration(declaration) {

--- a/packages/cli/scripts/plugin-host.mjs
+++ b/packages/cli/scripts/plugin-host.mjs
@@ -1,0 +1,458 @@
+import { createRequire } from "node:module"
+import path from "node:path"
+import { pathToFileURL } from "node:url"
+
+import { PALAMEDES_PLUGIN_API_VERSION } from "../plugin-api.mjs"
+import { spawnNative } from "./native.mjs"
+
+const BUILT_IN_NAMESPACES = new Set(["extract", "audit", "report", "catalog", "version"])
+const NAME_PATTERN = /^[a-z][a-z0-9-]*$/u
+
+export async function tryRunPluginCommand(argv, options = {}) {
+  const namespace = argv[0]
+  if (!namespace || namespace.startsWith("-")) {
+    return { handled: false, exitCode: 0 }
+  }
+
+  const io = options.io ?? defaultIo()
+  let invocation
+  try {
+    invocation = parseInvocation(argv)
+  } catch (error) {
+    const fallbackInvocation = {
+      namespace,
+      commandName: argv[1],
+      json: argv.includes("--json"),
+    }
+    return emitHostFailure(fallbackInvocation, io, "PLUGIN_ARGUMENT_INVALID", error)
+  }
+  const loadConfig = options.loadConfig ?? loadConfigFromPackage
+  let config
+
+  try {
+    config = await loadConfig({
+      cwd: options.cwd ?? process.cwd(),
+      ...(invocation.configPath ? { configPath: invocation.configPath } : {}),
+    })
+  } catch (error) {
+    if (!invocation.configPath && isConfigNotFound(error)) {
+      return { handled: false, exitCode: 0 }
+    }
+    return emitHostFailure(invocation, io, "PLUGIN_CONFIG_FAILED", error)
+  }
+
+  if (!config.plugins || config.plugins.length === 0) {
+    return { handled: false, exitCode: 0 }
+  }
+
+  let plugins
+  try {
+    plugins = await loadPlugins(config, options.importPlugin)
+  } catch (error) {
+    return emitHostFailure(invocation, io, error.code ?? "PLUGIN_LOAD_FAILED", error)
+  }
+
+  const loaded = plugins.get(namespace)
+  if (!loaded) {
+    return { handled: false, exitCode: 0 }
+  }
+
+  if (!invocation.commandName) {
+    return emitHostFailure(
+      invocation,
+      io,
+      "PLUGIN_COMMAND_REQUIRED",
+      new Error(`Plugin namespace "${namespace}" requires a command name.`)
+    )
+  }
+
+  const command = loaded.plugin.commands[invocation.commandName]
+  if (!command) {
+    const available = Object.keys(loaded.plugin.commands).sort().join(", ") || "none"
+    return emitHostFailure(
+      invocation,
+      io,
+      "PLUGIN_COMMAND_UNKNOWN",
+      new Error(
+        `Plugin "${namespace}" has no command "${invocation.commandName}". Available commands: ${available}.`
+      )
+    )
+  }
+
+  const diagnostics = []
+  const abortController = options.abortController ?? new AbortController()
+  const cleanupSignals = installSignalHandlers(abortController, options.installSignalHandlers)
+  const runNative = options.runNative ?? spawnNative
+  const nativeExecutable = options.nativeExecutable
+  const host = createHost({
+    config,
+    diagnostics,
+    abortController,
+    runNative,
+    nativeExecutable,
+    cwd: options.cwd ?? process.cwd(),
+  })
+
+  try {
+    const rawResult = await command.run({
+      args: invocation.commandArgs,
+      options: loaded.options,
+      json: invocation.json,
+      interactive: isInteractive(invocation, options.interactive),
+      signal: abortController.signal,
+      host,
+    })
+    if (abortController.signal.aborted) {
+      const exitCode = abortExitCode(abortController.signal.reason)
+      return emitHostFailure(
+        invocation,
+        io,
+        "PLUGIN_CANCELLED",
+        cancellationError(abortController.signal.reason),
+        exitCode
+      )
+    }
+    const result = normalizeResult(rawResult, diagnostics)
+    emitResult(invocation, io, result)
+    return { handled: true, exitCode: result.exitCode }
+  } catch (error) {
+    if (abortController.signal.aborted) {
+      const exitCode = abortExitCode(abortController.signal.reason)
+      return emitHostFailure(
+        invocation,
+        io,
+        "PLUGIN_CANCELLED",
+        cancellationError(abortController.signal.reason, error),
+        exitCode
+      )
+    }
+    return emitHostFailure(invocation, io, "PLUGIN_COMMAND_FAILED", error)
+  } finally {
+    cleanupSignals()
+  }
+}
+
+export async function loadPlugins(config, importPlugin = importPluginFromConfig) {
+  const registry = new Map()
+
+  for (const declaration of config.plugins ?? []) {
+    const [specifier, pluginOptions] = normalizeDeclaration(declaration)
+    let imported
+    try {
+      imported = await importPlugin(specifier, config.configPath)
+    } catch (error) {
+      throw codedError(
+        "PLUGIN_MISSING",
+        `Could not load configured Palamedes plugin "${specifier}": ${errorMessage(error)}`
+      )
+    }
+
+    const plugin = imported?.default ?? imported?.plugin ?? imported
+    validatePlugin(plugin, specifier)
+
+    if (registry.has(plugin.name)) {
+      throw codedError(
+        "PLUGIN_NAMESPACE_COLLISION",
+        `Multiple configured plugins declare the namespace "${plugin.name}".`
+      )
+    }
+    registry.set(plugin.name, { plugin, options: pluginOptions, specifier })
+  }
+
+  return registry
+}
+
+function parseInvocation(argv) {
+  const commandArgs = []
+  let configPath
+  let json = false
+  let passthrough = false
+
+  for (let index = 2; index < argv.length; index += 1) {
+    const value = argv[index]
+    if (passthrough) {
+      commandArgs.push(value)
+      continue
+    }
+    if (value === "--") {
+      passthrough = true
+      continue
+    }
+    if (value === "--json") {
+      json = true
+      continue
+    }
+    if (value === "--config" || value === "-c") {
+      const next = argv[index + 1]
+      if (!next || next.startsWith("-")) {
+        throw new Error(`${value} requires a path.`)
+      }
+      configPath = next
+      index += 1
+      continue
+    }
+    if (value.startsWith("--config=")) {
+      configPath = value.slice("--config=".length)
+      if (!configPath) {
+        throw new Error("--config requires a path.")
+      }
+      continue
+    }
+    commandArgs.push(value)
+  }
+
+  return {
+    namespace: argv[0],
+    commandName: argv[1],
+    commandArgs,
+    configPath,
+    json,
+  }
+}
+
+function createHost({ config, diagnostics, abortController, runNative, nativeExecutable, cwd }) {
+  return Object.freeze({
+    apiVersion: PALAMEDES_PLUGIN_API_VERSION,
+    config,
+    catalogs() {
+      return config.catalogs.map((catalog) => ({
+        path: catalog.path,
+        format: catalog.format ?? "po",
+        include: [...catalog.include],
+        exclude: [...(catalog.exclude ?? [])],
+        locales: config.locales.map((locale) => ({
+          locale,
+          path: path.resolve(config.rootDir, catalog.path.replace("{locale}", locale)),
+        })),
+      }))
+    },
+    async runBuiltIn(args) {
+      if (!Array.isArray(args) || args.length === 0 || !BUILT_IN_NAMESPACES.has(args[0])) {
+        throw new Error(
+          `runBuiltIn requires a built-in command (${[...BUILT_IN_NAMESPACES].join(", ")}).`
+        )
+      }
+      const exitCode = await runNative(args, {
+        cwd,
+        signal: abortController.signal,
+        nativeExecutable,
+      })
+      return { exitCode }
+    },
+    reportDiagnostic(diagnostic) {
+      diagnostics.push(normalizeDiagnostic(diagnostic))
+    },
+  })
+}
+
+function validatePlugin(plugin, specifier) {
+  if (!plugin || typeof plugin !== "object" || Array.isArray(plugin)) {
+    throw codedError(
+      "PLUGIN_INVALID",
+      `Palamedes plugin "${specifier}" must export a plugin object.`
+    )
+  }
+  if (typeof plugin.name !== "string" || !NAME_PATTERN.test(plugin.name)) {
+    throw codedError(
+      "PLUGIN_INVALID",
+      `Palamedes plugin "${specifier}" must declare a lowercase kebab-case name.`
+    )
+  }
+  if (BUILT_IN_NAMESPACES.has(plugin.name)) {
+    throw codedError(
+      "PLUGIN_NAMESPACE_COLLISION",
+      `Plugin namespace "${plugin.name}" collides with a built-in pmds command.`
+    )
+  }
+  if (plugin.apiVersion !== PALAMEDES_PLUGIN_API_VERSION) {
+    throw codedError(
+      "PLUGIN_API_INCOMPATIBLE",
+      `Plugin "${plugin.name}" requires Palamedes plugin API ${String(plugin.apiVersion)}; this CLI supports ${PALAMEDES_PLUGIN_API_VERSION}.`
+    )
+  }
+  if (!plugin.commands || typeof plugin.commands !== "object" || Array.isArray(plugin.commands)) {
+    throw codedError("PLUGIN_INVALID", `Plugin "${plugin.name}" must declare a commands object.`)
+  }
+  for (const [name, command] of Object.entries(plugin.commands)) {
+    if (!NAME_PATTERN.test(name) || !command || typeof command.run !== "function") {
+      throw codedError(
+        "PLUGIN_INVALID",
+        `Plugin "${plugin.name}" command "${name}" must be lowercase kebab-case and provide run().`
+      )
+    }
+  }
+}
+
+async function importPluginFromConfig(specifier, configPath) {
+  const require = createRequire(configPath)
+  const resolved = require.resolve(specifier)
+  return import(pathToFileURL(resolved).href)
+}
+
+function normalizeDeclaration(declaration) {
+  return typeof declaration === "string" ? [declaration, undefined] : declaration
+}
+
+function normalizeResult(rawResult, reportedDiagnostics) {
+  let result
+  if (rawResult === undefined) {
+    result = {}
+  } else if (typeof rawResult === "string") {
+    result = { text: rawResult }
+  } else if (isStructuredResult(rawResult)) {
+    result = rawResult
+  } else {
+    result = { data: rawResult }
+  }
+
+  const diagnostics = [
+    ...reportedDiagnostics,
+    ...(result.diagnostics ?? []).map(normalizeDiagnostic),
+  ]
+  const defaultExitCode = diagnostics.some((diagnostic) => diagnostic.severity === "error") ? 1 : 0
+  const exitCode = result.exitCode ?? defaultExitCode
+  if (!Number.isInteger(exitCode) || exitCode < 0 || exitCode > 255) {
+    throw new Error("Plugin command exitCode must be an integer from 0 to 255.")
+  }
+  return {
+    exitCode,
+    ...(result.text !== undefined ? { text: String(result.text) } : {}),
+    ...(Object.hasOwn(result, "data") ? { data: result.data } : {}),
+    diagnostics,
+  }
+}
+
+function isStructuredResult(value) {
+  return (
+    value &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    ["exitCode", "text", "data", "diagnostics"].some((key) => Object.hasOwn(value, key))
+  )
+}
+
+function normalizeDiagnostic(diagnostic) {
+  if (!diagnostic || typeof diagnostic !== "object") {
+    throw new Error("Plugin diagnostics must be objects.")
+  }
+  if (!new Set(["info", "warning", "error"]).has(diagnostic.severity)) {
+    throw new Error("Plugin diagnostic severity must be info, warning, or error.")
+  }
+  if (typeof diagnostic.message !== "string" || diagnostic.message.length === 0) {
+    throw new Error("Plugin diagnostic message must be a non-empty string.")
+  }
+  return {
+    severity: diagnostic.severity,
+    message: diagnostic.message,
+    ...(diagnostic.code ? { code: String(diagnostic.code) } : {}),
+    ...(Object.hasOwn(diagnostic, "details") ? { details: diagnostic.details } : {}),
+  }
+}
+
+function emitResult(invocation, io, result) {
+  if (invocation.json) {
+    io.stdout(
+      `${JSON.stringify({
+        ok: result.exitCode === 0,
+        plugin: invocation.namespace,
+        command: invocation.commandName,
+        exitCode: result.exitCode,
+        result: Object.hasOwn(result, "data") ? result.data : (result.text ?? null),
+        diagnostics: result.diagnostics,
+      })}\n`
+    )
+    return
+  }
+
+  if (result.text) {
+    io.stdout(`${result.text}\n`)
+  } else if (Object.hasOwn(result, "data")) {
+    io.stdout(`${JSON.stringify(result.data, null, 2)}\n`)
+  }
+  for (const diagnostic of result.diagnostics) {
+    io.stderr(`${formatDiagnostic(diagnostic)}\n`)
+  }
+}
+
+function emitHostFailure(invocation, io, code, error, exitCode = 1) {
+  const diagnostic = {
+    severity: "error",
+    code,
+    message: errorMessage(error),
+  }
+  if (invocation.json) {
+    io.stdout(
+      `${JSON.stringify({
+        ok: false,
+        plugin: invocation.namespace,
+        command: invocation.commandName ?? null,
+        exitCode,
+        result: null,
+        diagnostics: [diagnostic],
+      })}\n`
+    )
+  } else {
+    io.stderr(`${formatDiagnostic(diagnostic)}\n`)
+  }
+  return { handled: true, exitCode }
+}
+
+function formatDiagnostic(diagnostic) {
+  const code = diagnostic.code ? ` ${diagnostic.code}` : ""
+  return `[${diagnostic.severity}${code}] ${diagnostic.message}`
+}
+
+function installSignalHandlers(abortController, enabled = true) {
+  if (!enabled) return () => {}
+  const onInterrupt = () => abortController.abort({ signal: "SIGINT", exitCode: 130 })
+  const onTerminate = () => abortController.abort({ signal: "SIGTERM", exitCode: 143 })
+  process.once("SIGINT", onInterrupt)
+  process.once("SIGTERM", onTerminate)
+  return () => {
+    process.off("SIGINT", onInterrupt)
+    process.off("SIGTERM", onTerminate)
+  }
+}
+
+function abortExitCode(reason) {
+  return Number.isInteger(reason?.exitCode) ? reason.exitCode : 130
+}
+
+function isInteractive(invocation, override) {
+  if (invocation.json) return false
+  if (override !== undefined) return Boolean(override)
+  return Boolean(process.stdin.isTTY && process.stdout.isTTY && !process.env.CI)
+}
+
+function cancellationError(reason, fallback) {
+  if (reason?.signal) {
+    return new Error(`Plugin command cancelled by ${reason.signal}.`)
+  }
+  return fallback instanceof Error ? fallback : new Error("Plugin command cancelled.")
+}
+
+async function loadConfigFromPackage(options) {
+  const { loadPalamedesConfig } = await import("@palamedes/config")
+  return loadPalamedesConfig(options)
+}
+
+function isConfigNotFound(error) {
+  return errorMessage(error).startsWith("Could not find a Palamedes config.")
+}
+
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function codedError(code, message) {
+  const error = new Error(message)
+  error.code = code
+  return error
+}
+
+function defaultIo() {
+  return {
+    stdout: (value) => process.stdout.write(value),
+    stderr: (value) => process.stderr.write(value),
+  }
+}

--- a/packages/cli/scripts/plugin-host.test.mjs
+++ b/packages/cli/scripts/plugin-host.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict"
 import path from "node:path"
 import test from "node:test"
 
+import { spawnNative } from "./native.mjs"
 import { tryRunPluginCommand } from "./plugin-host.mjs"
 import { runCli } from "./run.mjs"
 
@@ -42,6 +43,18 @@ test("plugin resolution accepts CommonJS package exports", async () => {
 
   assert.deepEqual(result, { handled: true, exitCode: 0 })
   assert.equal(io.stdoutText(), "pong\n")
+})
+
+test("plugin resolution accepts import-only ESM package exports", async () => {
+  const io = captureIo()
+  const result = await tryRunPluginCommand(["import-only", "ping"], {
+    io,
+    loadConfig: async () => loadedConfig(["palamedes-import-only-plugin-fixture"]),
+    installSignalHandlers: false,
+  })
+
+  assert.deepEqual(result, { handled: true, exitCode: 0 })
+  assert.equal(io.stdoutText(), "esm pong\n")
 })
 
 test("built-in commands bypass plugin config and preserve native exit codes", async () => {
@@ -193,7 +206,45 @@ test("host API can run a built-in command without exposing native internals", as
   assert.equal(result.exitCode, 4)
   assert.deepEqual(builtInInvocation.args, ["report", "--json"])
   assert.equal(builtInInvocation.options.nativeExecutable, "/fixture/pmds-native")
+  assert.equal(builtInInvocation.options.captureOutput, true)
   assert.deepEqual(JSON.parse(io.stdoutText()).result, { exitCode: 4 })
+})
+
+test("nested built-in output is captured inside the plugin JSON envelope", async () => {
+  const io = captureIo()
+  const result = await runWithPlugin(
+    {
+      name: "workflow",
+      apiVersion: 1,
+      commands: {
+        report: {
+          async run({ host }) {
+            return { data: await host.runBuiltIn(["report", "--json"]) }
+          },
+        },
+      },
+    },
+    ["workflow", "report", "--json"],
+    {
+      io,
+      async runNative(_args, options) {
+        assert.equal(options.captureOutput, true)
+        return {
+          exitCode: 0,
+          stdout: '{"complete":true}\n',
+          stderr: "native warning\n",
+        }
+      },
+    }
+  )
+
+  assert.equal(result.exitCode, 0)
+  assert.equal(io.stdoutText().trim().split("\n").length, 1)
+  assert.deepEqual(JSON.parse(io.stdoutText()).result, {
+    exitCode: 0,
+    stdout: '{"complete":true}\n',
+    stderr: "native warning\n",
+  })
 })
 
 test("missing and incompatible plugins fail clearly", async (t) => {
@@ -271,6 +322,18 @@ test("cancellation uses shell-compatible exit code 130", async () => {
 
   assert.equal(result.exitCode, 130)
   assert.equal(JSON.parse(io.stdoutText()).diagnostics[0].code, "PLUGIN_CANCELLED")
+})
+
+test("a pre-aborted native invocation never starts work", async () => {
+  const abortController = new AbortController()
+  abortController.abort({ signal: "SIGINT", exitCode: 130 })
+
+  const result = await spawnNative(["-e", "process.exit(99)"], {
+    nativeExecutable: process.execPath,
+    signal: abortController.signal,
+  })
+
+  assert.equal(result, 130)
 })
 
 test("unknown namespaces remain native CLI concerns", async () => {

--- a/packages/cli/scripts/plugin-host.test.mjs
+++ b/packages/cli/scripts/plugin-host.test.mjs
@@ -1,0 +1,325 @@
+import assert from "node:assert/strict"
+import path from "node:path"
+import test from "node:test"
+
+import { tryRunPluginCommand } from "./plugin-host.mjs"
+import { runCli } from "./run.mjs"
+
+const fixtureRoot = path.resolve(import.meta.dirname, "../fixtures/plugin-project")
+const fixtureConfigPath = path.join(fixtureRoot, "palamedes.config.mjs")
+
+test("fixture plugin registers a namespaced command with resolved config and catalogs", async () => {
+  const io = captureIo()
+  const result = await tryRunPluginCommand(
+    ["example", "inspect", "--json", "first", "--", "--json"],
+    {
+      io,
+      loadConfig: async () => loadedConfig([["./example-plugin.mjs", { greeting: "hello" }]]),
+      installSignalHandlers: false,
+    }
+  )
+
+  assert.deepEqual(result, { handled: true, exitCode: 0 })
+  assert.equal(io.stderrText(), "")
+  const output = JSON.parse(io.stdoutText())
+  assert.equal(output.ok, true)
+  assert.equal(output.plugin, "example")
+  assert.equal(output.command, "inspect")
+  assert.deepEqual(output.result.args, ["first", "--json"])
+  assert.deepEqual(output.result.catalogs[0].locales, [
+    { locale: "en", path: path.join(fixtureRoot, "locales/en/messages") },
+    { locale: "de", path: path.join(fixtureRoot, "locales/de/messages") },
+  ])
+})
+
+test("plugin resolution accepts CommonJS package exports", async () => {
+  const io = captureIo()
+  const result = await tryRunPluginCommand(["commonjs", "ping"], {
+    io,
+    loadConfig: async () => loadedConfig(["./commonjs-plugin.cjs"]),
+    installSignalHandlers: false,
+  })
+
+  assert.deepEqual(result, { handled: true, exitCode: 0 })
+  assert.equal(io.stdoutText(), "pong\n")
+})
+
+test("built-in commands bypass plugin config and preserve native exit codes", async () => {
+  let pluginHostCalled = false
+  let nativeArgs
+  const result = await runCli(["report", "--json"], {
+    nativeExecutable: fixtureConfigPath,
+    async tryRunPluginCommand() {
+      pluginHostCalled = true
+      return { handled: false, exitCode: 0 }
+    },
+    async runNative(args) {
+      nativeArgs = args
+      return 7
+    },
+  })
+
+  assert.equal(result, 7)
+  assert.equal(pluginHostCalled, false)
+  assert.deepEqual(nativeArgs, ["report", "--json"])
+})
+
+test("plugin text, diagnostics, and exit codes use a stable text contract", async () => {
+  const io = captureIo()
+  const result = await runWithPlugin(
+    {
+      name: "quality",
+      apiVersion: 1,
+      commands: {
+        check: {
+          run({ host }) {
+            host.reportDiagnostic({
+              severity: "warning",
+              code: "QUALITY_STALE",
+              message: "One catalog is stale.",
+            })
+            return { text: "Checked catalogs", exitCode: 3 }
+          },
+        },
+      },
+    },
+    ["quality", "check"],
+    { io }
+  )
+
+  assert.deepEqual(result, { handled: true, exitCode: 3 })
+  assert.equal(io.stdoutText(), "Checked catalogs\n")
+  assert.equal(io.stderrText(), "[warning QUALITY_STALE] One catalog is stale.\n")
+})
+
+test("plugin failures produce one machine-readable JSON envelope", async () => {
+  const io = captureIo()
+  const result = await runWithPlugin(
+    {
+      name: "failing",
+      apiVersion: 1,
+      commands: {
+        sync: {
+          run() {
+            throw new Error("Remote workflow failed")
+          },
+        },
+      },
+    },
+    ["failing", "sync", "--json"],
+    { io }
+  )
+
+  assert.deepEqual(result, { handled: true, exitCode: 1 })
+  assert.equal(io.stderrText(), "")
+  assert.deepEqual(JSON.parse(io.stdoutText()), {
+    ok: false,
+    plugin: "failing",
+    command: "sync",
+    exitCode: 1,
+    result: null,
+    diagnostics: [
+      {
+        severity: "error",
+        code: "PLUGIN_COMMAND_FAILED",
+        message: "Remote workflow failed",
+      },
+    ],
+  })
+})
+
+test("JSON commands are explicitly non-interactive", async () => {
+  const io = captureIo()
+  const result = await runWithPlugin(
+    {
+      name: "automation",
+      apiVersion: 1,
+      commands: {
+        inspect: {
+          run({ interactive }) {
+            return { data: { interactive } }
+          },
+        },
+      },
+    },
+    ["automation", "inspect", "--json"],
+    { io, interactive: true }
+  )
+
+  assert.equal(result.exitCode, 0)
+  assert.deepEqual(JSON.parse(io.stdoutText()).result, { interactive: false })
+})
+
+test("reserved plugin arguments fail through the same JSON contract", async () => {
+  const io = captureIo()
+  const result = await tryRunPluginCommand(["example", "inspect", "--config", "--json"], {
+    io,
+    installSignalHandlers: false,
+  })
+
+  assert.equal(result.exitCode, 1)
+  const output = JSON.parse(io.stdoutText())
+  assert.equal(output.diagnostics[0].code, "PLUGIN_ARGUMENT_INVALID")
+  assert.match(output.diagnostics[0].message, /--config requires a path/u)
+})
+
+test("host API can run a built-in command without exposing native internals", async () => {
+  let builtInInvocation
+  const io = captureIo()
+  const result = await runWithPlugin(
+    {
+      name: "workflow",
+      apiVersion: 1,
+      commands: {
+        report: {
+          async run({ host }) {
+            const builtIn = await host.runBuiltIn(["report", "--json"])
+            return { data: builtIn, exitCode: builtIn.exitCode }
+          },
+        },
+      },
+    },
+    ["workflow", "report", "--json"],
+    {
+      io,
+      async runNative(args, options) {
+        builtInInvocation = { args, options }
+        return 4
+      },
+      nativeExecutable: "/fixture/pmds-native",
+    }
+  )
+
+  assert.equal(result.exitCode, 4)
+  assert.deepEqual(builtInInvocation.args, ["report", "--json"])
+  assert.equal(builtInInvocation.options.nativeExecutable, "/fixture/pmds-native")
+  assert.deepEqual(JSON.parse(io.stdoutText()).result, { exitCode: 4 })
+})
+
+test("missing and incompatible plugins fail clearly", async (t) => {
+  await t.test("missing package", async () => {
+    const io = captureIo()
+    const result = await tryRunPluginCommand(["missing", "sync"], {
+      io,
+      loadConfig: async () => loadedConfig(["@missing/palamedes-plugin"]),
+      async importPlugin() {
+        throw new Error("module not found")
+      },
+      installSignalHandlers: false,
+    })
+    assert.equal(result.exitCode, 1)
+    assert.match(io.stderrText(), /PLUGIN_MISSING.*@missing\/palamedes-plugin.*module not found/u)
+  })
+
+  await t.test("incompatible API version", async () => {
+    const io = captureIo()
+    const result = await runWithPlugin(
+      { name: "future", apiVersion: 2, commands: {} },
+      ["future", "sync"],
+      { io }
+    )
+    assert.equal(result.exitCode, 1)
+    assert.match(io.stderrText(), /PLUGIN_API_INCOMPATIBLE.*supports 1/u)
+  })
+})
+
+test("namespace collisions are rejected deterministically", async (t) => {
+  await t.test("built-in collision", async () => {
+    const io = captureIo()
+    const result = await runWithPlugin(
+      { name: "extract", apiVersion: 1, commands: {} },
+      ["other", "sync"],
+      { io }
+    )
+    assert.equal(result.exitCode, 1)
+    assert.match(io.stderrText(), /PLUGIN_NAMESPACE_COLLISION.*built-in/u)
+  })
+
+  await t.test("duplicate plugin namespaces", async () => {
+    const io = captureIo()
+    const plugin = { name: "duplicate", apiVersion: 1, commands: {} }
+    const result = await tryRunPluginCommand(["duplicate", "sync"], {
+      io,
+      loadConfig: async () => loadedConfig(["one", "two"]),
+      importPlugin: async () => ({ default: plugin }),
+      installSignalHandlers: false,
+    })
+    assert.equal(result.exitCode, 1)
+    assert.match(io.stderrText(), /PLUGIN_NAMESPACE_COLLISION.*Multiple configured plugins/u)
+  })
+})
+
+test("cancellation uses shell-compatible exit code 130", async () => {
+  const io = captureIo()
+  const abortController = new AbortController()
+  abortController.abort({ signal: "SIGINT", exitCode: 130 })
+  const result = await runWithPlugin(
+    {
+      name: "cancel",
+      apiVersion: 1,
+      commands: {
+        wait: {
+          run({ signal }) {
+            throw signal.reason
+          },
+        },
+      },
+    },
+    ["cancel", "wait", "--json"],
+    { io, abortController }
+  )
+
+  assert.equal(result.exitCode, 130)
+  assert.equal(JSON.parse(io.stdoutText()).diagnostics[0].code, "PLUGIN_CANCELLED")
+})
+
+test("unknown namespaces remain native CLI concerns", async () => {
+  const result = await runWithPlugin(
+    { name: "known", apiVersion: 1, commands: {} },
+    ["unknown", "command"],
+    { io: captureIo() }
+  )
+  assert.deepEqual(result, { handled: false, exitCode: 0 })
+})
+
+test("projects without configured plugins do not intercept commands", async () => {
+  const result = await tryRunPluginCommand(["unknown", "command"], {
+    io: captureIo(),
+    loadConfig: async () => loadedConfig(undefined),
+    installSignalHandlers: false,
+  })
+
+  assert.deepEqual(result, { handled: false, exitCode: 0 })
+})
+
+async function runWithPlugin(plugin, argv, options = {}) {
+  return tryRunPluginCommand(argv, {
+    loadConfig: async () => loadedConfig(["fixture-plugin"]),
+    importPlugin: async () => ({ default: plugin }),
+    installSignalHandlers: false,
+    ...options,
+  })
+}
+
+function loadedConfig(plugins) {
+  return {
+    configPath: fixtureConfigPath,
+    rootDir: fixtureRoot,
+    sourceReferenceRoot: fixtureRoot,
+    locales: ["en", "de"],
+    sourceLocale: "en",
+    catalogs: [{ path: "locales/{locale}/messages", include: ["src"] }],
+    plugins,
+  }
+}
+
+function captureIo() {
+  const stdout = []
+  const stderr = []
+  return {
+    stdout: (value) => stdout.push(value),
+    stderr: (value) => stderr.push(value),
+    stdoutText: () => stdout.join(""),
+    stderrText: () => stderr.join(""),
+  }
+}

--- a/packages/cli/scripts/run.mjs
+++ b/packages/cli/scripts/run.mjs
@@ -1,0 +1,68 @@
+import { existsSync } from "node:fs"
+import path from "node:path"
+
+import { spawnNative } from "./native.mjs"
+
+const BUILT_IN_COMMANDS = new Set(["extract", "audit", "report", "catalog", "version"])
+
+export async function runCli(argv, options = {}) {
+  const nativeExecutable = options.nativeExecutable ?? resolveNativeExecutable()
+  const runNative = options.runNative ?? spawnNative
+
+  if (shouldDelegateDirectly(argv)) {
+    return runNativeChecked(argv, { ...options, nativeExecutable, runNative })
+  }
+
+  let pluginResult
+  try {
+    const tryPlugin =
+      options.tryRunPluginCommand ?? (await import("./plugin-host.mjs")).tryRunPluginCommand
+    pluginResult = await tryPlugin(argv, {
+      ...options,
+      nativeExecutable,
+      runNative,
+    })
+  } catch (error) {
+    const stderr = options.io?.stderr ?? ((value) => process.stderr.write(value))
+    stderr(`[error PLUGIN_HOST_FAILED] ${error instanceof Error ? error.message : String(error)}\n`)
+    return 1
+  }
+
+  if (pluginResult.handled) {
+    return pluginResult.exitCode
+  }
+  return runNativeChecked(argv, { ...options, nativeExecutable, runNative })
+}
+
+function shouldDelegateDirectly(argv) {
+  return argv.length === 0 || argv[0].startsWith("-") || BUILT_IN_COMMANDS.has(argv[0])
+}
+
+async function runNativeChecked(argv, options) {
+  if (!options.nativeExecutable || !existsSync(options.nativeExecutable)) {
+    const stderr = options.io?.stderr ?? ((value) => process.stderr.write(value))
+    stderr("Palamedes CLI native binary was not installed for this platform.\n")
+    return 1
+  }
+  try {
+    return await options.runNative(argv, {
+      cwd: options.cwd ?? process.cwd(),
+      nativeExecutable: options.nativeExecutable,
+    })
+  } catch (error) {
+    const stderr = options.io?.stderr ?? ((value) => process.stderr.write(value))
+    stderr(
+      `Could not run Palamedes native CLI: ${error instanceof Error ? error.message : String(error)}\n`
+    )
+    return 1
+  }
+}
+
+function resolveNativeExecutable() {
+  const packageDir = path.resolve(import.meta.dirname, "..")
+  return path.join(
+    packageDir,
+    "bin",
+    process.platform === "win32" ? "pmds-native.exe" : "pmds-native"
+  )
+}

--- a/packages/cli/scripts/smoke.mjs
+++ b/packages/cli/scripts/smoke.mjs
@@ -30,9 +30,36 @@ const output = execFileSync(command, args, {
   cwd: packageDir,
   encoding: "utf8",
 })
+const nativeBin = path.join(
+  packageDir,
+  "bin",
+  process.platform === "win32" ? "pmds-native.exe" : "pmds-native"
+)
+const nativeOutput = execFileSync(nativeBin, ["version"], {
+  cwd: packageDir,
+  encoding: "utf8",
+})
 
 if (!output.includes("pmds (Palamedes)")) {
   throw new Error(`Unexpected pmds version output: ${output}`)
+}
+if (output !== nativeOutput) {
+  throw new Error("The npm wrapper changed built-in version output.")
+}
+
+const fixtureConfig = path.join(packageDir, "fixtures", "plugin-project", "palamedes.config.mjs")
+const pluginArgs = ["example", "inspect", "--config", fixtureConfig, "--json", "smoke"]
+const pluginOutput = execFileSync(
+  command,
+  process.platform === "win32" ? [publicBin, ...pluginArgs] : pluginArgs,
+  {
+    cwd: packageDir,
+    encoding: "utf8",
+  }
+)
+const pluginResult = JSON.parse(pluginOutput)
+if (!pluginResult.ok || pluginResult.result?.args?.[0] !== "smoke") {
+  throw new Error(`Unexpected pmds plugin output: ${pluginOutput}`)
 }
 
 function resolvePlatformPackage() {

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -5,5 +5,5 @@
     "rootDir": "src",
     "types": ["node"]
   },
-  "include": ["src/index.ts"]
+  "include": ["src/index.ts", "plugin-api.d.ts"]
 }

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -31,6 +31,7 @@ catalogs:
 - `expandFallbackLocales(locales, fallbackLocales?)`
 - `resolveCatalogPath(config, catalogPath, locale)`
 - `resolveConfigPattern(config, pattern)`
+- `PalamedesPluginDeclaration` (TypeScript)
 
 ## Configuration Notes
 
@@ -46,6 +47,9 @@ catalogs:
   relative to the config directory, or pass a custom path.
 - `catalogs[].format` defaults to `"po"`. Set it to `"fcl"` to use Ferrocat
   Catalog Lines for canonical, merge-friendly generated catalog storage.
+- `plugins` explicitly lists CLI plugin package specifiers or
+  `[specifier, options]` pairs. Packages are never auto-discovered, and built-in
+  CLI commands do not load them.
 - `loadPalamedesConfig()` returns `sourceReferenceRoot` in addition to
   `configPath` and `rootDir`; pass `skipValidation` only when inspecting a
   partially-authored config file.

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -27,6 +27,8 @@ export type PalamedesCatalogConfig = {
   exclude?: string[]
 }
 
+export type PalamedesPluginDeclaration = string | readonly [specifier: string, options: unknown]
+
 export type PalamedesConfig = {
   locales: string[]
   sourceLocale: string
@@ -34,6 +36,7 @@ export type PalamedesConfig = {
   pseudoLocale?: string
   sourceReferenceRoot?: PalamedesSourceReferenceRoot
   catalogs: PalamedesCatalogConfig[]
+  plugins?: PalamedesPluginDeclaration[]
 }
 
 type PalamedesDataConfig = {
@@ -47,6 +50,7 @@ type PalamedesDataConfig = {
   "source-reference-root"?: unknown
   source_reference_root?: unknown
   catalogs?: unknown
+  plugins?: unknown
 }
 
 export type LoadedPalamedesConfig = {
@@ -153,6 +157,9 @@ function normalizeDataConfig(config: PalamedesDataConfig): PalamedesConfig {
       ? { sourceReferenceRoot: sourceReferenceRoot as PalamedesSourceReferenceRoot }
       : {}),
     catalogs: config.catalogs as PalamedesCatalogConfig[],
+    ...(config.plugins !== undefined
+      ? { plugins: config.plugins as PalamedesPluginDeclaration[] }
+      : {}),
   }
 }
 
@@ -295,6 +302,7 @@ async function normalizeConfig(
       include: [...catalog.include],
       ...(catalog.exclude ? { exclude: [...catalog.exclude] } : {}),
     })),
+    ...(config.plugins ? { plugins: clonePluginDeclarations(config.plugins) } : {}),
   }
 }
 
@@ -314,7 +322,14 @@ function normalizeConfigSync(config: PalamedesConfig, configPath: string): Loade
       include: [...catalog.include],
       ...(catalog.exclude ? { exclude: [...catalog.exclude] } : {}),
     })),
+    ...(config.plugins ? { plugins: clonePluginDeclarations(config.plugins) } : {}),
   }
+}
+
+function clonePluginDeclarations(
+  plugins: readonly PalamedesPluginDeclaration[]
+): PalamedesPluginDeclaration[] {
+  return plugins.map((plugin) => (typeof plugin === "string" ? plugin : [plugin[0], plugin[1]]))
 }
 
 async function resolveSourceReferenceRoot(
@@ -427,9 +442,37 @@ function validateConfig(config: unknown, configPath: string): asserts config is 
   }
 
   validateFallbackLocales(record.fallbackLocales, configPath)
+  validatePlugins(record.plugins, configPath)
 
   for (const [index, catalog] of record.catalogs.entries()) {
     validateCatalog(catalog, configPath, index)
+  }
+}
+
+function validatePlugins(value: unknown, configPath: string): void {
+  if (value === undefined) {
+    return
+  }
+
+  if (!Array.isArray(value)) {
+    throw new TypeError(`Invalid Palamedes config in ${configPath}: "plugins" must be an array.`)
+  }
+
+  for (const [index, declaration] of value.entries()) {
+    if (typeof declaration === "string" && declaration.trim().length > 0) {
+      continue
+    }
+    if (
+      Array.isArray(declaration) &&
+      declaration.length === 2 &&
+      typeof declaration[0] === "string" &&
+      declaration[0].trim().length > 0
+    ) {
+      continue
+    }
+    throw new TypeError(
+      `Invalid Palamedes config in ${configPath}: "plugins[${index}]" must be a non-empty package specifier or [specifier, options].`
+    )
   }
 }
 

--- a/packages/config/src/loadConfig.test.ts
+++ b/packages/config/src/loadConfig.test.ts
@@ -59,6 +59,9 @@ describe("loadPalamedesConfig", () => {
             format: fcl
             include: [src]
             exclude: [src/generated]
+        plugins:
+          - "@acme/palamedes-workflows"
+          - ["./local-plugin.mjs", { mode: strict }]
       `
     )
 
@@ -73,6 +76,10 @@ describe("loadPalamedesConfig", () => {
       include: ["src"],
       exclude: ["src/generated"],
     })
+    expect(config.plugins).toStrictEqual([
+      "@acme/palamedes-workflows",
+      ["./local-plugin.mjs", { mode: "strict" }],
+    ])
   })
 
   it("loads a palamedes.yaml file synchronously with the same normalization", async () => {
@@ -305,6 +312,25 @@ describe("loadPalamedesConfig", () => {
 
     await expect(loadPalamedesConfig({ cwd: fixtureDir })).rejects.toThrow(
       /"sourceLocale" must be included in "locales"/
+    )
+  })
+
+  it("rejects malformed plugin declarations", async () => {
+    const fixtureDir = await createTempDir()
+    await writeFile(
+      path.join(fixtureDir, "palamedes.config.mjs"),
+      `
+        export default {
+          locales: ["en"],
+          sourceLocale: "en",
+          catalogs: [{ path: "locales/{locale}", include: ["src"] }],
+          plugins: [["@acme/plugin"]],
+        }
+      `
+    )
+
+    await expect(loadPalamedesConfig({ cwd: fixtureDir })).rejects.toThrow(
+      /"plugins\[0\]" must be a non-empty package specifier or \[specifier, options\]/
     )
   })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1273,6 +1273,9 @@ importers:
       '@palamedes/config':
         specifier: workspace:^
         version: link:../config
+      import-meta-resolve:
+        specifier: ^4.2.0
+        version: 4.2.0
     devDependencies:
       '@types/node':
         specifier: ^22.20.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1269,6 +1269,10 @@ importers:
         version: 8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
 
   packages/cli:
+    dependencies:
+      '@palamedes/config':
+        specifier: workspace:^
+        version: link:../config
     devDependencies:
       '@types/node':
         specifier: ^22.20.0


### PR DESCRIPTION
## Summary

- keep the npm `pmds` wrapper as a minimal dispatcher and install the Rust CLI as a private native sidecar
- delegate built-in commands before importing the plugin host or config package
- add explicit config declarations and versioned, namespaced command plugins through `@palamedes/cli/plugin`
- expose resolved config, catalog discovery, structured diagnostics, JSON/text output, cancellation, non-interactive detection, and guarded built-in execution
- add ESM/CommonJS fixtures, deterministic failure handling, security documentation, and ADR 001

## Compatibility and trust

Built-in namespaces (`extract`, `audit`, `report`, `catalog`, and `version`) bypass config and plugin loading and preserve the native sidecar's output and exit code. Installed packages are never discovered automatically.

Configured plugins are trusted project code with normal process permissions; the host is a versioned capability boundary, not a sandbox. API v1 follows Palamedes SemVer. Lifecycle hooks remain intentionally out of scope.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm check:release-set`
- `pnpm format:check`
- `pnpm build`
- `pnpm test`
- `pnpm check-types`
- `pnpm lint:oxlint`
- targeted ESLint for every changed executable file
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `pnpm --filter @palamedes/cli test`
- `pnpm pack --dry-run` (verifies the neutral package excludes the local native sidecar)

The repository-wide local ESLint glob also scans pre-existing ignored/minified `examples/*/build` output; changed source files pass ESLint and clean-checkout CI remains authoritative.

Closes #365