### PR TITLE
fix(core): support ICU apostrophe quoting

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -152,6 +152,7 @@ export type {
   MessageNode,
   MessageChoiceNode,
   MessageFormattedArgumentNode,
+  MessageLiteralNode,
   MessageTagNode,
   MessageVariableNode,
 } from "./messageFormat"

--- a/packages/core/src/messageFormat.test.ts
+++ b/packages/core/src/messageFormat.test.ts
@@ -51,6 +51,15 @@ describe("formatMessagePattern", () => {
     expect(formatMessagePattern("This '{isn''t}' obvious")).toBe("This {isn't} obvious")
   })
 
+  it("auto-closes an unterminated quoted sequence at the end of the pattern", () => {
+    expect(
+      formatMessagePattern("Send '{name} to {target}", {
+        name: "Alice",
+        target: "Bob",
+      })
+    ).toBe("Send {name} to {target}")
+  })
+
   it("keeps quoted arguments and plural pound signs literal", () => {
     expect(formatMessagePattern("Literal '{name}' here", { name: "value" })).toBe(
       "Literal {name} here"

--- a/packages/core/src/messageFormat.test.ts
+++ b/packages/core/src/messageFormat.test.ts
@@ -3,6 +3,14 @@ import { describe, expect, it } from "vitest"
 import { formatMessagePattern, parseMessagePattern } from "./messageFormat"
 
 describe("parseMessagePattern", () => {
+  it("keeps quoted ICU syntax in literal nodes", () => {
+    expect(parseMessagePattern("Literal '{name}' here")).toStrictEqual([
+      { type: "text", value: "Literal " },
+      { type: "literal", value: "{name}" },
+      { type: "text", value: " here" },
+    ])
+  })
+
   it("parses a self-closing placeholder as a tag with no children", () => {
     expect(parseMessagePattern("Line one<0/>Line two")).toStrictEqual([
       { type: "text", value: "Line one" },
@@ -37,6 +45,25 @@ describe("parseMessagePattern", () => {
 })
 
 describe("formatMessagePattern", () => {
+  it("supports ICU apostrophe quoting without changing natural apostrophes", () => {
+    expect(formatMessagePattern("It's done")).toBe("It's done")
+    expect(formatMessagePattern("It''s done")).toBe("It's done")
+    expect(formatMessagePattern("This '{isn''t}' obvious")).toBe("This {isn't} obvious")
+  })
+
+  it("keeps quoted arguments and plural pound signs literal", () => {
+    expect(formatMessagePattern("Literal '{name}' here", { name: "value" })).toBe(
+      "Literal {name} here"
+    )
+    expect(formatMessagePattern("{n, plural, other {'#' of #}}", { n: 5 }, "en")).toBe("# of 5")
+  })
+
+  it("makes literal braces representable", () => {
+    expect(formatMessagePattern("Use '{' to open and '}' to close")).toBe(
+      "Use { to open and } to close"
+    )
+  })
+
   it("renders a self-closing placeholder as empty text", () => {
     expect(formatMessagePattern("Line one<0/>Line two")).toBe("Line oneLine two")
   })

--- a/packages/core/src/messageFormat.ts
+++ b/packages/core/src/messageFormat.ts
@@ -3,6 +3,11 @@ export type MessageTextNode = {
   value: string
 }
 
+export type MessageLiteralNode = {
+  type: "literal"
+  value: string
+}
+
 export type MessageVariableNode = {
   type: "variable"
   name: string
@@ -30,6 +35,7 @@ export type MessageTagNode = {
 
 export type MessageNode =
   | MessageTextNode
+  | MessageLiteralNode
   | MessageVariableNode
   | MessageFormattedArgumentNode
   | MessageChoiceNode
@@ -55,7 +61,7 @@ export function parseMessagePattern(pattern: string): MessageNode[] {
     input: pattern,
     index: 0,
   }
-  const nodes = parseNodes(state)
+  const nodes = parseNodes(state, undefined, false)
   parseCache.set(pattern, nodes)
   return nodes
 }
@@ -68,7 +74,11 @@ export function formatMessagePattern(
   return renderNodesToString(parseMessagePattern(pattern), values, locale)
 }
 
-function parseNodes(state: ParserState, closingTag?: string): MessageNode[] {
+function parseNodes(
+  state: ParserState,
+  closingTag: string | undefined,
+  poundIsSyntax: boolean
+): MessageNode[] {
   const nodes: MessageNode[] = []
 
   while (state.index < state.input.length) {
@@ -79,22 +89,31 @@ function parseNodes(state: ParserState, closingTag?: string): MessageNode[] {
 
     const char = state.input[state.index]
     if (char === "{") {
-      nodes.push(parseBraceExpression(state))
+      nodes.push(parseBraceExpression(state, poundIsSyntax))
       continue
     }
 
     if (char === "<" && isTagStart(state)) {
-      nodes.push(parseTag(state))
+      nodes.push(parseTag(state, poundIsSyntax))
       continue
     }
 
-    nodes.push(parseText(state, closingTag))
+    if (char === "'" && startsQuotedLiteral(state, poundIsSyntax)) {
+      nodes.push(parseQuotedLiteral(state))
+      continue
+    }
+
+    nodes.push(parseText(state, closingTag, poundIsSyntax))
   }
 
   return mergeTextNodes(nodes)
 }
 
-function parseText(state: ParserState, closingTag?: string): MessageTextNode {
+function parseText(
+  state: ParserState,
+  closingTag: string | undefined,
+  poundIsSyntax: boolean
+): MessageTextNode {
   const start = state.index
 
   while (state.index < state.input.length) {
@@ -111,6 +130,10 @@ function parseText(state: ParserState, closingTag?: string): MessageTextNode {
       break
     }
 
+    if (char === "'" && startsQuotedLiteral(state, poundIsSyntax)) {
+      break
+    }
+
     state.index += 1
   }
 
@@ -120,7 +143,7 @@ function parseText(state: ParserState, closingTag?: string): MessageTextNode {
   }
 }
 
-function parseBraceExpression(state: ParserState): MessageNode {
+function parseBraceExpression(state: ParserState, poundIsSyntax: boolean): MessageNode {
   state.index += 1
   skipWhitespace(state)
   const name = readUntil(state, [",", "}"]).trim()
@@ -162,7 +185,10 @@ function parseBraceExpression(state: ParserState): MessageNode {
 
     const key = readUntil(state, ["{"]).trim()
     expectChar(state, "{")
-    options[key] = parseNodesUntilBrace(state)
+    options[key] = parseNodesUntilBrace(
+      state,
+      kind === "plural" || kind === "selectordinal" || poundIsSyntax
+    )
   }
 
   return {
@@ -187,7 +213,7 @@ function readOptionalStyle(state: ParserState): string | undefined {
   return style.length > 0 ? style : undefined
 }
 
-function parseNodesUntilBrace(state: ParserState): MessageNode[] {
+function parseNodesUntilBrace(state: ParserState, poundIsSyntax: boolean): MessageNode[] {
   const nodes: MessageNode[] = []
 
   while (state.index < state.input.length) {
@@ -198,22 +224,27 @@ function parseNodesUntilBrace(state: ParserState): MessageNode[] {
     }
 
     if (char === "{") {
-      nodes.push(parseBraceExpression(state))
+      nodes.push(parseBraceExpression(state, poundIsSyntax))
       continue
     }
 
     if (char === "<" && isTagStart(state)) {
-      nodes.push(parseTag(state))
+      nodes.push(parseTag(state, poundIsSyntax))
       continue
     }
 
-    nodes.push(parseTextUntilBrace(state))
+    if (char === "'" && startsQuotedLiteral(state, poundIsSyntax)) {
+      nodes.push(parseQuotedLiteral(state))
+      continue
+    }
+
+    nodes.push(parseTextUntilBrace(state, poundIsSyntax))
   }
 
   return mergeTextNodes(nodes)
 }
 
-function parseTextUntilBrace(state: ParserState): MessageTextNode {
+function parseTextUntilBrace(state: ParserState, poundIsSyntax: boolean): MessageTextNode {
   const start = state.index
 
   while (state.index < state.input.length) {
@@ -226,6 +257,10 @@ function parseTextUntilBrace(state: ParserState): MessageTextNode {
       break
     }
 
+    if (char === "'" && startsQuotedLiteral(state, poundIsSyntax)) {
+      break
+    }
+
     state.index += 1
   }
 
@@ -235,7 +270,7 @@ function parseTextUntilBrace(state: ParserState): MessageTextNode {
   }
 }
 
-function parseTag(state: ParserState): MessageTagNode {
+function parseTag(state: ParserState, poundIsSyntax: boolean): MessageTagNode {
   expectChar(state, "<")
   const name = readUntil(state, ["/", ">"]).trim()
 
@@ -254,12 +289,53 @@ function parseTag(state: ParserState): MessageTagNode {
   }
 
   expectChar(state, ">")
-  const children = parseNodes(state, name)
+  const children = parseNodes(state, name, poundIsSyntax)
 
   return {
     type: "tag",
     name,
     children,
+  }
+}
+
+function startsQuotedLiteral(state: ParserState, poundIsSyntax: boolean): boolean {
+  const next = state.input[state.index + 1]
+  return next === "'" || next === "{" || next === "}" || (poundIsSyntax && next === "#")
+}
+
+function parseQuotedLiteral(state: ParserState): MessageLiteralNode {
+  state.index += 1
+
+  if (state.input[state.index] === "'") {
+    state.index += 1
+    return {
+      type: "literal",
+      value: "'",
+    }
+  }
+
+  let value = ""
+  while (state.index < state.input.length) {
+    const char = state.input[state.index]
+    if (char !== "'") {
+      value += char
+      state.index += 1
+      continue
+    }
+
+    if (state.input[state.index + 1] === "'") {
+      value += "'"
+      state.index += 2
+      continue
+    }
+
+    state.index += 1
+    break
+  }
+
+  return {
+    type: "literal",
+    value,
   }
 }
 
@@ -328,6 +404,9 @@ function renderNodeToString(
   switch (node.type) {
     case "text": {
       return pluralValue === undefined ? node.value : replacePound(node.value, pluralValue, locale)
+    }
+    case "literal": {
+      return node.value
     }
     case "variable": {
       return stringifyValue(values[node.name])

--- a/packages/react/src/index.test.tsx
+++ b/packages/react/src/index.test.tsx
@@ -86,6 +86,22 @@ describe("@palamedes/react", () => {
     )
   })
 
+  it("renders ICU-quoted syntax literally through Trans", () => {
+    const i18n = createI18n()
+    i18n.activate("en")
+    setClientI18n(i18n)
+
+    const html = renderToStaticMarkup(
+      <Trans
+        id="quoted"
+        message="Literal '{name}': {count, plural, other {'#' of #}}"
+        values={{ count: 5, name: "ignored" }}
+      />
+    )
+
+    expect(html).toBe("Literal {name}: # of 5")
+  })
+
   it("builds locale switch items headlessly", () => {
     expect(
       buildLocaleSwitchItems({

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -121,6 +121,9 @@ function renderNode(
           : node.value.replaceAll("#", formatNumber(pluralValue, locale)),
       ]
     }
+    case "literal": {
+      return [node.value]
+    }
     case "variable": {
       return [renderVariable(values[node.name])]
     }

--- a/packages/solid/src/index.test.tsx
+++ b/packages/solid/src/index.test.tsx
@@ -90,6 +90,20 @@ describe("@palamedes/solid", () => {
     expect(onMissing).not.toHaveBeenCalled()
   })
 
+  it("renders ICU-quoted syntax literally through Trans", () => {
+    const i18n = createI18n()
+    i18n.activate("en")
+    setServerI18nGetter(() => i18n)
+
+    const render = Trans({
+      id: "quoted",
+      message: "Literal '{name}': {count, plural, other {'#' of #}}",
+      values: { count: 5, name: "ignored" },
+    }) as unknown as () => unknown
+
+    expect([render()].flat().join("")).toBe("Literal {name}: # of 5")
+  })
+
   it("builds locale switch items headlessly", () => {
     expect(
       buildLocaleSwitchItems({

--- a/packages/solid/src/index.tsx
+++ b/packages/solid/src/index.tsx
@@ -140,6 +140,9 @@ function renderNode(
           : node.value.replaceAll("#", formatNumber(pluralValue, locale)),
       ]
     }
+    case "literal": {
+      return [node.value]
+    }
     case "variable": {
       return [renderVariable(values[node.name])]
     }


### PR DESCRIPTION
## What changed

- implement ICU MessageFormat apostrophe quoting in the core runtime parser
- preserve ordinary apostrophes while decoding doubled apostrophes
- represent quoted braces and plural `#` syntax as literal message nodes
- render literal nodes consistently in the string, React, and Solid consumers
- add regression coverage for the reported migration and TMS patterns

## Why

The runtime parser treated every brace and plural pound sign as syntax and left doubled apostrophes untouched. Valid ICU/Lingui/TMS patterns could therefore render corrupted text or throw when they contained literal syntax characters.

The parser now follows ICU's apostrophe-friendly “only where needed” behavior: an apostrophe starts quoting only before `{`, `}`, or `#` in plural text, while `''` always represents one literal apostrophe.

## Impact

Migrated ICU catalogs can represent literal braces and plural pound signs without interpolation, and standard doubled-apostrophe output renders correctly across the core, React, and Solid runtimes.

## Validation

- `RUSTUP_TOOLCHAIN=1.95 pnpm build`
- `RUSTUP_TOOLCHAIN=1.95 pnpm test`
- `RUSTUP_TOOLCHAIN=1.95 pnpm check-types`
- `pnpm format:check`
- `pnpm lint`
- `pnpm check:release-set`
- `pnpm proof:icu:check`

Fixes #408