### PR TITLE
Enforce translation macro scope

### DIFF
--- a/crates/palamedes-cli/src/main.rs
+++ b/crates/palamedes-cli/src/main.rs
@@ -1080,7 +1080,7 @@ mod tests {
         write_config(&app, None);
         fs::write(
             app.join("app/page.tsx"),
-            "import { t } from \"@palamedes/core/macro\";\nexport const title = t`Dashboard`;\n",
+            "import { t } from \"@palamedes/core/macro\";\nexport function title() { return t`Dashboard`; }\n",
         )
         .expect("write source");
 
@@ -1099,7 +1099,7 @@ mod tests {
         write_config(&app, Some("config"));
         fs::write(
             app.join("app/page.tsx"),
-            "import { t } from \"@palamedes/core/macro\";\nexport const title = t`Dashboard`;\n",
+            "import { t } from \"@palamedes/core/macro\";\nexport function title() { return t`Dashboard`; }\n",
         )
         .expect("write source");
 
@@ -1127,7 +1127,7 @@ catalogs:
         .expect("write config");
         fs::write(
             app.join("app/page.tsx"),
-            "import { t } from \"@palamedes/core/macro\";\nexport const title = t`Dashboard`;\n",
+            "import { t } from \"@palamedes/core/macro\";\nexport function title() { return t`Dashboard`; }\n",
         )
         .expect("write source");
 

--- a/crates/palamedes/src/error.rs
+++ b/crates/palamedes/src/error.rs
@@ -173,6 +173,16 @@ pub enum PalamedesError {
         /// Human-readable explanation of the unsupported source shape.
         detail: String,
     },
+    /// An eager translation macro would run while its module is loading.
+    #[error(
+        "Translation macro `{macro_name}` must be used inside a function at {location}. Wrap the translation in a function, method, or callback so it runs after i18n activation."
+    )]
+    TranslationMacroOutsideFunction {
+        /// Public macro name used at module scope.
+        macro_name: String,
+        /// Source filename, line, and column.
+        location: String,
+    },
     /// A JSX message macro was nested inside another JSX message macro.
     #[error(
         "Nested i18n macro is not extractable as a single message at {location}. Move the full sentence into <Plural> branches or use plural() so translators receive the complete sentence."

--- a/crates/palamedes/src/extract.rs
+++ b/crates/palamedes/src/extract.rs
@@ -11,6 +11,7 @@ use crate::jsx_entities::decode_jsx_entities;
 use crate::jsx_message::{
     clean_jsx_text, join_jsx_message_parts, JoinedJsxMessage, JsxMessagePart,
 };
+use crate::translation_scope::validate_translation_macro_scopes;
 use oxc_allocator::Allocator;
 use oxc_ast::ast::{
     Argument, BindingPattern, CallExpression, Declaration, Expression, ImportDeclaration,
@@ -1331,6 +1332,13 @@ pub fn extract_messages(
         });
     }
 
+    validate_translation_macro_scopes(&parsed.program, filename, source, |local_name| {
+        collector
+            .imported_macros
+            .get(local_name)
+            .map(|macro_info| macro_info.imported_name.clone())
+    })?;
+
     let mut extractor =
         ExtractionVisitor::new(filename, source, &line_locator, &collector.imported_macros);
     extractor.visit_program(&parsed.program);
@@ -1379,7 +1387,8 @@ pub fn extract_catalog_messages_from_files(
             Err(
                 error @ (PalamedesError::ExplicitMessageIdsUnsupported
                 | PalamedesError::NestedMessageMacro { .. }
-                | PalamedesError::UnsupportedMacroSyntax { .. }),
+                | PalamedesError::UnsupportedMacroSyntax { .. }
+                | PalamedesError::TranslationMacroOutsideFunction { .. }),
             ) => {
                 return Err(error);
             }
@@ -1566,10 +1575,122 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     use super::{
-        extract_catalog_messages_from_files, extract_messages, ExtractCatalogMessagesRequest,
+        extract_catalog_messages_from_files, extract_messages as extract_messages_raw,
+        ExtractCatalogMessagesRequest, ExtractedMessageRecord,
     };
+    use crate::error::PalamedesResult;
 
     static TEMP_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+    fn extract_messages(
+        source: &str,
+        filename: &str,
+    ) -> PalamedesResult<Vec<ExtractedMessageRecord>> {
+        extract_messages_raw(&scope_macro_test_source(source), filename)
+    }
+
+    fn scope_macro_test_source(source: &str) -> String {
+        if ![
+            "@palamedes/core/macro",
+            "@palamedes/react/macro",
+            "@palamedes/solid/macro",
+        ]
+        .iter()
+        .any(|macro_module| source.contains(macro_module))
+        {
+            return source.to_string();
+        }
+
+        let mut last_import_end = None;
+        let mut offset = 0;
+
+        for line in source.split_inclusive('\n') {
+            let line_without_newline = line.strip_suffix('\n').unwrap_or(line);
+            if line_without_newline.trim_start().starts_with("import ") {
+                last_import_end = Some(offset + line_without_newline.len());
+            }
+            offset += line.len();
+        }
+
+        let Some(import_end) = last_import_end else {
+            return source.to_string();
+        };
+
+        let mut scoped = String::with_capacity(source.len() + 48);
+        scoped.push_str(&source[..import_end]);
+        scoped.push_str("; function __palamedes_test_scope() {");
+        scoped.push_str(&source[import_end..]);
+        scoped.push_str("\n}");
+        scoped
+    }
+
+    #[test]
+    fn rejects_eager_translation_macros_outside_functions() {
+        let cases = [
+            (
+                r#"import { t as translate } from "@palamedes/core/macro";
+const message = translate`Hello`;
+"#,
+                "test.ts",
+                "t",
+            ),
+            (
+                r##"import { plural } from "@palamedes/core/macro";
+const message = plural(count, { one: "# item", other: "# items" });
+"##,
+                "test.ts",
+                "plural",
+            ),
+            (
+                r#"import { Select as Choice } from "@palamedes/react/macro";
+const message = <Choice value={gender} other="They" />;
+"#,
+                "test.tsx",
+                "Select",
+            ),
+        ];
+
+        for (source, filename, macro_name) in cases {
+            let error = extract_messages_raw(source, filename)
+                .expect_err("top-level eager translation macros must fail");
+            let message = error.to_string();
+            assert!(message.contains(&format!(
+                "Translation macro `{macro_name}` must be used inside a function"
+            )));
+            assert!(message.contains(filename));
+        }
+    }
+
+    #[test]
+    fn extracts_translation_macros_in_deferred_scopes_and_trans_at_module_scope() {
+        let source = r##"import { plural, t } from "@palamedes/core/macro";
+import { Plural, Trans } from "@palamedes/react/macro";
+
+const safe = <Trans>Rendered later</Trans>;
+function declaration() { return t`Function`; }
+const arrow = () => t`Arrow`;
+const object = { method() { return t`Method`; } };
+class Formatter { method() { return t`Class method`; } }
+items.map(() => t`Callback`);
+function Component() {
+  return <Plural value={count} one="# item" other="# items" />;
+}
+function choices() {
+  return plural(count, { one: "# item", other: "# items" });
+}
+"##;
+
+        let messages = extract_messages_raw(source, "test.tsx")
+            .expect("function-scoped macros and top-level Trans should extract");
+        let source_messages = messages
+            .iter()
+            .map(|message| message.message.as_str())
+            .collect::<Vec<_>>();
+
+        assert!(source_messages.contains(&"Rendered later"));
+        assert!(source_messages.contains(&"Class method"));
+        assert!(source_messages.contains(&"{count, plural, one {# item} other {# items}}"));
+    }
 
     #[test]
     fn extracts_tagged_templates() {
@@ -2152,8 +2273,11 @@ const message = t({ message })
             &first,
             r#"
               import { t } from "@palamedes/core/macro"
-              const a = t({ message: "Hello {name}", comment: "Greeting" })
-              const b = t`Computed ${user.name}`
+              function firstMessages() {
+                const a = t({ message: "Hello {name}", comment: "Greeting" })
+                const b = t`Computed ${user.name}`
+                return [a, b]
+              }
             "#,
         )
         .expect("first source");
@@ -2161,7 +2285,9 @@ const message = t({ message })
             &second,
             r#"
               import { t } from "@palamedes/core/macro"
-              const a = t({ message: "Hello {name}", comment: "Greeting" })
+              function secondMessages() {
+                return t({ message: "Hello {name}", comment: "Greeting" })
+              }
             "#,
         )
         .expect("second source");
