### PR TITLE
fix: correct published TypeScript declarations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,10 @@ jobs:
       - name: Build packages
         run: pnpm build
 
+      - name: Check published TypeScript declarations
+        if: ${{ matrix.full }}
+        run: pnpm check:published-types
+
       - name: Verify ICU semantics proof
         if: ${{ matrix.full }}
         run: pnpm proof:icu:check

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -97,6 +97,9 @@ jobs:
       - name: Build packages
         run: pnpm build
 
+      - name: Check published TypeScript declarations
+        run: pnpm check:published-types
+
       - name: Run tests
         run: pnpm test
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "proof:icu:check": "node ./scripts/proof-icu-semantics.mjs",
     "test": "pnpm -r --filter \"./packages/**\" --if-present test",
     "check:native-types": "pnpm --filter @palamedes/core-node check-native-types",
+    "check:published-types": "node ./scripts/check-published-types.mjs",
     "check:release-set": "node ./scripts/check-release-set.mjs",
     "check-types": "pnpm check:native-types && pnpm -r --filter \"./packages/**\" exec tsc --noEmit -p tsconfig.json",
     "lint": "pnpm lint:oxlint && pnpm lint:eslint",
@@ -47,7 +48,7 @@
     "build:native": "cargo build --workspace",
     "check:rust": "cargo check --workspace",
     "test:rust": "cargo test --workspace",
-    "agent:check": "pnpm build && concurrently --kill-others-on-fail --group --names release,format,lint,test,types,rustfmt,rust \"pnpm check:release-set\" \"pnpm format:check\" \"pnpm lint\" \"pnpm test\" \"pnpm check-types\" \"cargo fmt --all --check\" \"cargo clippy --workspace --all-targets --locked -- -D warnings && cargo test --workspace --locked\""
+    "agent:check": "pnpm build && concurrently --kill-others-on-fail --group --names release,published-types,format,lint,test,types,rustfmt,rust \"pnpm check:release-set\" \"pnpm check:published-types\" \"pnpm format:check\" \"pnpm lint\" \"pnpm test\" \"pnpm check-types\" \"cargo fmt --all --check\" \"cargo clippy --workspace --all-targets --locked -- -D warnings && cargo test --workspace --locked\""
   },
   "devDependencies": {
     "@playwright/test": "^1.61.1",

--- a/packages/core/src/macro.ts
+++ b/packages/core/src/macro.ts
@@ -4,18 +4,18 @@ function throwMacroError(): never {
   )
 }
 
