### PR TITLE
fix: support interpolated descriptor templates

### DIFF
--- a/crates/palamedes/src/descriptor.rs
+++ b/crates/palamedes/src/descriptor.rs
@@ -1,0 +1,58 @@
+use oxc_ast::ast::{Expression, ObjectExpression, ObjectPropertyKind};
+
+use crate::error::{PalamedesError, PalamedesResult};
+
+pub(crate) fn descriptor_property_value<'a>(
+    object: &'a ObjectExpression<'a>,
+    property_name: &str,
+) -> Option<&'a Expression<'a>> {
+    object.properties.iter().rev().find_map(|property| {
+        let ObjectPropertyKind::ObjectProperty(property) = property else {
+            return None;
+        };
+        (property.key.static_name().as_deref() == Some(property_name)).then_some(&property.value)
+    })
+}
+
+pub(crate) fn descriptor_static_property(
+    object: &ObjectExpression<'_>,
+    property_name: &str,
+    macro_name: &str,
+    location: &str,
+) -> PalamedesResult<Option<String>> {
+    let Some(value) = descriptor_property_value(object, property_name) else {
+        return Ok(None);
+    };
+    let Some(value) = static_string_value(value) else {
+        return Err(unsupported_macro_syntax(
+            macro_name,
+            location,
+            format!(
+                "the descriptor `{property_name}` must be a string literal or expression-free template literal"
+            ),
+        ));
+    };
+    Ok(Some(value))
+}
+
+pub(crate) fn unsupported_macro_syntax(
+    macro_name: &str,
+    location: &str,
+    detail: impl Into<String>,
+) -> PalamedesError {
+    PalamedesError::UnsupportedMacroSyntax {
+        macro_name: macro_name.to_string(),
+        location: location.to_string(),
+        detail: detail.into(),
+    }
+}
+
+fn static_string_value(expression: &Expression<'_>) -> Option<String> {
+    match expression.without_parentheses() {
+        Expression::StringLiteral(literal) => Some(literal.value.to_string()),
+        Expression::TemplateLiteral(template) => {
+            template.single_quasi().map(|value| value.to_string())
+        }
+        _ => None,
+    }
+}

--- a/crates/palamedes/src/error.rs
+++ b/crates/palamedes/src/error.rs
@@ -163,6 +163,16 @@ pub enum PalamedesError {
         /// Value names provided by values but not referenced by the message.
         extra: String,
     },
+    /// A recognized macro call used a source shape that cannot be transformed safely.
+    #[error("Unsupported `{macro_name}` macro usage at {location}: {detail}")]
+    UnsupportedMacroSyntax {
+        /// Public macro name used at the call site.
+        macro_name: String,
+        /// Source filename, line, and column.
+        location: String,
+        /// Human-readable explanation of the unsupported source shape.
+        detail: String,
+    },
     /// A JSX message macro was nested inside another JSX message macro.
     #[error(
         "Nested i18n macro is not extractable as a single message at {location}. Move the full sentence into <Plural> branches or use plural() so translators receive the complete sentence."

--- a/crates/palamedes/src/extract.rs
+++ b/crates/palamedes/src/extract.rs
@@ -3,6 +3,9 @@ use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 
 use crate::catalog_update::{CatalogUpdateMessage, CatalogUpdateOrigin};
+use crate::descriptor::{
+    descriptor_property_value, descriptor_static_property, unsupported_macro_syntax,
+};
 use crate::error::{PalamedesError, PalamedesResult};
 use crate::jsx_entities::decode_jsx_entities;
 use crate::jsx_message::{
@@ -769,51 +772,6 @@ fn extract_from_descriptor_call(
         origin,
         scope,
     }))
-}
-
-fn descriptor_property_value<'a>(
-    object: &'a ObjectExpression<'a>,
-    property_name: &str,
-) -> Option<&'a Expression<'a>> {
-    object.properties.iter().rev().find_map(|property| {
-        let ObjectPropertyKind::ObjectProperty(property) = property else {
-            return None;
-        };
-        (property.key.static_name().as_deref() == Some(property_name)).then_some(&property.value)
-    })
-}
-
-fn descriptor_static_property(
-    object: &ObjectExpression<'_>,
-    property_name: &str,
-    macro_name: &str,
-    location: &str,
-) -> PalamedesResult<Option<String>> {
-    let Some(value) = descriptor_property_value(object, property_name) else {
-        return Ok(None);
-    };
-    let Some(value) = string_value(value) else {
-        return Err(unsupported_macro_syntax(
-            macro_name,
-            location,
-            format!(
-                "the descriptor `{property_name}` must be a string literal or expression-free template literal"
-            ),
-        ));
-    };
-    Ok(Some(value))
-}
-
-fn unsupported_macro_syntax(
-    macro_name: &str,
-    location: &str,
-    detail: impl Into<String>,
-) -> PalamedesError {
-    PalamedesError::UnsupportedMacroSyntax {
-        macro_name: macro_name.to_string(),
-        location: location.to_string(),
-        detail: detail.into(),
-    }
 }
 
 fn extract_from_choice_call(

--- a/crates/palamedes/src/extract.rs
+++ b/crates/palamedes/src/extract.rs
@@ -200,6 +200,14 @@ impl<'a> ExtractionVisitor<'a> {
         }
     }
 
