### PR TITLE
Remove deferred message APIs

### DIFF
--- a/crates/palamedes/src/extract.rs
+++ b/crates/palamedes/src/extract.rs
@@ -133,12 +133,14 @@ impl LineLocator {
 
 struct MacroCollector {
     imported_macros: HashMap<String, ImportedMacro>,
+    removed_macro_import: Option<(String, usize)>,
 }
 
 impl MacroCollector {
     fn new() -> Self {
         Self {
             imported_macros: HashMap::new(),
+            removed_macro_import: None,
         }
     }
 }
@@ -153,11 +155,16 @@ impl<'a> Visit<'a> for MacroCollector {
         if let Some(specifiers) = &it.specifiers {
             for specifier in specifiers {
                 if let ImportDeclarationSpecifier::ImportSpecifier(specifier) = specifier {
+                    let imported_name = specifier.imported.name().to_string();
+                    if matches!(imported_name.as_str(), "msg" | "defineMessage")
+                        && self.removed_macro_import.is_none()
+                    {
+                        self.removed_macro_import =
+                            Some((imported_name.clone(), it.span.start as usize));
+                    }
                     self.imported_macros.insert(
                         specifier.local.name.to_string(),
-                        ImportedMacro {
-                            imported_name: specifier.imported.name().to_string(),
-                        },
+                        ImportedMacro { imported_name },
                     );
                 }
             }
@@ -331,7 +338,7 @@ impl<'a> Visit<'a> for ExtractionVisitor<'a> {
 
         if let Some(tag_name) = identifier_name(&it.tag) {
             if let Some(macro_name) = self
-                .imported_macro_name(tag_name, &["t", "msg"])
+                .imported_macro_name(tag_name, &["t"])
                 .map(str::to_string)
             {
                 match extract_from_tagged_template(
@@ -381,17 +388,7 @@ impl<'a> Visit<'a> for ExtractionVisitor<'a> {
 
         if let Some(callee_name) = identifier_name(&it.callee) {
             if let Some(macro_name) = self
-                .imported_macro_name(
-                    callee_name,
-                    &[
-                        "t",
-                        "defineMessage",
-                        "msg",
-                        "plural",
-                        "select",
-                        "selectOrdinal",
-                    ],
-                )
+                .imported_macro_name(callee_name, &["t", "plural", "select", "selectOrdinal"])
                 .map(str::to_string)
             {
                 let message = match macro_name.as_str() {
@@ -743,16 +740,7 @@ fn extract_from_descriptor_call(
 
     let (message, placeholders) = match message_expression.without_parentheses() {
         Expression::StringLiteral(literal) => (literal.value.to_string(), BTreeMap::new()),
-        Expression::TemplateLiteral(template) => {
-            if macro_name == "defineMessage" && !template.expressions.is_empty() {
-                return Err(unsupported_macro_syntax(
-                    macro_name,
-                    location,
-                    "interpolated descriptor templates require runtime values; use `t()` or `msg()`, or write a static ICU message",
-                ));
-            }
-            template_to_message(template, source)?
-        }
+        Expression::TemplateLiteral(template) => template_to_message(template, source)?,
         _ => {
             return Err(unsupported_macro_syntax(
                 macro_name,
@@ -857,22 +845,12 @@ fn extract_from_runtime_call(
         return Ok(None);
     };
 
-    if let Argument::ObjectExpression(object) = first_arg {
-        let props = extract_object_properties(object);
-        if props.contains_key("id") {
-            return Err(PalamedesError::ExplicitMessageIdsUnsupported);
-        }
-        let Some(message) = props.get("message").cloned() else {
-            return Ok(None);
-        };
-        return Ok(Some(ExtractedMessageRecord {
-            message,
-            comment: props.get("comment").cloned(),
-            context: props.get("context").cloned(),
-            placeholders: None,
-            origin,
-            scope,
-        }));
+    if matches!(first_arg, Argument::ObjectExpression(_)) {
+        return Err(PalamedesError::UnsupportedMacroSyntax {
+            macro_name: "i18n._".to_string(),
+            location: format!("{}:{}:1", origin.0, origin.1),
+            detail: "object-form runtime messages have been removed; pass a string id as the first argument and source metadata as the third argument".to_string(),
+        });
     }
 
     let mut message = argument_string_value(first_arg);
@@ -1344,6 +1322,15 @@ pub fn extract_messages(
     let mut collector = MacroCollector::new();
     collector.visit_program(&parsed.program);
 
+    if let Some((macro_name, offset)) = collector.removed_macro_import.as_ref() {
+        let (line, column) = line_locator.get_location(*offset);
+        return Err(PalamedesError::UnsupportedMacroSyntax {
+            macro_name: macro_name.clone(),
+            location: format!("{filename}:{line}:{column}"),
+            detail: "this deferred message macro has been removed; translate at the point of use with `t`".to_string(),
+        });
+    }
+
     let mut extractor =
         ExtractionVisitor::new(filename, source, &line_locator, &collector.imported_macros);
     extractor.visit_program(&parsed.program);
@@ -1611,12 +1598,12 @@ mod tests {
     fn extracts_interpolated_descriptor_templates() {
         let messages = extract_messages(
             r#"
-              import { msg, t } from "@palamedes/core/macro"
+              import { t } from "@palamedes/core/macro"
               const first = t({
                 message: `Descriptor ${name}`,
                 context: "probe context",
               })
-              const second = msg({ message: `Locale ${resolved.locale}` })
+              const second = t({ message: `Locale ${resolved.locale}` })
             "#,
             "test.tsx",
         )
@@ -1640,18 +1627,22 @@ mod tests {
     }
 
     #[test]
-    fn rejects_interpolated_define_message_descriptors() {
-        let error = extract_messages(
-            r#"import { defineMessage } from "@palamedes/core/macro"
-const message = defineMessage({ message: `Hello ${name}` })
-"#,
-            "test.ts",
-        )
-        .expect_err("defineMessage cannot capture runtime template values");
+    fn rejects_removed_deferred_macro_imports() {
+        for macro_name in ["msg", "defineMessage"] {
+            let source = format!(
+                r#"import {{ t, {macro_name} as deferred }} from "@palamedes/core/macro"
+const message = t`Hello`
+"#
+            );
+            let error = extract_messages(&source, "test.ts")
+                .expect_err("removed deferred macro imports must fail");
 
-        let message = error.to_string();
-        assert!(message.contains("Unsupported `defineMessage` macro usage at test.ts:2:17"));
-        assert!(message.contains("interpolated descriptor templates require runtime values"));
+            let message = error.to_string();
+            assert!(message.contains(&format!(
+                "Unsupported `{macro_name}` macro usage at test.ts:1:1"
+            )));
+            assert!(message.contains("deferred message macro has been removed"));
+        }
     }
 
     #[test]
@@ -1680,6 +1671,16 @@ const message = t({ message })
         .expect("messages should extract");
 
         assert_eq!(messages[0].message, "Hello {name}");
+    }
+
+    #[test]
+    fn rejects_object_form_runtime_messages() {
+        let error = extract_messages(r#"const message = i18n._({ message: "Hello" })"#, "test.ts")
+            .expect_err("object-form runtime messages must fail");
+
+        assert!(error
+            .to_string()
+            .contains("object-form runtime messages have been removed"));
     }
 
     #[test]

--- a/crates/palamedes/src/transform/imports.rs
+++ b/crates/palamedes/src/transform/imports.rs
@@ -20,6 +20,7 @@ pub(super) struct ImportCollector {
     runtime_import_name: String,
     pub macro_imports: HashMap<String, ImportedMacro>,
     pub macro_import_ranges: Vec<(usize, usize)>,
+    pub removed_macro_import: Option<(String, usize)>,
     pub has_runtime_import: bool,
     pub trans_import_sources: HashSet<String>,
 }
@@ -31,6 +32,7 @@ impl ImportCollector {
             runtime_import_name: runtime_import_name.to_string(),
             macro_imports: HashMap::new(),
             macro_import_ranges: Vec::new(),
+            removed_macro_import: None,
             has_runtime_import: false,
             trans_import_sources: HashSet::new(),
         }
@@ -48,10 +50,17 @@ impl<'a> Visit<'a> for ImportCollector {
             if let Some(specifiers) = &it.specifiers {
                 for specifier in specifiers {
                     if let ImportDeclarationSpecifier::ImportSpecifier(specifier) = specifier {
+                        let imported_name = specifier.imported.name().to_string();
+                        if matches!(imported_name.as_str(), "msg" | "defineMessage")
+                            && self.removed_macro_import.is_none()
+                        {
+                            self.removed_macro_import =
+                                Some((imported_name.clone(), it.span.start as usize));
+                        }
                         self.macro_imports.insert(
                             specifier.local.name.to_string(),
                             ImportedMacro {
-                                imported_name: specifier.imported.name().to_string(),
+                                imported_name,
                                 source: source.to_string(),
                             },
                         );

--- a/crates/palamedes/src/transform/mod.rs
+++ b/crates/palamedes/src/transform/mod.rs
@@ -18,7 +18,7 @@ use string_wizard::{Hires, MagicString, SourceMapOptions};
 use crate::error::{PalamedesError, PalamedesResult};
 
 use self::imports::ImportCollector;
-use self::visitor::{Replacement, TransformVisitor};
+use self::visitor::{source_location, Replacement, TransformVisitor};
 
 /// Options controlling how macro transforms emit runtime code.
 #[derive(Debug, Default, Deserialize)]
@@ -131,6 +131,14 @@ pub fn transform_macros(
 
     let mut collector = ImportCollector::new(&runtime_module, &runtime_import_name);
     collector.visit_program(&parsed.program);
+
+    if let Some((macro_name, offset)) = collector.removed_macro_import.as_ref() {
+        return Err(PalamedesError::UnsupportedMacroSyntax {
+            macro_name: macro_name.clone(),
+            location: source_location(source, filename, *offset),
+            detail: "this deferred message macro has been removed; translate at the point of use with `t`".to_string(),
+        });
+    }
 
     if collector.macro_imports.is_empty() {
         return Ok(unchanged_result(source));

--- a/crates/palamedes/src/transform/runtime.rs
+++ b/crates/palamedes/src/transform/runtime.rs
@@ -85,13 +85,6 @@ fn transform_descriptor_object(
     let (message, implicit_values) = match message_expression.without_parentheses() {
         Expression::StringLiteral(literal) => (literal.value.to_string(), Vec::new()),
         Expression::TemplateLiteral(template) => {
-            if macro_name == "defineMessage" && !template.expressions.is_empty() {
-                return Err(unsupported_macro_syntax(
-                    macro_name,
-                    location,
-                    "interpolated descriptor templates require runtime values; use `t()` or `msg()`, or write a static ICU message",
-                ));
-            }
             let (message, values) = template_to_message(template, source)?;
             (message, values.unwrap_or_default())
         }
@@ -107,38 +100,25 @@ fn transform_descriptor_object(
     let comment = descriptor_static_property(object, "comment", macro_name, location)?;
 
     let lookup_key = compiled_key(&message, context.as_deref());
-    let descriptor = build_message_descriptor(
-        &lookup_key,
-        Some(&message),
-        None,
-        context.as_deref(),
-        comment.as_deref(),
-        options,
-    );
-
-    if macro_name == "defineMessage" {
-        Ok(Some((descriptor, lookup_key)))
-    } else {
-        let values_text = descriptor_values_argument(
-            call,
-            source,
-            &message,
-            implicit_values,
-            macro_name,
-            location,
-        )?;
-        Ok(Some((
-            build_runtime_call_with_values_text(
-                &lookup_key,
-                Some(&message),
-                values_text.as_deref(),
-                context.as_deref(),
-                comment.as_deref(),
-                options,
-            ),
-            lookup_key,
-        )))
-    }
+    let values_text = descriptor_values_argument(
+        call,
+        source,
+        &message,
+        implicit_values,
+        macro_name,
+        location,
+    )?;
+    Ok(Some((
+        build_runtime_call_with_values_text(
+            &lookup_key,
+            Some(&message),
+            values_text.as_deref(),
+            context.as_deref(),
+            comment.as_deref(),
+            options,
+        ),
+        lookup_key,
+    )))
 }
 
 enum DescriptorValues {
@@ -461,43 +441,6 @@ pub(super) fn transform_choice_jsx_element(
         ),
         lookup_key,
     )))
-}
-
-fn build_message_descriptor(
-    lookup_key: &str,
-    message: Option<&str>,
-    values: Option<&[String]>,
-    context: Option<&str>,
-    comment: Option<&str>,
-    options: &NativeTransformOptions,
-) -> String {
-    let mut parts = vec![format!("id: \"{}\"", escape_string(lookup_key))];
-
-    if let Some(message) = message {
-        if !options.strip_message_field.unwrap_or(false) {
-            parts.push(format!("message: \"{}\"", escape_string(message)));
-        }
-    }
-
-    if let Some(values) = values {
-        if !values.is_empty() {
-            parts.push(format!("values: {{ {} }}", values.join(", ")));
-        }
-    }
-
-    if let Some(context) = context {
-        if !options.strip_non_essential_props.unwrap_or(false) {
-            parts.push(format!("context: \"{}\"", escape_string(context)));
-        }
-    }
-
-    if let Some(comment) = comment {
-        if !options.strip_non_essential_props.unwrap_or(false) {
-            parts.push(format!("comment: \"{}\"", escape_string(comment)));
-        }
-    }
-
-    format!("{{ {} }}", parts.join(", "))
 }
 
 fn build_runtime_call(

--- a/crates/palamedes/src/transform/tests.rs
+++ b/crates/palamedes/src/transform/tests.rs
@@ -78,43 +78,24 @@ fn preserves_member_expression_values_in_tagged_templates() {
 }
 
 #[test]
-fn transforms_define_message_without_runtime_import() {
-    let result = transform_macros(
-        "import { defineMessage } from \"@palamedes/core/macro\";\nconst msg = defineMessage({ message: \"Hello\" });\n",
-        "test.ts",
-        None,
-    )
-    .expect("transform should succeed");
-
-    assert!(result.code.contains("id:"));
-    assert!(result.code.contains("message: \"Hello\""));
-    assert!(!result.code.contains("getI18n()._("));
-    assert_eq!(result.compiled_ids, vec![compiled_key("Hello", None)]);
-}
-
-#[test]
 fn transforms_interpolated_descriptor_templates() {
-    for macro_name in ["t", "msg"] {
-        let source = format!(
-            r#"import {{ {macro_name} }} from "@palamedes/core/macro";
-const message = {macro_name}({{
-  message: `Descriptor ${{name}}`,
+    let source = r#"import { t } from "@palamedes/core/macro";
+const message = t({
+  message: `Descriptor ${name}`,
   context: "probe context",
-}});
-"#
-        );
-        let result = transform_macros(&source, "test.ts", None).expect("transform should succeed");
+});
+"#;
+    let result = transform_macros(source, "test.ts", None).expect("transform should succeed");
 
-        assert!(result.code.contains("message: \"Descriptor {name}\""));
-        assert!(result.code.contains("{ name }"));
-        assert!(result.code.contains("context: \"probe context\""));
-        assert!(!result.code.contains("@palamedes/core/macro"));
-        assert!(!result.code.contains(&format!("{macro_name}({{")));
-        assert_eq!(
-            result.compiled_ids,
-            vec![compiled_key("Descriptor {name}", Some("probe context"))]
-        );
-    }
+    assert!(result.code.contains("message: \"Descriptor {name}\""));
+    assert!(result.code.contains("{ name }"));
+    assert!(result.code.contains("context: \"probe context\""));
+    assert!(!result.code.contains("@palamedes/core/macro"));
+    assert!(!result.code.contains("t({"));
+    assert_eq!(
+        result.compiled_ids,
+        vec![compiled_key("Descriptor {name}", Some("probe context"))]
+    );
 }
 
 #[test]
@@ -151,19 +132,22 @@ const message = t({ message: `Hello ${name}, you have {count}` });
 }
 
 #[test]
-fn rejects_interpolated_define_message_descriptors() {
-    let error = transform_macros(
-        r#"import { defineMessage } from "@palamedes/core/macro";
-const message = defineMessage({ message: `Hello ${name}` });
-"#,
-        "test.ts",
-        None,
-    )
-    .expect_err("defineMessage cannot capture runtime template values");
+fn rejects_removed_deferred_macro_imports_before_removing_shared_imports() {
+    for macro_name in ["msg", "defineMessage"] {
+        let source = format!(
+            r#"import {{ t, {macro_name} as deferred }} from "@palamedes/core/macro";
+const valid = t`Hello`;
+"#
+        );
+        let error = transform_macros(&source, "test.ts", None)
+            .expect_err("removed deferred macro imports must fail");
 
-    let message = error.to_string();
-    assert!(message.contains("Unsupported `defineMessage` macro usage at test.ts:2:17"));
-    assert!(message.contains("interpolated descriptor templates require runtime values"));
+        let message = error.to_string();
+        assert!(message.contains(&format!(
+            "Unsupported `{macro_name}` macro usage at test.ts:1:1"
+        )));
+        assert!(message.contains("deferred message macro has been removed"));
+    }
 }
 
 #[test]

--- a/crates/palamedes/src/transform/visitor.rs
+++ b/crates/palamedes/src/transform/visitor.rs
@@ -196,7 +196,7 @@ impl<'a> Visit<'a> for TransformVisitor<'a> {
             return;
         };
 
-        if !matches!(macro_info.imported_name.as_str(), "t" | "msg") {
+        if macro_info.imported_name != "t" {
             walk::walk_tagged_template_expression(self, it);
             return;
         }
@@ -241,7 +241,7 @@ impl<'a> Visit<'a> for TransformVisitor<'a> {
         let location = source_location(self.source, self.filename, it.span.start as usize);
 
         match macro_info.imported_name.as_str() {
-            "t" | "msg" | "defineMessage" => {
+            "t" => {
                 match transform_descriptor_call(
                     it,
                     self.source,
@@ -256,9 +256,7 @@ impl<'a> Visit<'a> for TransformVisitor<'a> {
                             text,
                         });
                         self.push_compiled_id(&compiled_id);
-                        if macro_info.imported_name != "defineMessage" {
-                            self.needs_runtime_import = true;
-                        }
+                        self.needs_runtime_import = true;
                     }
                     Ok(None) => {
                         self.fail_unsupported_macro(
@@ -383,7 +381,7 @@ fn is_jsx_message_macro(
         })
 }
 
-fn source_location(source: &str, filename: &str, offset: usize) -> String {
+pub(super) fn source_location(source: &str, filename: &str, offset: usize) -> String {
     let mut line = 1usize;
     let mut line_start = 0usize;
 

--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -11,7 +11,7 @@ package names.
 - `parseAcceptLanguage(header)` from `@palamedes/core/locale`
 - `buildLocaleSwitchItems(options)` from `@palamedes/core/locale`
 - `defineLocaleControls(config)` from `@palamedes/core/locale`
-- `MessageDescriptor`
+- `MessageMetadata`
 - `CatalogMessages`
 - `PalamedesI18n`
 - `CreateI18nOptions`
@@ -53,35 +53,36 @@ const label = i18n._("Hello {name}", { name: "Ada" })
 ```ts
 interface PalamedesI18n {
   locale?: string
-  _(idOrDescriptor, values?, descriptor?): string
+  _(id: string, values?, metadata?): string
   load(locale: string, messages: CatalogMessages): void
   activate(locale: string): void
-  getMessage(id: string, descriptor?: MessageDescriptor): string
+  getMessage(id: string, metadata?: MessageMetadata): string
 }
 ```
 
 `load()` merges messages into the locale catalog. `activate()` selects the
 locale used by `_()` and `getMessage()`.
 
-Fallback order for `getMessage(id, descriptor)`:
+Fallback order for `getMessage(id, metadata)`:
 
 1. active catalog entry for `id`
-2. `descriptor.message`
+2. `metadata.message`
 3. `id`
 
-## `MessageDescriptor`
+## `MessageMetadata`
 
 ```ts
-interface MessageDescriptor {
-  id?: string
+interface MessageMetadata {
   message?: string
   context?: string
   comment?: string
 }
 ```
 
-Palamedes source authoring is source-string-first. Use `context` when the same
-source message needs different translations in different UI contexts.
+The compiler emits this metadata alongside compact internal lookup ids so the
+runtime can fall back to the source message and report useful diagnostics.
+It is not a deferred authoring API. Author translations with `t` at the point
+where they are evaluated.
 
 ## Locale Controls
 
@@ -104,8 +105,6 @@ Palamedes plugin before runtime.
 Supported macro names:
 
 - `t`
-- `msg`
-- `defineMessage`
 - `plural`
 - `select`
 - `selectOrdinal`

--- a/docs/api/remix.md
+++ b/docs/api/remix.md
@@ -89,8 +89,8 @@ different param name. Cookie serialization is available through
 
 The Remix v3 support path covers:
 
-- JS macros in server-loaded modules: `t`, `msg`, `plural`, `select`,
-  `selectOrdinal`, and `defineMessage`
+- JS macros in server-loaded modules: `t`, `plural`, `select`, and
+  `selectOrdinal`
 - request-local i18n activation for Fetch `Request` handlers
 - cookie, route, subdomain, TLD, and `Accept-Language` locale negotiation
 - `.po` catalog imports through `@palamedes/remix/register`

--- a/docs/migrate-from-lingui.md
+++ b/docs/migrate-from-lingui.md
@@ -52,7 +52,7 @@ The Palamedes transform recognizes Palamedes macro packages; Lingui macro
 imports are left untouched.
 
 ```ts
-import { t, msg, defineMessage, plural, select, selectOrdinal } from "@palamedes/core/macro"
+import { t, plural, select, selectOrdinal } from "@palamedes/core/macro"
 ```
 
 ```tsx
@@ -85,7 +85,7 @@ const locale = getI18n().locale
 
 ### 2. Explicit IDs
 
-Before:
+Before (Lingui):
 
 ```ts
 t({ id: "checkout.cta", message: "Buy now" })
@@ -96,8 +96,15 @@ After:
 
 ```ts
 t({ message: "Buy now" })
-defineMessage({ message: "Buy now", context: "checkout button" })
+
+function checkoutButtonLabel() {
+  return t({ message: "Buy now", context: "checkout button" })
+}
 ```
+
+Palamedes does not expose deferred message descriptors. Move former `msg` or
+`defineMessage` declarations into a function or callback and translate with
+`t` when the value is actually needed.
 
 ### 3. Framework integration
 

--- a/examples/nextjs-cookie/src/app/page.tsx
+++ b/examples/nextjs-cookie/src/app/page.tsx
@@ -1,5 +1,4 @@
-import { defineMessage } from "@palamedes/core/macro"
-import type { MessageDescriptor, PalamedesI18n } from "@palamedes/core"
+import { t } from "@palamedes/core/macro"
 import { EVENT } from "@palamedes/example-ui"
 import { ClientLocaleBoundary } from "@/components/ClientLocaleBoundary"
 import { ClientReady } from "@/components/ClientReady"
@@ -9,40 +8,34 @@ import { TicketPanel } from "@/components/TicketPanel"
 import { createActiveServerI18n } from "@/lib/i18n.server"
 import { getLocaleLabel } from "@/lib/i18n"
 
-// Server-rendered strings resolve through the concrete request-local i18n
-// instance (see `translate` below). Direct `<Trans>`/`t` macros are reserved
-// for the client components, where the client i18n scope is active; the RSC
-// server scope is addressed explicitly here.
-const eyebrowMessage = defineMessage({
-  message: "Localized live with Palamedes",
-}) as unknown as MessageDescriptor
-const headlineMessage = defineMessage({
-  message: "Book your seat at Frontend Stage 2026",
-}) as unknown as MessageDescriptor
-const greetMessage = defineMessage({
-  message: "Welcome back, {attendeeName}.",
-}) as unknown as MessageDescriptor
-const ledeMessage = defineMessage({
-  message: "Three days of talks on the craft of building for the web. Choose your tickets below.",
-}) as unknown as MessageDescriptor
-const renderedWithMessage = defineMessage({
-  message: "Rendered with Next.js",
-}) as unknown as MessageDescriptor
-const serverLocaleMessage = defineMessage({
-  message: "server locale",
-}) as unknown as MessageDescriptor
+// These functions run only after `createActiveServerI18n()` activated the
+// request-local runtime scope.
+function translateEyebrow(): string {
+  return t`Localized live with Palamedes`
+}
 
-function translate(
-  i18n: PalamedesI18n,
-  descriptor: MessageDescriptor,
-  values?: Record<string, unknown>
-): string {
-  const id = descriptor.id ?? descriptor.message ?? ""
-  return i18n._(id, values, descriptor)
+function translateHeadline(): string {
+  return t`Book your seat at Frontend Stage 2026`
+}
+
+function translateGreeting(attendeeName: string): string {
+  return t`Welcome back, ${attendeeName}.`
+}
+
+function translateLede(): string {
+  return t`Three days of talks on the craft of building for the web. Choose your tickets below.`
+}
+
+function translateRenderedWith(): string {
+  return t`Rendered with Next.js`
+}
+
+function translateServerLocale(): string {
+  return t`server locale`
 }
 
 export default async function Home() {
-  const { i18n, locale } = await createActiveServerI18n()
+  const { locale } = await createActiveServerI18n()
   const localeLabel = getLocaleLabel(locale)
 
   return (
@@ -60,13 +53,11 @@ export default async function Home() {
       <section className="hero">
         <p className="eyebrow">
           <span className="dot" aria-hidden="true" />
-          {translate(i18n, eyebrowMessage)}
+          {translateEyebrow()}
         </p>
-        <h1>{translate(i18n, headlineMessage)}</h1>
-        <p className="greet">
-          {translate(i18n, greetMessage, { attendeeName: EVENT.attendeeName })}
-        </p>
-        <p className="lede">{translate(i18n, ledeMessage)}</p>
+        <h1>{translateHeadline()}</h1>
+        <p className="greet">{translateGreeting(EVENT.attendeeName)}</p>
+        <p className="lede">{translateLede()}</p>
       </section>
 
       <ClientLocaleBoundary locale={locale}>
@@ -78,10 +69,9 @@ export default async function Home() {
 
       <footer className="foot">
         <span className="foot-badge">Palamedes</span>
-        {translate(i18n, renderedWithMessage)}
+        {translateRenderedWith()}
         {" · "}
-        {translate(i18n, serverLocaleMessage)}{" "}
-        <strong data-testid="server-locale-value">{localeLabel}</strong>
+        {translateServerLocale()} <strong data-testid="server-locale-value">{localeLabel}</strong>
       </footer>
 
       <ClientReady />

--- a/examples/nextjs-cookie/src/lib/actions.ts
+++ b/examples/nextjs-cookie/src/lib/actions.ts
@@ -2,14 +2,9 @@
 
 import { cookies } from "next/headers"
 import { revalidatePath } from "next/cache"
-import { defineMessage } from "@palamedes/core/macro"
-import type { MessageDescriptor } from "@palamedes/core"
+import { t } from "@palamedes/core/macro"
 import { getLocaleLabel, type Locale, LOCALES, LOCALE_COOKIE } from "./i18n"
 import { createActiveServerI18n } from "./i18n.server"
-
-const serverActionMessage = defineMessage({
-  message: "Server action confirmed locale {locale}.",
-}) as unknown as MessageDescriptor
 
 export async function setLocaleAction(locale: Locale) {
   if (!LOCALES.includes(locale)) {
@@ -27,16 +22,12 @@ export async function setLocaleAction(locale: Locale) {
 }
 
 export async function getServerActionProof() {
-  const { i18n, locale } = await createActiveServerI18n()
+  const { locale } = await createActiveServerI18n()
 
   return {
     locale,
     localeLabel: getLocaleLabel(locale),
     handledAt: new Date().toISOString(),
-    message: i18n._(
-      serverActionMessage.id ?? serverActionMessage.message ?? "",
-      { locale },
-      serverActionMessage
-    ),
+    message: t`Server action confirmed locale ${locale}.`,
   }
 }

--- a/examples/nextjs-route/src/app/[locale]/page.tsx
+++ b/examples/nextjs-route/src/app/[locale]/page.tsx
@@ -1,5 +1,4 @@
-import { defineMessage } from "@palamedes/core/macro"
-import type { MessageDescriptor, PalamedesI18n } from "@palamedes/core"
+import { t } from "@palamedes/core/macro"
 import { EVENT } from "@palamedes/example-ui"
 import { ClientLocaleBoundary } from "@/components/ClientLocaleBoundary"
 import { ClientReady } from "@/components/ClientReady"
@@ -10,52 +9,47 @@ import { TicketPanel } from "@/components/TicketPanel"
 import { createActiveServerI18n, getRouteLocale } from "@/lib/i18n.server"
 import { getLocaleLabel, type Locale } from "@/lib/i18n"
 
-// Server-rendered strings resolve through the concrete request-local i18n
-// instance (see `translate` below). Direct `<Trans>`/`t` macros are reserved
-// for the client components, where the client i18n scope is active; the RSC
-// server scope is addressed explicitly here.
-const eyebrowMessage = defineMessage({
-  message: "Localized live with Palamedes",
-}) as unknown as MessageDescriptor
-const headlineMessage = defineMessage({
-  message: "Book your seat at Frontend Stage 2026",
-}) as unknown as MessageDescriptor
-const greetMessage = defineMessage({
-  message: "Welcome back, {attendeeName}.",
-}) as unknown as MessageDescriptor
-const ledeMessage = defineMessage({
-  message: "Three days of talks on the craft of building for the web. Choose your tickets below.",
-}) as unknown as MessageDescriptor
-const renderedWithMessage = defineMessage({
-  message: "Rendered with Next.js",
-}) as unknown as MessageDescriptor
-const serverLocaleMessage = defineMessage({
-  message: "server locale",
-}) as unknown as MessageDescriptor
-const switchToRecommendedMessage = defineMessage({
-  message: "Switch to the recommended locale",
-}) as unknown as MessageDescriptor
+// These functions run only after `createActiveServerI18n()` activated the
+// request-local runtime scope.
+function translateEyebrow(): string {
+  return t`Localized live with Palamedes`
+}
 
-function translate(
-  i18n: PalamedesI18n,
-  descriptor: MessageDescriptor,
-  values?: Record<string, unknown>
-): string {
-  const id = descriptor.id ?? descriptor.message ?? ""
-  return i18n._(id, values, descriptor)
+function translateHeadline(): string {
+  return t`Book your seat at Frontend Stage 2026`
+}
+
+function translateGreeting(attendeeName: string): string {
+  return t`Welcome back, ${attendeeName}.`
+}
+
+function translateLede(): string {
+  return t`Three days of talks on the craft of building for the web. Choose your tickets below.`
+}
+
+function translateRenderedWith(): string {
+  return t`Rendered with Next.js`
+}
+
+function translateServerLocale(): string {
+  return t`server locale`
+}
+
+function translateSwitchToRecommended(): string {
+  return t`Switch to the recommended locale`
 }
 
 export default async function RouteHome({ params }: { params: Promise<{ locale: string }> }) {
   const { locale: rawLocale } = await params
   const { banner, locale } = await getRouteLocale(rawLocale)
-  const { i18n } = await createActiveServerI18n(locale as Locale)
+  await createActiveServerI18n(locale as Locale)
   const localeLabel = getLocaleLabel(locale)
 
   return (
     <main className="page-shell">
       {banner ? (
         <SuggestionBanner
-          ctaLabel={translate(i18n, switchToRecommendedMessage)}
+          ctaLabel={translateSwitchToRecommended()}
           currentLocale={locale}
           description={banner.description}
           recommendedLocale={banner.recommendedLocale}
@@ -76,13 +70,11 @@ export default async function RouteHome({ params }: { params: Promise<{ locale: 
       <section className="hero">
         <p className="eyebrow">
           <span className="dot" aria-hidden="true" />
-          {translate(i18n, eyebrowMessage)}
+          {translateEyebrow()}
         </p>
-        <h1>{translate(i18n, headlineMessage)}</h1>
-        <p className="greet">
-          {translate(i18n, greetMessage, { attendeeName: EVENT.attendeeName })}
-        </p>
-        <p className="lede">{translate(i18n, ledeMessage)}</p>
+        <h1>{translateHeadline()}</h1>
+        <p className="greet">{translateGreeting(EVENT.attendeeName)}</p>
+        <p className="lede">{translateLede()}</p>
       </section>
 
       <ClientLocaleBoundary locale={locale}>
@@ -94,10 +86,9 @@ export default async function RouteHome({ params }: { params: Promise<{ locale: 
 
       <footer className="foot">
         <span className="foot-badge">Palamedes</span>
-        {translate(i18n, renderedWithMessage)}
+        {translateRenderedWith()}
         {" · "}
-        {translate(i18n, serverLocaleMessage)}{" "}
-        <strong data-testid="server-locale-value">{localeLabel}</strong>
+        {translateServerLocale()} <strong data-testid="server-locale-value">{localeLabel}</strong>
       </footer>
 
       <ClientReady />

--- a/examples/nextjs-route/src/lib/actions.ts
+++ b/examples/nextjs-route/src/lib/actions.ts
@@ -1,29 +1,20 @@
 "use server"
 
-import { defineMessage } from "@palamedes/core/macro"
-import type { MessageDescriptor } from "@palamedes/core"
+import { t } from "@palamedes/core/macro"
 import { getLocaleLabel, type Locale, LOCALES } from "./i18n"
 import { createActiveServerI18n } from "./i18n.server"
-
-const serverActionMessage = defineMessage({
-  message: "Server action confirmed locale {locale}.",
-}) as unknown as MessageDescriptor
 
 export async function getServerActionProof(locale: Locale) {
   if (!LOCALES.includes(locale)) {
     throw new Error(`Invalid locale: ${locale}`)
   }
 
-  const { i18n } = await createActiveServerI18n(locale)
+  await createActiveServerI18n(locale)
 
   return {
     locale,
     localeLabel: getLocaleLabel(locale),
     handledAt: new Date().toISOString(),
-    message: i18n._(
-      serverActionMessage.id ?? serverActionMessage.message ?? "",
-      { locale },
-      serverActionMessage
-    ),
+    message: t`Server action confirmed locale ${locale}.`,
   }
 }

--- a/examples/nextjs-subdomain/src/app/page.tsx
+++ b/examples/nextjs-subdomain/src/app/page.tsx
@@ -1,5 +1,4 @@
-import { defineMessage } from "@palamedes/core/macro"
-import type { MessageDescriptor, PalamedesI18n } from "@palamedes/core"
+import { t } from "@palamedes/core/macro"
 import { EVENT } from "@palamedes/example-ui"
 import { ClientLocaleBoundary } from "@/components/ClientLocaleBoundary"
 import { ClientReady } from "@/components/ClientReady"
@@ -10,51 +9,46 @@ import { TicketPanel } from "@/components/TicketPanel"
 import { createActiveServerI18n, getSubdomainLocale } from "@/lib/i18n.server"
 import { getLocaleLabel, type Locale } from "@/lib/i18n"
 
-// Server-rendered strings resolve through the concrete request-local i18n
-// instance (see `translate` below). Direct `<Trans>`/`t` macros are reserved
-// for the client components, where the client i18n scope is active; the RSC
-// server scope is addressed explicitly here.
-const eyebrowMessage = defineMessage({
-  message: "Localized live with Palamedes",
-}) as unknown as MessageDescriptor
-const headlineMessage = defineMessage({
-  message: "Book your seat at Frontend Stage 2026",
-}) as unknown as MessageDescriptor
-const greetMessage = defineMessage({
-  message: "Welcome back, {attendeeName}.",
-}) as unknown as MessageDescriptor
-const ledeMessage = defineMessage({
-  message: "Three days of talks on the craft of building for the web. Choose your tickets below.",
-}) as unknown as MessageDescriptor
-const renderedWithMessage = defineMessage({
-  message: "Rendered with Next.js",
-}) as unknown as MessageDescriptor
-const serverLocaleMessage = defineMessage({
-  message: "server locale",
-}) as unknown as MessageDescriptor
-const switchToRecommendedMessage = defineMessage({
-  message: "Switch to the recommended locale",
-}) as unknown as MessageDescriptor
+// These functions run only after `createActiveServerI18n()` activated the
+// request-local runtime scope.
+function translateEyebrow(): string {
+  return t`Localized live with Palamedes`
+}
 
-function translate(
-  i18n: PalamedesI18n,
-  descriptor: MessageDescriptor,
-  values?: Record<string, unknown>
-): string {
-  const id = descriptor.id ?? descriptor.message ?? ""
-  return i18n._(id, values, descriptor)
+function translateHeadline(): string {
+  return t`Book your seat at Frontend Stage 2026`
+}
+
+function translateGreeting(attendeeName: string): string {
+  return t`Welcome back, ${attendeeName}.`
+}
+
+function translateLede(): string {
+  return t`Three days of talks on the craft of building for the web. Choose your tickets below.`
+}
+
+function translateRenderedWith(): string {
+  return t`Rendered with Next.js`
+}
+
+function translateServerLocale(): string {
+  return t`server locale`
+}
+
+function translateSwitchToRecommended(): string {
+  return t`Switch to the recommended locale`
 }
 
 export default async function SubdomainHome() {
   const { banner, host, locale } = await getSubdomainLocale()
-  const { i18n } = await createActiveServerI18n(locale as Locale)
+  await createActiveServerI18n(locale as Locale)
   const localeLabel = getLocaleLabel(locale)
 
   return (
     <main className="page-shell">
       {banner ? (
         <SuggestionBanner
-          ctaLabel={translate(i18n, switchToRecommendedMessage)}
+          ctaLabel={translateSwitchToRecommended()}
           currentLocale={locale}
           description={banner.description}
           recommendedLocale={banner.recommendedLocale}
@@ -75,13 +69,11 @@ export default async function SubdomainHome() {
       <section className="hero">
         <p className="eyebrow">
           <span className="dot" aria-hidden="true" />
-          {translate(i18n, eyebrowMessage)}
+          {translateEyebrow()}
         </p>
-        <h1>{translate(i18n, headlineMessage)}</h1>
-        <p className="greet">
-          {translate(i18n, greetMessage, { attendeeName: EVENT.attendeeName })}
-        </p>
-        <p className="lede">{translate(i18n, ledeMessage)}</p>
+        <h1>{translateHeadline()}</h1>
+        <p className="greet">{translateGreeting(EVENT.attendeeName)}</p>
+        <p className="lede">{translateLede()}</p>
       </section>
 
       <ClientLocaleBoundary locale={locale}>
@@ -93,10 +85,9 @@ export default async function SubdomainHome() {
 
       <footer className="foot">
         <span className="foot-badge">Palamedes</span>
-        {translate(i18n, renderedWithMessage)}
+        {translateRenderedWith()}
         {" · "}
-        {translate(i18n, serverLocaleMessage)}{" "}
-        <strong data-testid="server-locale-value">{localeLabel}</strong>
+        {translateServerLocale()} <strong data-testid="server-locale-value">{localeLabel}</strong>
       </footer>
 
       <ClientReady />

--- a/examples/nextjs-subdomain/src/lib/actions.ts
+++ b/examples/nextjs-subdomain/src/lib/actions.ts
@@ -1,29 +1,20 @@
 "use server"
 
-import { defineMessage } from "@palamedes/core/macro"
-import type { MessageDescriptor } from "@palamedes/core"
+import { t } from "@palamedes/core/macro"
 import { getLocaleLabel, type Locale, LOCALES } from "./i18n"
 import { createActiveServerI18n } from "./i18n.server"
-
-const serverActionMessage = defineMessage({
-  message: "Server action confirmed locale {locale}.",
-}) as unknown as MessageDescriptor
 
 export async function getServerActionProof(locale: Locale) {
   if (!LOCALES.includes(locale)) {
     throw new Error(`Invalid locale: ${locale}`)
   }
 
-  const { i18n } = await createActiveServerI18n(locale)
+  await createActiveServerI18n(locale)
 
   return {
     locale,
     localeLabel: getLocaleLabel(locale),
     handledAt: new Date().toISOString(),
-    message: i18n._(
-      serverActionMessage.id ?? serverActionMessage.message ?? "",
-      { locale },
-      serverActionMessage
-    ),
+    message: t`Server action confirmed locale ${locale}.`,
   }
 }

--- a/examples/nextjs-tld/src/app/page.tsx
+++ b/examples/nextjs-tld/src/app/page.tsx
@@ -1,5 +1,4 @@
-import { defineMessage } from "@palamedes/core/macro"
-import type { MessageDescriptor, PalamedesI18n } from "@palamedes/core"
+import { t } from "@palamedes/core/macro"
 import { EVENT } from "@palamedes/example-ui"
 import { ClientLocaleBoundary } from "@/components/ClientLocaleBoundary"
 import { ClientReady } from "@/components/ClientReady"
@@ -10,51 +9,46 @@ import { TicketPanel } from "@/components/TicketPanel"
 import { createActiveServerI18n, getTldLocale } from "@/lib/i18n.server"
 import { getLocaleLabel, type Locale } from "@/lib/i18n"
 
-// Server-rendered strings resolve through the concrete request-local i18n
-// instance (see `translate` below). Direct `<Trans>`/`t` macros are reserved
-// for the client components, where the client i18n scope is active; the RSC
-// server scope is addressed explicitly here.
-const eyebrowMessage = defineMessage({
-  message: "Localized live with Palamedes",
-}) as unknown as MessageDescriptor
-const headlineMessage = defineMessage({
-  message: "Book your seat at Frontend Stage 2026",
-}) as unknown as MessageDescriptor
-const greetMessage = defineMessage({
-  message: "Welcome back, {attendeeName}.",
-}) as unknown as MessageDescriptor
-const ledeMessage = defineMessage({
-  message: "Three days of talks on the craft of building for the web. Choose your tickets below.",
-}) as unknown as MessageDescriptor
-const renderedWithMessage = defineMessage({
-  message: "Rendered with Next.js",
-}) as unknown as MessageDescriptor
-const serverLocaleMessage = defineMessage({
-  message: "server locale",
-}) as unknown as MessageDescriptor
-const switchToRecommendedMessage = defineMessage({
-  message: "Switch to the recommended locale",
-}) as unknown as MessageDescriptor
+// These functions run only after `createActiveServerI18n()` activated the
+// request-local runtime scope.
+function translateEyebrow(): string {
+  return t`Localized live with Palamedes`
+}
 
-function translate(
-  i18n: PalamedesI18n,
-  descriptor: MessageDescriptor,
-  values?: Record<string, unknown>
-): string {
-  const id = descriptor.id ?? descriptor.message ?? ""
-  return i18n._(id, values, descriptor)
+function translateHeadline(): string {
+  return t`Book your seat at Frontend Stage 2026`
+}
+
+function translateGreeting(attendeeName: string): string {
+  return t`Welcome back, ${attendeeName}.`
+}
+
+function translateLede(): string {
+  return t`Three days of talks on the craft of building for the web. Choose your tickets below.`
+}
+
+function translateRenderedWith(): string {
+  return t`Rendered with Next.js`
+}
+
+function translateServerLocale(): string {
+  return t`server locale`
+}
+
+function translateSwitchToRecommended(): string {
+  return t`Switch to the recommended locale`
 }
 
 export default async function TldHome() {
   const { banner, host, locale } = await getTldLocale()
-  const { i18n } = await createActiveServerI18n(locale as Locale)
+  await createActiveServerI18n(locale as Locale)
   const localeLabel = getLocaleLabel(locale)
 
   return (
     <main className="page-shell">
       {banner ? (
         <SuggestionBanner
-          ctaLabel={translate(i18n, switchToRecommendedMessage)}
+          ctaLabel={translateSwitchToRecommended()}
           currentLocale={locale}
           description={banner.description}
           recommendedLocale={banner.recommendedLocale}
@@ -75,13 +69,11 @@ export default async function TldHome() {
       <section className="hero">
         <p className="eyebrow">
           <span className="dot" aria-hidden="true" />
-          {translate(i18n, eyebrowMessage)}
+          {translateEyebrow()}
         </p>
-        <h1>{translate(i18n, headlineMessage)}</h1>
-        <p className="greet">
-          {translate(i18n, greetMessage, { attendeeName: EVENT.attendeeName })}
-        </p>
-        <p className="lede">{translate(i18n, ledeMessage)}</p>
+        <h1>{translateHeadline()}</h1>
+        <p className="greet">{translateGreeting(EVENT.attendeeName)}</p>
+        <p className="lede">{translateLede()}</p>
       </section>
 
       <ClientLocaleBoundary locale={locale}>
@@ -93,10 +85,9 @@ export default async function TldHome() {
 
       <footer className="foot">
         <span className="foot-badge">Palamedes</span>
-        {translate(i18n, renderedWithMessage)}
+        {translateRenderedWith()}
         {" · "}
-        {translate(i18n, serverLocaleMessage)}{" "}
-        <strong data-testid="server-locale-value">{localeLabel}</strong>
+        {translateServerLocale()} <strong data-testid="server-locale-value">{localeLabel}</strong>
       </footer>
 
       <ClientReady />

--- a/examples/nextjs-tld/src/lib/actions.ts
+++ b/examples/nextjs-tld/src/lib/actions.ts
@@ -1,29 +1,20 @@
 "use server"
 
-import { defineMessage } from "@palamedes/core/macro"
-import type { MessageDescriptor } from "@palamedes/core"
+import { t } from "@palamedes/core/macro"
 import { getLocaleLabel, type Locale, LOCALES } from "./i18n"
 import { createActiveServerI18n } from "./i18n.server"
-
-const serverActionMessage = defineMessage({
-  message: "Server action confirmed locale {locale}.",
-}) as unknown as MessageDescriptor
 
 export async function getServerActionProof(locale: Locale) {
   if (!LOCALES.includes(locale)) {
     throw new Error(`Invalid locale: ${locale}`)
   }
 
-  const { i18n } = await createActiveServerI18n(locale)
+  await createActiveServerI18n(locale)
 
   return {
     locale,
     localeLabel: getLocaleLabel(locale),
     handledAt: new Date().toISOString(),
-    message: i18n._(
-      serverActionMessage.id ?? serverActionMessage.message ?? "",
-      { locale },
-      serverActionMessage
-    ),
+    message: t`Server action confirmed locale ${locale}.`,
   }
 }

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -49,7 +49,7 @@ const i18n = createI18n({
 
 Use `pmds audit --fail-on error` in CI for checked-in catalogs, then wire these
 hooks to observe runtime-loaded catalogs or fast-moving translation changes.
-`getMessage(id, descriptor)` uses the same missing-catalog lookup path as `_()`,
+`getMessage(id, metadata)` uses the same missing-catalog lookup path as `_()`,
 so `onMissing` also fires when callers ask for a raw pattern by id and the
 active catalog does not contain that id.
 
@@ -59,8 +59,7 @@ For authoring imports, use:
 import { t } from "@palamedes/core/macro"
 ```
 
-The macro entry exports `t`, `msg`, `defineMessage`, `plural`, `select`, and
-`selectOrdinal`.
+The macro entry exports `t`, `plural`, `select`, and `selectOrdinal`.
 
 ## Locale Controls
 
@@ -88,15 +87,10 @@ Palamedes supports the common ICU argument types that product UIs usually need
 inside translated sentences:
 
 ```ts
-i18n._(
-  {
-    message: "Paid {amount, number, ::currency/EUR} on {when, date, medium} at {when, time, short}",
-  },
-  {
-    amount: 12.3,
-    when: new Date(),
-  }
-)
+i18n._("Paid {amount, number, ::currency/EUR} on {when, date, medium} at {when, time, short}", {
+  amount: 12.3,
+  when: new Date(),
+})
 ```
 
 Supported runtime styles:

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -15,7 +15,7 @@ describe("createI18n", () => {
     expect(i18n._("greeting", { name: "Ada" })).toBe("Hallo Ada")
   })
 
-  it("falls back to the descriptor message when the compiled catalog is missing a key", () => {
+  it("falls back to source metadata when the compiled catalog is missing a key", () => {
     const i18n = createI18n()
     i18n.activate("en")
 
@@ -28,7 +28,7 @@ describe("createI18n", () => {
     ).toBe("2 files")
   })
 
-  it("resolves descriptor ids through the active catalog", () => {
+  it("resolves compiled ids through the active catalog", () => {
     const i18n = createI18n()
 
     i18n.load("de", {
@@ -38,31 +38,27 @@ describe("createI18n", () => {
 
     expect(
       i18n._(
-        {
-          id: "inbox.summary",
-          message: "{count, plural, one {# message} other {# messages}} for {name}",
-        },
-        { count: 2, name: "Ada" }
+        "inbox.summary",
+        { count: 2, name: "Ada" },
+        { message: "{count, plural, one {# message} other {# messages}} for {name}" }
       )
     ).toBe("2 Nachrichten fuer Ada")
   })
 
-  it("falls back to the descriptor message when its active catalog is missing", () => {
+  it("falls back to source metadata when its active catalog is missing", () => {
     const i18n = createI18n()
     i18n.activate("de")
 
     expect(
       i18n._(
-        {
-          id: "inbox.summary",
-          message: "{count, plural, one {# message} other {# messages}} for {name}",
-        },
-        { count: 1, name: "Ada" }
+        "inbox.summary",
+        { count: 1, name: "Ada" },
+        { message: "{count, plural, one {# message} other {# messages}} for {name}" }
       )
     ).toBe("1 message for Ada")
   })
 
-  it("falls back to the descriptor message when its active catalog lacks the id", () => {
+  it("falls back to source metadata when its active catalog lacks the id", () => {
     const i18n = createI18n()
 
     i18n.load("de", {
@@ -72,11 +68,9 @@ describe("createI18n", () => {
 
     expect(
       i18n._(
-        {
-          id: "inbox.summary",
-          message: "{count, plural, one {# message} other {# messages}} for {name}",
-        },
-        { count: 2, name: "Ada" }
+        "inbox.summary",
+        { count: 2, name: "Ada" },
+        { message: "{count, plural, one {# message} other {# messages}} for {name}" }
       )
     ).toBe("2 messages for Ada")
   })
@@ -155,7 +149,7 @@ describe("createI18n", () => {
       },
     })
 
-    expect(i18n._({ message: "{count, plural one {# file} other {# files}}" }, { count: 2 })).toBe(
+    expect(i18n._("{count, plural one {# file} other {# files}}", { count: 2 })).toBe(
       "{count, plural one {# file} other {# files}}"
     )
     expect(errors).toStrictEqual(["{count, plural one {# file} other {# files}}"])
@@ -174,17 +168,6 @@ describe("createI18n", () => {
     i18n.activate("de")
 
     expect(i18n._("broken", {}, { message: "{name" })).toBe("{name")
-  })
-
-  it("keeps descriptors without ids message-only", () => {
-    const i18n = createI18n()
-
-    i18n.load("de", {
-      "{name}": "Ada aus dem Katalog",
-    })
-    i18n.activate("de")
-
-    expect(i18n._({ message: "{name}" }, { name: "Inline" })).toBe("Inline")
   })
 
   it("formats select and selectordinal messages", () => {
@@ -211,16 +194,16 @@ describe("createI18n", () => {
     const i18n = createI18n()
     i18n.activate("en-US")
 
-    expect(i18n._({ message: "Total: {amount, number, ::currency/EUR}" }, { amount: 12.3 })).toBe(
+    expect(i18n._("Total: {amount, number, ::currency/EUR}", { amount: 12.3 })).toBe(
       `Total: ${new Intl.NumberFormat("en-US", { style: "currency", currency: "EUR" }).format(12.3)}`
     )
-    expect(i18n._({ message: "Bare: {amount, number, currency/EUR}" }, { amount: 12.3 })).toBe(
+    expect(i18n._("Bare: {amount, number, currency/EUR}", { amount: 12.3 })).toBe(
       `Bare: ${new Intl.NumberFormat("en-US").format(12.3)}`
     )
-    expect(i18n._({ message: "Progress: {ratio, number, percent}" }, { ratio: 0.42 })).toBe(
+    expect(i18n._("Progress: {ratio, number, percent}", { ratio: 0.42 })).toBe(
       `Progress: ${new Intl.NumberFormat("en-US", { style: "percent" }).format(0.42)}`
     )
-    expect(i18n._({ message: "Rounded: {count, number, integer}" }, { count: 12.8 })).toBe(
+    expect(i18n._("Rounded: {count, number, integer}", { count: 12.8 })).toBe(
       `Rounded: ${new Intl.NumberFormat("en-US", { maximumFractionDigits: 0 }).format(12.8)}`
     )
   })
@@ -229,15 +212,12 @@ describe("createI18n", () => {
     const i18n = createI18n()
     i18n.activate("en-US")
 
-    expect(i18n._({ message: "Total: {amount, number, ::currency/EUR}" }, {})).toBe("Total: ")
+    expect(i18n._("Total: {amount, number, ::currency/EUR}", {})).toBe("Total: ")
+    expect(i18n._("Total: {amount, number, ::currency/EUR}", { amount: Number.NaN })).toBe(
+      "Total: NaN"
+    )
     expect(
-      i18n._({ message: "Total: {amount, number, ::currency/EUR}" }, { amount: Number.NaN })
-    ).toBe("Total: NaN")
-    expect(
-      i18n._(
-        { message: "Total: {amount, number, ::currency/EUR}" },
-        { amount: Number.POSITIVE_INFINITY }
-      )
+      i18n._("Total: {amount, number, ::currency/EUR}", { amount: Number.POSITIVE_INFINITY })
     ).toBe("Total: Infinity")
   })
 
@@ -246,13 +226,13 @@ describe("createI18n", () => {
     i18n.activate("en-US")
     const when = new Date(Date.UTC(2026, 5, 12, 13, 45, 0))
 
-    expect(i18n._({ message: "Due {when, date, medium}" }, { when })).toBe(
+    expect(i18n._("Due {when, date, medium}", { when })).toBe(
       `Due ${new Intl.DateTimeFormat("en-US", { dateStyle: "medium" }).format(when)}`
     )
-    expect(i18n._({ message: "Starts {when, time, short}" }, { when })).toBe(
+    expect(i18n._("Starts {when, time, short}", { when })).toBe(
       `Starts ${new Intl.DateTimeFormat("en-US", { timeStyle: "short" }).format(when)}`
     )
-    expect(i18n._({ message: "Starts {when, time}" }, { when })).toBe(
+    expect(i18n._("Starts {when, time}", { when })).toBe(
       `Starts ${new Intl.DateTimeFormat("en-US", { timeStyle: "short" }).format(when)}`
     )
   })

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,7 +1,6 @@
 import { formatMessagePattern, parseMessagePattern } from "./messageFormat"
 
-export type MessageDescriptor = {
-  id?: string
+export type MessageMetadata = {
   message?: string
   context?: string
   comment?: string
@@ -12,7 +11,7 @@ export type CatalogMessages = Record<string, string>
 export type MissingMessageInfo = {
   id: string
   locale: string
-  descriptor?: MessageDescriptor
+  metadata?: MessageMetadata
 }
 
 export type MessageFormatErrorInfo = {
@@ -21,7 +20,7 @@ export type MessageFormatErrorInfo = {
   error: Error
   pattern: string
   fallback: string
-  descriptor?: MessageDescriptor
+  metadata?: MessageMetadata
 }
 
 export type CreateI18nOptions = {
@@ -31,14 +30,10 @@ export type CreateI18nOptions = {
 
 export type PalamedesI18n = {
   locale?: string
-  _: (
-    idOrDescriptor: string | MessageDescriptor,
-    values?: Record<string, unknown>,
-    descriptor?: MessageDescriptor
-  ) => string
+  _: (id: string, values?: Record<string, unknown>, metadata?: MessageMetadata) => string
   load: (locale: string, messages: CatalogMessages) => void
   activate: (locale: string) => void
-  getMessage: (id: string, descriptor?: MessageDescriptor) => string
+  getMessage: (id: string, metadata?: MessageMetadata) => string
 }
 
 type ResolvedMessage = {
@@ -66,10 +61,10 @@ export function createI18n(options: CreateI18nOptions = {}): PalamedesI18n {
     }
   }
 
-  function resolveMessage(id: string, descriptor?: MessageDescriptor): ResolvedMessage {
+  function resolveMessage(id: string, metadata?: MessageMetadata): ResolvedMessage {
     const catalog = activeLocale ? catalogs.get(activeLocale) : undefined
     const catalogMessage = catalog?.[id]
-    const fallback = descriptor?.message ?? id
+    const fallback = metadata?.message ?? id
 
     if (catalogMessage !== undefined) {
       return {
@@ -82,7 +77,7 @@ export function createI18n(options: CreateI18nOptions = {}): PalamedesI18n {
       notifyMissing({
         id,
         locale: activeLocale,
-        descriptor,
+        metadata,
       })
     }
 
@@ -96,7 +91,7 @@ export function createI18n(options: CreateI18nOptions = {}): PalamedesI18n {
     message: ResolvedMessage,
     values: Record<string, unknown>,
     id?: string,
-    descriptor?: MessageDescriptor
+    metadata?: MessageMetadata
   ): string {
     try {
       return formatMessagePattern(message.pattern, values, activeLocale)
@@ -107,7 +102,7 @@ export function createI18n(options: CreateI18nOptions = {}): PalamedesI18n {
         error: normalizeError(error),
         pattern: message.pattern,
         fallback: message.fallback,
-        descriptor,
+        metadata,
       })
     }
 
@@ -138,31 +133,12 @@ export function createI18n(options: CreateI18nOptions = {}): PalamedesI18n {
       activeLocale = locale
     },
 
-    getMessage(id, descriptor) {
-      return resolveMessage(id, descriptor).pattern
+    getMessage(id, metadata) {
+      return resolveMessage(id, metadata).pattern
     },
 
-    _(idOrDescriptor, values = {}, descriptor) {
-      if (typeof idOrDescriptor === "string") {
-        return renderMessage(
-          resolveMessage(idOrDescriptor, descriptor),
-          values,
-          idOrDescriptor,
-          descriptor
-        )
-      }
-
-      if (idOrDescriptor.id !== undefined) {
-        return renderMessage(
-          resolveMessage(idOrDescriptor.id, idOrDescriptor),
-          values,
-          idOrDescriptor.id,
-          idOrDescriptor
-        )
-      }
-
-      const pattern = idOrDescriptor.message ?? ""
-      return renderMessage({ pattern, fallback: pattern }, values, undefined, idOrDescriptor)
+    _(id, values = {}, metadata) {
+      return renderMessage(resolveMessage(id, metadata), values, id, metadata)
     },
   }
 }

--- a/packages/core/src/macro.ts
+++ b/packages/core/src/macro.ts
@@ -8,14 +8,6 @@ export function t(..._args: any[]): never {
   return throwMacroError()
 }
 
-export function msg(..._args: any[]): never {
-  return throwMacroError()
-}
-
-export function defineMessage(..._args: any[]): never {
-  return throwMacroError()
-}
-
 export function plural(..._args: any[]): never {
   return throwMacroError()
 }

--- a/packages/extractor/README.md
+++ b/packages/extractor/README.md
@@ -44,7 +44,7 @@ console.log(messages)
 
 ## Supported Inputs
 
-- `t`, `msg`, `defineMessage`, `plural`, `select`, `selectOrdinal`
+- `t`, `plural`, `select`, `selectOrdinal`
 - `<Trans>`, `<Plural>`, `<Select>`, `<SelectOrdinal>`
 - `i18n._(...)` and `i18n.t\`...\`` style runtime calls
 - JavaScript, TypeScript, JSX, and TSX sources

--- a/packages/extractor/src/extractMessages.test.ts
+++ b/packages/extractor/src/extractMessages.test.ts
@@ -136,9 +136,9 @@ describe("extractMessages", () => {
   describe("macro calls", () => {
     it("extracts descriptor messages", () => {
       const code = `
-        import { defineMessage, t } from "@palamedes/core/macro"
+        import { t } from "@palamedes/core/macro"
         const one = t({ message: "Hello" })
-        const two = defineMessage({ message: "Hello {name}", context: "email.subject" })
+        const two = t({ message: "Hello {name}", context: "email.subject" }, { name })
       `
       const messages = extract(code)
       expect(messages).toHaveLength(2)
@@ -149,12 +149,12 @@ describe("extractMessages", () => {
 
     it("extracts interpolated descriptor templates with placeholder metadata", () => {
       const code = `
-        import { msg, t } from "@palamedes/core/macro"
+        import { t } from "@palamedes/core/macro"
         const one = t({
           message: \`Descriptor \${name}\`,
           context: "probe context",
         })
-        const two = msg({ message: \`Locale \${resolved.locale}\` })
+        const two = t({ message: \`Locale \${resolved.locale}\` })
       `
       const messages = extract(code)
 
@@ -170,13 +170,15 @@ describe("extractMessages", () => {
       })
     })
 
-    it("rejects interpolated defineMessage descriptor templates", () => {
-      const code = `import { defineMessage } from "@palamedes/core/macro"
-const descriptor = defineMessage({ message: \`Descriptor \${name}\` })
+    it.each(["msg", "defineMessage"])("rejects removed %s imports", (macroName) => {
+      const code = `import { t, ${macroName} as deferred } from "@palamedes/core/macro"
+const message = t\`Hello\`
 `
 
       expect(() => extract(code)).toThrow(
-        /Unsupported `defineMessage` macro usage at test\.tsx:2:20.*runtime values/
+        new RegExp(
+          `Unsupported \`${macroName}\` macro usage at test\\.tsx:1:1.*deferred message macro has been removed`
+        )
       )
     })
 
@@ -335,12 +337,12 @@ const descriptor = t({ message })
       expect(() => extract(code)).toThrow(/Explicit message ids/)
     })
 
-    it("rejects explicit ids in runtime descriptors", () => {
+    it("rejects object-form runtime messages", () => {
       const code = `
         const x = i18n._({ id: "greeting", message: "Hello" })
       `
 
-      expect(() => extract(code)).toThrow(/Explicit message ids/)
+      expect(() => extract(code)).toThrow(/object-form runtime messages have been removed/)
     })
 
     it("rejects unnamed template placeholders", () => {

--- a/packages/extractor/src/index.ts
+++ b/packages/extractor/src/index.ts
@@ -26,7 +26,7 @@ export function extractMessages(source: string, filename: string): ExtractedMess
  *
  * Supports:
  * - JSX: <Trans>, <Plural>, <Select>, <SelectOrdinal>
- * - JS: t`...`, t({...}), plural(), select(), selectOrdinal(), msg`...`, defineMessage()
+ * - JS: t`...`, t({...}), plural(), select(), selectOrdinal()
  *
  * @example
  * ```ts

--- a/packages/react/src/index.test.tsx
+++ b/packages/react/src/index.test.tsx
@@ -6,7 +6,7 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 import { createI18n } from "@palamedes/core"
 import { resetI18nRuntime, setClientI18n } from "@palamedes/runtime"
 
-import { Plural, Trans, buildLocaleSwitchItems } from "./index"
+import { Plural, Select, SelectOrdinal, Trans, buildLocaleSwitchItems } from "./index"
 import { useClientLocale } from "./client"
 
 describe("@palamedes/react", () => {
@@ -48,6 +48,24 @@ describe("@palamedes/react", () => {
     const html = renderToStaticMarkup(<Plural value={2} one="# item" other="# items" />)
 
     expect(html).toBe("2 items")
+  })
+
+  it("formats direct choice components without reporting missing catalog entries", () => {
+    const onMissing = vi.fn()
+    const i18n = createI18n({ onMissing })
+    i18n.activate("en")
+    setClientI18n(i18n)
+
+    const html = renderToStaticMarkup(
+      <>
+        <Plural value={2} one="# item" other="# items" />
+        <Select value="female" female="She" other="They" />
+        <SelectOrdinal value={2} one="#st" two="#nd" other="#th" />
+      </>
+    )
+
+    expect(html).toBe("2 itemsShe2nd")
+    expect(onMissing).not.toHaveBeenCalled()
   })
 
   it("renders formatted ICU arguments through Trans", () => {

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -4,12 +4,7 @@ import type { ReactElement, ReactNode } from "react"
 
 import { getI18n } from "@palamedes/runtime"
 import { formatMessagePattern, parseMessagePattern } from "@palamedes/core"
-import type {
-  MessageChoiceNode,
-  MessageDescriptor,
-  MessageNode,
-  PalamedesI18n,
-} from "@palamedes/core"
+import type { MessageChoiceNode, MessageNode, PalamedesI18n } from "@palamedes/core"
 
 export {
   buildLocaleSwitchItems,
@@ -22,9 +17,12 @@ export type TransProps = {
   // (or choice props) and the Palamedes compiler transform injects the resolved
   // `id` at build time. Hand-written runtime usage may still pass `id` directly.
   id?: string
+  message?: string
+  context?: string
+  comment?: string
   values?: Record<string, unknown>
   components?: Record<string, ReactElement>
-} & MessageDescriptor
+}
 
 type ChoiceComponentProps = {
   value: string | number
@@ -57,7 +55,6 @@ export function Trans({
   const i18n = getI18n<PalamedesI18n>()
   const resolvedId = id ?? message ?? ""
   const pattern = i18n.getMessage(resolvedId, {
-    id: resolvedId,
     message,
     context,
     comment,
@@ -69,19 +66,20 @@ export function Trans({
 
 export function Plural({ value, ...choices }: PluralProps): ReactNode {
   const i18n = getI18n<PalamedesI18n>()
-  return <>{i18n._({ message: buildChoiceMessage("value", "plural", choices) }, { value })}</>
+  const message = buildChoiceMessage("value", "plural", choices)
+  return <>{i18n._(message, { value }, { message })}</>
 }
 
 export function SelectOrdinal({ value, ...choices }: SelectOrdinalProps): ReactNode {
   const i18n = getI18n<PalamedesI18n>()
-  return (
-    <>{i18n._({ message: buildChoiceMessage("value", "selectordinal", choices) }, { value })}</>
-  )
+  const message = buildChoiceMessage("value", "selectordinal", choices)
+  return <>{i18n._(message, { value }, { message })}</>
 }
 
 export function Select({ value, ...choices }: SelectProps): ReactNode {
   const i18n = getI18n<PalamedesI18n>()
-  return <>{i18n._({ message: buildChoiceMessage("value", "select", choices) }, { value })}</>
+  const message = buildChoiceMessage("value", "select", choices)
+  return <>{i18n._(message, { value }, { message })}</>
 }
 
 function buildChoiceMessage(

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -67,19 +67,19 @@ export function Trans({
 export function Plural({ value, ...choices }: PluralProps): ReactNode {
   const i18n = getI18n<PalamedesI18n>()
   const message = buildChoiceMessage("value", "plural", choices)
-  return <>{i18n._(message, { value }, { message })}</>
+  return <>{formatMessagePattern(message, { value }, i18n.locale)}</>
 }
 
 export function SelectOrdinal({ value, ...choices }: SelectOrdinalProps): ReactNode {
   const i18n = getI18n<PalamedesI18n>()
   const message = buildChoiceMessage("value", "selectordinal", choices)
-  return <>{i18n._(message, { value }, { message })}</>
+  return <>{formatMessagePattern(message, { value }, i18n.locale)}</>
 }
 
 export function Select({ value, ...choices }: SelectProps): ReactNode {
   const i18n = getI18n<PalamedesI18n>()
   const message = buildChoiceMessage("value", "select", choices)
-  return <>{i18n._(message, { value }, { message })}</>
+  return <>{formatMessagePattern(message, { value }, i18n.locale)}</>
 }
 
 function buildChoiceMessage(

--- a/packages/remix/README.md
+++ b/packages/remix/README.md
@@ -22,14 +22,14 @@ transform before Node executes the module.
 This integration is tested against `remix@3.0.0-beta.5` and supports
 server-loaded Remix modules:
 
-| Area                                                                         | Status                                                                        |
-| ---------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
-| JS macros (`t`, `msg`, `plural`, `select`, `selectOrdinal`, `defineMessage`) | Supported in server-loaded modules                                            |
-| `.po` catalog imports                                                        | Supported through the Palamedes register hook                                 |
-| Request-local i18n                                                           | Supported through `createRemixI18nServer()` and middleware/request helpers    |
-| Locale strategies                                                            | Cookie, route, subdomain, and TLD examples are covered by smoke tests         |
-| Rich JSX messages                                                            | Not supported yet; Remix lowers JSX before the Palamedes hook sees the source |
-| Browser/client modules                                                       | Not supported yet; Remix's asset pipeline has no script transform hook        |
+| Area                                                 | Status                                                                        |
+| ---------------------------------------------------- | ----------------------------------------------------------------------------- |
+| JS macros (`t`, `plural`, `select`, `selectOrdinal`) | Supported in server-loaded modules                                            |
+| `.po` catalog imports                                | Supported through the Palamedes register hook                                 |
+| Request-local i18n                                   | Supported through `createRemixI18nServer()` and middleware/request helpers    |
+| Locale strategies                                    | Cookie, route, subdomain, and TLD examples are covered by smoke tests         |
+| Rich JSX messages                                    | Not supported yet; Remix lowers JSX before the Palamedes hook sees the source |
+| Browser/client modules                               | Not supported yet; Remix's asset pipeline has no script transform hook        |
 
 The hook only reaches server-executed modules. Browser-delivered Remix v3 modules
 are compiled by Remix's asset pipeline, which does not currently expose a script

--- a/packages/solid/src/index.test.tsx
+++ b/packages/solid/src/index.test.tsx
@@ -1,12 +1,12 @@
 /* @jsxImportSource solid-js */
 import { createRenderEffect, createRoot, createSignal } from "solid-js"
 import { renderToString } from "solid-js/web/dist/server.js"
-import { afterEach, describe, expect, it } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 
 import { createI18n } from "@palamedes/core"
 import { resetI18nRuntime, setClientI18n, setServerI18nGetter } from "@palamedes/runtime"
 
-import { Plural, Trans, buildLocaleSwitchItems } from "./index"
+import { Plural, Select, SelectOrdinal, Trans, buildLocaleSwitchItems } from "./index"
 import { createClientLocaleEffect } from "./client"
 
 describe("@palamedes/solid", () => {
@@ -72,6 +72,22 @@ describe("@palamedes/solid", () => {
     const html = renderToString(() => <Plural value={2} one="# item" other="# items" />)
 
     expect(html).toBe("2 items")
+  })
+
+  it("formats direct choice components without reporting missing catalog entries", () => {
+    const onMissing = vi.fn()
+    const i18n = createI18n({ onMissing })
+    i18n.activate("en")
+    setServerI18nGetter(() => i18n)
+
+    const plural = renderToString(() => <Plural value={2} one="# item" other="# items" />)
+    const select = renderToString(() => <Select value="female" female="She" other="They" />)
+    const ordinal = renderToString(() => (
+      <SelectOrdinal value={2} one="#st" two="#nd" other="#th" />
+    ))
+
+    expect([plural, select, ordinal]).toStrictEqual(["2 items", "She", "2nd"])
+    expect(onMissing).not.toHaveBeenCalled()
   })
 
   it("builds locale switch items headlessly", () => {

--- a/packages/solid/src/index.tsx
+++ b/packages/solid/src/index.tsx
@@ -81,7 +81,7 @@ export function Plural({ value, ...choices }: PluralProps): JSX.Element {
   return (() => {
     const i18n = useReactiveI18n()
     const message = buildChoiceMessage("value", "plural", choices)
-    return i18n._(message, { value }, { message })
+    return formatMessagePattern(message, { value }, i18n.locale)
   }) as unknown as JSX.Element
 }
 
@@ -89,7 +89,7 @@ export function SelectOrdinal({ value, ...choices }: SelectOrdinalProps): JSX.El
   return (() => {
     const i18n = useReactiveI18n()
     const message = buildChoiceMessage("value", "selectordinal", choices)
-    return i18n._(message, { value }, { message })
+    return formatMessagePattern(message, { value }, i18n.locale)
   }) as unknown as JSX.Element
 }
 
@@ -97,7 +97,7 @@ export function Select({ value, ...choices }: SelectProps): JSX.Element {
   return (() => {
     const i18n = useReactiveI18n()
     const message = buildChoiceMessage("value", "select", choices)
-    return i18n._(message, { value }, { message })
+    return formatMessagePattern(message, { value }, i18n.locale)
   }) as unknown as JSX.Element
 }
 

--- a/packages/solid/src/index.tsx
+++ b/packages/solid/src/index.tsx
@@ -1,12 +1,7 @@
 import type { JSX } from "solid-js"
 
 import { formatMessagePattern, parseMessagePattern } from "@palamedes/core"
-import type {
-  MessageChoiceNode,
-  MessageDescriptor,
-  MessageNode,
-  PalamedesI18n,
-} from "@palamedes/core"
+import type { MessageChoiceNode, MessageNode, PalamedesI18n } from "@palamedes/core"
 
 import { getI18n } from "./runtime"
 
@@ -31,9 +26,12 @@ export type TransProps = {
   // (or choice props) and the Palamedes compiler transform injects the resolved
   // `id` at build time. Hand-written runtime usage may still pass `id` directly.
   id?: string
+  message?: string
+  context?: string
+  comment?: string
   values?: Record<string, unknown>
   components?: Record<string, WrapperComponent | JSX.Element>
-} & MessageDescriptor
+}
 
 type ChoiceComponentProps = {
   value: string | number
@@ -70,7 +68,6 @@ export function Trans({
   return (() => {
     const i18n = useReactiveI18n()
     const pattern = i18n.getMessage(resolvedId, {
-      id: resolvedId,
       message,
       context,
       comment,
@@ -83,21 +80,24 @@ export function Trans({
 export function Plural({ value, ...choices }: PluralProps): JSX.Element {
   return (() => {
     const i18n = useReactiveI18n()
-    return i18n._({ message: buildChoiceMessage("value", "plural", choices) }, { value })
+    const message = buildChoiceMessage("value", "plural", choices)
+    return i18n._(message, { value }, { message })
   }) as unknown as JSX.Element
 }
 
 export function SelectOrdinal({ value, ...choices }: SelectOrdinalProps): JSX.Element {
   return (() => {
     const i18n = useReactiveI18n()
-    return i18n._({ message: buildChoiceMessage("value", "selectordinal", choices) }, { value })
+    const message = buildChoiceMessage("value", "selectordinal", choices)
+    return i18n._(message, { value }, { message })
   }) as unknown as JSX.Element
 }
 
 export function Select({ value, ...choices }: SelectProps): JSX.Element {
   return (() => {
     const i18n = useReactiveI18n()
-    return i18n._({ message: buildChoiceMessage("value", "select", choices) }, { value })
+    const message = buildChoiceMessage("value", "select", choices)
+    return i18n._(message, { value }, { message })
   }) as unknown as JSX.Element
 }
 

--- a/packages/transform/README.md
+++ b/packages/transform/README.md
@@ -71,9 +71,8 @@ The root package also re-exports catalog-loader helpers from
 
 ## Supported Macro Shapes
 
-- tagged templates such as `t\`...\``and`msg\`...\``
+- tagged templates such as `t\`...\``
 - descriptor calls such as `t({ message: "..." })`
-- `defineMessage(...)`
 - `plural(...)`, `select(...)`, `selectOrdinal(...)`
 - `<Trans>`, `<Plural>`, `<Select>`, `<SelectOrdinal>`
 

--- a/packages/transform/src/transform.test.ts
+++ b/packages/transform/src/transform.test.ts
@@ -67,25 +67,22 @@ const msg = t({ message: "Hello", context: "informal", comment: "A greeting" });
     expect(result.code).not.toContain('id: "greeting"')
   })
 
-  it.each(["t", "msg"])(
-    "transforms interpolated %s descriptor templates with runtime values",
-    (macroName) => {
-      const code = `
-import { ${macroName} } from "@palamedes/core/macro";
-const descriptor = ${macroName}({
+  it("transforms interpolated descriptor templates with runtime values", () => {
+    const code = `
+import { t } from "@palamedes/core/macro";
+const message = t({
   message: \`Descriptor \${name}\`,
   context: "probe context",
 });
 `
-      const result = transformPalamedesMacros(code, "test.ts")
+    const result = transformPalamedesMacros(code, "test.ts")
 
-      expect(result.code).toContain('message: "Descriptor {name}"')
-      expect(result.code).toContain("{ name }")
-      expect(result.code).toContain('context: "probe context"')
-      expect(result.code).not.toContain("@palamedes/core/macro")
-      expect(result.code).not.toContain(`${macroName}({`)
-    }
-  )
+    expect(result.code).toContain('message: "Descriptor {name}"')
+    expect(result.code).toContain("{ name }")
+    expect(result.code).toContain('context: "probe context"')
+    expect(result.code).not.toContain("@palamedes/core/macro")
+    expect(result.code).not.toContain("t({")
+  })
 
   it("rejects missing ICU values in interpolated descriptor templates", () => {
     const code = `
@@ -96,15 +93,20 @@ const descriptor = t({ message: \`Hello \${name}, you have {count}\` });
     expect(() => transformPalamedesMacros(code, "test.ts")).toThrow(/Missing value\(s\): count/)
   })
 
-  it("rejects interpolated defineMessage descriptor templates with a source location", () => {
-    const code = `import { defineMessage } from "@palamedes/core/macro";
-const descriptor = defineMessage({ message: \`Descriptor \${name}\` });
+  it.each(["msg", "defineMessage"])(
+    "rejects removed %s imports before removing a shared macro import",
+    (macroName) => {
+      const code = `import { t, ${macroName} as deferred } from "@palamedes/core/macro";
+const valid = t\`Hello\`;
 `
 
-    expect(() => transformPalamedesMacros(code, "test.ts")).toThrow(
-      /Unsupported `defineMessage` macro usage at test\.ts:2:20.*runtime values/
-    )
-  })
+      expect(() => transformPalamedesMacros(code, "test.ts")).toThrow(
+        new RegExp(
+          `Unsupported \`${macroName}\` macro usage at test\\.ts:1:1.*deferred message macro has been removed`
+        )
+      )
+    }
+  )
 
   it("rejects unsupported macro calls before removing a shared macro import", () => {
     const code = `import { t } from "@palamedes/core/macro";
@@ -144,20 +146,6 @@ const msg = t({ message: "Hello" }, { name });
 `
 
     expect(() => transformPalamedesMacros(code, "test.ts")).toThrow(/extra value\(s\): name/)
-  })
-
-  it("transforms defineMessage to a descriptor with an internal lookup key", () => {
-    const code = `
-import { defineMessage } from "@palamedes/core/macro";
-const msg = defineMessage({ message: "Hello" });
-`
-    const result = transformPalamedesMacros(code, "test.ts")
-
-    expect(result.hasChanged).toBe(true)
-    expect(result.code).toContain('id: "')
-    expect(result.code).toContain('message: "Hello"')
-    expect(result.code).not.toContain("getI18n()._")
-    expect(result.compiledIds).toHaveLength(1)
   })
 
   it("transforms <Trans> with generated internal ids", () => {

--- a/packages/transform/src/types.ts
+++ b/packages/transform/src/types.ts
@@ -54,7 +54,7 @@ export const PALAMEDES_MACRO_PACKAGES = [
 /**
  * JS macro function names
  */
-export const JS_MACROS = ["t", "msg", "defineMessage", "plural", "select", "selectOrdinal"] as const
+export const JS_MACROS = ["t", "plural", "select", "selectOrdinal"] as const
 
 /**
  * JSX macro component names


### PR DESCRIPTION
## Summary

- remove `msg` and `defineMessage` from the public macro surface
- remove object-form/deferred descriptors from the core runtime API and rename generated fallback data to message metadata
- reject legacy macro imports with an actionable diagnostic before imports can be removed
- move the affected Next.js examples to eager `t` calls inside functions after request-local i18n activation
- update extractor, transformer, framework bindings, tests, and documentation

## Validation

- `RUSTUP_TOOLCHAIN=1.95 pnpm agent:check`
- TypeScript checks for all four affected Next.js examples
- Next.js production build for `@palamedes/example-nextjs-cookie`

Closes #389