### PR TITLE
docs: prove lossless ICU semantics across the Palamedes pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,10 @@ jobs:
       - name: Build packages
         run: pnpm build
 
+      - name: Verify ICU semantics proof
+        if: ${{ matrix.full }}
+        run: pnpm proof:icu:check
+
       - name: Build site
         if: ${{ matrix.full }}
         run: pnpm build:site

--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ The same foundation also matters for future translation workflows:
 - [Benchmarking against Lingui v6](https://github.com/sebastian-software/palamedes/blob/main/docs/benchmark-lingui-v6-preview.md)
 - [End-to-end workflow benchmark against Lingui and i18next-parser](https://github.com/sebastian-software/palamedes/blob/main/docs/benchmark-e2e-workflow.md)
 - [Approach comparison across Lingui, next-intl, and GT](https://github.com/sebastian-software/palamedes/blob/main/docs/approach-comparison.md)
+- [Checked ICU semantics proof from source to runtime](https://github.com/sebastian-software/palamedes/blob/main/docs/icu-semantics-proof.md)
 - [Palamedes principles](https://github.com/sebastian-software/palamedes/blob/main/docs/principles.md)
 - [Translation workflow surface](https://github.com/sebastian-software/palamedes/blob/main/docs/translation-workflow-surface.md)
 - [Translation module boundaries](https://github.com/sebastian-software/palamedes/blob/main/docs/translation-module-boundaries.md)

--- a/docs/approach-comparison.md
+++ b/docs/approach-comparison.md
@@ -156,6 +156,25 @@ catalogs, and prefer a narrower system that stays easier to trust.
 It is also for teams that care about not having their i18n strategy become
 framework-fragmented as the application evolves.
 
+## ICU As A Pipeline Contract
+
+ICU support is not a useful yes/no checkbox by itself. A library may use ICU
+natively or through a plugin; a translation platform may edit the raw message,
+split it into forms, convert it into another model, or only validate it.
+
+Palamedes therefore makes a narrower claim about the stages it owns: nested ICU
+selectors remain intact from source through extraction, PO catalog update,
+catalog compilation, and runtime rendering. That claim has a checked fixture
+and command instead of relying on a vendor comparison:
+
+```bash
+pnpm proof:icu
+```
+
+See [ICU Semantics Proof: Source to Runtime](./icu-semantics-proof.md) for the
+reproducible proof, the exact claim boundary, and a dated snapshot of public
+FormatJS, i18next, Crowdin, Phrase, and Weblate documentation.
+
 That is the right way to read the benchmark story as well. The Lingui benchmark
 is not meant to imply that every i18n library should be forced into the same
 race. It exists because Lingui and Palamedes actually run on comparable

--- a/docs/approach-comparison.md
+++ b/docs/approach-comparison.md
@@ -163,9 +163,9 @@ natively or through a plugin; a translation platform may edit the raw message,
 split it into forms, convert it into another model, or only validate it.
 
 Palamedes therefore makes a narrower claim about the stages it owns: nested ICU
-selectors remain intact from source through extraction, PO catalog update,
-catalog compilation, and runtime rendering. That claim has a checked fixture
-and command instead of relying on a vendor comparison:
+selectors remain intact from source through extraction, macro transformation,
+PO catalog update, catalog compilation, and runtime rendering. That claim has a
+checked fixture and command instead of relying on a vendor comparison:
 
 ```bash
 pnpm proof:icu

--- a/docs/icu-semantics-proof.md
+++ b/docs/icu-semantics-proof.md
@@ -4,7 +4,7 @@ Palamedes preserves ICU MessageFormat semantics across every pipeline stage it
 controls:
 
 ```text
-source -> extraction -> PO catalog -> catalog compile -> runtime render
+source -> extraction -> macro transform -> PO catalog -> catalog compile -> runtime render
 ```
 
 That scope is deliberate. A translation management system sits outside the
@@ -25,14 +25,17 @@ The fixture contains a `plural` nested inside both branches of a `select`. The
 proof asserts:
 
 1. extraction returns the exact source ICU message and context;
-2. a PO catalog update retains the exact `msgid`, `msgctxt`, and German
+2. the macro transform binds `role` and `count` to the generated runtime call
+   and emits the same compiled message ID as the catalog compiler;
+3. a PO catalog update retains the exact `msgid`, `msgctxt`, and German
    translation;
-3. source and translation retain the same argument names, selector kinds,
+4. source and translation retain the same argument names, selector kinds,
    branch keys, nesting, and `#` substitutions;
-4. catalog compilation emits the exact translated ICU message without missing
+5. catalog compilation emits the exact translated ICU message without missing
    entries or ICU errors;
-5. the runtime renders six checked combinations across both `select` branches
-   and the `=0`, `one`, and `other` plural branches.
+6. the transformed fixture is imported and renders six checked combinations
+   across both `select` branches and the `=0`, `one`, and `other` plural
+   branches.
 
 The script prints hashes, the normalized selector shape, and the number of
 runtime scenarios after all assertions pass.

--- a/docs/icu-semantics-proof.md
+++ b/docs/icu-semantics-proof.md
@@ -1,0 +1,77 @@
+# ICU Semantics Proof: Source to Runtime
+
+Palamedes preserves ICU MessageFormat semantics across every pipeline stage it
+controls:
+
+```text
+source -> extraction -> PO catalog -> catalog compile -> runtime render
+```
+
+That scope is deliberate. A translation management system sits outside the
+Palamedes boundary, so its import and export behavior depends on the chosen
+product, file format, and project configuration.
+
+## Re-run the claim
+
+```bash
+pnpm proof:icu
+```
+
+The command uses the checked fixture under
+[`proof/icu-semantics`](https://github.com/sebastian-software/palamedes/tree/main/proof/icu-semantics).
+It does not call a hosted service or use a mocked TMS.
+
+The fixture contains a `plural` nested inside both branches of a `select`. The
+proof asserts:
+
+1. extraction returns the exact source ICU message and context;
+2. a PO catalog update retains the exact `msgid`, `msgctxt`, and German
+   translation;
+3. source and translation retain the same argument names, selector kinds,
+   branch keys, nesting, and `#` substitutions;
+4. catalog compilation emits the exact translated ICU message without missing
+   entries or ICU errors;
+5. the runtime renders six checked combinations across both `select` branches
+   and the `=0`, `one`, and `other` plural branches.
+
+The script prints hashes, the normalized selector shape, and the number of
+runtime scenarios after all assertions pass.
+
+## The claim boundary
+
+Safe public wording:
+
+> Palamedes keeps ICU semantics intact from source code through PO catalogs to
+> runtime. Within the stages Palamedes controls, nested selectors are not
+> flattened into a proprietary plural model.
+
+Avoid claiming that every TMS preserves arbitrary ICU messages. Palamedes can
+provide a lossless boundary on both sides of a TMS exchange, but only the
+selected TMS can determine what happens during its import, editing, and export
+steps.
+
+## Public market snapshot
+
+The following examples are a documentation snapshot checked on
+**2026-07-23**, not a permanent or exhaustive ranking:
+
+| Product    | Publicly documented ICU behavior                                                                                                                                                                    |
+| ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| FormatJS   | Uses ICU Message syntax as its native message model, including `plural`, `select`, and `selectordinal`.                                                                                             |
+| i18next    | Uses its own interpolation format by default. ICU is available through an i18n-format plugin; i18next documents that format plugins replace its native plural, interpolation, and context behavior. |
+| Crowdin    | Documents editor support for ICU arguments, nested plurals, target-language plural categories, previews, and syntax errors.                                                                         |
+| Phrase TMS | Parses ICU for supported formats when enabled; parsing is an all-or-nothing file/template setting, and ICU messages cannot be split or joined.                                                      |
+| Weblate    | Documents ICU syntax and placeholder validation as a quality check enabled by a flag and automatically enabled for ARB and FormatJS JSON.                                                           |
+
+Direct sources, all checked 2026-07-23:
+
+- [FormatJS ICU syntax](https://formatjs.github.io/docs/core-concepts/icu-syntax/)
+- [i18next plugins and i18n formats](https://www.i18next.com/overview/plugins-and-utils)
+- [Crowdin ICU Message Syntax](https://support.crowdin.com/icu-message-syntax/)
+- [Phrase ICU Message Format](https://support.phrase.com/hc/en-us/articles/7765077293852-ICU-Message-Format-TMS)
+- [Weblate checks and fixups](https://docs.weblate.org/en/latest/user/checks.html#icu-message-format)
+
+The broader research notes remain under
+[`docs/research/competitors`](https://github.com/sebastian-software/palamedes/tree/main/docs/research/competitors).
+Re-check their dates and primary sources before promoting another comparison
+claim to the public site.

--- a/docs/proof-and-benchmarks.md
+++ b/docs/proof-and-benchmarks.md
@@ -7,12 +7,13 @@ This page shows the work behind that claim. The goal is confidence, not hype.
 
 ## What This Repo Can Prove
 
-This repo can credibly prove four things:
+This repo can credibly prove five things:
 
 - Palamedes is verified across Next.js, TanStack Start, SolidStart, Waku, and React Router
 - the runtime model stays centered on `getI18n()`
 - the message identity model stays centered on `message + context`
 - transform, extract, catalog update, and catalog compile steps are measured locally and reproducibly
+- nested ICU semantics survive source, extraction, PO catalog update, catalog compile, and runtime rendering
 
 This page is not here to manufacture headline numbers. It is here to make the
 evidence easy to inspect.
@@ -137,6 +138,17 @@ That workflow benchmark times source discovery, source parsing needed for
 message extraction, extraction, catalog update/merge, and catalog writes in one
 CLI command per tool. It does not time runtime catalog/artifact compilation,
 type-checking, linting, bundling, or the post-run semantic validation step.
+
+For the checked ICU semantics proof:
+
+```bash
+pnpm proof:icu
+```
+
+This runs one nested `select` + `plural` message through extraction, PO catalog
+update, catalog compilation, and runtime rendering. The exact scope and the
+dated public market snapshot are documented in
+[ICU Semantics Proof: Source to Runtime](./icu-semantics-proof.md).
 
 ## Methodology
 

--- a/docs/proof-and-benchmarks.md
+++ b/docs/proof-and-benchmarks.md
@@ -13,7 +13,7 @@ This repo can credibly prove five things:
 - the runtime model stays centered on `getI18n()`
 - the message identity model stays centered on `message + context`
 - transform, extract, catalog update, and catalog compile steps are measured locally and reproducibly
-- nested ICU semantics survive source, extraction, PO catalog update, catalog compile, and runtime rendering
+- nested ICU semantics survive source, extraction, macro transformation, PO catalog update, catalog compile, and runtime rendering
 
 This page is not here to manufacture headline numbers. It is here to make the
 evidence easy to inspect.
@@ -145,9 +145,10 @@ For the checked ICU semantics proof:
 pnpm proof:icu
 ```
 
-This runs one nested `select` + `plural` message through extraction, PO catalog
-update, catalog compilation, and runtime rendering. The exact scope and the
-dated public market snapshot are documented in
+This runs one nested `select` + `plural` message through extraction, macro
+transformation, PO catalog update, catalog compilation, and execution of the
+transformed runtime function. The exact scope and the dated public market
+snapshot are documented in
 [ICU Semantics Proof: Source to Runtime](./icu-semantics-proof.md).
 
 ## Methodology

--- a/docs/site/comparison.mdx
+++ b/docs/site/comparison.mdx
@@ -52,3 +52,17 @@ Use this framing:
 - "The win is speed in service of a translation model that stays steady."
 - "The same i18n habits keep working across framework boundaries."
 - "The repo shows the work instead of asking for trust."
+- "Palamedes keeps ICU semantics intact across the source, catalog, compile, and runtime stages it controls."
+
+## ICU Claim Boundary
+
+Do not say that every TMS preserves ICU or that Palamedes controls a TMS
+round-trip. Public comparison copy should distinguish:
+
+- the checked Palamedes pipeline proof;
+- dated observations from official competitor and TMS documentation;
+- TMS import/export behavior, which varies by product, format, and project
+  configuration.
+
+The approved proof and current source snapshot live in
+`docs/icu-semantics-proof.md`.

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "benchmark:e2e-workflow:quick": "cargo build --release -p palamedes-cli && pnpm --filter @palamedes/benchmark-e2e-workflow benchmark:quick",
     "benchmark:lingui-v6": "pnpm build && pnpm --filter @palamedes/benchmark-lingui-v6 benchmark",
     "benchmark:lingui-v6:quick": "pnpm build && pnpm --filter @palamedes/benchmark-lingui-v6 benchmark:quick",
+    "proof:icu": "pnpm build && node ./scripts/proof-icu-semantics.mjs",
+    "proof:icu:check": "node ./scripts/proof-icu-semantics.mjs",
     "test": "pnpm -r --filter \"./packages/**\" --if-present test",
     "check:native-types": "pnpm --filter @palamedes/core-node check-native-types",
     "check:release-set": "node ./scripts/check-release-set.mjs",

--- a/proof/icu-semantics/README.md
+++ b/proof/icu-semantics/README.md
@@ -1,0 +1,26 @@
+# ICU semantics proof fixture
+
+This fixture backs the public claim that Palamedes preserves ICU MessageFormat
+semantics across every pipeline stage it controls:
+
+```text
+source -> extraction -> PO catalog update -> catalog compile -> runtime render
+```
+
+The message deliberately nests a `plural` inside both branches of a `select`.
+The German catalog changes the prose while retaining the argument names,
+selector types, branch keys, nesting, and `#` substitutions.
+
+Run the checked proof from the repository root:
+
+```bash
+pnpm proof:icu
+```
+
+The command builds the public packages, performs the pipeline in a temporary
+directory, compares the ICU syntax tree before and after translation, and
+asserts all runtime outputs from `expected.json`.
+
+This fixture does not simulate a translation management system. TMS
+import/export behavior is outside the Palamedes boundary and must be described
+per product, format, configuration, and observation date.

--- a/proof/icu-semantics/README.md
+++ b/proof/icu-semantics/README.md
@@ -4,7 +4,7 @@ This fixture backs the public claim that Palamedes preserves ICU MessageFormat
 semantics across every pipeline stage it controls:
 
 ```text
-source -> extraction -> PO catalog update -> catalog compile -> runtime render
+source -> extraction -> macro transform -> PO catalog update -> catalog compile -> runtime render
 ```
 
 The message deliberately nests a `plural` inside both branches of a `select`.
@@ -17,9 +17,9 @@ Run the checked proof from the repository root:
 pnpm proof:icu
 ```
 
-The command builds the public packages, performs the pipeline in a temporary
-directory, compares the ICU syntax tree before and after translation, and
-asserts all runtime outputs from `expected.json`.
+The command builds the public packages, transforms and executes the fixture in
+a temporary directory, compares the ICU syntax tree before and after
+translation, and asserts all runtime outputs from `expected.json`.
 
 This fixture does not simulate a translation management system. TMS
 import/export behavior is outside the Palamedes boundary and must be described

--- a/proof/icu-semantics/expected.json
+++ b/proof/icu-semantics/expected.json
@@ -1,0 +1,49 @@
+{
+  "message": "{role, select, admin {{count, plural, =0 {No pending approvals} one {# pending approval} other {# pending approvals}}} other {{count, plural, =0 {No pending tasks} one {# pending task} other {# pending tasks}}}}",
+  "context": "dashboard.notifications",
+  "translation": "{role, select, admin {{count, plural, =0 {Keine ausstehenden Freigaben} one {# ausstehende Freigabe} other {# ausstehende Freigaben}}} other {{count, plural, =0 {Keine ausstehenden Aufgaben} one {# ausstehende Aufgabe} other {# ausstehende Aufgaben}}}}",
+  "scenarios": [
+    {
+      "values": {
+        "role": "admin",
+        "count": 0
+      },
+      "output": "Keine ausstehenden Freigaben"
+    },
+    {
+      "values": {
+        "role": "admin",
+        "count": 1
+      },
+      "output": "1 ausstehende Freigabe"
+    },
+    {
+      "values": {
+        "role": "admin",
+        "count": 3
+      },
+      "output": "3 ausstehende Freigaben"
+    },
+    {
+      "values": {
+        "role": "member",
+        "count": 0
+      },
+      "output": "Keine ausstehenden Aufgaben"
+    },
+    {
+      "values": {
+        "role": "member",
+        "count": 1
+      },
+      "output": "1 ausstehende Aufgabe"
+    },
+    {
+      "values": {
+        "role": "member",
+        "count": 4
+      },
+      "output": "4 ausstehende Aufgaben"
+    }
+  ]
+}

--- a/proof/icu-semantics/locales/de/messages.po
+++ b/proof/icu-semantics/locales/de/messages.po
@@ -1,0 +1,13 @@
+msgid ""
+msgstr ""
+"Content-Transfer-Encoding: 8bit\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"X-Generator: palamedes\n"
+
+#. Nested select and plural fixture for the checked ICU semantics proof.
+#: proof/icu-semantics/src/notification-summary.ts#notificationSummary
+msgctxt "dashboard.notifications"
+msgid "{role, select, admin {{count, plural, =0 {No pending approvals} one {# pending approval} other {# pending approvals}}} other {{count, plural, =0 {No pending tasks} one {# pending task} other {# pending tasks}}}}"
+msgstr "{role, select, admin {{count, plural, =0 {Keine ausstehenden Freigaben} one {# ausstehende Freigabe} other {# ausstehende Freigaben}}} other {{count, plural, =0 {Keine ausstehenden Aufgaben} one {# ausstehende Aufgabe} other {# ausstehende Aufgaben}}}}"

--- a/proof/icu-semantics/src/notification-summary.ts
+++ b/proof/icu-semantics/src/notification-summary.ts
@@ -1,0 +1,10 @@
+import { t } from "@palamedes/core/macro"
+
+export function notificationSummary(role: "admin" | "member", count: number) {
+  return t({
+    message:
+      "{role, select, admin {{count, plural, =0 {No pending approvals} one {# pending approval} other {# pending approvals}}} other {{count, plural, =0 {No pending tasks} one {# pending task} other {# pending tasks}}}}",
+    context: "dashboard.notifications",
+    comment: "Nested select and plural fixture for the checked ICU semantics proof.",
+  })
+}

--- a/proof/icu-semantics/src/notification-summary.ts
+++ b/proof/icu-semantics/src/notification-summary.ts
@@ -1,10 +1,13 @@
 import { t } from "@palamedes/core/macro"
 
-export function notificationSummary(role: "admin" | "member", count: number) {
-  return t({
-    message:
-      "{role, select, admin {{count, plural, =0 {No pending approvals} one {# pending approval} other {# pending approvals}}} other {{count, plural, =0 {No pending tasks} one {# pending task} other {# pending tasks}}}}",
-    context: "dashboard.notifications",
-    comment: "Nested select and plural fixture for the checked ICU semantics proof.",
-  })
+export function notificationSummary(role, count) {
+  return t(
+    {
+      message:
+        "{role, select, admin {{count, plural, =0 {No pending approvals} one {# pending approval} other {# pending approvals}}} other {{count, plural, =0 {No pending tasks} one {# pending task} other {# pending tasks}}}}",
+      context: "dashboard.notifications",
+      comment: "Nested select and plural fixture for the checked ICU semantics proof.",
+    },
+    { role, count }
+  )
 }

--- a/scripts/proof-icu-semantics.mjs
+++ b/scripts/proof-icu-semantics.mjs
@@ -1,0 +1,200 @@
+import assert from "node:assert/strict"
+import { createHash } from "node:crypto"
+import { copyFile, mkdir, mkdtemp, readFile, rm } from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { pathToFileURL } from "node:url"
+
+const repoRoot = path.resolve(import.meta.dirname, "..")
+const fixtureRoot = path.join(repoRoot, "proof", "icu-semantics")
+const fixtureSourcePath = path.join(fixtureRoot, "src", "notification-summary.ts")
+const fixtureSourceName = "proof/icu-semantics/src/notification-summary.ts"
+const fixtureTranslationPath = path.join(fixtureRoot, "locales", "de", "messages.po")
+const expected = JSON.parse(await readFile(path.join(fixtureRoot, "expected.json"), "utf8"))
+
+const coreNode = await import(
+  pathToFileURL(path.join(repoRoot, "packages", "core-node", "dist", "index.mjs")).href
+)
+const core = await import(
+  pathToFileURL(path.join(repoRoot, "packages", "core", "dist", "index.mjs")).href
+)
+
+const { compileCatalogArtifact, extractMessagesNative, parsePo, updateCatalogFile } = coreNode
+const { createI18n, parseMessagePattern } = core
+
+const tempRoot = await mkdtemp(path.join(os.tmpdir(), "palamedes-icu-proof-"))
+
+try {
+  const source = await readFile(fixtureSourcePath, "utf8")
+  const extracted = extractMessagesNative(source, fixtureSourceName)
+
+  assert.equal(extracted.length, 1, "the fixture must extract exactly one message")
+  assert.equal(extracted[0].message, expected.message, "extraction changed the ICU source")
+  assert.equal(extracted[0].context, expected.context, "extraction changed the message context")
+
+  const messages = extracted.map((message) => ({
+    message: message.message,
+    context: message.context,
+    placeholders: toCatalogPlaceholders(message.placeholders),
+    extractedComments: message.comment ? [message.comment] : [],
+    origins: [
+      {
+        file: message.origin[0],
+        line: message.origin[1],
+        scope: message.origin.scope,
+      },
+    ],
+  }))
+
+  const enCatalogPath = path.join(tempRoot, "locales", "en", "messages.po")
+  const deCatalogPath = path.join(tempRoot, "locales", "de", "messages.po")
+  await mkdir(path.dirname(enCatalogPath), { recursive: true })
+  await mkdir(path.dirname(deCatalogPath), { recursive: true })
+
+  updateCatalogFile({
+    targetPath: enCatalogPath,
+    locale: "en",
+    sourceLocale: "en",
+    clean: true,
+    messages,
+  })
+  await copyFile(fixtureTranslationPath, deCatalogPath)
+  updateCatalogFile({
+    targetPath: deCatalogPath,
+    locale: "de",
+    sourceLocale: "en",
+    clean: true,
+    messages,
+  })
+
+  const sourceEntry = onlyMessage(parsePo(await readFile(enCatalogPath, "utf8")))
+  const translatedEntry = onlyMessage(parsePo(await readFile(deCatalogPath, "utf8")))
+
+  assert.equal(sourceEntry.msgid, expected.message, "the PO source message changed")
+  assert.equal(sourceEntry.msgctxt, expected.context, "the PO source context changed")
+  assert.equal(translatedEntry.msgid, expected.message, "the translated PO source changed")
+  assert.equal(translatedEntry.msgctxt, expected.context, "the translated PO context changed")
+  assert.deepEqual(
+    translatedEntry.msgstr,
+    [expected.translation],
+    "the translated ICU message changed during the catalog update"
+  )
+
+  assert.deepEqual(
+    semanticShape(parseMessagePattern(expected.translation)),
+    semanticShape(parseMessagePattern(expected.message)),
+    "the translation changed the ICU selector structure"
+  )
+
+  const artifact = compileCatalogArtifact(
+    {
+      rootDir: tempRoot,
+      locales: ["en", "de"],
+      sourceLocale: "en",
+      catalogs: [{ path: "locales/{locale}/messages", include: ["src"] }],
+    },
+    deCatalogPath
+  )
+
+  assert.deepEqual(artifact.missing, [], "the compiled catalog contains missing messages")
+  assert.deepEqual(
+    artifact.diagnostics.filter((diagnostic) => diagnostic.severity === "error"),
+    [],
+    "the compiled catalog contains ICU errors"
+  )
+
+  const compiledEntries = Object.entries(artifact.messages)
+  assert.equal(compiledEntries.length, 1, "the compiled catalog must contain one message")
+  const [compiledId, compiledMessage] = compiledEntries[0]
+  assert.equal(compiledMessage, expected.translation, "catalog compilation changed the translation")
+
+  const i18n = createI18n()
+  i18n.load("de", artifact.messages)
+  i18n.activate("de")
+
+  for (const scenario of expected.scenarios) {
+    assert.equal(
+      i18n._(compiledId, scenario.values, {
+        message: expected.message,
+        context: expected.context,
+      }),
+      scenario.output,
+      `runtime output changed for ${JSON.stringify(scenario.values)}`
+    )
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        status: "passed",
+        pipeline: ["source", "extraction", "po-catalog", "compile", "runtime"],
+        messageSha256: sha256(expected.message),
+        translationSha256: sha256(expected.translation),
+        selectorShape: semanticShape(parseMessagePattern(expected.message)),
+        runtimeScenarios: expected.scenarios.length,
+      },
+      null,
+      2
+    )
+  )
+} finally {
+  await rm(tempRoot, { recursive: true, force: true })
+}
+
+function onlyMessage(catalog) {
+  assert.equal(catalog.items.length, 1, "the proof catalog must contain exactly one message")
+  return catalog.items[0]
+}
+
+function toCatalogPlaceholders(placeholders) {
+  if (!placeholders) {
+    return
+  }
+
+  return Object.fromEntries(Object.entries(placeholders).map(([name, value]) => [name, [value]]))
+}
+
+function semanticShape(nodes) {
+  return nodes.map((node) => {
+    switch (node.type) {
+      case "text":
+        return {
+          type: "text",
+          poundSigns: [...node.value].filter((character) => character === "#").length,
+        }
+      case "variable":
+        return { type: "variable", variable: node.variable }
+      case "formatted":
+        return {
+          type: "formatted",
+          variable: node.variable,
+          format: node.format,
+          style: node.style ?? null,
+        }
+      case "tag":
+        return {
+          type: "tag",
+          name: node.name,
+          children: semanticShape(node.children),
+        }
+      case "choice":
+        return {
+          type: "choice",
+          variable: node.variable,
+          kind: node.kind,
+          offset: node.offset ?? 0,
+          options: Object.fromEntries(
+            Object.entries(node.options)
+              .sort(([left], [right]) => left.localeCompare(right))
+              .map(([key, children]) => [key, semanticShape(children)])
+          ),
+        }
+    }
+
+    throw new Error(`Unsupported ICU node type: ${node.type}`)
+  })
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex")
+}

--- a/scripts/proof-icu-semantics.mjs
+++ b/scripts/proof-icu-semantics.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict"
 import { createHash } from "node:crypto"
-import { copyFile, mkdir, mkdtemp, readFile, rm } from "node:fs/promises"
+import { copyFile, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
 import { pathToFileURL } from "node:url"
@@ -11,6 +11,8 @@ const fixtureSourcePath = path.join(fixtureRoot, "src", "notification-summary.ts
 const fixtureSourceName = "proof/icu-semantics/src/notification-summary.ts"
 const fixtureTranslationPath = path.join(fixtureRoot, "locales", "de", "messages.po")
 const expected = JSON.parse(await readFile(path.join(fixtureRoot, "expected.json"), "utf8"))
+const runtimeSymbolName = "palamedes.icu-semantics-proof.i18n"
+const runtimeSymbol = Symbol.for(runtimeSymbolName)
 
 const coreNode = await import(
   pathToFileURL(path.join(repoRoot, "packages", "core-node", "dist", "index.mjs")).href
@@ -19,7 +21,13 @@ const core = await import(
   pathToFileURL(path.join(repoRoot, "packages", "core", "dist", "index.mjs")).href
 )
 
-const { compileCatalogArtifact, extractMessagesNative, parsePo, updateCatalogFile } = coreNode
+const {
+  compileCatalogArtifact,
+  extractMessagesNative,
+  parsePo,
+  transformMacrosNative,
+  updateCatalogFile,
+} = coreNode
 const { createI18n, parseMessagePattern } = core
 
 const tempRoot = await mkdtemp(path.join(os.tmpdir(), "palamedes-icu-proof-"))
@@ -31,6 +39,32 @@ try {
   assert.equal(extracted.length, 1, "the fixture must extract exactly one message")
   assert.equal(extracted[0].message, expected.message, "extraction changed the ICU source")
   assert.equal(extracted[0].context, expected.context, "extraction changed the message context")
+
+  const transformedModulePath = path.join(tempRoot, "notification-summary.mjs")
+  const runtimeBridgePath = path.join(tempRoot, "runtime-bridge.mjs")
+  const transformed = transformMacrosNative(source, fixtureSourceName, {
+    runtimeModule: "./runtime-bridge.mjs",
+    runtimeImportName: "getI18n",
+  })
+
+  assert.equal(transformed.hasChanged, true, "the source fixture was not transformed")
+  assert.equal(
+    transformed.compiledIds.length,
+    1,
+    "the transformed fixture must reference one compiled message"
+  )
+  await writeFile(transformedModulePath, transformed.code, "utf8")
+  await writeFile(
+    runtimeBridgePath,
+    `const proofI18nKey = Symbol.for(${JSON.stringify(runtimeSymbolName)})
+export function getI18n() {
+  const i18n = globalThis[proofI18nKey]
+  if (!i18n) throw new Error("ICU proof runtime is not installed")
+  return i18n
+}
+`,
+    "utf8"
+  )
 
   const messages = extracted.map((message) => ({
     message: message.message,
@@ -106,28 +140,42 @@ try {
   const compiledEntries = Object.entries(artifact.messages)
   assert.equal(compiledEntries.length, 1, "the compiled catalog must contain one message")
   const [compiledId, compiledMessage] = compiledEntries[0]
+  assert.equal(
+    transformed.compiledIds[0],
+    compiledId,
+    "the macro transform and catalog compiler produced different message IDs"
+  )
   assert.equal(compiledMessage, expected.translation, "catalog compilation changed the translation")
 
   const i18n = createI18n()
   i18n.load("de", artifact.messages)
   i18n.activate("de")
 
-  for (const scenario of expected.scenarios) {
+  globalThis[runtimeSymbol] = i18n
+  try {
+    const fixtureModule = await import(pathToFileURL(transformedModulePath).href)
     assert.equal(
-      i18n._(compiledId, scenario.values, {
-        message: expected.message,
-        context: expected.context,
-      }),
-      scenario.output,
-      `runtime output changed for ${JSON.stringify(scenario.values)}`
+      typeof fixtureModule.notificationSummary,
+      "function",
+      "the transformed fixture did not export its runtime function"
     )
+
+    for (const scenario of expected.scenarios) {
+      assert.equal(
+        fixtureModule.notificationSummary(scenario.values.role, scenario.values.count),
+        scenario.output,
+        `runtime output changed for ${JSON.stringify(scenario.values)}`
+      )
+    }
+  } finally {
+    delete globalThis[runtimeSymbol]
   }
 
   console.log(
     JSON.stringify(
       {
         status: "passed",
-        pipeline: ["source", "extraction", "po-catalog", "compile", "runtime"],
+        pipeline: ["source", "extraction", "transform", "po-catalog", "compile", "runtime"],
         messageSha256: sha256(expected.message),
         translationSha256: sha256(expected.translation),
         selectorShape: semanticShape(parseMessagePattern(expected.message)),

--- a/site/app/routes.ts
+++ b/site/app/routes.ts
@@ -114,6 +114,7 @@ export default [
   route("docs/demo-deployments", "routes/docs/demo-deployments.md"),
   route("docs/first-working-translation", "routes/docs/first-working-translation.md"),
   route("docs/framework-example-notes", "routes/docs/framework-example-notes.md"),
+  route("docs/icu-semantics-proof", "routes/docs/icu-semantics-proof.md"),
   route("docs/locale-strategies", "routes/docs/locale-strategies.md"),
   route("docs/migrate-from-lingui", "routes/docs/migrate-from-lingui.md"),
   route("docs/principles", "routes/docs/principles.md"),

--- a/site/app/routes/compare.tsx
+++ b/site/app/routes/compare.tsx
@@ -156,14 +156,15 @@ export default function Compare() {
       <Section
         num="04 — ICU semantics"
         title="The durable claim is about the pipeline we control."
-        lede="ICU support changes across libraries, TMS products, file formats, and project settings. Palamedes makes a narrower, executable claim: nested ICU selectors stay intact from source through PO catalogs, compilation, and runtime rendering."
+        lede="ICU support changes across libraries, TMS products, file formats, and project settings. Palamedes makes a narrower, executable claim: nested ICU selectors stay intact from source through transformation, PO catalogs, compilation, and runtime rendering."
       >
         <div className="hairline-grid grid-cols-2 max-tight:grid-cols-1">
           <div className="bg-paper px-6 py-6">
             <h3 className="text-[15px] font-bold">What we prove</h3>
             <p className="mt-2 text-[13.5px] leading-relaxed text-ink/85">
               One checked fixture exercises nested select and plural branches across extraction,
-              catalog update, compilation, and six runtime outputs.
+              transformation, catalog update, compilation, and six executions of the transformed
+              runtime function.
             </p>
           </div>
           <div className="bg-paper px-6 py-6">

--- a/site/app/routes/compare.tsx
+++ b/site/app/routes/compare.tsx
@@ -153,7 +153,36 @@ export default function Compare() {
         lede="A category difference, not a feature race. GT is a translation platform — hosted workflows, AI translation, delivery. Palamedes is local-first tooling: your repo owns the catalogs, the QA, and the history. The two concerns can even stack: Palamedes as the local foundation, a service layer on top."
       />
 
-      <StatementBand num="04 — The honest bit">
+      <Section
+        num="04 — ICU semantics"
+        title="The durable claim is about the pipeline we control."
+        lede="ICU support changes across libraries, TMS products, file formats, and project settings. Palamedes makes a narrower, executable claim: nested ICU selectors stay intact from source through PO catalogs, compilation, and runtime rendering."
+      >
+        <div className="hairline-grid grid-cols-2 max-tight:grid-cols-1">
+          <div className="bg-paper px-6 py-6">
+            <h3 className="text-[15px] font-bold">What we prove</h3>
+            <p className="mt-2 text-[13.5px] leading-relaxed text-ink/85">
+              One checked fixture exercises nested select and plural branches across extraction,
+              catalog update, compilation, and six runtime outputs.
+            </p>
+          </div>
+          <div className="bg-paper px-6 py-6">
+            <h3 className="text-[15px] font-bold">What we snapshot</h3>
+            <p className="mt-2 text-[13.5px] leading-relaxed text-ink/85">
+              Statements about other tools are dated observations from their public docs, not
+              permanent claims about their internals or roadmap.
+            </p>
+          </div>
+        </div>
+        <a
+          href={docsHref("icu-semantics-proof")}
+          className="mono-nums mt-6 block text-[13px] text-accent"
+        >
+          Re-run the proof and inspect the sources →
+        </a>
+      </Section>
+
+      <StatementBand num="05 — The honest bit">
         Every tool on this page is good software. The question is which tradeoffs match your team —
         ours are written down in 16 ADRs, so you can check before you commit.
       </StatementBand>

--- a/site/app/routes/proof.tsx
+++ b/site/app/routes/proof.tsx
@@ -16,7 +16,7 @@ export function meta() {
   return pageMeta({
     title: "Palamedes — benchmarks, verification, and the decision trail",
     description:
-      "Claims you can re-run: checked-in extraction benchmarks against Lingui, FormatJS, i18next-parser, and i18next-cli, 24 browser-verified example apps, and 16 architecture decision records.",
+      "Claims you can re-run: checked-in extraction benchmarks, an executable ICU semantics proof, 24 browser-verified example apps, and 16 architecture decision records.",
     path: "/proof",
   })
 }
@@ -106,7 +106,36 @@ export default function Proof() {
       </Section>
 
       <Section
-        num="04 — Decision trail"
+        num="04 — ICU semantics"
+        title="ICU stays ICU from source to runtime."
+        lede="A checked-in nested select + plural message runs through extraction, PO catalog update, catalog compilation, and six runtime scenarios. The proof compares exact messages and selector structure instead of treating ICU as a yes/no feature checkbox."
+      >
+        <div className="max-w-[56em] border-l-4 border-accent pl-4">
+          <p className="micro text-[10px] text-gray-spec">Exact boundary</p>
+          <p className="mt-1 text-[13.5px]">
+            This proves every stage Palamedes controls. A TMS remains an external boundary, so
+            import and export fidelity depends on the selected product, format, and project
+            configuration.
+          </p>
+        </div>
+        <div className="mt-6 space-y-2">
+          <a
+            href={docsHref("icu-semantics-proof")}
+            className="mono-nums block text-[13px] text-accent"
+          >
+            Inspect and re-run the ICU proof →
+          </a>
+          <a
+            href={repoHref("proof/icu-semantics", "tree")}
+            className="mono-nums block text-[13px] text-accent"
+          >
+            Browse the fixture →
+          </a>
+        </div>
+      </Section>
+
+      <Section
+        num="05 — Decision trail"
         title="16 decisions, written down before you depend on them."
         lede="The ADRs cover message identity, the native boundary, adapter architecture — and, just as deliberately, what Palamedes refuses to own. Reading them is the fastest way to know if our tradeoffs match yours."
       >

--- a/site/app/routes/proof.tsx
+++ b/site/app/routes/proof.tsx
@@ -108,7 +108,7 @@ export default function Proof() {
       <Section
         num="04 — ICU semantics"
         title="ICU stays ICU from source to runtime."
-        lede="A checked-in nested select + plural message runs through extraction, PO catalog update, catalog compilation, and six runtime scenarios. The proof compares exact messages and selector structure instead of treating ICU as a yes/no feature checkbox."
+        lede="A checked-in nested select + plural message runs through extraction, macro transformation, PO catalog update, catalog compilation, and six executions of the transformed runtime function. The proof compares exact messages and selector structure instead of treating ICU as a yes/no feature checkbox."
       >
         <div className="max-w-[56em] border-l-4 border-accent pl-4">
           <p className="micro text-[10px] text-gray-spec">Exact boundary</p>

--- a/site/scripts/prebuild-content.mjs
+++ b/site/scripts/prebuild-content.mjs
@@ -73,6 +73,7 @@ async function collectDocs() {
     ["comparison-with-lingui.md", 80],
     ["approach-comparison.md", 90],
     ["proof-and-benchmarks.md", 100],
+    ["icu-semantics-proof.md", 105],
     ["benchmark-e2e-workflow.md", 110],
     ["benchmark-lingui-v6-preview.md", 120],
     ["stability.md", 130],


### PR DESCRIPTION
## What changed

- add a checked nested `select` + `plural` fixture and `pnpm proof:icu` command
- transform the actual fixture through the Palamedes macro, verify the compiled message ID against extraction, then execute that transformed function for six runtime scenarios
- verify PO catalog update, ICU selector shape, catalog compilation, and localized runtime outputs
- run the proof in CI on the full Node 22 and Node 24 jobs
- document the exact public claim boundary: Palamedes-controlled stages are reproducible; TMS import/export behavior remains product-, format-, and configuration-specific
- add a dated 2026-07-23 market snapshot sourced only from current official FormatJS, i18next, Crowdin, Phrase, and Weblate documentation
- surface the proof on the public Proof and Compare pages

## Why

Issue #354 is primarily positioning work. It does not need access to a private or paid TMS project if we separate two kinds of evidence honestly:

1. The Palamedes-controlled source → extraction → macro transform → PO catalog → compile → runtime path is executable and controlled by this repository.
2. Other products behavior is a dated observation of their public documentation, not a permanent claim about their internals or roadmap.

This keeps the marketing useful without claiming that Palamedes controls an arbitrary TMS round-trip.

## Validation

- `pnpm proof:icu`
- `pnpm proof:icu:check` after the review fix
- `pnpm build:site`
- `pnpm format:check`
- `pnpm lint`
- `pnpm test` (191 tests)
- `pnpm check-types`
- `pnpm --filter @palamedes/site typecheck` after the review fix

Closes #354