@@ -2216,7 +2342,9 @@ const message = t({ message })
             &shared,
             r#"
               import { t } from "@palamedes/core/macro"
-              export const label = t`Shared action`
+              export function label() {
+                return t`Shared action`
+              }
             "#,
         )
         .expect("shared source");
@@ -2266,7 +2394,7 @@ const message = t({ message })
                 return <Trans>Wrapped checkout</Trans>
               })
 
-              export const topLevelLabel = t`Top level label`
+              export const deferredLabel = () => t`Deferred label`
             "#,
         )
         .expect("source");
@@ -2304,14 +2432,14 @@ const message = t({ message })
         assert_eq!(wrapped.origins[0].file, "src/App.tsx");
         assert_eq!(wrapped.origins[0].scope.as_deref(), Some("WrappedButton"));
 
-        let top_level = result
+        let deferred = result
             .messages
             .iter()
-            .find(|message| message.message == "Top level label")
-            .expect("top-level message");
-        assert_eq!(top_level.origins.len(), 1);
-        assert_eq!(top_level.origins[0].file, "src/App.tsx");
-        assert_eq!(top_level.origins[0].scope, None);
+            .find(|message| message.message == "Deferred label")
+            .expect("deferred message");
+        assert_eq!(deferred.origins.len(), 1);
+        assert_eq!(deferred.origins[0].file, "src/App.tsx");
+        assert_eq!(deferred.origins[0].scope.as_deref(), Some("deferredLabel"));
 
         fs::remove_dir_all(root).expect("cleanup");
     }
@@ -2327,9 +2455,9 @@ const message = t({ message })
             &first,
             concat!(
                 "import { t } from \"@palamedes/core/macro\"\n",
-                "export const early = t`Shared origin`\n",
+                "export const early = () => t`Shared origin`\n",
                 "\n",
-                "export const later = t`Shared origin`\n",
+                "export const later = () => t`Shared origin`\n",
             ),
         )
         .expect("first source");
@@ -2337,7 +2465,7 @@ const message = t({ message })
             &second,
             concat!(
                 "import { t } from \"@palamedes/core/macro\"\n",
-                "export const duplicate = t`Shared origin`\n",
+                "export const duplicate = () => t`Shared origin`\n",
             ),
         )
         .expect("second source");
@@ -2398,7 +2526,9 @@ const message = t({ message })
             &source,
             r#"
               import { t } from "@palamedes/core/macro"
-              const message = t({ id: "greeting", message: "Hello" })
+              function message() {
+                return t({ id: "greeting", message: "Hello" })
+              }
             "#,
         )
         .expect("source");
@@ -2414,6 +2544,32 @@ const message = t({ message })
     }
 
     #[test]
+    fn batch_keeps_top_level_translation_macros_fatal() {
+        let root = temp_root("batch-top-level-translation");
+        fs::create_dir_all(&root).expect("root dir");
+        let source = root.join("bad.ts");
+        fs::write(
+            &source,
+            r#"
+              import { t } from "@palamedes/core/macro"
+              const message = t`Hello`
+            "#,
+        )
+        .expect("source");
+
+        let error = extract_catalog_messages_from_files(ExtractCatalogMessagesRequest {
+            root_dir: root.to_string_lossy().into_owned(),
+            files: vec![source.to_string_lossy().into_owned()],
+        })
+        .expect_err("top-level translation macros should fail");
+
+        assert!(error
+            .to_string()
+            .contains("Translation macro `t` must be used inside a function"));
+        fs::remove_dir_all(root).expect("cleanup");
+    }
+
+    #[test]
     fn batch_keeps_nested_jsx_message_macros_fatal() {
         let root = temp_root("batch-nested-message-macro");
         fs::create_dir_all(&root).expect("root dir");
@@ -2422,7 +2578,9 @@ const message = t({ message })
             &source,
             r##"
               import { Plural, Trans } from "@palamedes/react/macro"
-              const message = <Trans><Plural value={count} one="# item" other="# items" /> total</Trans>
+              function Message() {
+                return <Trans><Plural value={count} one="# item" other="# items" /> total</Trans>
+              }
             "##,
         )
         .expect("source");
@@ -2446,7 +2604,9 @@ const message = t({ message })
             &source,
             r#"
               import { t } from "@palamedes/core/macro"
-              const message = t({ message })
+              function message() {
+                return t({ message })
+              }
             "#,
         )
         .expect("source");

--- a/crates/palamedes/src/extract.rs
+++ b/crates/palamedes/src/extract.rs
@@ -1579,6 +1579,7 @@ mod tests {
         ExtractCatalogMessagesRequest, ExtractedMessageRecord,
     };
     use crate::error::PalamedesResult;
+    use crate::test_support::scope_macro_test_source;
 
     static TEMP_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
@@ -1586,42 +1587,7 @@ mod tests {
         source: &str,
         filename: &str,
     ) -> PalamedesResult<Vec<ExtractedMessageRecord>> {
-        extract_messages_raw(&scope_macro_test_source(source), filename)
-    }
-
-    fn scope_macro_test_source(source: &str) -> String {
-        if ![
-            "@palamedes/core/macro",
-            "@palamedes/react/macro",
-            "@palamedes/solid/macro",
-        ]
-        .iter()
-        .any(|macro_module| source.contains(macro_module))
-        {
-            return source.to_string();
-        }
-
-        let mut last_import_end = None;
-        let mut offset = 0;
-
-        for line in source.split_inclusive('\n') {
-            let line_without_newline = line.strip_suffix('\n').unwrap_or(line);
-            if line_without_newline.trim_start().starts_with("import ") {
-                last_import_end = Some(offset + line_without_newline.len());
-            }
-            offset += line.len();
-        }
-
-        let Some(import_end) = last_import_end else {
-            return source.to_string();
-        };
-
-        let mut scoped = String::with_capacity(source.len() + 48);
-        scoped.push_str(&source[..import_end]);
-        scoped.push_str("; function __palamedes_test_scope() {");
-        scoped.push_str(&source[import_end..]);
-        scoped.push_str("\n}");
-        scoped
+        extract_messages_raw(&scope_macro_test_source(source, filename), filename)
     }
 
     #[test]
@@ -1647,6 +1613,13 @@ const message = <Choice value={gender} other="They" />;
 "#,
                 "test.tsx",
                 "Select",
+            ),
+            (
+                r#"import { t } from "@palamedes/core/macro";
+class Formatter { label = t`Hello`; }
+"#,
+                "test.ts",
+                "t",
             ),
         ];
 

--- a/crates/palamedes/src/lib.rs
+++ b/crates/palamedes/src/lib.rs
@@ -29,6 +29,8 @@ mod extract;
 mod jsx_entities;
 mod jsx_message;
 mod message_metadata;
+#[cfg(test)]
+mod test_support;
 mod transform;
 mod translation_scope;
 

--- a/crates/palamedes/src/lib.rs
+++ b/crates/palamedes/src/lib.rs
@@ -30,6 +30,7 @@ mod jsx_entities;
 mod jsx_message;
 mod message_metadata;
 mod transform;
+mod translation_scope;
 
 use ferrocat::{parse_po as ferrocat_parse_po, MsgStr, PoFile, PoItem};
 use serde::Serialize;

--- a/crates/palamedes/src/test_support.rs
+++ b/crates/palamedes/src/test_support.rs
@@ -1,0 +1,64 @@
+use oxc_allocator::Allocator;
+use oxc_ast::ast::Statement;
+use oxc_parser::Parser;
+use oxc_span::SourceType;
+
+/// Moves a macro test fixture into a synthetic function while keeping imports
+/// at module scope and preserving the original macro line numbers.
+pub(crate) fn scope_macro_test_source(source: &str, filename: &str) -> String {
+    if ![
+        "@palamedes/core/macro",
+        "@palamedes/react/macro",
+        "@palamedes/solid/macro",
+    ]
+    .iter()
+    .any(|macro_module| source.contains(macro_module))
+    {
+        return source.to_string();
+    }
+
+    let allocator = Allocator::default();
+    let source_type = SourceType::from_path(filename).unwrap_or_else(|_| SourceType::tsx());
+    let parsed = Parser::new(&allocator, source, source_type).parse();
+    if !parsed.diagnostics.is_empty() {
+        return source.to_string();
+    }
+
+    let Some(import_end) = parsed
+        .program
+        .body
+        .iter()
+        .filter_map(|statement| match statement {
+            Statement::ImportDeclaration(import) => Some(import.span.end as usize),
+            _ => None,
+        })
+        .max()
+    else {
+        return source.to_string();
+    };
+
+    let mut scoped = String::with_capacity(source.len() + 48);
+    scoped.push_str(&source[..import_end]);
+    scoped.push_str("; function __palamedes_test_scope() {");
+    scoped.push_str(&source[import_end..]);
+    scoped.push_str("\n}");
+    scoped
+}
+
+#[test]
+fn scopes_fixtures_after_multiline_imports() {
+    let source = r#"import {
+  plural,
+  t,
+} from "@palamedes/core/macro"
+const message = t`Hello`
+"#;
+
+    let scoped = scope_macro_test_source(source, "test.ts");
+
+    assert!(scoped.contains("from \"@palamedes/core/macro\"; function __palamedes_test_scope() {"));
+
+    let allocator = Allocator::default();
+    let parsed = Parser::new(&allocator, &scoped, SourceType::ts()).parse();
+    assert!(parsed.diagnostics.is_empty());
+}

