### PR TITLE
chore(deps): update Docker Actions

### DIFF
--- a/.github/workflows/publish-examples-container.yml
+++ b/.github/workflows/publish-examples-container.yml
@@ -77,10 +77,10 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -88,7 +88,7 @@ jobs:
 
       - name: Extract image metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository_owner }}/palamedes-examples
           tags: |
@@ -99,7 +99,7 @@ jobs:
       # runner: the Containerfile compiles the native Rust addon at build time, so
       # an emulated build would be prohibitively slow.
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Containerfile


### PR DESCRIPTION
## Summary

Updates the Docker image publishing action chain together:

- `docker/setup-buildx-action` v3 → v4
- `docker/login-action` v3 → v4
- `docker/metadata-action` v5 → v6
- `docker/build-push-action` v6 → v7

These actions are used by the same image-build job and are kept in one PR so the build, metadata, registry authentication, and push steps remain compatible.

Refs #211.

## Validation

- `git diff --check`
- Confirmed the replaced Docker action references no longer occur in the workflow

GitHub Actions will validate the workflow on the PR.