+    fn fail_unsupported_macro(&mut self, macro_name: &str, span_start: usize) {
+        self.fail(PalamedesError::UnsupportedMacroSyntax {
+            macro_name: macro_name.to_string(),
+            location: self.location(span_start),
+            detail: "the macro could not be statically extracted; use a supported literal, template, descriptor, or choice shape".to_string(),
+        });
+    }
+
     fn origin(&self, span_start: usize) -> (String, usize, Option<usize>) {
         (
             self.filename.clone(),
@@ -275,10 +283,13 @@ impl<'a> Visit<'a> for ExtractionVisitor<'a> {
             return;
         };
 
-        if let Some(macro_name) = self.imported_macro_name(
-            tag_name.as_str(),
-            &["Trans", "Plural", "Select", "SelectOrdinal"],
-        ) {
+        if let Some(macro_name) = self
+            .imported_macro_name(
+                tag_name.as_str(),
+                &["Trans", "Plural", "Select", "SelectOrdinal"],
+            )
+            .map(str::to_string)
+        {
             if let Some(nested_start) =
                 nested_message_macro_in_children(&it.children, self.imported_macros)
             {
@@ -290,13 +301,16 @@ impl<'a> Visit<'a> for ExtractionVisitor<'a> {
 
             match extract_from_jsx_element(
                 it,
-                macro_name,
+                &macro_name,
                 self.origin(it.span.start as usize),
                 self.current_scope(),
                 self.source,
             ) {
                 Ok(Some(message)) => self.push(message),
-                Ok(None) => {}
+                Ok(None) => {
+                    self.fail_unsupported_macro(&macro_name, it.span.start as usize);
+                    return;
+                }
                 Err(error) => {
                     self.fail(error);
                     return;
@@ -313,10 +327,10 @@ impl<'a> Visit<'a> for ExtractionVisitor<'a> {
         }
 
         if let Some(tag_name) = identifier_name(&it.tag) {
-            if matches!(
-                self.imported_macro_name(tag_name, &["t", "msg"]),
-                Some("t" | "msg")
-            ) {
+            if let Some(macro_name) = self
+                .imported_macro_name(tag_name, &["t", "msg"])
+                .map(str::to_string)
+            {
                 match extract_from_tagged_template(
                     &it.quasi,
                     self.origin(it.span.start as usize),
@@ -325,7 +339,10 @@ impl<'a> Visit<'a> for ExtractionVisitor<'a> {
                     false,
                 ) {
                     Ok(Some(message)) => self.push(message),
-                    Ok(None) => {}
+                    Ok(None) => {
+                        self.fail_unsupported_macro(&macro_name, it.span.start as usize);
+                        return;
+                    }
                     Err(error) => {
                         self.fail(error);
                         return;
@@ -360,36 +377,44 @@ impl<'a> Visit<'a> for ExtractionVisitor<'a> {
         }
 
         if let Some(callee_name) = identifier_name(&it.callee) {
-            if let Some(macro_name) = self.imported_macro_name(
-                callee_name,
-                &[
-                    "t",
-                    "defineMessage",
-                    "msg",
-                    "plural",
-                    "select",
-                    "selectOrdinal",
-                ],
-            ) {
-                let message = match macro_name {
+            if let Some(macro_name) = self
+                .imported_macro_name(
+                    callee_name,
+                    &[
+                        "t",
+                        "defineMessage",
+                        "msg",
+                        "plural",
+                        "select",
+                        "selectOrdinal",
+                    ],
+                )
+                .map(str::to_string)
+            {
+                let message = match macro_name.as_str() {
                     "plural" | "select" | "selectOrdinal" => extract_from_choice_call(
                         it,
-                        macro_name,
+                        &macro_name,
                         self.origin(it.span.start as usize),
                         self.current_scope(),
                         self.source,
                     ),
                     _ => extract_from_descriptor_call(
                         it,
-                        macro_name,
+                        &macro_name,
                         self.origin(it.span.start as usize),
                         self.current_scope(),
+                        self.source,
+                        &self.location(it.span.start as usize),
                     ),
                 };
 
                 match message {
                     Ok(Some(message)) => self.push(message),
-                    Ok(None) => {}
+                    Ok(None) => {
+                        self.fail_unsupported_macro(&macro_name, it.span.start as usize);
+                        return;
+                    }
                     Err(error) => {
                         self.fail(error);
                         return;
@@ -683,40 +708,112 @@ fn extract_from_descriptor_call(
     macro_name: &str,
     origin: (String, usize, Option<usize>),
     scope: Option<String>,
+    source: &str,
+    location: &str,
 ) -> PalamedesResult<Option<ExtractedMessageRecord>> {
     let Some(first_arg) = call.arguments.first() else {
-        return Ok(None);
+        return Err(unsupported_macro_syntax(
+            macro_name,
+            location,
+            "the first argument must be a descriptor object",
+        ));
     };
     let Argument::ObjectExpression(object) = first_arg else {
-        return Ok(None);
+        return Err(unsupported_macro_syntax(
+            macro_name,
+            location,
+            "the first argument must be a descriptor object",
+        ));
     };
 
-    let props = extract_object_properties(object);
-    if props.contains_key("id") {
+    if descriptor_property_value(object, "id").is_some() {
         return Err(PalamedesError::ExplicitMessageIdsUnsupported);
     }
-    let message = props.get("message").cloned();
-    let comment = props.get("comment").cloned();
-    let context = props.get("context").cloned();
 
-    if message.is_none() {
-        return Ok(None);
-    }
-
-    let message = if macro_name == "t" || macro_name == "defineMessage" || macro_name == "msg" {
-        message
-    } else {
-        None
+    let Some(message_expression) = descriptor_property_value(object, "message") else {
+        return Err(unsupported_macro_syntax(
+            macro_name,
+            location,
+            "the descriptor must contain a static `message` property",
+        ));
     };
 
-    Ok(message.map(|message| ExtractedMessageRecord {
+    let (message, placeholders) = match message_expression.without_parentheses() {
+        Expression::StringLiteral(literal) => (literal.value.to_string(), BTreeMap::new()),
+        Expression::TemplateLiteral(template) => {
+            if macro_name == "defineMessage" && !template.expressions.is_empty() {
+                return Err(unsupported_macro_syntax(
+                    macro_name,
+                    location,
+                    "interpolated descriptor templates require runtime values; use `t()` or `msg()`, or write a static ICU message",
+                ));
+            }
+            template_to_message(template, source)?
+        }
+        _ => {
+            return Err(unsupported_macro_syntax(
+                macro_name,
+                location,
+                "the descriptor `message` must be a string literal or template literal",
+            ));
+        }
+    };
+    let comment = descriptor_static_property(object, "comment", macro_name, location)?;
+    let context = descriptor_static_property(object, "context", macro_name, location)?;
+
+    Ok(Some(ExtractedMessageRecord {
         message,
         comment,
         context,
-        placeholders: None,
+        placeholders: (!placeholders.is_empty()).then_some(placeholders),
         origin,
         scope,
     }))
+}
+
+fn descriptor_property_value<'a>(
+    object: &'a ObjectExpression<'a>,
+    property_name: &str,
+) -> Option<&'a Expression<'a>> {
+    object.properties.iter().rev().find_map(|property| {
+        let ObjectPropertyKind::ObjectProperty(property) = property else {
+            return None;
+        };
+        (property.key.static_name().as_deref() == Some(property_name)).then_some(&property.value)
+    })
+}
+
+fn descriptor_static_property(
+    object: &ObjectExpression<'_>,
+    property_name: &str,
+    macro_name: &str,
+    location: &str,
+) -> PalamedesResult<Option<String>> {
+    let Some(value) = descriptor_property_value(object, property_name) else {
+        return Ok(None);
+    };
+    let Some(value) = string_value(value) else {
+        return Err(unsupported_macro_syntax(
+            macro_name,
+            location,
+            format!(
+                "the descriptor `{property_name}` must be a string literal or expression-free template literal"
+            ),
+        ));
+    };
+    Ok(Some(value))
+}
+
+fn unsupported_macro_syntax(
+    macro_name: &str,
+    location: &str,
+    detail: impl Into<String>,
+) -> PalamedesError {
+    PalamedesError::UnsupportedMacroSyntax {
+        macro_name: macro_name.to_string(),
+        location: location.to_string(),
+        detail: detail.into(),
+    }
 }
 
 fn extract_from_choice_call(
@@ -1336,7 +1433,8 @@ pub fn extract_catalog_messages_from_files(
             Ok(messages) => messages,
             Err(
                 error @ (PalamedesError::ExplicitMessageIdsUnsupported
-                | PalamedesError::NestedMessageMacro { .. }),
+                | PalamedesError::NestedMessageMacro { .. }
+                | PalamedesError::UnsupportedMacroSyntax { .. }),
             ) => {
                 return Err(error);
             }
@@ -1549,6 +1647,68 @@ mod tests {
             placeholders.get("locale").map(String::as_str),
             Some("resolved.locale")
         );
+    }
+
+    #[test]
+    fn extracts_interpolated_descriptor_templates() {
+        let messages = extract_messages(
+            r#"
+              import { msg, t } from "@palamedes/core/macro"
+              const first = t({
+                message: `Descriptor ${name}`,
+                context: "probe context",
+              })
+              const second = msg({ message: `Locale ${resolved.locale}` })
+            "#,
+            "test.tsx",
+        )
+        .expect("messages should extract");
+
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].message, "Descriptor {name}");
+        assert_eq!(messages[0].context.as_deref(), Some("probe context"));
+        assert_eq!(
+            messages[0].placeholders,
+            Some(BTreeMap::from([("name".to_string(), "name".to_string())]))
+        );
+        assert_eq!(messages[1].message, "Locale {locale}");
+        assert_eq!(
+            messages[1].placeholders,
+            Some(BTreeMap::from([(
+                "locale".to_string(),
+                "resolved.locale".to_string()
+            )]))
+        );
+    }
+
+    #[test]
+    fn rejects_interpolated_define_message_descriptors() {
+        let error = extract_messages(
+            r#"import { defineMessage } from "@palamedes/core/macro"
+const message = defineMessage({ message: `Hello ${name}` })
+"#,
+            "test.ts",
+        )
+        .expect_err("defineMessage cannot capture runtime template values");
+
+        let message = error.to_string();
+        assert!(message.contains("Unsupported `defineMessage` macro usage at test.ts:2:17"));
+        assert!(message.contains("interpolated descriptor templates require runtime values"));
+    }
+
+    #[test]
+    fn rejects_dynamic_descriptor_messages_with_location() {
+        let error = extract_messages(
+            r#"import { t } from "@palamedes/core/macro"
+const message = t({ message })
+"#,
+            "test.ts",
+        )
+        .expect_err("dynamic descriptor messages must fail");
+
+        let message = error.to_string();
+        assert!(message.contains("Unsupported `t` macro usage at test.ts:2:17"));
+        assert!(message.contains("must be a string literal or template literal"));
     }
 
     #[test]
@@ -2315,6 +2475,30 @@ mod tests {
         .expect_err("nested message macros should fail");
 
         assert!(error.to_string().contains("Nested i18n macro"));
+        fs::remove_dir_all(root).expect("cleanup");
+    }
+
+    #[test]
+    fn batch_keeps_unsupported_macro_syntax_fatal() {
+        let root = temp_root("batch-unsupported-macro");
+        fs::create_dir_all(&root).expect("root dir");
+        let source = root.join("bad.ts");
+        fs::write(
+            &source,
+            r#"
+              import { t } from "@palamedes/core/macro"
+              const message = t({ message })
+            "#,
+        )
+        .expect("source");
+
+        let error = extract_catalog_messages_from_files(ExtractCatalogMessagesRequest {
+            root_dir: root.to_string_lossy().into_owned(),
+            files: vec![source.to_string_lossy().into_owned()],
+        })
+        .expect_err("unsupported macro syntax should fail");
+
+        assert!(error.to_string().contains("Unsupported `t` macro usage"));
         fs::remove_dir_all(root).expect("cleanup");
     }
 

--- a/crates/palamedes/src/lib.rs
+++ b/crates/palamedes/src/lib.rs
@@ -22,6 +22,7 @@ mod catalog_artifact;
 mod catalog_audit;
 mod catalog_combine;
 mod catalog_update;
+mod descriptor;
 mod diagnostic;
 mod error;
 mod extract;

--- a/crates/palamedes/src/transform/messages.rs
+++ b/crates/palamedes/src/transform/messages.rs
@@ -42,25 +42,6 @@ pub(super) fn string_value(expr: &Expression<'_>) -> Option<String> {
     }
 }
 
-pub(super) fn extract_object_properties(object: &ObjectExpression<'_>) -> HashMap<String, String> {
-    let mut properties = HashMap::new();
-
-    for property in &object.properties {
-        let ObjectPropertyKind::ObjectProperty(property) = property else {
-            continue;
-        };
-        let Some(key) = property.key.static_name() else {
-            continue;
-        };
-        let Some(value) = string_value(&property.value) else {
-            continue;
-        };
-        properties.insert(key.into_owned(), value);
-    }
-
-    properties
-}
-
 pub(super) fn extract_choice_options(
     object: &ObjectExpression<'_>,
     source: &str,

--- a/crates/palamedes/src/transform/messages.rs
+++ b/crates/palamedes/src/transform/messages.rs
@@ -32,16 +32,6 @@ pub(super) fn identifier_name<'a>(expr: &'a Expression<'a>) -> Option<&'a str> {
     }
 }
 
-pub(super) fn string_value(expr: &Expression<'_>) -> Option<String> {
-    match expr.without_parentheses() {
-        Expression::StringLiteral(literal) => Some(literal.value.to_string()),
-        Expression::TemplateLiteral(template) => {
-            template.single_quasi().map(|value| value.to_string())
-        }
-        _ => None,
-    }
-}
-
 pub(super) fn extract_choice_options(
     object: &ObjectExpression<'_>,
     source: &str,

--- a/crates/palamedes/src/transform/runtime.rs
+++ b/crates/palamedes/src/transform/runtime.rs
@@ -7,13 +7,16 @@ use oxc_ast::ast::{
 };
 use oxc_span::GetSpan;
 
+use crate::descriptor::{
+    descriptor_property_value, descriptor_static_property, unsupported_macro_syntax,
+};
 use crate::error::{PalamedesError, PalamedesResult};
 
 use super::messages::{
     append_unique_bindings, build_icu_message, choice_expression_binding, escape_string,
     expression_source, extract_choice_options, extract_choice_options_from_jsx,
     extract_jsx_children_parts, extract_jsx_value_binding, first_argument_object, jsx_attributes,
-    string_value, template_to_message, ValueBinding,
+    template_to_message, ValueBinding,
 };
 use super::NativeTransformOptions;
 
@@ -67,11 +70,11 @@ fn transform_descriptor_object(
     location: &str,
     options: &NativeTransformOptions,
 ) -> PalamedesResult<Option<(String, String)>> {
-    if object_property_value(object, "id").is_some() {
+    if descriptor_property_value(object, "id").is_some() {
         return Err(PalamedesError::ExplicitMessageIdsUnsupported);
     }
 
-    let Some(message_expression) = object_property_value(object, "message") else {
+    let Some(message_expression) = descriptor_property_value(object, "message") else {
         return Err(unsupported_macro_syntax(
             macro_name,
             location,
@@ -143,39 +146,6 @@ enum DescriptorValues {
     Raw(String),
 }
 
-fn object_property_value<'a>(
-    object: &'a ObjectExpression<'a>,
-    property_name: &str,
-) -> Option<&'a Expression<'a>> {
-    object.properties.iter().rev().find_map(|property| {
-        let ObjectPropertyKind::ObjectProperty(property) = property else {
-            return None;
-        };
-        (property.key.static_name().as_deref() == Some(property_name)).then_some(&property.value)
-    })
-}
-
-fn descriptor_static_property(
-    object: &ObjectExpression<'_>,
-    property_name: &str,
-    macro_name: &str,
-    location: &str,
-) -> PalamedesResult<Option<String>> {
-    let Some(value) = object_property_value(object, property_name) else {
-        return Ok(None);
-    };
-    let Some(value) = string_value(value) else {
-        return Err(unsupported_macro_syntax(
-            macro_name,
-            location,
-            format!(
-                "the descriptor `{property_name}` must be a string literal or expression-free template literal"
-            ),
-        ));
-    };
-    Ok(Some(value))
-}
-
 fn descriptor_values_argument(
     call: &CallExpression<'_>,
     source: &str,
@@ -185,7 +155,11 @@ fn descriptor_values_argument(
     location: &str,
 ) -> PalamedesResult<Option<String>> {
     let Some(argument) = call.arguments.get(1) else {
-        return Ok((!implicit_values.is_empty()).then(|| render_values_object(&implicit_values)));
+        if implicit_values.is_empty() {
+            return Ok(None);
+        }
+        validate_message_values(message, &implicit_values)?;
+        return Ok(Some(render_values_object(&implicit_values)));
     };
 
     match extract_descriptor_values(argument, source) {
@@ -234,18 +208,6 @@ fn merge_descriptor_values(
         implicit_values.push(binding);
     }
     Ok(implicit_values)
-}
-
-fn unsupported_macro_syntax(
-    macro_name: &str,
-    location: &str,
-    detail: impl Into<String>,
-) -> PalamedesError {
-    PalamedesError::UnsupportedMacroSyntax {
-        macro_name: macro_name.to_string(),
-        location: location.to_string(),
-        detail: detail.into(),
-    }
 }
 
 fn extract_descriptor_values(argument: &Argument<'_>, source: &str) -> DescriptorValues {

--- a/crates/palamedes/src/transform/runtime.rs
+++ b/crates/palamedes/src/transform/runtime.rs
@@ -2,7 +2,8 @@ use ferrocat::compiled_key;
 use std::collections::BTreeSet;
 
 use oxc_ast::ast::{
-    Argument, CallExpression, JSXElement, ObjectExpression, ObjectPropertyKind, TemplateLiteral,
+    Argument, CallExpression, Expression, JSXElement, ObjectExpression, ObjectPropertyKind,
+    TemplateLiteral,
 };
 use oxc_span::GetSpan;
 
@@ -11,8 +12,8 @@ use crate::error::{PalamedesError, PalamedesResult};
 use super::messages::{
     append_unique_bindings, build_icu_message, choice_expression_binding, escape_string,
     expression_source, extract_choice_options, extract_choice_options_from_jsx,
-    extract_jsx_children_parts, extract_jsx_value_binding, extract_object_properties,
-    first_argument_object, jsx_attributes, template_to_message, ValueBinding,
+    extract_jsx_children_parts, extract_jsx_value_binding, first_argument_object, jsx_attributes,
+    string_value, template_to_message, ValueBinding,
 };
 use super::NativeTransformOptions;
 
@@ -44,13 +45,18 @@ pub(super) fn transform_descriptor_call(
     call: &CallExpression<'_>,
     source: &str,
     macro_name: &str,
+    location: &str,
     options: &NativeTransformOptions,
 ) -> PalamedesResult<Option<(String, String)>> {
     let Some(object) = first_argument_object(call) else {
-        return Ok(None);
+        return Err(unsupported_macro_syntax(
+            macro_name,
+            location,
+            "the first argument must be a descriptor object",
+        ));
     };
 
-    transform_descriptor_object(call, object, source, macro_name, options)
+    transform_descriptor_object(call, object, source, macro_name, location, options)
 }
 
 fn transform_descriptor_object(
@@ -58,25 +64,44 @@ fn transform_descriptor_object(
     object: &ObjectExpression<'_>,
     source: &str,
     macro_name: &str,
+    location: &str,
     options: &NativeTransformOptions,
 ) -> PalamedesResult<Option<(String, String)>> {
-    let props = extract_object_properties(object);
-    if props.contains_key("id") {
+    if object_property_value(object, "id").is_some() {
         return Err(PalamedesError::ExplicitMessageIdsUnsupported);
     }
-    let message = props.get("message").cloned();
-    let context = props.get("context").cloned();
-    let comment = props.get("comment").cloned();
 
-    let Some(message) = message else {
-        return Ok(None);
+    let Some(message_expression) = object_property_value(object, "message") else {
+        return Err(unsupported_macro_syntax(
+            macro_name,
+            location,
+            "the descriptor must contain a static `message` property",
+        ));
     };
 
-    let message = if matches!(macro_name, "t" | "defineMessage" | "msg") {
-        message
-    } else {
-        return Ok(None);
+    let (message, implicit_values) = match message_expression.without_parentheses() {
+        Expression::StringLiteral(literal) => (literal.value.to_string(), Vec::new()),
+        Expression::TemplateLiteral(template) => {
+            if macro_name == "defineMessage" && !template.expressions.is_empty() {
+                return Err(unsupported_macro_syntax(
+                    macro_name,
+                    location,
+                    "interpolated descriptor templates require runtime values; use `t()` or `msg()`, or write a static ICU message",
+                ));
+            }
+            let (message, values) = template_to_message(template, source)?;
+            (message, values.unwrap_or_default())
+        }
+        _ => {
+            return Err(unsupported_macro_syntax(
+                macro_name,
+                location,
+                "the descriptor `message` must be a string literal or template literal",
+            ));
+        }
     };
+    let context = descriptor_static_property(object, "context", macro_name, location)?;
+    let comment = descriptor_static_property(object, "comment", macro_name, location)?;
 
     let lookup_key = compiled_key(&message, context.as_deref());
     let descriptor = build_message_descriptor(
@@ -91,7 +116,14 @@ fn transform_descriptor_object(
     if macro_name == "defineMessage" {
         Ok(Some((descriptor, lookup_key)))
     } else {
-        let values_text = descriptor_values_argument(call, source, &message)?;
+        let values_text = descriptor_values_argument(
+            call,
+            source,
+            &message,
+            implicit_values,
+            macro_name,
+            location,
+        )?;
         Ok(Some((
             build_runtime_call_with_values_text(
                 &lookup_key,
@@ -111,21 +143,108 @@ enum DescriptorValues {
     Raw(String),
 }
 
+fn object_property_value<'a>(
+    object: &'a ObjectExpression<'a>,
+    property_name: &str,
+) -> Option<&'a Expression<'a>> {
+    object.properties.iter().rev().find_map(|property| {
+        let ObjectPropertyKind::ObjectProperty(property) = property else {
+            return None;
+        };
+        (property.key.static_name().as_deref() == Some(property_name)).then_some(&property.value)
+    })
+}
+
+fn descriptor_static_property(
+    object: &ObjectExpression<'_>,
+    property_name: &str,
+    macro_name: &str,
+    location: &str,
+) -> PalamedesResult<Option<String>> {
+    let Some(value) = object_property_value(object, property_name) else {
+        return Ok(None);
+    };
+    let Some(value) = string_value(value) else {
+        return Err(unsupported_macro_syntax(
+            macro_name,
+            location,
+            format!(
+                "the descriptor `{property_name}` must be a string literal or expression-free template literal"
+            ),
+        ));
+    };
+    Ok(Some(value))
+}
+
 fn descriptor_values_argument(
     call: &CallExpression<'_>,
     source: &str,
     message: &str,
+    implicit_values: Vec<ValueBinding>,
+    macro_name: &str,
+    location: &str,
 ) -> PalamedesResult<Option<String>> {
     let Some(argument) = call.arguments.get(1) else {
-        return Ok(None);
+        return Ok((!implicit_values.is_empty()).then(|| render_values_object(&implicit_values)));
     };
 
     match extract_descriptor_values(argument, source) {
-        DescriptorValues::Bindings(bindings) => {
+        DescriptorValues::Bindings(explicit_values) => {
+            let bindings = merge_descriptor_values(
+                implicit_values,
+                explicit_values,
+                macro_name,
+                location,
+            )?;
             validate_message_values(message, &bindings)?;
             Ok(Some(render_values_object(&bindings)))
         }
-        DescriptorValues::Raw(source) => Ok(Some(source)),
+        DescriptorValues::Raw(source) if implicit_values.is_empty() => Ok(Some(source)),
+        DescriptorValues::Raw(_) => Err(unsupported_macro_syntax(
+            macro_name,
+            location,
+            "interpolated descriptor templates can only be combined with an object-literal values argument",
+        )),
+    }
+}
+
+fn merge_descriptor_values(
+    mut implicit_values: Vec<ValueBinding>,
+    explicit_values: Vec<ValueBinding>,
+    macro_name: &str,
+    location: &str,
+) -> PalamedesResult<Vec<ValueBinding>> {
+    for binding in explicit_values {
+        if let Some(existing) = implicit_values
+            .iter()
+            .find(|existing| existing.name == binding.name)
+        {
+            if existing.expression == binding.expression {
+                continue;
+            }
+            return Err(unsupported_macro_syntax(
+                macro_name,
+                location,
+                format!(
+                    "the explicit value `{}` conflicts with the expression captured by the message template",
+                    binding.name
+                ),
+            ));
+        }
+        implicit_values.push(binding);
+    }
+    Ok(implicit_values)
+}
+
+fn unsupported_macro_syntax(
+    macro_name: &str,
+    location: &str,
+    detail: impl Into<String>,
+) -> PalamedesError {
+    PalamedesError::UnsupportedMacroSyntax {
+        macro_name: macro_name.to_string(),
+        location: location.to_string(),
+        detail: detail.into(),
     }
 }
 

--- a/crates/palamedes/src/transform/tests.rs
+++ b/crates/palamedes/src/transform/tests.rs
@@ -135,6 +135,22 @@ const message = t({ message: `Hello ${name}, you have {count}` }, { count });
 }
 
 #[test]
+fn rejects_missing_icu_values_in_interpolated_descriptor_templates() {
+    let error = transform_macros(
+        r#"import { t } from "@palamedes/core/macro";
+const message = t({ message: `Hello ${name}, you have {count}` });
+"#,
+        "test.ts",
+        None,
+    )
+    .expect_err("implicit template values must validate all message placeholders");
+
+    let message = error.to_string();
+    assert!(message.contains("Missing value(s): count"));
+    assert!(message.contains("extra value(s): none"));
+}
+
+#[test]
 fn rejects_interpolated_define_message_descriptors() {
     let error = transform_macros(
         r#"import { defineMessage } from "@palamedes/core/macro";

--- a/crates/palamedes/src/transform/tests.rs
+++ b/crates/palamedes/src/transform/tests.rs
@@ -93,6 +93,81 @@ fn transforms_define_message_without_runtime_import() {
 }
 
 #[test]
+fn transforms_interpolated_descriptor_templates() {
+    for macro_name in ["t", "msg"] {
+        let source = format!(
+            r#"import {{ {macro_name} }} from "@palamedes/core/macro";
+const message = {macro_name}({{
+  message: `Descriptor ${{name}}`,
+  context: "probe context",
+}});
+"#
+        );
+        let result = transform_macros(&source, "test.ts", None).expect("transform should succeed");
+
+        assert!(result.code.contains("message: \"Descriptor {name}\""));
+        assert!(result.code.contains("{ name }"));
+        assert!(result.code.contains("context: \"probe context\""));
+        assert!(!result.code.contains("@palamedes/core/macro"));
+        assert!(!result.code.contains(&format!("{macro_name}({{")));
+        assert_eq!(
+            result.compiled_ids,
+            vec![compiled_key("Descriptor {name}", Some("probe context"))]
+        );
+    }
+}
+
+#[test]
+fn merges_interpolated_descriptor_values_with_explicit_values() {
+    let result = transform_macros(
+        r#"import { t } from "@palamedes/core/macro";
+const message = t({ message: `Hello ${name}, you have {count}` }, { count });
+"#,
+        "test.ts",
+        None,
+    )
+    .expect("transform should succeed");
+
+    assert!(result
+        .code
+        .contains("message: \"Hello {name}, you have {count}\""));
+    assert!(result.code.contains("{ name, count }"));
+}
+
+#[test]
+fn rejects_interpolated_define_message_descriptors() {
+    let error = transform_macros(
+        r#"import { defineMessage } from "@palamedes/core/macro";
+const message = defineMessage({ message: `Hello ${name}` });
+"#,
+        "test.ts",
+        None,
+    )
+    .expect_err("defineMessage cannot capture runtime template values");
+
+    let message = error.to_string();
+    assert!(message.contains("Unsupported `defineMessage` macro usage at test.ts:2:17"));
+    assert!(message.contains("interpolated descriptor templates require runtime values"));
+}
+
+#[test]
+fn rejects_untransformable_macro_calls_before_removing_imports() {
+    let error = transform_macros(
+        r#"import { t } from "@palamedes/core/macro";
+const valid = t`Hello`;
+const broken = t({ message });
+"#,
+        "test.ts",
+        None,
+    )
+    .expect_err("untransformable macros must fail the module");
+
+    let message = error.to_string();
+    assert!(message.contains("Unsupported `t` macro usage at test.ts:3:16"));
+    assert!(message.contains("must be a string literal or template literal"));
+}
+
+#[test]
 fn transforms_plural_choice_macros() {
     let result = transform_macros(
         "import { plural } from \"@palamedes/core/macro\";\nconst msg = plural(count, { one: \"# item\", other: \"# items\" });\n",

--- a/crates/palamedes/src/transform/visitor.rs
+++ b/crates/palamedes/src/transform/visitor.rs
@@ -72,6 +72,14 @@ impl<'a> TransformVisitor<'a> {
         }
     }
 
+    fn fail_unsupported_macro(&mut self, macro_name: &str, start: usize) {
+        self.fail(PalamedesError::UnsupportedMacroSyntax {
+            macro_name: macro_name.to_string(),
+            location: source_location(self.source, self.filename, start),
+            detail: "the macro could not be statically transformed; use a supported literal, template, descriptor, or choice shape".to_string(),
+        });
+    }
+
     fn is_current_jsx_child_element(&self, element: &JSXElement<'_>) -> bool {
         self.jsx_child_element_spans
             .last()
@@ -92,7 +100,7 @@ impl<'a> Visit<'a> for TransformVisitor<'a> {
             return;
         };
 
-        let Some(macro_info) = self.macro_imports.get(tag_name.as_str()) else {
+        let Some(macro_info) = self.macro_imports.get(tag_name.as_str()).cloned() else {
             walk::walk_jsx_element(self, it);
             return;
         };
@@ -152,16 +160,14 @@ impl<'a> Visit<'a> for TransformVisitor<'a> {
                 } else {
                     self.needs_runtime_import = true;
                 }
-                return;
             }
-            Ok(None) => {}
+            Ok(None) => {
+                self.fail_unsupported_macro(&macro_info.imported_name, it.span.start as usize);
+            }
             Err(error) => {
                 self.fail(error);
-                return;
             }
         }
-
-        walk::walk_jsx_element(self, it);
     }
 
     fn visit_jsx_child(&mut self, it: &JSXChild<'a>) {
@@ -185,7 +191,7 @@ impl<'a> Visit<'a> for TransformVisitor<'a> {
             return;
         };
 
-        let Some(macro_info) = self.macro_imports.get(local_name) else {
+        let Some(macro_info) = self.macro_imports.get(local_name).cloned() else {
             walk::walk_tagged_template_expression(self, it);
             return;
         };
@@ -205,7 +211,10 @@ impl<'a> Visit<'a> for TransformVisitor<'a> {
                 self.push_compiled_id(&compiled_id);
                 self.needs_runtime_import = true;
             }
-            Ok(None) => {}
+            Ok(None) => {
+                self.fail_unsupported_macro(&macro_info.imported_name, it.span.start as usize);
+                return;
+            }
             Err(error) => {
                 self.fail(error);
                 return;
@@ -225,10 +234,11 @@ impl<'a> Visit<'a> for TransformVisitor<'a> {
             return;
         };
 
-        let Some(macro_info) = self.macro_imports.get(local_name) else {
+        let Some(macro_info) = self.macro_imports.get(local_name).cloned() else {
             walk::walk_call_expression(self, it);
             return;
         };
+        let location = source_location(self.source, self.filename, it.span.start as usize);
 
         match macro_info.imported_name.as_str() {
             "t" | "msg" | "defineMessage" => {
@@ -236,6 +246,7 @@ impl<'a> Visit<'a> for TransformVisitor<'a> {
                     it,
                     self.source,
                     &macro_info.imported_name,
+                    &location,
                     self.options,
                 ) {
                     Ok(Some((text, compiled_id))) => {
@@ -249,7 +260,13 @@ impl<'a> Visit<'a> for TransformVisitor<'a> {
                             self.needs_runtime_import = true;
                         }
                     }
-                    Ok(None) => {}
+                    Ok(None) => {
+                        self.fail_unsupported_macro(
+                            &macro_info.imported_name,
+                            it.span.start as usize,
+                        );
+                        return;
+                    }
                     Err(error) => {
                         self.fail(error);
                         return;
@@ -272,7 +289,13 @@ impl<'a> Visit<'a> for TransformVisitor<'a> {
                         self.push_compiled_id(&compiled_id);
                         self.needs_runtime_import = true;
                     }
-                    Ok(None) => {}
+                    Ok(None) => {
+                        self.fail_unsupported_macro(
+                            &macro_info.imported_name,
+                            it.span.start as usize,
+                        );
+                        return;
+                    }
                     Err(error) => {
                         self.fail(error);
                         return;

--- a/packages/extractor/src/extractMessages.test.ts
+++ b/packages/extractor/src/extractMessages.test.ts
@@ -147,6 +147,49 @@ describe("extractMessages", () => {
       expect(messages[1].context).toBe("email.subject")
     })
 
+    it("extracts interpolated descriptor templates with placeholder metadata", () => {
+      const code = `
+        import { msg, t } from "@palamedes/core/macro"
+        const one = t({
+          message: \`Descriptor \${name}\`,
+          context: "probe context",
+        })
+        const two = msg({ message: \`Locale \${resolved.locale}\` })
+      `
+      const messages = extract(code)
+
+      expect(messages).toHaveLength(2)
+      expect(messages[0]).toMatchObject({
+        message: "Descriptor {name}",
+        context: "probe context",
+        placeholders: { name: "name" },
+      })
+      expect(messages[1]).toMatchObject({
+        message: "Locale {locale}",
+        placeholders: { locale: "resolved.locale" },
+      })
+    })
+
+    it("rejects interpolated defineMessage descriptor templates", () => {
+      const code = `import { defineMessage } from "@palamedes/core/macro"
+const descriptor = defineMessage({ message: \`Descriptor \${name}\` })
+`
+
+      expect(() => extract(code)).toThrow(
+        /Unsupported `defineMessage` macro usage at test\.tsx:2:20.*runtime values/
+      )
+    })
+
+    it("rejects dynamic descriptor messages with a source location", () => {
+      const code = `import { t } from "@palamedes/core/macro"
+const descriptor = t({ message })
+`
+
+      expect(() => extract(code)).toThrow(
+        /Unsupported `t` macro usage at test\.tsx:2:20.*string literal or template literal/
+      )
+    })
+
     it("extracts plural and select messages", () => {
       const code = `
         import { plural, select } from "@palamedes/core/macro"

--- a/packages/transform/src/transform.test.ts
+++ b/packages/transform/src/transform.test.ts
@@ -67,6 +67,47 @@ const msg = t({ message: "Hello", context: "informal", comment: "A greeting" });
     expect(result.code).not.toContain('id: "greeting"')
   })
 
+  it.each(["t", "msg"])(
+    "transforms interpolated %s descriptor templates with runtime values",
+    (macroName) => {
+      const code = `
+import { ${macroName} } from "@palamedes/core/macro";
+const descriptor = ${macroName}({
+  message: \`Descriptor \${name}\`,
+  context: "probe context",
+});
+`
+      const result = transformPalamedesMacros(code, "test.ts")
+
+      expect(result.code).toContain('message: "Descriptor {name}"')
+      expect(result.code).toContain("{ name }")
+      expect(result.code).toContain('context: "probe context"')
+      expect(result.code).not.toContain("@palamedes/core/macro")
+      expect(result.code).not.toContain(`${macroName}({`)
+    }
+  )
+
+  it("rejects interpolated defineMessage descriptor templates with a source location", () => {
+    const code = `import { defineMessage } from "@palamedes/core/macro";
+const descriptor = defineMessage({ message: \`Descriptor \${name}\` });
+`
+
+    expect(() => transformPalamedesMacros(code, "test.ts")).toThrow(
+      /Unsupported `defineMessage` macro usage at test\.ts:2:20.*runtime values/
+    )
+  })
+
+  it("rejects unsupported macro calls before removing a shared macro import", () => {
+    const code = `import { t } from "@palamedes/core/macro";
+const valid = t\`Hello\`;
+const broken = t({ message });
+`
+
+    expect(() => transformPalamedesMacros(code, "test.ts")).toThrow(
+      /Unsupported `t` macro usage at test\.ts:3:16.*string literal or template literal/
+    )
+  })
+
   it("forwards descriptor macro values object literals", () => {
     const code = `
 import { t } from "@palamedes/core/macro";

--- a/packages/transform/src/transform.test.ts
+++ b/packages/transform/src/transform.test.ts
@@ -87,6 +87,15 @@ const descriptor = ${macroName}({
     }
   )
 
+  it("rejects missing ICU values in interpolated descriptor templates", () => {
+    const code = `
+import { t } from "@palamedes/core/macro";
+const descriptor = t({ message: \`Hello \${name}, you have {count}\` });
+`
+
+    expect(() => transformPalamedesMacros(code, "test.ts")).toThrow(/Missing value\(s\): count/)
+  })
+
   it("rejects interpolated defineMessage descriptor templates with a source location", () => {
     const code = `import { defineMessage } from "@palamedes/core/macro";
 const descriptor = defineMessage({ message: \`Descriptor \${name}\` });


### PR DESCRIPTION
## Summary

- lower interpolated `t()` and `msg()` descriptor templates through the existing ICU placeholder pipeline
- extract descriptor template placeholders and preserve static context/comment metadata
- merge captured template values with explicit object-literal values
- fail unsupported macro shapes with file/line/column diagnostics before macro imports can be removed
- reject interpolated `defineMessage()` descriptors because descriptors cannot capture runtime values

## Root cause

Descriptor parsing reused a string-only object-property helper. That helper accepted string literals and expression-free templates, but silently skipped template literals containing expressions. Extraction therefore emitted no catalog entry. If another macro in the same module transformed successfully, the transformer removed the shared macro import while leaving the unsupported descriptor call behind.

## Impact

Interpolated descriptor messages now enter catalogs as ICU messages and receive the runtime values needed for rendering. Unsupported descriptor shapes fail during extraction/transformation instead of being silently dropped or producing an unresolved runtime macro call.

## Validation

- `RUSTUP_TOOLCHAIN=1.95 pnpm agent:check`
  - package build
  - release-set validation
  - formatting
  - Oxlint and ESLint
  - all package tests
  - native type generation and TypeScript checks
  - Rustfmt
  - workspace Clippy with warnings denied
  - workspace Rust tests
- targeted transformer suite: 47 tests passed
- targeted extractor suite: 31 tests passed
- Palamedes Rust suite: 145 tests plus doc test passed

Closes #387