--- a/crates/palamedes/src/transform/mod.rs
+++ b/crates/palamedes/src/transform/mod.rs
@@ -16,6 +16,7 @@ use serde::{Deserialize, Serialize};
 use string_wizard::{Hires, MagicString, SourceMapOptions};
 
 use crate::error::{PalamedesError, PalamedesResult};
+use crate::translation_scope::validate_translation_macro_scopes;
 
 use self::imports::ImportCollector;
 use self::visitor::{source_location, Replacement, TransformVisitor};
@@ -143,6 +144,13 @@ pub fn transform_macros(
     if collector.macro_imports.is_empty() {
         return Ok(unchanged_result(source));
     }
+
+    validate_translation_macro_scopes(&parsed.program, filename, source, |local_name| {
+        collector
+            .macro_imports
+            .get(local_name)
+            .map(|macro_info| macro_info.imported_name.clone())
+    })?;
 
     let mut visitor = TransformVisitor::new(filename, source, &collector.macro_imports, &options);
     visitor.visit_program(&parsed.program);

--- a/crates/palamedes/src/transform/mod.rs
+++ b/crates/palamedes/src/transform/mod.rs
@@ -16,10 +16,10 @@ use serde::{Deserialize, Serialize};
 use string_wizard::{Hires, MagicString, SourceMapOptions};
 
 use crate::error::{PalamedesError, PalamedesResult};
-use crate::translation_scope::validate_translation_macro_scopes;
+use crate::translation_scope::{source_location, validate_translation_macro_scopes};
 
 use self::imports::ImportCollector;
-use self::visitor::{source_location, Replacement, TransformVisitor};
+use self::visitor::{Replacement, TransformVisitor};
 
 /// Options controlling how macro transforms emit runtime code.
 #[derive(Debug, Default, Deserialize)]

--- a/crates/palamedes/src/transform/tests.rs
+++ b/crates/palamedes/src/transform/tests.rs
@@ -1,5 +1,122 @@
-use super::{transform_macros, NativeTransformOptions};
+use super::{
+    transform_macros as transform_macros_raw, NativeTransformOptions, NativeTransformResult,
+};
+use crate::error::PalamedesResult;
 use ferrocat::compiled_key;
+
+fn transform_macros(
+    source: &str,
+    filename: &str,
+    options: Option<NativeTransformOptions>,
+) -> PalamedesResult<NativeTransformResult> {
+    let scoped_source = scope_macro_test_source(source);
+    let mut result = transform_macros_raw(&scoped_source, filename, options)?;
+
+    if let Some(map) = result.map.as_mut() {
+        map.sources_content = Some(vec![Some(source.to_string())]);
+    }
+
+    Ok(result)
+}
+
+fn scope_macro_test_source(source: &str) -> String {
+    if ![
+        "@palamedes/core/macro",
+        "@palamedes/react/macro",
+        "@palamedes/solid/macro",
+    ]
+    .iter()
+    .any(|macro_module| source.contains(macro_module))
+    {
+        return source.to_string();
+    }
+
+    let mut last_import_end = None;
+    let mut offset = 0;
+
+    for line in source.split_inclusive('\n') {
+        let line_without_newline = line.strip_suffix('\n').unwrap_or(line);
+        if line_without_newline.trim_start().starts_with("import ") {
+            last_import_end = Some(offset + line_without_newline.len());
+        }
+        offset += line.len();
+    }
+
+    let Some(import_end) = last_import_end else {
+        return source.to_string();
+    };
+
+    let mut scoped = String::with_capacity(source.len() + 48);
+    scoped.push_str(&source[..import_end]);
+    scoped.push_str("; function __palamedes_test_scope() {");
+    scoped.push_str(&source[import_end..]);
+    scoped.push_str("\n}");
+    scoped
+}
+
+#[test]
+fn rejects_eager_translation_macros_outside_functions() {
+    let cases = [
+        (
+            r#"import { t as translate } from "@palamedes/core/macro";
+const message = translate`Hello`;
+"#,
+            "test.ts",
+            "t",
+        ),
+        (
+            r##"import { plural } from "@palamedes/core/macro";
+const message = plural(count, { one: "# item", other: "# items" });
+"##,
+            "test.ts",
+            "plural",
+        ),
+        (
+            r#"import { Select as Choice } from "@palamedes/react/macro";
+const message = <Choice value={gender} other="They" />;
+"#,
+            "test.tsx",
+            "Select",
+        ),
+    ];
+
+    for (source, filename, macro_name) in cases {
+        let error = transform_macros_raw(source, filename, None)
+            .expect_err("top-level eager translation macros must fail");
+        let message = error.to_string();
+        assert!(message.contains(&format!(
+            "Translation macro `{macro_name}` must be used inside a function"
+        )));
+        assert!(message.contains(filename));
+    }
+}
+
+#[test]
+fn accepts_translation_macros_in_deferred_scopes_and_trans_at_module_scope() {
+    let source = r##"import { plural, t } from "@palamedes/core/macro";
+import { Plural, Trans } from "@palamedes/react/macro";
+
+const safe = <Trans>Rendered later</Trans>;
+function declaration() { return t`Function`; }
+const arrow = () => t`Arrow`;
+const object = { method() { return t`Method`; } };
+class Formatter { method() { return t`Class method`; } }
+items.map(() => t`Callback`);
+function Component() {
+  return <Plural value={count} one="# item" other="# items" />;
+}
+function choices() {
+  return plural(count, { one: "# item", other: "# items" });
+}
+"##;
+
+    let result = transform_macros_raw(source, "test.tsx", None)
+        .expect("function-scoped macros and top-level Trans should succeed");
+
+    assert!(result.has_changed);
+    assert!(result.code.contains("Rendered later"));
+    assert!(result.code.contains("Class method"));
+}
 
 #[test]
 fn transforms_tagged_templates() {

--- a/crates/palamedes/src/transform/tests.rs
+++ b/crates/palamedes/src/transform/tests.rs
@@ -2,6 +2,7 @@ use super::{
     transform_macros as transform_macros_raw, NativeTransformOptions, NativeTransformResult,
 };
 use crate::error::PalamedesResult;
+use crate::test_support::scope_macro_test_source;
 use ferrocat::compiled_key;
 
 fn transform_macros(
@@ -9,7 +10,7 @@ fn transform_macros(
     filename: &str,
     options: Option<NativeTransformOptions>,
 ) -> PalamedesResult<NativeTransformResult> {
-    let scoped_source = scope_macro_test_source(source);
+    let scoped_source = scope_macro_test_source(source, filename);
     let mut result = transform_macros_raw(&scoped_source, filename, options)?;
 
     if let Some(map) = result.map.as_mut() {
@@ -17,41 +18,6 @@ fn transform_macros(
     }
 
     Ok(result)
-}
-
-fn scope_macro_test_source(source: &str) -> String {
-    if ![
-        "@palamedes/core/macro",
-        "@palamedes/react/macro",
-        "@palamedes/solid/macro",
-    ]
-    .iter()
-    .any(|macro_module| source.contains(macro_module))
-    {
-        return source.to_string();
-    }
-
-    let mut last_import_end = None;
-    let mut offset = 0;
-
-    for line in source.split_inclusive('\n') {
-        let line_without_newline = line.strip_suffix('\n').unwrap_or(line);
-        if line_without_newline.trim_start().starts_with("import ") {
-            last_import_end = Some(offset + line_without_newline.len());
-        }
-        offset += line.len();
-    }
-
-    let Some(import_end) = last_import_end else {
-        return source.to_string();
-    };
-
-    let mut scoped = String::with_capacity(source.len() + 48);
-    scoped.push_str(&source[..import_end]);
-    scoped.push_str("; function __palamedes_test_scope() {");
-    scoped.push_str(&source[import_end..]);
-    scoped.push_str("\n}");
-    scoped
 }
 
 #[test]
@@ -77,6 +43,13 @@ const message = <Choice value={gender} other="They" />;
 "#,
             "test.tsx",
             "Select",
+        ),
+        (
+            r#"import { t } from "@palamedes/core/macro";
+class Formatter { label = t`Hello`; }
+"#,
+            "test.ts",
+            "t",
         ),
     ];
 

--- a/crates/palamedes/src/transform/visitor.rs
+++ b/crates/palamedes/src/transform/visitor.rs
@@ -6,6 +6,7 @@ use oxc_ast::ast::{
 use oxc_ast_visit::{walk, Visit};
 
 use crate::error::PalamedesError;
+use crate::translation_scope::source_location;
 
 use super::imports::ImportedMacro;
 use super::messages::identifier_name;
@@ -379,23 +380,4 @@ fn is_jsx_message_macro(
                 "Trans" | "Plural" | "Select" | "SelectOrdinal"
             )
         })
-}
-
-pub(super) fn source_location(source: &str, filename: &str, offset: usize) -> String {
-    let mut line = 1usize;
-    let mut line_start = 0usize;
-
-    for (index, ch) in source.char_indices() {
-        if index >= offset {
-            break;
-        }
-        if ch == '\n' {
-            line += 1;
-            line_start = index + 1;
-        }
-    }
-
-    let column = offset.saturating_sub(line_start) + 1;
-
-    format!("{filename}:{line}:{column}")
 }