-export function t(..._args: any[]): never {
+export function t(..._args: any[]): string {
   return throwMacroError()
 }
 
-export function plural(..._args: any[]): never {
+export function plural(..._args: any[]): string {
   return throwMacroError()
 }
 
-export function select(..._args: any[]): never {
+export function select(..._args: any[]): string {
   return throwMacroError()
 }
 
-export function selectOrdinal(..._args: any[]): never {
+export function selectOrdinal(..._args: any[]): string {
   return throwMacroError()
 }

--- a/packages/next-plugin/package.json
+++ b/packages/next-plugin/package.json
@@ -4,7 +4,7 @@
   "description": "Next.js integration for Palamedes using OXC-based macro transformation",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
-  "types": "./dist/index.d.mts",
+  "types": "./dist/index.d.ts",
   "sideEffects": false,
   "license": "MIT",
   "keywords": [

--- a/packages/next-plugin/package.json
+++ b/packages/next-plugin/package.json
@@ -4,7 +4,7 @@
   "description": "Next.js integration for Palamedes using OXC-based macro transformation",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/index.d.mts",
   "sideEffects": false,
   "license": "MIT",
   "keywords": [
@@ -44,9 +44,14 @@
   ],
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs"
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     },
     "./palamedes-loader": "./palamedes-loader.cjs",
     "./palamedes-po-loader": "./palamedes-po-loader.cjs"

--- a/scripts/check-published-types.mjs
+++ b/scripts/check-published-types.mjs
@@ -1,0 +1,82 @@
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import process from "node:process"
+import ts from "typescript"
+
+const root = process.cwd()
+const fixtureRoot = mkdtempSync(path.join(os.tmpdir(), "palamedes-published-types-"))
+const scopeDirectory = path.join(fixtureRoot, "node_modules", "@palamedes")
+
+function linkPackage(name) {
+  const packageDirectory = path.join(root, "packages", name)
+  const fixturePackage = path.join(scopeDirectory, name)
+  symlinkSync(packageDirectory, fixturePackage, process.platform === "win32" ? "junction" : "dir")
+}
+
+function formatDiagnostics(diagnostics) {
+  return ts.formatDiagnosticsWithColorAndContext(diagnostics, {
+    getCanonicalFileName: (fileName) => fileName,
+    getCurrentDirectory: () => root,
+    getNewLine: () => os.EOL,
+  })
+}
+
+function checkProgram(fileName, compilerOptions) {
+  const program = ts.createProgram([fileName], {
+    noEmit: true,
+    skipLibCheck: true,
+    strict: true,
+    target: ts.ScriptTarget.ES2022,
+    ...compilerOptions,
+  })
+  const diagnostics = ts.getPreEmitDiagnostics(program)
+
+  if (diagnostics.length > 0) {
+    throw new Error(formatDiagnostics(diagnostics))
+  }
+}
+
+try {
+  mkdirSync(scopeDirectory, { recursive: true })
+  linkPackage("core")
+  linkPackage("next-plugin")
+
+  const esmFixture = path.join(fixtureRoot, "consumer.mts")
+  writeFileSync(
+    esmFixture,
+    `import { plural, select, selectOrdinal, t } from "@palamedes/core/macro"
+import withPalamedes from "@palamedes/next-plugin"
+
+export const lengths = [
+  t\`Hello\`.length,
+  plural(2, { one: "one", other: "other" }).length,
+  select("a", { a: "A", other: "Other" }).length,
+  selectOrdinal(2, { one: "first", other: "other" }).length,
+]
+
+export default withPalamedes({})
+`
+  )
+  checkProgram(esmFixture, {
+    module: ts.ModuleKind.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+  })
+
+  const commonJsFixture = path.join(fixtureRoot, "consumer.cts")
+  writeFileSync(
+    commonJsFixture,
+    `import nextPlugin = require("@palamedes/next-plugin")
+
+export const config = nextPlugin.withPalamedes({})
+`
+  )
+  checkProgram(commonJsFixture, {
+    module: ts.ModuleKind.NodeNext,
+    moduleResolution: ts.ModuleResolutionKind.NodeNext,
+  })
+} finally {
+  rmSync(fixtureRoot, { force: true, recursive: true })
+}
+
+console.log("Published TypeScript declarations support ESM and CommonJS consumers.")

--- a/scripts/check-published-types.mjs
+++ b/scripts/check-published-types.mjs
@@ -75,6 +75,20 @@ export const config = nextPlugin.withPalamedes({})
     module: ts.ModuleKind.NodeNext,
     moduleResolution: ts.ModuleResolutionKind.NodeNext,
   })
+
+  const legacyCommonJsFixture = path.join(fixtureRoot, "legacy-consumer.ts")
+  writeFileSync(
+    legacyCommonJsFixture,
+    `import nextPlugin = require("@palamedes/next-plugin")
+
+export const config = nextPlugin.withPalamedes({})
+`
+  )
+  checkProgram(legacyCommonJsFixture, {
+    ignoreDeprecations: "6.0",
+    module: ts.ModuleKind.CommonJS,
+    moduleResolution: ts.ModuleResolutionKind.Node10,
+  })
 } finally {
   rmSync(fixtureRoot, { force: true, recursive: true })
 }


### PR DESCRIPTION
## Summary

- declare the transformed `@palamedes/core/macro` APIs as returning `string`
- route `@palamedes/next-plugin` ESM consumers to `index.d.mts` and CommonJS consumers to `index.d.cts`
- add a published-package consumer typecheck to CI and the publish validation workflow

## Root cause

The core macro stubs used their throwing fallback implementation's `never` return type as their public declaration, even though transformed macro expressions evaluate to strings.

The Next.js plugin build already emitted correct module-specific declaration files, but its package exports sent every consumer to the CommonJS-shaped shared `index.d.ts`. ESM default imports therefore resolved against an incompatible declaration.

## Impact

TypeScript 6 projects using `moduleResolution: "bundler"` can use the documented ESM default import for `@palamedes/next-plugin`, and transformed core macro values expose normal string APIs such as `.length`. CommonJS consumers retain their dedicated declaration path.

## Validation

- `RUSTUP_TOOLCHAIN=stable pnpm build`
- `RUSTUP_TOOLCHAIN=stable pnpm test`
- `RUSTUP_TOOLCHAIN=stable pnpm check-types`
- `pnpm check:published-types`
- `pnpm format:check`
- `pnpm lint`
- `pnpm check:release-set`

Closes #393
Closes #394