### PR TITLE
fix(ui): make Trans catalog parsing resilient

### DIFF
--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -155,6 +155,32 @@ describe("createI18n", () => {
     expect(errors).toStrictEqual(["{count, plural one {# file} other {# files}}"])
   })
 
+  it("returns fallback nodes when a catalog pattern is malformed", () => {
+    const errors: string[] = []
+    const i18n = createI18n({
+      onError(info) {
+        errors.push(info.pattern)
+      },
+    })
+
+    i18n.load("de", {
+      greeting: "Hallo {name",
+    })
+    i18n.activate("de")
+
+    expect(i18n.getMessageNodes("greeting", { message: "Hello {name}" })).toStrictEqual([
+      { type: "text", value: "Hello " },
+      { type: "variable", name: "name" },
+    ])
+    expect(errors).toStrictEqual(["Hallo {name"])
+  })
+
+  it("returns malformed source messages as plain-text nodes", () => {
+    const i18n = createI18n()
+
+    expect(i18n.getMessageNodes("{name")).toStrictEqual([{ type: "text", value: "{name" }])
+  })
+
   it("keeps rendering resilient when hooks throw", () => {
     const i18n = createI18n({
       onMissing() {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,4 @@
-import { formatMessagePattern, parseMessagePattern } from "./messageFormat"
+import { formatMessagePattern, parseMessagePattern, type MessageNode } from "./messageFormat"
 
 export type MessageMetadata = {
   message?: string
@@ -34,6 +34,7 @@ export type PalamedesI18n = {
   load: (locale: string, messages: CatalogMessages) => void
   activate: (locale: string) => void
   getMessage: (id: string, metadata?: MessageMetadata) => string
+  getMessageNodes: (id: string, metadata?: MessageMetadata) => MessageNode[]
 }
 
 type ResolvedMessage = {
@@ -119,6 +120,37 @@ export function createI18n(options: CreateI18nOptions = {}): PalamedesI18n {
     return message.fallback
   }
 
+  function parseMessage(
+    message: ResolvedMessage,
+    id?: string,
+    metadata?: MessageMetadata
+  ): MessageNode[] {
+    try {
+      return parseMessagePattern(message.pattern)
+    } catch (error) {
+      notifyError({
+        id,
+        locale: activeLocale,
+        error: normalizeError(error),
+        pattern: message.pattern,
+        fallback: message.fallback,
+        metadata,
+      })
+    }
+
+    // Rich-text renderers need the same resilience as string formatting:
+    // parse the source fallback, then render malformed source as plain text.
+    if (message.pattern !== message.fallback) {
+      try {
+        return parseMessagePattern(message.fallback)
+      } catch {
+        return [{ type: "text", value: message.fallback }]
+      }
+    }
+
+    return [{ type: "text", value: message.fallback }]
+  }
+
   return {
     get locale() {
       return activeLocale
@@ -135,6 +167,10 @@ export function createI18n(options: CreateI18nOptions = {}): PalamedesI18n {
 
     getMessage(id, metadata) {
       return resolveMessage(id, metadata).pattern
+    },
+
+    getMessageNodes(id, metadata) {
+      return parseMessage(resolveMessage(id, metadata), id, metadata)
     },
 
     _(id, values = {}, metadata) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -190,5 +190,6 @@ export type {
   MessageFormattedArgumentNode,
   MessageLiteralNode,
   MessageTagNode,
+  MessageTextNode,
   MessageVariableNode,
 } from "./messageFormat"

--- a/packages/react/src/index.test.tsx
+++ b/packages/react/src/index.test.tsx
@@ -102,6 +102,23 @@ describe("@palamedes/react", () => {
     expect(html).toBe("Literal {name}: # of 5")
   })
 
+  it("falls back when Trans encounters a malformed catalog pattern", () => {
+    const onError = vi.fn()
+    const i18n = createI18n({ onError })
+    i18n.load("de", {
+      greeting: "Hallo {name",
+    })
+    i18n.activate("de")
+    setClientI18n(i18n)
+
+    const html = renderToStaticMarkup(
+      <Trans id="greeting" message="Hello {name}" values={{ name: "Ada" }} />
+    )
+
+    expect(html).toBe("Hello Ada")
+    expect(onError).toHaveBeenCalledOnce()
+  })
+
   it("builds locale switch items headlessly", () => {
     expect(
       buildLocaleSwitchItems({

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -3,7 +3,7 @@ import { cloneElement, Fragment, isValidElement } from "react"
 import type { ReactElement, ReactNode } from "react"
 
 import { getI18n } from "@palamedes/runtime"
-import { formatMessagePattern, parseMessagePattern } from "@palamedes/core"
+import { formatMessagePattern } from "@palamedes/core"
 import type { MessageChoiceNode, MessageNode, PalamedesI18n } from "@palamedes/core"
 
 export {
@@ -54,14 +54,12 @@ export function Trans({
 }: TransProps): ReactNode {
   const i18n = getI18n<PalamedesI18n>()
   const resolvedId = id ?? message ?? ""
-  const pattern = i18n.getMessage(resolvedId, {
+  const nodes = i18n.getMessageNodes(resolvedId, {
     message,
     context,
     comment,
   })
-  return (
-    <>{renderNodes(parseMessagePattern(pattern), values ?? {}, components ?? {}, i18n.locale)}</>
-  )
+  return <>{renderNodes(nodes, values ?? {}, components ?? {}, i18n.locale)}</>
 }
 
 export function Plural({ value, ...choices }: PluralProps): ReactNode {

--- a/packages/solid/src/index.test.tsx
+++ b/packages/solid/src/index.test.tsx
@@ -104,6 +104,25 @@ describe("@palamedes/solid", () => {
     expect([render()].flat().join("")).toBe("Literal {name}: # of 5")
   })
 
+  it("falls back when Trans encounters a malformed catalog pattern", () => {
+    const onError = vi.fn()
+    const i18n = createI18n({ onError })
+    i18n.load("de", {
+      greeting: "Hallo {name",
+    })
+    i18n.activate("de")
+    setServerI18nGetter(() => i18n)
+
+    const render = Trans({
+      id: "greeting",
+      message: "Hello {name}",
+      values: { name: "Ada" },
+    }) as unknown as () => unknown
+
+    expect([render()].flat().join("")).toBe("Hello Ada")
+    expect(onError).toHaveBeenCalledOnce()
+  })
+
   it("builds locale switch items headlessly", () => {
     expect(
       buildLocaleSwitchItems({

--- a/packages/solid/src/index.tsx
+++ b/packages/solid/src/index.tsx
@@ -1,6 +1,6 @@
 import type { JSX } from "solid-js"
 
-import { formatMessagePattern, parseMessagePattern } from "@palamedes/core"
+import { formatMessagePattern } from "@palamedes/core"
 import type { MessageChoiceNode, MessageNode, PalamedesI18n } from "@palamedes/core"
 
 import { getI18n } from "./runtime"
@@ -67,13 +67,13 @@ export function Trans({
   // a client locale switch, so the rendered nodes follow the active i18n.
   return (() => {
     const i18n = useReactiveI18n()
-    const pattern = i18n.getMessage(resolvedId, {
+    const nodes = i18n.getMessageNodes(resolvedId, {
       message,
       context,
       comment,
     })
 
-    return renderNodes(parseMessagePattern(pattern), values ?? {}, components ?? {}, i18n.locale)
+    return renderNodes(nodes, values ?? {}, components ?? {}, i18n.locale)
   }) as unknown as JSX.Element
 }
 


### PR DESCRIPTION
## Summary
- add a resilient `getMessageNodes` path to the core i18n instance
- route React and Solid `Trans` parsing through the same `onError` and source-fallback behavior as string formatting
- render malformed source patterns as plain text and cover catalog/source failures with core and integration tests

## Verification
- `RUSTUP_TOOLCHAIN=1.95 pnpm build`
- `RUSTUP_TOOLCHAIN=1.95 pnpm test`
- `RUSTUP_TOOLCHAIN=1.95 pnpm check-types`
- `pnpm format:check`
- `pnpm lint`
- `pnpm check:release-set`

Fixes #403