--- a/crates/palamedes/src/translation_scope.rs
+++ b/crates/palamedes/src/translation_scope.rs
@@ -138,7 +138,8 @@ fn identifier_name<'a>(expression: &'a Expression<'a>) -> Option<&'a str> {
     }
 }
 
-fn source_location(source: &str, filename: &str, offset: usize) -> String {
+/// Formats a byte offset as a one-based filename, line, and column location.
+pub(crate) fn source_location(source: &str, filename: &str, offset: usize) -> String {
     let mut line = 1usize;
     let mut line_start = 0usize;
 

--- a/crates/palamedes/src/translation_scope.rs
+++ b/crates/palamedes/src/translation_scope.rs
@@ -1,0 +1,158 @@
+use oxc_ast::ast::{CallExpression, Expression, JSXElement, Program, TaggedTemplateExpression};
+use oxc_ast::ast_kind::AstKind;
+use oxc_ast_visit::{walk, Visit};
+
+use crate::error::{PalamedesError, PalamedesResult};
+
+const EAGER_JS_MACROS: [&str; 4] = ["t", "plural", "select", "selectOrdinal"];
+const EAGER_JSX_MACROS: [&str; 3] = ["Plural", "Select", "SelectOrdinal"];
+
+pub(crate) fn validate_translation_macro_scopes<'a, F>(
+    program: &Program<'a>,
+    filename: &str,
+    source: &str,
+    imported_macro_name: F,
+) -> PalamedesResult<()>
+where
+    F: Fn(&str) -> Option<String>,
+{
+    let mut validator = TranslationScopeValidator {
+        filename,
+        source,
+        imported_macro_name: &imported_macro_name,
+        function_depth: 0,
+        error: None,
+    };
+    validator.visit_program(program);
+
+    match validator.error {
+        Some(error) => Err(error),
+        None => Ok(()),
+    }
+}
+
+struct TranslationScopeValidator<'a, F> {
+    filename: &'a str,
+    source: &'a str,
+    imported_macro_name: &'a F,
+    function_depth: usize,
+    error: Option<PalamedesError>,
+}
+
+impl<F> TranslationScopeValidator<'_, F>
+where
+    F: Fn(&str) -> Option<String>,
+{
+    fn validate_macro(&mut self, local_name: &str, expected: &[&str], offset: usize) {
+        if self.error.is_some() || self.function_depth > 0 {
+            return;
+        }
+
+        let Some(macro_name) = (self.imported_macro_name)(local_name) else {
+            return;
+        };
+        if !expected.contains(&macro_name.as_str()) {
+            return;
+        }
+
+        self.error = Some(PalamedesError::TranslationMacroOutsideFunction {
+            macro_name,
+            location: source_location(self.source, self.filename, offset),
+        });
+    }
+}
+
+impl<'a, F> Visit<'a> for TranslationScopeValidator<'_, F>
+where
+    F: Fn(&str) -> Option<String>,
+{
+    fn enter_node(&mut self, kind: AstKind<'a>) {
+        if matches!(
+            kind,
+            AstKind::Function(_) | AstKind::ArrowFunctionExpression(_)
+        ) {
+            self.function_depth += 1;
+        }
+    }
+
+    fn leave_node(&mut self, kind: AstKind<'a>) {
+        if matches!(
+            kind,
+            AstKind::Function(_) | AstKind::ArrowFunctionExpression(_)
+        ) {
+            self.function_depth = self.function_depth.saturating_sub(1);
+        }
+    }
+
+    fn visit_jsx_element(&mut self, it: &JSXElement<'a>) {
+        if self.error.is_some() {
+            return;
+        }
+
+        if let Some(local_name) = it.opening_element.name.get_identifier_name() {
+            self.validate_macro(
+                local_name.as_str(),
+                &EAGER_JSX_MACROS,
+                it.span.start as usize,
+            );
+        }
+
+        if self.error.is_none() {
+            walk::walk_jsx_element(self, it);
+        }
+    }
+
+    fn visit_tagged_template_expression(&mut self, it: &TaggedTemplateExpression<'a>) {
+        if self.error.is_some() {
+            return;
+        }
+
+        if let Some(local_name) = identifier_name(&it.tag) {
+            self.validate_macro(local_name, &["t"], it.span.start as usize);
+        }
+
+        if self.error.is_none() {
+            walk::walk_tagged_template_expression(self, it);
+        }
+    }
+
+    fn visit_call_expression(&mut self, it: &CallExpression<'a>) {
+        if self.error.is_some() {
+            return;
+        }
+
+        if let Some(local_name) = identifier_name(&it.callee) {
+            self.validate_macro(local_name, &EAGER_JS_MACROS, it.span.start as usize);
+        }
+
+        if self.error.is_none() {
+            walk::walk_call_expression(self, it);
+        }
+    }
+}
+
+fn identifier_name<'a>(expression: &'a Expression<'a>) -> Option<&'a str> {
+    match expression.without_parentheses() {
+        Expression::Identifier(identifier) => Some(identifier.name.as_str()),
+        _ => None,
+    }
+}
+
+fn source_location(source: &str, filename: &str, offset: usize) -> String {
+    let mut line = 1usize;
+    let mut line_start = 0usize;
+
+    for (index, ch) in source.char_indices() {
+        if index >= offset {
+            break;
+        }
+        if ch == '\n' {
+            line += 1;
+            line_start = index + 1;
+        }
+    }
+
+    let column = offset.saturating_sub(line_start) + 1;
+
+    format!("{filename}:{line}:{column}")
+}

--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -112,7 +112,8 @@ Supported macro names:
 All four macros resolve translations eagerly. They must therefore be used
 inside a function, method, or callback, after the application has activated
 the relevant i18n scope. Palamedes rejects these macros at module scope during
-transformation and extraction.
+transformation and extraction. Class field initializers, including instance
+fields, do not satisfy this syntactic rule; use a method or getter instead.
 
 ## Runtime Formatting
 

--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -109,6 +109,11 @@ Supported macro names:
 - `select`
 - `selectOrdinal`
 
+All four macros resolve translations eagerly. They must therefore be used
+inside a function, method, or callback, after the application has activated
+the relevant i18n scope. Palamedes rejects these macros at module scope during
+transformation and extraction.
+
 ## Runtime Formatting
 
 `formatMessagePattern()` and `createI18n()._()` support the formatter subset

