### PR TITLE
chore(deps): update Ardo to v4

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1618,8 +1618,8 @@ importers:
         specifier: 8.3.0
         version: 8.3.0(react-router@8.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(typescript@6.0.3)
       ardo:
-        specifier: 3.8.1
-        version: 3.8.1(23cb7908c74b9bafde3777443f7fa3d7)
+        specifier: 4.2.0
+        version: 4.2.0(8fb7729cabe7b4860dbb120983fd3f2a)
       isbot:
         specifier: ^5.2.1
         version: 5.2.1
@@ -1954,6 +1954,33 @@ packages:
   '@base-ui-components/utils@0.2.2':
     resolution: {integrity: sha512-rNJCD6TFy3OSRDKVHJDzLpxO3esTV1/drRtWNUpe7rCpPN9HZVHUCuP+6rdDYDGWfXnQHbqi05xOyRP2iZAlkw==}
     deprecated: Package was renamed to @base-ui/utils
+    peerDependencies:
+      '@types/react': ^17 || ^18 || ^19
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@base-ui/react@1.6.0':
+    resolution: {integrity: sha512-/jzjTWJYXhRFO45Bev9lc3cHbmjzCMpUqbMZ2AgKy/z25mY9B6shGSNcXcjQar9n5doM0KYW1W8fcFv2jZBuMw==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@date-fns/tz': ^1.2.0
+      '@types/react': ^17 || ^18 || ^19
+      date-fns: ^4.0.0
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@date-fns/tz':
+        optional: true
+      '@types/react':
+        optional: true
+      date-fns:
+        optional: true
+
+  '@base-ui/utils@0.3.1':
+    resolution: {integrity: sha512-gFFiltORVmW/N6IILTGxizP3PBpVpysqML1ALY5Vk0mH+7faVkCknOU31goYHN5Aoek2dkjxva1XOD2Ce9WuIg==}
     peerDependencies:
       '@types/react': ^17 || ^18 || ^19
       react: ^17 || ^18 || ^19
@@ -7061,18 +7088,19 @@ packages:
     resolution: {integrity: sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==}
     engines: {node: '>= 14'}
 
-  ardo@3.8.1:
-    resolution: {integrity: sha512-F8ui4UN1OEiLEfLTh515nyatT9w5Gk9wBNlPf/W70xAQckpQbbvEs1RnmXnx8UiRfXmkblh2u6RGu/Vj/h6L3w==}
+  ardo@4.2.0:
+    resolution: {integrity: sha512-kyK5M8Wqdf8uZfR7i7cnAnInYeZcBmmYi4vXRG4nHFxjPr+VCzUU9tdGIGByh9qF/Jn2jwaV+KBxm1mBe2/7Vg==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       '@react-router/dev': ^8.0.0
       lucide-react: '>=0.400.0 <2.0.0'
+      mermaid: ^11.0.0
       react: '>=19.0.0 <20.0.0'
       react-dom: '>=19.0.0 <20.0.0'
       react-router: ^8.0.0
       vite: ^8.0.0
     peerDependenciesMeta:
-      lucide-react:
+      mermaid:
         optional: true
 
   are-docs-informative@0.0.2:
@@ -13468,6 +13496,29 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
 
+  '@base-ui/react@1.6.0(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@base-ui/utils': 0.3.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@floating-ui/utils': 0.2.11
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      use-sync-external-store: 1.6.0(react@19.2.8)
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@base-ui/utils@0.3.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@floating-ui/utils': 0.2.11
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      reselect: 5.2.0
+      use-sync-external-store: 1.6.0(react@19.2.8)
+    optionalDependencies:
+      '@types/react': 19.2.17
+
   '@bramus/specificity@2.4.2':
     dependencies:
       css-tree: 3.2.1
@@ -18093,8 +18144,9 @@ snapshots:
       - bare-buffer
       - react-native-b4a
 
-  ardo@3.8.1(23cb7908c74b9bafde3777443f7fa3d7):
+  ardo@4.2.0(8fb7729cabe7b4860dbb120983fd3f2a):
     dependencies:
+      '@base-ui/react': 1.6.0(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@mdx-js/rollup': 3.1.1(rollup@4.59.0)(supports-color@10.2.2)
       '@react-router/dev': 8.3.0(@react-router/serve@8.3.0(react-router@8.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@10.2.2)(typescript@6.0.3))(@vitejs/plugin-rsc@0.5.27(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.7(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.105.4(@swc/core@1.15.46)(cssnano@7.1.3(postcss@8.5.22))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.22)))(react@19.2.8)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(react-router@8.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-server-dom-webpack@19.2.7(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.105.4(@swc/core@1.15.46)(cssnano@7.1.3(postcss@8.5.22))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.22)))(supports-color@10.2.2)(typescript@6.0.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
       '@resvg/resvg-js': 2.6.2
@@ -18105,6 +18157,7 @@ snapshots:
       '@vanilla-extract/vite-plugin': 5.2.3(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(supports-color@10.2.2)(terser@5.49.0)(tsx@4.21.0)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
       '@vitejs/plugin-react': 6.0.3(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
       gray-matter: 4.0.3
+      lucide-react: 0.577.0(react@19.2.8)
       minisearch: 7.2.0
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
@@ -18121,14 +18174,16 @@ snapshots:
       unified: 11.0.5
       unist-util-visit: 5.1.0
       vite: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)
-    optionalDependencies:
-      lucide-react: 0.577.0(react@19.2.8)
+      yaml: 2.9.0
     transitivePeerDependencies:
+      - '@date-fns/tz'
       - '@rolldown/plugin-babel'
       - '@types/node'
+      - '@types/react'
       - '@vitejs/devtools'
       - babel-plugin-macros
       - babel-plugin-react-compiler
+      - date-fns
       - esbuild
       - jiti
       - less
@@ -18141,7 +18196,6 @@ snapshots:
       - terser
       - tsx
       - typescript
-      - yaml
 
   are-docs-informative@0.0.2: {}
 

--- a/site/app/ardo-env.d.ts
+++ b/site/app/ardo-env.d.ts
@@ -11,10 +11,3 @@ declare module "virtual:ardo/config" {
   const config: ArdoConfig
   export default config
 }
-
-declare module "virtual:ardo/sidebars" {
-  import type { SidebarItem } from "ardo"
-
-  const sidebars: Record<string, SidebarItem[]>
-  export default sidebars
-}

--- a/site/app/root.tsx
+++ b/site/app/root.tsx
@@ -1,14 +1,18 @@
 import {
   ArdoErrorBoundary,
+  ArdoFooter,
+  ArdoGeneratedSidebar,
+  ArdoHeader,
+  ArdoHeaderActions,
   ArdoNav,
   ArdoNavLink,
   ArdoRoot,
   ArdoRootLayout,
   ArdoSidebar,
+  ArdoSidebarSection,
   ArdoSocialLink,
 } from "ardo/ui"
 import config from "virtual:ardo/config"
-import sidebars from "virtual:ardo/sidebars"
 
 import { ButtonLink } from "~/components/chrome/Button"
 import { SiteFooter } from "~/components/chrome/SiteFooter"
@@ -31,6 +35,25 @@ export function Layout({ children }: { children: React.ReactNode }) {
   return <ArdoRootLayout>{children}</ArdoRootLayout>
 }
 
+function renderSidebarSections() {
+  return (
+    <>
+      <ArdoSidebarSection id="docs" label="Docs" to="/docs">
+        <ArdoGeneratedSidebar section="docs" />
+      </ArdoSidebarSection>
+      <ArdoSidebarSection id="api-reference" label="API" to="/api-reference">
+        <ArdoGeneratedSidebar section="api-reference" />
+      </ArdoSidebarSection>
+      <ArdoSidebarSection id="decisions" label="Decisions" to="/decisions">
+        <ArdoGeneratedSidebar section="decisions" />
+      </ArdoSidebarSection>
+      <ArdoSidebarSection id="blog" label="Blog" to="/blog" match="/blog/">
+        <ArdoGeneratedSidebar section="blog" />
+      </ArdoSidebarSection>
+    </>
+  )
+}
+
 /*
  * ARDO owns the chrome: its header and footer render on every route (marketing
  * pages included), so nothing below <ArdoRoot> may add a second nav or footer.
@@ -41,77 +64,66 @@ export default function App() {
   return (
     <ArdoRoot
       config={config}
-      sidebar={sidebars}
-      contexts={[
-        { id: "docs", label: "Docs", href: "/docs" },
-        { id: "api-reference", label: "API", href: "/api-reference" },
-        { id: "decisions", label: "Decisions", href: "/decisions" },
-        { id: "blog", label: "Blog", href: "/blog", match: "/blog/" },
-      ]}
       editLink={{
         pattern: "https://github.com/sebastian-software/palamedes/edit/main/:path",
         text: "Edit this page on GitHub",
       }}
       lastUpdated={{ enabled: true, text: "Last updated" }}
-      headerProps={{
-        logo: "/logo.svg",
-        searchPlaceholder: "Search Palamedes docs...",
+    >
+      <ArdoHeader
+        logo="/logo.svg"
+        searchPlaceholder="Search Palamedes docs..."
         /* Light-only site by design ("Swiss Spec Grid" is a paper spec sheet);
          * re-enable once both token systems ship a dark set. */
-        themeToggle: false,
-        nav: (
-          <ArdoNav>
-            <ArdoNavLink className="pmds-nav-link" to="/frameworks">
-              Frameworks
-            </ArdoNavLink>
-            <ArdoNavLink className="pmds-nav-link" to="/proof">
-              Proof
-            </ArdoNavLink>
-            <ArdoNavLink className="pmds-nav-link" to="/compare">
-              Compare
-            </ArdoNavLink>
-            <ArdoNavLink className="pmds-nav-link" to="/blog">
-              Blog
-            </ArdoNavLink>
-            <ArdoNavLink className="pmds-nav-link" to="/docs">
-              Docs
-            </ArdoNavLink>
-          </ArdoNav>
-        ),
-        /* Always provide mobile-menu content: without it ARDO skips the
-         * hamburger and marketing pages would lose their nav below 1024px.
-         * The zero-config <ArdoSidebar> resolves the active context's items
-         * (empty on marketing routes — the panel still shows the nav links).
-         * The CTA lives here too because the header hides it below 560px. */
-        mobileMenuContent: (
-          <>
-            <div className="px-4 pb-4">
-              <ButtonLink variant="primary" href="/get-started" className="w-full text-center">
-                Get started
-              </ButtonLink>
-            </div>
-            <ArdoSidebar />
-          </>
-        ),
-        actions: (
-          <>
-            <ArdoSocialLink
-              href="https://github.com/sebastian-software/palamedes"
-              icon="github"
-              ariaLabel="Palamedes on GitHub"
-            />
-            <ButtonLink variant="small" href="/get-started" className="max-tight:hidden">
+        themeToggle={false}
+      >
+        <ArdoNav>
+          <ArdoNavLink className="pmds-nav-link" to="/frameworks">
+            Frameworks
+          </ArdoNavLink>
+          <ArdoNavLink className="pmds-nav-link" to="/proof">
+            Proof
+          </ArdoNavLink>
+          <ArdoNavLink className="pmds-nav-link" to="/compare">
+            Compare
+          </ArdoNavLink>
+          <ArdoNavLink className="pmds-nav-link" to="/blog">
+            Blog
+          </ArdoNavLink>
+          <ArdoNavLink className="pmds-nav-link" to="/docs">
+            Docs
+          </ArdoNavLink>
+        </ArdoNav>
+        <ArdoHeaderActions>
+          <ArdoSocialLink
+            href="https://github.com/sebastian-software/palamedes"
+            icon="github"
+            ariaLabel="Palamedes on GitHub"
+          />
+          <ButtonLink variant="small" href="/get-started" className="max-tight:hidden">
+            Get started
+          </ButtonLink>
+        </ArdoHeaderActions>
+      </ArdoHeader>
+      <ArdoSidebar
+        /* ArdoRoot supplies this sidebar to the mobile panel. Keep the CTA
+         * there below the tight breakpoint, where the header action is hidden. */
+        header={
+          <div className="hidden px-4 pb-4 max-tight:block">
+            <ButtonLink variant="primary" href="/get-started" className="w-full text-center">
               Get started
             </ButtonLink>
-          </>
-        ),
-      }}
-      footer={
+          </div>
+        }
+      >
+        {renderSidebarSections()}
+      </ArdoSidebar>
+      <ArdoFooter>
         <div className="frame border-t-0">
           <SiteFooter />
         </div>
-      }
-    />
+      </ArdoFooter>
+    </ArdoRoot>
   )
 }
 

--- a/site/app/routes.ts
+++ b/site/app/routes.ts
@@ -40,6 +40,7 @@ export default [
   route("docs", "routes/docs/index.md"),
   route("docs/api", "routes/docs/api/index.md"),
   route("docs/api/cli", "routes/docs/api/cli/index.md"),
+  route("docs/api/cli-plugin", "routes/docs/api/cli-plugin/index.md"),
   route("docs/api/config", "routes/docs/api/config/index.md"),
   route("docs/api/core", "routes/docs/api/core/index.md"),
   route("docs/api/core-node", "routes/docs/api/core-node/index.md"),

--- a/site/package.json
+++ b/site/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@base-ui-components/react": "1.0.0-rc.0",
     "@react-router/node": "8.3.0",
-    "ardo": "3.8.1",
+    "ardo": "4.2.0",
     "lucide-react": "^0.577.0",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",


### PR DESCRIPTION
## Summary

- update the documentation framework from Ardo 3.8.1 to 4.2.0
- migrate the site chrome to Ardo v4’s compositional header, sidebar, and footer APIs
- preserve generated documentation sections, mobile sidebar CTA, and the Ardo-generated route manifest

Refs #211.

## Validation

- `pnpm --filter @palamedes/site typecheck`
- `pnpm --filter @palamedes/site build`
- `pnpm format:check`
- `pnpm install --lockfile-only --frozen-lockfile`
- rendered docs navigation checked in a local preview