--- a/docs/migrate-from-lingui.md
+++ b/docs/migrate-from-lingui.md
@@ -59,6 +59,13 @@ import { t, plural, select, selectOrdinal } from "@palamedes/core/macro"
 import { Trans, Plural, Select, SelectOrdinal } from "@palamedes/react/macro"
 ```
 
+Palamedes requires eager translation macros to live inside a function, method,
+or callback. This applies to `t`, `plural`, `select`, `selectOrdinal`,
+`<Plural>`, `<Select>`, and `<SelectOrdinal>` and prevents translation from
+running while a module is loaded, before request- or render-local i18n
+activation. `<Trans>` can remain at module scope because it resolves when the
+component renders.
+
 That continuity is the point. The migration is primarily a tooling, catalog,
 and runtime cleanup, not an authoring reset.
 

--- a/docs/migrate-from-lingui.md
+++ b/docs/migrate-from-lingui.md
@@ -64,7 +64,8 @@ or callback. This applies to `t`, `plural`, `select`, `selectOrdinal`,
 `<Plural>`, `<Select>`, and `<SelectOrdinal>` and prevents translation from
 running while a module is loaded, before request- or render-local i18n
 activation. `<Trans>` can remain at module scope because it resolves when the
-component renders.
+component renders. Class field initializers do not satisfy the rule, even for
+instance fields; migrate those calls to a method or getter.
 
 That continuity is the point. The migration is primarily a tooling, catalog,
 and runtime cleanup, not an authoring reset.

--- a/packages/core-node/src/index.test.ts
+++ b/packages/core-node/src/index.test.ts
@@ -60,7 +60,9 @@ msgstr "Oeffnen"
 
   it("maps native transform results into JavaScript strings and source maps", () => {
     const source = `import { t } from "@palamedes/core/macro";
-const msg = t\`Hello \${name}\`;
+function message(name) {
+  return t\`Hello \${name}\`;
+}
 `
     const result = transformMacrosNative(source, "sample.ts")
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -60,6 +60,9 @@ import { t } from "@palamedes/core/macro"
 ```
 
 The macro entry exports `t`, `plural`, `select`, and `selectOrdinal`.
+These eager macros must be used inside a function, method, or callback so they
+run after the relevant i18n instance has been activated. The transformer and
+extractor reject module-scope usage.
 
 ## Locale Controls
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -62,7 +62,8 @@ import { t } from "@palamedes/core/macro"
 The macro entry exports `t`, `plural`, `select`, and `selectOrdinal`.
 These eager macros must be used inside a function, method, or callback so they
 run after the relevant i18n instance has been activated. The transformer and
-extractor reject module-scope usage.
+extractor reject module-scope usage. Class field initializers do not count as
+function scope; use a method or getter instead.
 
 ## Locale Controls
 

--- a/packages/extractor/README.md
+++ b/packages/extractor/README.md
@@ -32,7 +32,8 @@ pnpm add -D @palamedes/extractor
 ```ts
 import { extractor } from "@palamedes/extractor"
 
-const source = 'import { t } from "@palamedes/core/macro"; const message = t`Hello ${name}`'
+const source =
+  'import { t } from "@palamedes/core/macro"; function message(name) { return t`Hello ${name}` }'
 const messages = []
 
 await extractor.extract("example.ts", source, (message) => {
@@ -48,6 +49,11 @@ console.log(messages)
 - `<Trans>`, `<Plural>`, `<Select>`, `<SelectOrdinal>`
 - `i18n._(...)` and `i18n.t\`...\`` style runtime calls
 - JavaScript, TypeScript, JSX, and TSX sources
+
+The extractor rejects eager `t`, `plural`, `select`, and `selectOrdinal`
+macros, plus `<Plural>`, `<Select>`, and `<SelectOrdinal>`, when they appear
+outside a function, method, or callback. `<Trans>` is safe at module scope
+because translation occurs during component rendering.
 
 Rich JSX children inside `<Trans>` are extracted with numeric component slots. For example,
 `<Trans><strong>A</strong> and <strong>B</strong></Trans>` extracts as

--- a/packages/extractor/README.md
+++ b/packages/extractor/README.md
@@ -53,7 +53,8 @@ console.log(messages)
 The extractor rejects eager `t`, `plural`, `select`, and `selectOrdinal`
 macros, plus `<Plural>`, `<Select>`, and `<SelectOrdinal>`, when they appear
 outside a function, method, or callback. `<Trans>` is safe at module scope
-because translation occurs during component rendering.
+because translation occurs during component rendering. Class field initializers
+do not count as function scope; use a method or getter instead.
 
 Rich JSX children inside `<Trans>` are extracted with numeric component slots. For example,
 `<Trans><strong>A</strong> and <strong>B</strong></Trans>` extracts as

--- a/packages/extractor/src/extractMessages.test.ts
+++ b/packages/extractor/src/extractMessages.test.ts
@@ -1,10 +1,70 @@
 import { extractMessages, extractor, type ExtractedMessageInfo } from "./index"
 
 function extract(code: string) {
-  return extractMessages(code, "test.tsx")
+  return extractMessages(scopeMacroTestSource(code), "test.tsx")
+}
+
+function scopeMacroTestSource(code: string): string {
+  if (!/@palamedes\/(?:core|react|solid)\/macro/.test(code)) {
+    return code
+  }
+
+  const imports = [...code.matchAll(/^[ \t]*import[^\n]*$/gm)]
+  const lastImport = imports.at(-1)
+  if (!lastImport || lastImport.index === undefined) {
+    return code
+  }
+
+  const insertion = lastImport.index + lastImport[0].length
+  return `${code.slice(0, insertion)}; function __palamedesTestScope() {${code.slice(insertion)}\n}`
 }
 
 describe("extractMessages", () => {
+  describe("translation scope", () => {
+    it.each([
+      [
+        'import { t as translate } from "@palamedes/core/macro"\nconst value = translate`Hello`',
+        "t",
+      ],
+      [
+        'import { plural } from "@palamedes/core/macro"\nconst value = plural(count, { one: "# item", other: "# items" })',
+        "plural",
+      ],
+      [
+        'import { Select } from "@palamedes/react/macro"\nconst value = <Select value={kind} other="Other" />',
+        "Select",
+      ],
+    ])("rejects top-level %s usage", (code, macroName) => {
+      expect(() => extractMessages(code, "test.tsx")).toThrow(
+        new RegExp(`Translation macro \`${macroName}\` must be used inside a function`)
+      )
+    })
+
+    it("allows eager macros inside functions, methods, and callbacks", () => {
+      const code = `
+        import { t, plural } from "@palamedes/core/macro"
+        import { Select } from "@palamedes/react/macro"
+        function label() { return t\`Hello\` }
+        const countLabel = () => plural(count, { one: "# item", other: "# items" })
+        const formatter = { label() { return t\`Method\` } }
+        class Formatter { label() { return t\`Class method\` } }
+        items.map((item) => t\`Item \${item.name}\`)
+        function View() { return <Select value={kind} other="Other" /> }
+      `
+
+      expect(() => extractMessages(code, "test.tsx")).not.toThrow()
+    })
+
+    it("keeps Trans safe at module scope", () => {
+      const code = `
+        import { Trans } from "@palamedes/react/macro"
+        const value = <Trans>Hello</Trans>
+      `
+
+      expect(extractMessages(code, "test.tsx")).toHaveLength(1)
+    })
+  })
+
   describe("JSX Trans", () => {
     it("extracts simple Trans", () => {
       const code = `
@@ -281,7 +341,9 @@ const descriptor = t({ message })
     it("extracts directly from source without a caller-provided AST", async () => {
       const code = `
         import { t } from "@palamedes/core/macro"
-        const message = t\`Hello \${name}\`
+        function message() {
+          return t\`Hello \${name}\`
+        }
       `
       const messages: ExtractedMessageInfo[] = []
 
@@ -318,7 +380,9 @@ const descriptor = t({ message })
     it("does not hide fatal native extraction errors", async () => {
       const code = `
         import { t } from "@palamedes/core/macro"
-        const message = t({ id: "greeting", message: "Hello" })
+        function test() {
+          return t({ id: "greeting", message: "Hello" })
+        }
       `
 
       await expect(extractor.extract("test.ts", code, () => {})).rejects.toThrow(

--- a/packages/extractor/src/extractMessages.test.ts
+++ b/packages/extractor/src/extractMessages.test.ts
@@ -1,22 +1,7 @@
 import { extractMessages, extractor, type ExtractedMessageInfo } from "./index"
 
 function extract(code: string) {
-  return extractMessages(scopeMacroTestSource(code), "test.tsx")
-}
-
-function scopeMacroTestSource(code: string): string {
-  if (!/@palamedes\/(?:core|react|solid)\/macro/.test(code)) {
-    return code
-  }
-
-  const imports = [...code.matchAll(/^[ \t]*import[^\n]*$/gm)]
-  const lastImport = imports.at(-1)
-  if (!lastImport || lastImport.index === undefined) {
-    return code
-  }
-
-  const insertion = lastImport.index + lastImport[0].length
-  return `${code.slice(0, insertion)}; function __palamedesTestScope() {${code.slice(insertion)}\n}`
+  return extractMessages(code, "test.tsx")
 }
 
 describe("extractMessages", () => {
@@ -34,6 +19,7 @@ describe("extractMessages", () => {
         'import { Select } from "@palamedes/react/macro"\nconst value = <Select value={kind} other="Other" />',
         "Select",
       ],
+      ['import { t } from "@palamedes/core/macro"\nclass Formatter { label = t`Hello` }', "t"],
     ])("rejects top-level %s usage", (code, macroName) => {
       expect(() => extractMessages(code, "test.tsx")).toThrow(
         new RegExp(`Translation macro \`${macroName}\` must be used inside a function`)
@@ -42,7 +28,10 @@ describe("extractMessages", () => {
 
     it("allows eager macros inside functions, methods, and callbacks", () => {
       const code = `
-        import { t, plural } from "@palamedes/core/macro"
+        import {
+          plural,
+          t,
+        } from "@palamedes/core/macro"
         import { Select } from "@palamedes/react/macro"
         function label() { return t\`Hello\` }
         const countLabel = () => plural(count, { one: "# item", other: "# items" })
@@ -196,9 +185,10 @@ describe("extractMessages", () => {
   describe("macro calls", () => {
     it("extracts descriptor messages", () => {
       const code = `
-        import { t } from "@palamedes/core/macro"
+        import { t } from "@palamedes/core/macro"; function messages() {
         const one = t({ message: "Hello" })
         const two = t({ message: "Hello {name}", context: "email.subject" }, { name })
+        }
       `
       const messages = extract(code)
       expect(messages).toHaveLength(2)
@@ -209,12 +199,13 @@ describe("extractMessages", () => {
 
     it("extracts interpolated descriptor templates with placeholder metadata", () => {
       const code = `
-        import { t } from "@palamedes/core/macro"
+        import { t } from "@palamedes/core/macro"; function messages() {
         const one = t({
           message: \`Descriptor \${name}\`,
           context: "probe context",
         })
         const two = t({ message: \`Locale \${resolved.locale}\` })
+        }
       `
       const messages = extract(code)
 
@@ -243,8 +234,9 @@ const message = t\`Hello\`
     })
 
     it("rejects dynamic descriptor messages with a source location", () => {
-      const code = `import { t } from "@palamedes/core/macro"
+      const code = `import { t } from "@palamedes/core/macro"; function message() {
 const descriptor = t({ message })
+}
 `
 
       expect(() => extract(code)).toThrow(
@@ -254,9 +246,10 @@ const descriptor = t({ message })
 
     it("extracts plural and select messages", () => {
       const code = `
-        import { plural, select } from "@palamedes/core/macro"
+        import { plural, select } from "@palamedes/core/macro"; function messages() {
         const one = plural(count, { one: "# item", other: "# items" })
         const two = select(gender, { male: "He", female: "She", other: "They" })
+        }
       `
       const messages = extract(code)
       expect(messages).toHaveLength(2)
@@ -267,7 +260,7 @@ const descriptor = t({ message })
     it("extracts interpolated plural branches with placeholder metadata", () => {
       const code = `
         import { plural } from "@palamedes/core/macro"
-        import { Plural } from "@palamedes/react/macro"
+        import { Plural } from "@palamedes/react/macro"; function messages() {
         const call = plural(count, {
           one: \`# item will be archived because \${planLabel} allows a maximum of \${max}\`,
           other: \`# items will be archived because \${planLabel} allows a maximum of \${max}\`,
@@ -277,6 +270,7 @@ const descriptor = t({ message })
           one={\`# item will be archived because \${planLabel} allows a maximum of \${max}\`}
           other={\`# items will be archived because \${planLabel} allows a maximum of \${max}\`}
         />
+        }
       `
       const messages = extract(code)
       const expected =
@@ -323,8 +317,9 @@ const descriptor = t({ message })
   describe("placeholder metadata", () => {
     it("keeps source expressions for template literal placeholder hints", () => {
       const code = `
-        import { t } from "@palamedes/core/macro"
+        import { t } from "@palamedes/core/macro"; function message() {
         const message = t\`Hello \${name}, \${resolved.locale}\`
+        }
       `
       const messages = extract(code)
 
@@ -394,8 +389,9 @@ const descriptor = t({ message })
   describe("breaking changes", () => {
     it("rejects explicit ids in macros", () => {
       const code = `
-        import { t } from "@palamedes/core/macro"
+        import { t } from "@palamedes/core/macro"; function message() {
         const x = t({ id: "greeting", message: "Hello" })
+        }
       `
 
       expect(() => extract(code)).toThrow(/Explicit message ids/)
@@ -411,8 +407,9 @@ const descriptor = t({ message })
 
     it("rejects unnamed template placeholders", () => {
       const code = [
-        `import { t } from "@palamedes/core/macro"`,
+        `import { t } from "@palamedes/core/macro"; function message() {`,
         "const x = t`Hello ${firstName + lastName}`",
+        "}",
       ].join("\n")
 
       expect(() => extract(code)).toThrow(/stable placeholder name/)
@@ -429,8 +426,9 @@ const descriptor = t({ message })
 
     it("rejects nested JSX message macros", () => {
       const code = `
-        import { Plural, Trans } from "@palamedes/react/macro"
+        import { Plural, Trans } from "@palamedes/react/macro"; function Message() {
         const x = <Trans><Plural value={contractCount} one="# contract" other="# contracts" /> ({capacityMW} MW)</Trans>
+        }
       `
 
       expect(() => extract(code)).toThrow(
@@ -447,8 +445,9 @@ const descriptor = t({ message })
 
       for (const jsx of cases) {
         const code = `
-          import { Plural, Trans } from "@palamedes/react/macro"
+          import { Plural, Trans } from "@palamedes/react/macro"; function Message() {
           const x = ${jsx}
+          }
         `
 
         expect(() => extract(code)).toThrow(
@@ -472,10 +471,11 @@ const descriptor = t({ message })
     it("accepts computed, defaulted, and literal choice values", () => {
       const code = `
         import { plural } from "@palamedes/core/macro"
-        import { Plural } from "@palamedes/react/macro"
+        import { Plural } from "@palamedes/react/macro"; function messages() {
         const computed = plural(periodCounts[period] ?? 0, { one: "# entry", other: "# entries" })
         const literal = plural(21, { one: "# month", other: "# months" })
         const jsx = <Plural value={node.locationCount ?? 0} one="# location" other="# locations" />
+        }
       `
       const messages = extract(code)
 

--- a/packages/remix/src/index.test.ts
+++ b/packages/remix/src/index.test.ts
@@ -91,7 +91,8 @@ describe("createPalamedesRemixLoadHook", () => {
   })
 
   it("skips CommonJS files by default because runtime injection is ESM", () => {
-    const source = 'import { t } from "@palamedes/core/macro"; export const label = t`Hello`'
+    const source =
+      'import { t } from "@palamedes/core/macro"; export function label() { return t`Hello` }'
     const load = createPalamedesRemixLoadHook()
 
     const loaded = load(new URL("file:///repo/app/legacy.cjs").href, loadContext, () => ({
@@ -116,7 +117,8 @@ describe("createPalamedesRemixLoadHook", () => {
   })
 
   it("skips non-file urls and node_modules", () => {
-    const source = 'import { t } from "@palamedes/core/macro"; export const label = t`Hello`'
+    const source =
+      'import { t } from "@palamedes/core/macro"; export function label() { return t`Hello` }'
     const load = createPalamedesRemixLoadHook()
 
     const virtual = load("data:text/javascript,export{}", loadContext, () => ({
@@ -137,7 +139,8 @@ describe("createPalamedesRemixLoadHook", () => {
   })
 
   it("does not exclude paths that only contain node_modules as a substring", () => {
-    const source = 'import { t } from "@palamedes/core/macro"; export const label = t`Hello`'
+    const source =
+      'import { t } from "@palamedes/core/macro"; export function label() { return t`Hello` }'
     const load = createPalamedesRemixLoadHook()
 
     const loaded = load(

--- a/packages/transform/README.md
+++ b/packages/transform/README.md
@@ -38,7 +38,7 @@ pnpm add -D @palamedes/transform
 import { transformPalamedesMacros } from "@palamedes/transform"
 
 const result = transformPalamedesMacros(
-  'import { t } from "@palamedes/core/macro"; const message = t`Hello ${name}`',
+  'import { t } from "@palamedes/core/macro"; function message(name) { return t`Hello ${name}` }',
   "example.ts",
   {
     runtimeModule: "@palamedes/runtime",
@@ -75,6 +75,12 @@ The root package also re-exports catalog-loader helpers from
 - descriptor calls such as `t({ message: "..." })`
 - `plural(...)`, `select(...)`, `selectOrdinal(...)`
 - `<Trans>`, `<Plural>`, `<Select>`, `<SelectOrdinal>`
+
+The eager `t`, `plural`, `select`, and `selectOrdinal` macros, plus
+`<Plural>`, `<Select>`, and `<SelectOrdinal>`, must be syntactically inside a
+function, method, or callback. This prevents translation from running as a
+module-loading side effect before i18n activation. `<Trans>` may remain at
+module scope because translation occurs when the component renders.
 
 Explicit author-facing `id` fields are intentionally not part of the supported end-state model.
 

--- a/packages/transform/README.md
+++ b/packages/transform/README.md
@@ -80,7 +80,9 @@ The eager `t`, `plural`, `select`, and `selectOrdinal` macros, plus
 `<Plural>`, `<Select>`, and `<SelectOrdinal>`, must be syntactically inside a
 function, method, or callback. This prevents translation from running as a
 module-loading side effect before i18n activation. `<Trans>` may remain at
-module scope because translation occurs when the component renders.
+module scope because translation occurs when the component renders. Class field
+initializers, including instance fields, are intentionally rejected; use a
+method or getter instead.
 
 Explicit author-facing `id` fields are intentionally not part of the supported end-state model.
 

--- a/packages/transform/src/transform.test.ts
+++ b/packages/transform/src/transform.test.ts
@@ -1,33 +1,4 @@
-import { transformPalamedesMacros as transformPalamedesMacrosRaw } from "./transform"
-import type { TransformOptions, TransformResult } from "./types"
-
-function transformPalamedesMacros(
-  code: string,
-  filename: string,
-  options: TransformOptions = {}
-): TransformResult {
-  const scopedCode = scopeMacroTestSource(code)
-  const result = transformPalamedesMacrosRaw(scopedCode, filename, options)
-  if (result.map?.sourcesContent) {
-    result.map.sourcesContent = [code]
-  }
-  return result
-}
-
-function scopeMacroTestSource(code: string): string {
-  if (!/@palamedes\/(?:core|react|solid)\/macro/.test(code)) {
-    return code
-  }
-
-  const imports = [...code.matchAll(/^[ \t]*import[^\n]*$/gm)]
-  const lastImport = imports.at(-1)
-  if (!lastImport || lastImport.index === undefined) {
-    return code
-  }
-
-  const insertion = lastImport.index + lastImport[0].length
-  return `${code.slice(0, insertion)}; function __palamedesTestScope() {${code.slice(insertion)}\n}`
-}
+import { transformPalamedesMacros } from "./transform"
 
 type SourceMapLike = {
   file?: string
@@ -51,16 +22,20 @@ describe("transformPalamedesMacros", () => {
       'import { Select } from "@palamedes/react/macro";\nconst value = <Select value={kind} other="Other" />;',
       "Select",
     ],
+    ['import { t } from "@palamedes/core/macro";\nclass Formatter { label = t`Hello`; }', "t"],
   ])("rejects top-level %s usage", (code, macroName) => {
-    expect(() => transformPalamedesMacrosRaw(code, "test.tsx")).toThrow(
+    expect(() => transformPalamedesMacros(code, "test.tsx")).toThrow(
       new RegExp(`Translation macro \`${macroName}\` must be used inside a function`)
     )
   })
 
   it("allows eager macros inside functions, methods, and callbacks", () => {
     const code = `
-import { t, plural } from "@palamedes/core/macro";
-import { Select } from "@palamedes/react/macro";
+	import {
+	  plural,
+	  t,
+	} from "@palamedes/core/macro";
+	import { Select } from "@palamedes/react/macro";
 function label() { return t\`Hello\`; }
 const countLabel = () => plural(count, { one: "# item", other: "# items" });
 const formatter = { label() { return t\`Method\`; } };
@@ -69,7 +44,7 @@ items.map((item) => t\`Item \${item.name}\`);
 function View() { return <Select value={kind} other="Other" />; }
 `
 
-    expect(() => transformPalamedesMacrosRaw(code, "test.tsx")).not.toThrow()
+    expect(() => transformPalamedesMacros(code, "test.tsx")).not.toThrow()
   })
 
   it("returns unchanged code without Palamedes macro imports", () => {
@@ -84,7 +59,9 @@ function View() { return <Select value={kind} other="Other" />; }
   it("transforms tagged templates into compact runtime lookups", () => {
     const code = `
 import { t } from "@palamedes/core/macro";
+function message() {
 const msg = t\`Hello \${name}\`;
+}
 `
     const result = transformPalamedesMacros(code, "test.ts")
 
@@ -108,7 +85,9 @@ const msg = t\`Hello \${name}\`;
   it("preserves member expression values in tagged templates", () => {
     const code = `
 import { t } from "@palamedes/core/macro";
+function message() {
 const msg = t\`Locale \${resolved.locale}\`;
+}
 `
     const result = transformPalamedesMacros(code, "test.ts")
 
@@ -119,7 +98,9 @@ const msg = t\`Locale \${resolved.locale}\`;
   it("transforms descriptor macros without preserving public ids", () => {
     const code = `
 import { t } from "@palamedes/core/macro";
+function message() {
 const msg = t({ message: "Hello", context: "informal", comment: "A greeting" });
+}
 `
     const result = transformPalamedesMacros(code, "test.ts")
 
@@ -133,10 +114,12 @@ const msg = t({ message: "Hello", context: "informal", comment: "A greeting" });
   it("transforms interpolated descriptor templates with runtime values", () => {
     const code = `
 import { t } from "@palamedes/core/macro";
+function message() {
 const message = t({
   message: \`Descriptor \${name}\`,
   context: "probe context",
 });
+}
 `
     const result = transformPalamedesMacros(code, "test.ts")
 
@@ -149,8 +132,9 @@ const message = t({
 
   it("rejects missing ICU values in interpolated descriptor templates", () => {
     const code = `
-import { t } from "@palamedes/core/macro";
+import { t } from "@palamedes/core/macro"; function message() {
 const descriptor = t({ message: \`Hello \${name}, you have {count}\` });
+}
 `
 
     expect(() => transformPalamedesMacros(code, "test.ts")).toThrow(/Missing value\(s\): count/)
@@ -172,9 +156,10 @@ const valid = t\`Hello\`;
   )
 
   it("rejects unsupported macro calls before removing a shared macro import", () => {
-    const code = `import { t } from "@palamedes/core/macro";
+    const code = `import { t } from "@palamedes/core/macro"; function test() {
 const valid = t\`Hello\`;
 const broken = t({ message });
+}
 `
 
     expect(() => transformPalamedesMacros(code, "test.ts")).toThrow(
@@ -185,7 +170,9 @@ const broken = t({ message });
   it("forwards descriptor macro values object literals", () => {
     const code = `
 import { t } from "@palamedes/core/macro";
+function message() {
 const msg = t({ message: "Hello {name}" }, { name });
+}
 `
     const result = transformPalamedesMacros(code, "test.ts")
 
@@ -196,7 +183,9 @@ const msg = t({ message: "Hello {name}" }, { name });
   it("rejects descriptor macro values missing message placeholders", () => {
     const code = `
 import { t } from "@palamedes/core/macro";
+function message() {
 const msg = t({ message: "Hello {name}" }, { naem: user.name });
+}
 `
 
     expect(() => transformPalamedesMacros(code, "test.ts")).toThrow(/Missing value\(s\): name/)
@@ -205,7 +194,9 @@ const msg = t({ message: "Hello {name}" }, { naem: user.name });
   it("rejects descriptor macro values not used by the message", () => {
     const code = `
 import { t } from "@palamedes/core/macro";
+function message() {
 const msg = t({ message: "Hello" }, { name });
+}
 `
 
     expect(() => transformPalamedesMacros(code, "test.ts")).toThrow(/extra value\(s\): name/)
@@ -343,7 +334,9 @@ const manager = <Trans> — no manager</Trans>;
   it("strips the message field when requested", () => {
     const code = `
 import { t } from "@palamedes/core/macro";
+function message() {
 const msg = t({ message: "Hello" });
+}
 `
     const result = transformPalamedesMacros(code, "test.ts", {
       stripMessageField: true,
@@ -408,8 +401,9 @@ export function Demo({ totalRows }: { totalRows: number }) {
 
   it("rejects nested JSX message macros", () => {
     const code = `
-import { Plural, Trans } from "@palamedes/react/macro";
+import { Plural, Trans } from "@palamedes/react/macro"; function Message() {
 const el = <Trans><Plural value={contractCount} one="# contract" other="# contracts" /> ({capacityMW} MW)</Trans>;
+}
 `
 
     expect(() => transformPalamedesMacros(code, "test.tsx")).toThrow(
@@ -419,8 +413,9 @@ const el = <Trans><Plural value={contractCount} one="# contract" other="# contra
 
   it("keeps JSX choice macro replacements as expressions outside JSX children", () => {
     const code = `
-import { Plural } from "@palamedes/react/macro";
+import { Plural } from "@palamedes/react/macro"; function message() {
 const text = <Plural one="# row" other="# rows" value={totalRows} />;
+}
 `
     const result = transformPalamedesMacros(code, "test.tsx")
 
@@ -485,8 +480,9 @@ function ResultCount({ shownCount, totalCount, quickSearch }) {
 
   it("accepts getter call value names for JSX choice macros", () => {
     const code = `
-import { Plural } from "@palamedes/react/macro";
+import { Plural } from "@palamedes/react/macro"; function message() {
 const text = <Plural one="# unit" other="# units" value={getDemand()} />;
+}
 `
     const result = transformPalamedesMacros(code, "test.tsx")
 
@@ -497,7 +493,9 @@ const text = <Plural one="# unit" other="# units" value={getDemand()} />;
   it("rejects explicit ids in macro authoring", () => {
     const code = `
 import { t } from "@palamedes/core/macro";
+function message() {
 const msg = t({ id: "greeting", message: "Hello" });
+}
 `
 
     expect(() => transformPalamedesMacros(code, "test.ts")).toThrow(/Explicit message ids/)
@@ -515,7 +513,9 @@ const el = <Trans id="greeting">Hello</Trans>;
   it("rejects unnamed template placeholders", () => {
     const code = `
 import { t } from "@palamedes/core/macro";
+function message() {
 const msg = t\`Hello \${firstName + lastName}\`;
+}
 `
 
     expect(() => transformPalamedesMacros(code, "test.ts")).toThrow(/stable placeholder name/)
@@ -539,8 +539,9 @@ const el = <Trans>Hello {firstName + lastName}</Trans>;
 
     for (const jsx of cases) {
       const code = `
-import { Plural, Trans } from "@palamedes/react/macro";
-const el = ${jsx};
+	import { Plural, Trans } from "@palamedes/react/macro"; function Message() {
+	const el = ${jsx};
+	}
 `
 
       expect(() => transformPalamedesMacros(code, "test.tsx")).toThrow(
@@ -566,8 +567,10 @@ const el = <Trans><List renderItem={() => <Plural value={count} one="one" other=
   it("accepts computed, defaulted, and literal choice values", () => {
     const code = `
 import { plural } from "@palamedes/core/macro";
+function messages() {
 const computed = plural(periodCounts[period] ?? 0, { one: "# entry", other: "# entries" });
 const literal = plural(21, { one: "# month", other: "# months" });
+}
 `
     const result = transformPalamedesMacros(code, "test.ts")
 
@@ -580,7 +583,7 @@ const literal = plural(21, { one: "# month", other: "# months" });
   it("transforms interpolated plural branches and forwards their values", () => {
     const code = `
 import { plural } from "@palamedes/core/macro";
-import { Plural } from "@palamedes/react/macro";
+import { Plural } from "@palamedes/react/macro"; function messages() {
 const call = plural(count, {
   one: \`# item will be archived because \${planLabel} allows a maximum of \${max}\`,
   other: \`# items will be archived because \${planLabel} allows a maximum of \${max}\`,
@@ -590,6 +593,7 @@ const jsx = <Plural
   one={\`# item will be archived because \${planLabel} allows a maximum of \${max}\`}
   other={\`# items will be archived because \${planLabel} allows a maximum of \${max}\`}
 />;
+}
 `
     const result = transformPalamedesMacros(code, "test.tsx")
     const expected =
@@ -601,8 +605,9 @@ const jsx = <Plural
 
   it("accepts defaulted JSX choice values", () => {
     const code = `
-import { Plural } from "@palamedes/react/macro";
+import { Plural } from "@palamedes/react/macro"; function message() {
 const el = <Plural value={node.locationCount ?? 0} one="# location" other="# locations" />;
+}
 `
     const result = transformPalamedesMacros(code, "test.tsx")
 

--- a/packages/transform/src/transform.test.ts
+++ b/packages/transform/src/transform.test.ts
@@ -1,4 +1,33 @@
-import { transformPalamedesMacros } from "./transform"
+import { transformPalamedesMacros as transformPalamedesMacrosRaw } from "./transform"
+import type { TransformOptions, TransformResult } from "./types"
+
+function transformPalamedesMacros(
+  code: string,
+  filename: string,
+  options: TransformOptions = {}
+): TransformResult {
+  const scopedCode = scopeMacroTestSource(code)
+  const result = transformPalamedesMacrosRaw(scopedCode, filename, options)
+  if (result.map?.sourcesContent) {
+    result.map.sourcesContent = [code]
+  }
+  return result
+}
+
+function scopeMacroTestSource(code: string): string {
+  if (!/@palamedes\/(?:core|react|solid)\/macro/.test(code)) {
+    return code
+  }
+
+  const imports = [...code.matchAll(/^[ \t]*import[^\n]*$/gm)]
+  const lastImport = imports.at(-1)
+  if (!lastImport || lastImport.index === undefined) {
+    return code
+  }
+
+  const insertion = lastImport.index + lastImport[0].length
+  return `${code.slice(0, insertion)}; function __palamedesTestScope() {${code.slice(insertion)}\n}`
+}
 
 type SourceMapLike = {
   file?: string
@@ -9,6 +38,40 @@ type SourceMapLike = {
 }
 
 describe("transformPalamedesMacros", () => {
+  it.each([
+    [
+      'import { t as translate } from "@palamedes/core/macro";\nconst value = translate`Hello`;',
+      "t",
+    ],
+    [
+      'import { plural } from "@palamedes/core/macro";\nconst value = plural(count, { one: "# item", other: "# items" });',
+      "plural",
+    ],
+    [
+      'import { Select } from "@palamedes/react/macro";\nconst value = <Select value={kind} other="Other" />;',
+      "Select",
+    ],
+  ])("rejects top-level %s usage", (code, macroName) => {
+    expect(() => transformPalamedesMacrosRaw(code, "test.tsx")).toThrow(
+      new RegExp(`Translation macro \`${macroName}\` must be used inside a function`)
+    )
+  })
+
+  it("allows eager macros inside functions, methods, and callbacks", () => {
+    const code = `
+import { t, plural } from "@palamedes/core/macro";
+import { Select } from "@palamedes/react/macro";
+function label() { return t\`Hello\`; }
+const countLabel = () => plural(count, { one: "# item", other: "# items" });
+const formatter = { label() { return t\`Method\`; } };
+class Formatter { label() { return t\`Class method\`; } }
+items.map((item) => t\`Item \${item.name}\`);
+function View() { return <Select value={kind} other="Other" />; }
+`
+
+    expect(() => transformPalamedesMacrosRaw(code, "test.tsx")).not.toThrow()
+  })
+
   it("returns unchanged code without Palamedes macro imports", () => {
     const code = `const x = 1;`
     const result = transformPalamedesMacros(code, "test.ts")


### PR DESCRIPTION
## Summary

- reject eager t, plural, select, and selectOrdinal macros at module scope
- apply the same rule to Plural, Select, and SelectOrdinal JSX macros while keeping Trans valid at module scope
- share the AST validation between transformation and extraction, including CLI batch extraction
- document the authoring rule and update integration fixtures

## Validation

- RUSTUP_TOOLCHAIN=1.95 pnpm agent:check
- pnpm --dir examples/nextjs-cookie build

## Stack

- based on #391, which removes msg, defineMessage, and deferred descriptors