### PR TITLE
fix(runtime): isolate SSR client locale activation

### DIFF
--- a/docs/api/react.md
+++ b/docs/api/react.md
@@ -66,7 +66,7 @@ After the client commits, it synchronizes the locale and subscribes to
 `setClientI18n()` activations so translated descendants re-render.
 
 Initialize the client i18n before hydration when translated client components
-render in the initial HTML. The hook retains a synchronous browser-only
-bootstrap for existing integrations, but pre-hydration initialization avoids
-render-phase state changes. The sync function may return a promise; the hook
-intentionally does not own loading UI or routing policy.
+render in the initial HTML. The hook never invokes the sync callback during
+render; this avoids external-store mutations during both SSR and client render
+retries. The sync function may return a promise; the hook intentionally does
+not own loading UI or routing policy.

--- a/docs/api/react.md
+++ b/docs/api/react.md
@@ -61,6 +61,12 @@ const items = buildLocaleSwitchItems({
 })
 ```
 
-`useClientLocale(locale, sync)` calls `sync(locale)` from a client component.
-The sync function may return a promise; the hook intentionally does not own
-loading UI or routing policy.
+`useClientLocale(locale, sync)` never calls `sync` during server rendering.
+After the client commits, it synchronizes the locale and subscribes to
+`setClientI18n()` activations so translated descendants re-render.
+
+Initialize the client i18n before hydration when translated client components
+render in the initial HTML. The hook retains a synchronous browser-only
+bootstrap for existing integrations, but pre-hydration initialization avoids
+render-phase state changes. The sync function may return a promise; the hook
+intentionally does not own loading UI or routing policy.

--- a/docs/api/runtime.md
+++ b/docs/api/runtime.md
@@ -6,8 +6,10 @@ macro output.
 ## Exports
 
 - `getI18n<T>()`
+- `getClientI18nSnapshot()`
 - `setClientI18n(i18n)`
 - `subscribeClientI18n(listener)`
+- `activateServerI18n(i18n)`
 - `setServerI18nGetter(getter)`
 - `resetI18nRuntime()`
 - `I18nInstance`
@@ -56,6 +58,11 @@ const unsubscribe = subscribeClientI18n((i18n) => {
 })
 ```
 
+`getClientI18nSnapshot()` returns the current client instance plus a monotonic
+activation revision. The snapshot changes on every `setClientI18n()` call, even
+when an application reuses and mutates the same i18n object. Framework bindings
+use it with external-store APIs; application code rarely needs it directly.
+
 ## Server Runtime
 
 For request-local server rendering, prefer `@palamedes/runtime/server`:
@@ -71,6 +78,12 @@ serverI18n.activate(i18n)
 
 `createServerI18nScope()` uses Node `AsyncLocalStorage`, so keep it out of
 client bundles and Edge-only runtime paths.
+
+Isomorphic SSR client-component bundles can call `activateServerI18n(i18n)` to
+enter that existing request scope without importing the Node-only server
+subpath. The helper requires `createServerI18nScope()` to have been configured
+by the server entry point; it does not create a scope or make an i18n singleton
+request-safe.
 
 ## Test Reset
 

--- a/examples/nextjs-cookie/src/app/page.tsx
+++ b/examples/nextjs-cookie/src/app/page.tsx
@@ -5,11 +5,10 @@ import { ClientReady } from "@/components/ClientReady"
 import { LocaleSwitcher } from "@/components/LocaleSwitcher"
 import { ProofPanel } from "@/components/ProofPanel"
 import { TicketPanel } from "@/components/TicketPanel"
-import { createActiveServerI18n } from "@/lib/i18n.server"
+import { createActiveServerI18n, runWithServerI18n } from "@/lib/i18n.server"
 import { getLocaleLabel } from "@/lib/i18n"
 
-// These functions run only after `createActiveServerI18n()` activated the
-// request-local runtime scope.
+// These functions run only inside `runWithServerI18n()`'s request-local scope.
 function translateEyebrow(): string {
   return t`Localized live with Palamedes`
 }
@@ -35,10 +34,10 @@ function translateServerLocale(): string {
 }
 
 export default async function Home() {
-  const { locale } = await createActiveServerI18n()
+  const { i18n, locale } = await createActiveServerI18n()
   const localeLabel = getLocaleLabel(locale)
 
-  return (
+  return runWithServerI18n(i18n, () => (
     <main className="page-shell">
       <header className="topbar">
         <div className="brand">
@@ -76,5 +75,5 @@ export default async function Home() {
 
       <ClientReady />
     </main>
-  )
+  ))
 }

--- a/examples/nextjs-cookie/src/app/page.tsx
+++ b/examples/nextjs-cookie/src/app/page.tsx
@@ -38,42 +38,40 @@ export default async function Home() {
   const localeLabel = getLocaleLabel(locale)
 
   return runWithServerI18n(i18n, () => (
-    <main className="page-shell">
-      <header className="topbar">
-        <div className="brand">
-          <b>Frontend Stage</b>
-          <span className="brand-meta">Berlin · 2026</span>
-        </div>
-        <ClientLocaleBoundary locale={locale}>
+    <ClientLocaleBoundary locale={locale}>
+      <main className="page-shell">
+        <header className="topbar">
+          <div className="brand">
+            <b>Frontend Stage</b>
+            <span className="brand-meta">Berlin · 2026</span>
+          </div>
           <LocaleSwitcher locale={locale} />
-        </ClientLocaleBoundary>
-      </header>
+        </header>
 
-      <section className="hero">
-        <p className="eyebrow">
-          <span className="dot" aria-hidden="true" />
-          {translateEyebrow()}
-        </p>
-        <h1>{translateHeadline()}</h1>
-        <p className="greet">{translateGreeting(EVENT.attendeeName)}</p>
-        <p className="lede">{translateLede()}</p>
-      </section>
+        <section className="hero">
+          <p className="eyebrow">
+            <span className="dot" aria-hidden="true" />
+            {translateEyebrow()}
+          </p>
+          <h1>{translateHeadline()}</h1>
+          <p className="greet">{translateGreeting(EVENT.attendeeName)}</p>
+          <p className="lede">{translateLede()}</p>
+        </section>
 
-      <ClientLocaleBoundary locale={locale}>
         <div className="grid">
           <TicketPanel locale={locale} />
           <ProofPanel locale={locale} />
         </div>
-      </ClientLocaleBoundary>
 
-      <footer className="foot">
-        <span className="foot-badge">Palamedes</span>
-        {translateRenderedWith()}
-        {" · "}
-        {translateServerLocale()} <strong data-testid="server-locale-value">{localeLabel}</strong>
-      </footer>
+        <footer className="foot">
+          <span className="foot-badge">Palamedes</span>
+          {translateRenderedWith()}
+          {" · "}
+          {translateServerLocale()} <strong data-testid="server-locale-value">{localeLabel}</strong>
+        </footer>
 
-      <ClientReady />
-    </main>
+        <ClientReady />
+      </main>
+    </ClientLocaleBoundary>
   ))
 }

--- a/examples/nextjs-cookie/src/components/ClientLocaleBoundary.tsx
+++ b/examples/nextjs-cookie/src/components/ClientLocaleBoundary.tsx
@@ -5,7 +5,7 @@ import type { ReactNode } from "react"
 import { useClientLocale } from "@palamedes/react/client"
 
 import type { Locale } from "@/lib/i18n"
-import { syncClientI18n } from "@/lib/i18n.client"
+import { activateServerClientI18n, syncClientI18n } from "@/lib/i18n.client"
 
 type ClientLocaleBoundaryProps = {
   children: ReactNode
@@ -13,6 +13,19 @@ type ClientLocaleBoundaryProps = {
 }
 
 export function ClientLocaleBoundary({ children, locale }: ClientLocaleBoundaryProps) {
+  if (typeof window === "undefined") {
+    activateServerClientI18n(locale)
+  }
   useClientLocale(locale, syncClientI18n)
-  return <>{children}</>
+  const serializedLocale = JSON.stringify(locale).replaceAll("<", "\\u003c")
+  return (
+    <>
+      <script
+        dangerouslySetInnerHTML={{
+          __html: `window.__PALAMEDES_LOCALE__=${serializedLocale};`,
+        }}
+      />
+      {children}
+    </>
+  )
 }

--- a/examples/nextjs-cookie/src/lib/actions.ts
+++ b/examples/nextjs-cookie/src/lib/actions.ts
@@ -4,7 +4,7 @@ import { cookies } from "next/headers"
 import { revalidatePath } from "next/cache"
 import { t } from "@palamedes/core/macro"
 import { getLocaleLabel, type Locale, LOCALES, LOCALE_COOKIE } from "./i18n"
-import { createActiveServerI18n } from "./i18n.server"
+import { createActiveServerI18n, runWithServerI18n } from "./i18n.server"
 
 export async function setLocaleAction(locale: Locale) {
   if (!LOCALES.includes(locale)) {
@@ -22,12 +22,12 @@ export async function setLocaleAction(locale: Locale) {
 }
 
 export async function getServerActionProof() {
-  const { locale } = await createActiveServerI18n()
+  const { i18n, locale } = await createActiveServerI18n()
 
-  return {
+  return runWithServerI18n(i18n, () => ({
     locale,
     localeLabel: getLocaleLabel(locale),
     handledAt: new Date().toISOString(),
     message: t`Server action confirmed locale ${locale}.`,
-  }
+  }))
 }

--- a/examples/nextjs-cookie/src/lib/i18n.client.ts
+++ b/examples/nextjs-cookie/src/lib/i18n.client.ts
@@ -1,5 +1,6 @@
 import type { CatalogMessages } from "@palamedes/core"
 import { activateServerI18n, setClientI18n } from "@palamedes/runtime"
+import { cache } from "react"
 import { createExampleI18n, locales, type Locale } from "./i18n"
 import { messages as enMessages } from "../locales/en.po"
 import { messages as deMessages } from "../locales/de.po"
@@ -18,11 +19,15 @@ const CATALOGS: Record<Locale, CatalogMessages> = {
 
 const clientI18n = createExampleI18n()
 
-export function activateServerClientI18n(locale: Locale) {
+const getServerClientI18n = cache((locale: Locale) => {
   const i18n = createExampleI18n()
   i18n.load(locale, CATALOGS[locale])
   i18n.activate(locale)
-  activateServerI18n(i18n)
+  return i18n
+})
+
+export function activateServerClientI18n(locale: Locale) {
+  activateServerI18n(getServerClientI18n(locale))
 }
 
 export function syncClientI18n(locale: Locale) {

--- a/examples/nextjs-cookie/src/lib/i18n.client.ts
+++ b/examples/nextjs-cookie/src/lib/i18n.client.ts
@@ -1,6 +1,6 @@
 import type { CatalogMessages } from "@palamedes/core"
-import { setClientI18n, setServerI18nGetter } from "@palamedes/runtime"
-import { createExampleI18n, type Locale } from "./i18n"
+import { activateServerI18n, setClientI18n } from "@palamedes/runtime"
+import { createExampleI18n, locales, type Locale } from "./i18n"
 import { messages as enMessages } from "../locales/en.po"
 import { messages as deMessages } from "../locales/de.po"
 import { messages as esMessages } from "../locales/es.po"
@@ -18,19 +18,29 @@ const CATALOGS: Record<Locale, CatalogMessages> = {
 
 const clientI18n = createExampleI18n()
 
+export function activateServerClientI18n(locale: Locale) {
+  const i18n = createExampleI18n()
+  i18n.load(locale, CATALOGS[locale])
+  i18n.activate(locale)
+  activateServerI18n(i18n)
+}
+
 export function syncClientI18n(locale: Locale) {
+  if (typeof window === "undefined") {
+    return
+  }
+
   clientI18n.load(locale, CATALOGS[locale])
   clientI18n.activate(locale)
+  setClientI18n(clientI18n)
+}
 
-  if (typeof window === "undefined") {
-    // During SSR the client components still render on the server, so they
-    // resolve translations through the server scope. Point it at this
-    // synchronously-populated instance.
-    setServerI18nGetter(() => clientI18n)
-  } else {
-    // At hydration the catalog is already loaded synchronously above, so the
-    // client i18n is active in the same render pass — no async gap that would
-    // throw "No active client i18n instance".
-    setClientI18n(clientI18n)
+declare global {
+  interface Window {
+    __PALAMEDES_LOCALE__?: string
   }
+}
+
+if (typeof window !== "undefined" && locales.isLocale(window.__PALAMEDES_LOCALE__)) {
+  syncClientI18n(window.__PALAMEDES_LOCALE__)
 }

--- a/examples/nextjs-route/src/app/[locale]/page.tsx
+++ b/examples/nextjs-route/src/app/[locale]/page.tsx
@@ -6,11 +6,10 @@ import { LocaleSwitcher } from "@/components/LocaleSwitcher"
 import { ProofPanel } from "@/components/ProofPanel"
 import { SuggestionBanner } from "@/components/SuggestionBanner"
 import { TicketPanel } from "@/components/TicketPanel"
-import { createActiveServerI18n, getRouteLocale } from "@/lib/i18n.server"
+import { createActiveServerI18n, getRouteLocale, runWithServerI18n } from "@/lib/i18n.server"
 import { getLocaleLabel, type Locale } from "@/lib/i18n"
 
-// These functions run only after `createActiveServerI18n()` activated the
-// request-local runtime scope.
+// These functions run only inside `runWithServerI18n()`'s request-local scope.
 function translateEyebrow(): string {
   return t`Localized live with Palamedes`
 }
@@ -42,10 +41,10 @@ function translateSwitchToRecommended(): string {
 export default async function RouteHome({ params }: { params: Promise<{ locale: string }> }) {
   const { locale: rawLocale } = await params
   const { banner, locale } = await getRouteLocale(rawLocale)
-  await createActiveServerI18n(locale as Locale)
+  const { i18n } = await createActiveServerI18n(locale as Locale)
   const localeLabel = getLocaleLabel(locale)
 
-  return (
+  return runWithServerI18n(i18n, () => (
     <main className="page-shell">
       {banner ? (
         <SuggestionBanner
@@ -93,5 +92,5 @@ export default async function RouteHome({ params }: { params: Promise<{ locale: 
 
       <ClientReady />
     </main>
-  )
+  ))
 }

--- a/examples/nextjs-route/src/app/[locale]/page.tsx
+++ b/examples/nextjs-route/src/app/[locale]/page.tsx
@@ -45,52 +45,50 @@ export default async function RouteHome({ params }: { params: Promise<{ locale: 
   const localeLabel = getLocaleLabel(locale)
 
   return runWithServerI18n(i18n, () => (
-    <main className="page-shell">
-      {banner ? (
-        <SuggestionBanner
-          ctaLabel={translateSwitchToRecommended()}
-          currentLocale={locale}
-          description={banner.description}
-          recommendedLocale={banner.recommendedLocale}
-          recommendedUrl={banner.recommendedUrl}
-        />
-      ) : null}
+    <ClientLocaleBoundary locale={locale}>
+      <main className="page-shell">
+        {banner ? (
+          <SuggestionBanner
+            ctaLabel={translateSwitchToRecommended()}
+            currentLocale={locale}
+            description={banner.description}
+            recommendedLocale={banner.recommendedLocale}
+            recommendedUrl={banner.recommendedUrl}
+          />
+        ) : null}
 
-      <header className="topbar">
-        <div className="brand">
-          <b>Frontend Stage</b>
-          <span className="brand-meta">Berlin · 2026</span>
-        </div>
-        <ClientLocaleBoundary locale={locale}>
+        <header className="topbar">
+          <div className="brand">
+            <b>Frontend Stage</b>
+            <span className="brand-meta">Berlin · 2026</span>
+          </div>
           <LocaleSwitcher locale={locale} />
-        </ClientLocaleBoundary>
-      </header>
+        </header>
 
-      <section className="hero">
-        <p className="eyebrow">
-          <span className="dot" aria-hidden="true" />
-          {translateEyebrow()}
-        </p>
-        <h1>{translateHeadline()}</h1>
-        <p className="greet">{translateGreeting(EVENT.attendeeName)}</p>
-        <p className="lede">{translateLede()}</p>
-      </section>
+        <section className="hero">
+          <p className="eyebrow">
+            <span className="dot" aria-hidden="true" />
+            {translateEyebrow()}
+          </p>
+          <h1>{translateHeadline()}</h1>
+          <p className="greet">{translateGreeting(EVENT.attendeeName)}</p>
+          <p className="lede">{translateLede()}</p>
+        </section>
 
-      <ClientLocaleBoundary locale={locale}>
         <div className="grid">
           <TicketPanel locale={locale} />
           <ProofPanel locale={locale} />
         </div>
-      </ClientLocaleBoundary>
 
-      <footer className="foot">
-        <span className="foot-badge">Palamedes</span>
-        {translateRenderedWith()}
-        {" · "}
-        {translateServerLocale()} <strong data-testid="server-locale-value">{localeLabel}</strong>
-      </footer>
+        <footer className="foot">
+          <span className="foot-badge">Palamedes</span>
+          {translateRenderedWith()}
+          {" · "}
+          {translateServerLocale()} <strong data-testid="server-locale-value">{localeLabel}</strong>
+        </footer>
 
-      <ClientReady />
-    </main>
+        <ClientReady />
+      </main>
+    </ClientLocaleBoundary>
   ))
 }

--- a/examples/nextjs-route/src/components/ClientLocaleBoundary.tsx
+++ b/examples/nextjs-route/src/components/ClientLocaleBoundary.tsx
@@ -5,7 +5,7 @@ import type { ReactNode } from "react"
 import { useClientLocale } from "@palamedes/react/client"
 
 import type { Locale } from "@/lib/i18n"
-import { syncClientI18n } from "@/lib/i18n.client"
+import { activateServerClientI18n, syncClientI18n } from "@/lib/i18n.client"
 
 type ClientLocaleBoundaryProps = {
   children: ReactNode
@@ -13,6 +13,19 @@ type ClientLocaleBoundaryProps = {
 }
 
 export function ClientLocaleBoundary({ children, locale }: ClientLocaleBoundaryProps) {
+  if (typeof window === "undefined") {
+    activateServerClientI18n(locale)
+  }
   useClientLocale(locale, syncClientI18n)
-  return <>{children}</>
+  const serializedLocale = JSON.stringify(locale).replaceAll("<", "\\u003c")
+  return (
+    <>
+      <script
+        dangerouslySetInnerHTML={{
+          __html: `window.__PALAMEDES_LOCALE__=${serializedLocale};`,
+        }}
+      />
+      {children}
+    </>
+  )
 }

--- a/examples/nextjs-route/src/lib/actions.ts
+++ b/examples/nextjs-route/src/lib/actions.ts
@@ -2,19 +2,19 @@
 
 import { t } from "@palamedes/core/macro"
 import { getLocaleLabel, type Locale, LOCALES } from "./i18n"
-import { createActiveServerI18n } from "./i18n.server"
+import { createActiveServerI18n, runWithServerI18n } from "./i18n.server"
 
 export async function getServerActionProof(locale: Locale) {
   if (!LOCALES.includes(locale)) {
     throw new Error(`Invalid locale: ${locale}`)
   }
 
-  await createActiveServerI18n(locale)
+  const { i18n } = await createActiveServerI18n(locale)
 
-  return {
+  return runWithServerI18n(i18n, () => ({
     locale,
     localeLabel: getLocaleLabel(locale),
     handledAt: new Date().toISOString(),
     message: t`Server action confirmed locale ${locale}.`,
-  }
+  }))
 }

--- a/examples/nextjs-route/src/lib/i18n.client.ts
+++ b/examples/nextjs-route/src/lib/i18n.client.ts
@@ -1,5 +1,6 @@
 import type { CatalogMessages } from "@palamedes/core"
 import { activateServerI18n, setClientI18n } from "@palamedes/runtime"
+import { cache } from "react"
 import { createExampleI18n, locales, type Locale } from "./i18n"
 import { messages as enMessages } from "../locales/en.po"
 import { messages as deMessages } from "../locales/de.po"
@@ -18,11 +19,15 @@ const CATALOGS: Record<Locale, CatalogMessages> = {
 
 const clientI18n = createExampleI18n()
 
-export function activateServerClientI18n(locale: Locale) {
+const getServerClientI18n = cache((locale: Locale) => {
   const i18n = createExampleI18n()
   i18n.load(locale, CATALOGS[locale])
   i18n.activate(locale)
-  activateServerI18n(i18n)
+  return i18n
+})
+
+export function activateServerClientI18n(locale: Locale) {
+  activateServerI18n(getServerClientI18n(locale))
 }
 
 export function syncClientI18n(locale: Locale) {

--- a/examples/nextjs-route/src/lib/i18n.client.ts
+++ b/examples/nextjs-route/src/lib/i18n.client.ts
@@ -1,6 +1,6 @@
 import type { CatalogMessages } from "@palamedes/core"
-import { setClientI18n, setServerI18nGetter } from "@palamedes/runtime"
-import { createExampleI18n, type Locale } from "./i18n"
+import { activateServerI18n, setClientI18n } from "@palamedes/runtime"
+import { createExampleI18n, locales, type Locale } from "./i18n"
 import { messages as enMessages } from "../locales/en.po"
 import { messages as deMessages } from "../locales/de.po"
 import { messages as esMessages } from "../locales/es.po"
@@ -18,19 +18,29 @@ const CATALOGS: Record<Locale, CatalogMessages> = {
 
 const clientI18n = createExampleI18n()
 
+export function activateServerClientI18n(locale: Locale) {
+  const i18n = createExampleI18n()
+  i18n.load(locale, CATALOGS[locale])
+  i18n.activate(locale)
+  activateServerI18n(i18n)
+}
+
 export function syncClientI18n(locale: Locale) {
+  if (typeof window === "undefined") {
+    return
+  }
+
   clientI18n.load(locale, CATALOGS[locale])
   clientI18n.activate(locale)
+  setClientI18n(clientI18n)
+}
 
-  if (typeof window === "undefined") {
-    // During SSR the client components still render on the server, so they
-    // resolve translations through the server scope. Point it at this
-    // synchronously-populated instance.
-    setServerI18nGetter(() => clientI18n)
-  } else {
-    // At hydration the catalog is already loaded synchronously above, so the
-    // client i18n is active in the same render pass — no async gap that would
-    // throw "No active client i18n instance".
-    setClientI18n(clientI18n)
+declare global {
+  interface Window {
+    __PALAMEDES_LOCALE__?: string
   }
+}
+
+if (typeof window !== "undefined" && locales.isLocale(window.__PALAMEDES_LOCALE__)) {
+  syncClientI18n(window.__PALAMEDES_LOCALE__)
 }

--- a/examples/nextjs-route/src/lib/i18n.server.ts
+++ b/examples/nextjs-route/src/lib/i18n.server.ts
@@ -8,6 +8,10 @@ import { createExampleI18n, DEFAULT_LOCALE, type Locale, loadMessages, locales }
 
 export const serverI18nScope = createServerI18nScope<PalamedesI18n>()
 
+export function runWithServerI18n<Result>(i18n: PalamedesI18n, callback: () => Result): Result {
+  return serverI18nScope.run(i18n, callback)
+}
+
 export async function getRouteLocale(paramsLocale?: string): Promise<{
   banner: LocaleSuggestion<Locale> | null
   locale: Locale

--- a/examples/nextjs-subdomain/src/app/page.tsx
+++ b/examples/nextjs-subdomain/src/app/page.tsx
@@ -6,11 +6,10 @@ import { LocaleSwitcher } from "@/components/LocaleSwitcher"
 import { ProofPanel } from "@/components/ProofPanel"
 import { SuggestionBanner } from "@/components/SuggestionBanner"
 import { TicketPanel } from "@/components/TicketPanel"
-import { createActiveServerI18n, getSubdomainLocale } from "@/lib/i18n.server"
+import { createActiveServerI18n, getSubdomainLocale, runWithServerI18n } from "@/lib/i18n.server"
 import { getLocaleLabel, type Locale } from "@/lib/i18n"
 
-// These functions run only after `createActiveServerI18n()` activated the
-// request-local runtime scope.
+// These functions run only inside `runWithServerI18n()`'s request-local scope.
 function translateEyebrow(): string {
   return t`Localized live with Palamedes`
 }
@@ -41,10 +40,10 @@ function translateSwitchToRecommended(): string {
 
 export default async function SubdomainHome() {
   const { banner, host, locale } = await getSubdomainLocale()
-  await createActiveServerI18n(locale as Locale)
+  const { i18n } = await createActiveServerI18n(locale as Locale)
   const localeLabel = getLocaleLabel(locale)
 
-  return (
+  return runWithServerI18n(i18n, () => (
     <main className="page-shell">
       {banner ? (
         <SuggestionBanner
@@ -92,5 +91,5 @@ export default async function SubdomainHome() {
 
       <ClientReady />
     </main>
-  )
+  ))
 }

--- a/examples/nextjs-subdomain/src/app/page.tsx
+++ b/examples/nextjs-subdomain/src/app/page.tsx
@@ -44,52 +44,50 @@ export default async function SubdomainHome() {
   const localeLabel = getLocaleLabel(locale)
 
   return runWithServerI18n(i18n, () => (
-    <main className="page-shell">
-      {banner ? (
-        <SuggestionBanner
-          ctaLabel={translateSwitchToRecommended()}
-          currentLocale={locale}
-          description={banner.description}
-          recommendedLocale={banner.recommendedLocale}
-          recommendedUrl={banner.recommendedUrl}
-        />
-      ) : null}
+    <ClientLocaleBoundary locale={locale}>
+      <main className="page-shell">
+        {banner ? (
+          <SuggestionBanner
+            ctaLabel={translateSwitchToRecommended()}
+            currentLocale={locale}
+            description={banner.description}
+            recommendedLocale={banner.recommendedLocale}
+            recommendedUrl={banner.recommendedUrl}
+          />
+        ) : null}
 
-      <header className="topbar">
-        <div className="brand">
-          <b>Frontend Stage</b>
-          <span className="brand-meta">Berlin · 2026</span>
-        </div>
-        <ClientLocaleBoundary locale={locale}>
+        <header className="topbar">
+          <div className="brand">
+            <b>Frontend Stage</b>
+            <span className="brand-meta">Berlin · 2026</span>
+          </div>
           <LocaleSwitcher host={host} locale={locale} />
-        </ClientLocaleBoundary>
-      </header>
+        </header>
 
-      <section className="hero">
-        <p className="eyebrow">
-          <span className="dot" aria-hidden="true" />
-          {translateEyebrow()}
-        </p>
-        <h1>{translateHeadline()}</h1>
-        <p className="greet">{translateGreeting(EVENT.attendeeName)}</p>
-        <p className="lede">{translateLede()}</p>
-      </section>
+        <section className="hero">
+          <p className="eyebrow">
+            <span className="dot" aria-hidden="true" />
+            {translateEyebrow()}
+          </p>
+          <h1>{translateHeadline()}</h1>
+          <p className="greet">{translateGreeting(EVENT.attendeeName)}</p>
+          <p className="lede">{translateLede()}</p>
+        </section>
 
-      <ClientLocaleBoundary locale={locale}>
         <div className="grid">
           <TicketPanel locale={locale} />
           <ProofPanel locale={locale} />
         </div>
-      </ClientLocaleBoundary>
 
-      <footer className="foot">
-        <span className="foot-badge">Palamedes</span>
-        {translateRenderedWith()}
-        {" · "}
-        {translateServerLocale()} <strong data-testid="server-locale-value">{localeLabel}</strong>
-      </footer>
+        <footer className="foot">
+          <span className="foot-badge">Palamedes</span>
+          {translateRenderedWith()}
+          {" · "}
+          {translateServerLocale()} <strong data-testid="server-locale-value">{localeLabel}</strong>
+        </footer>
 
-      <ClientReady />
-    </main>
+        <ClientReady />
+      </main>
+    </ClientLocaleBoundary>
   ))
 }

--- a/examples/nextjs-subdomain/src/components/ClientLocaleBoundary.tsx
+++ b/examples/nextjs-subdomain/src/components/ClientLocaleBoundary.tsx
@@ -5,7 +5,7 @@ import type { ReactNode } from "react"
 import { useClientLocale } from "@palamedes/react/client"
 
 import type { Locale } from "@/lib/i18n"
-import { syncClientI18n } from "@/lib/i18n.client"
+import { activateServerClientI18n, syncClientI18n } from "@/lib/i18n.client"
 
 type ClientLocaleBoundaryProps = {
   children: ReactNode
@@ -13,6 +13,19 @@ type ClientLocaleBoundaryProps = {
 }
 
 export function ClientLocaleBoundary({ children, locale }: ClientLocaleBoundaryProps) {
+  if (typeof window === "undefined") {
+    activateServerClientI18n(locale)
+  }
   useClientLocale(locale, syncClientI18n)
-  return <>{children}</>
+  const serializedLocale = JSON.stringify(locale).replaceAll("<", "\\u003c")
+  return (
+    <>
+      <script
+        dangerouslySetInnerHTML={{
+          __html: `window.__PALAMEDES_LOCALE__=${serializedLocale};`,
+        }}
+      />
+      {children}
+    </>
+  )
 }

--- a/examples/nextjs-subdomain/src/lib/actions.ts
+++ b/examples/nextjs-subdomain/src/lib/actions.ts
@@ -2,19 +2,19 @@
 
 import { t } from "@palamedes/core/macro"
 import { getLocaleLabel, type Locale, LOCALES } from "./i18n"
-import { createActiveServerI18n } from "./i18n.server"
+import { createActiveServerI18n, runWithServerI18n } from "./i18n.server"
 
 export async function getServerActionProof(locale: Locale) {
   if (!LOCALES.includes(locale)) {
     throw new Error(`Invalid locale: ${locale}`)
   }
 
-  await createActiveServerI18n(locale)
+  const { i18n } = await createActiveServerI18n(locale)
 
-  return {
+  return runWithServerI18n(i18n, () => ({
     locale,
     localeLabel: getLocaleLabel(locale),
     handledAt: new Date().toISOString(),
     message: t`Server action confirmed locale ${locale}.`,
-  }
+  }))
 }

--- a/examples/nextjs-subdomain/src/lib/i18n.client.ts
+++ b/examples/nextjs-subdomain/src/lib/i18n.client.ts
@@ -1,5 +1,6 @@
 import type { CatalogMessages } from "@palamedes/core"
 import { activateServerI18n, setClientI18n } from "@palamedes/runtime"
+import { cache } from "react"
 import { createExampleI18n, locales, type Locale } from "./i18n"
 import { messages as enMessages } from "../locales/en.po"
 import { messages as deMessages } from "../locales/de.po"
@@ -18,11 +19,15 @@ const CATALOGS: Record<Locale, CatalogMessages> = {
 
 const clientI18n = createExampleI18n()
 
-export function activateServerClientI18n(locale: Locale) {
+const getServerClientI18n = cache((locale: Locale) => {
   const i18n = createExampleI18n()
   i18n.load(locale, CATALOGS[locale])
   i18n.activate(locale)
-  activateServerI18n(i18n)
+  return i18n
+})
+
+export function activateServerClientI18n(locale: Locale) {
+  activateServerI18n(getServerClientI18n(locale))
 }
 
 export function syncClientI18n(locale: Locale) {

--- a/examples/nextjs-subdomain/src/lib/i18n.client.ts
+++ b/examples/nextjs-subdomain/src/lib/i18n.client.ts
@@ -1,6 +1,6 @@
 import type { CatalogMessages } from "@palamedes/core"
-import { setClientI18n, setServerI18nGetter } from "@palamedes/runtime"
-import { createExampleI18n, type Locale } from "./i18n"
+import { activateServerI18n, setClientI18n } from "@palamedes/runtime"
+import { createExampleI18n, locales, type Locale } from "./i18n"
 import { messages as enMessages } from "../locales/en.po"
 import { messages as deMessages } from "../locales/de.po"
 import { messages as esMessages } from "../locales/es.po"
@@ -18,19 +18,29 @@ const CATALOGS: Record<Locale, CatalogMessages> = {
 
 const clientI18n = createExampleI18n()
 
+export function activateServerClientI18n(locale: Locale) {
+  const i18n = createExampleI18n()
+  i18n.load(locale, CATALOGS[locale])
+  i18n.activate(locale)
+  activateServerI18n(i18n)
+}
+
 export function syncClientI18n(locale: Locale) {
+  if (typeof window === "undefined") {
+    return
+  }
+
   clientI18n.load(locale, CATALOGS[locale])
   clientI18n.activate(locale)
+  setClientI18n(clientI18n)
+}
 
-  if (typeof window === "undefined") {
-    // During SSR the client components still render on the server, so they
-    // resolve translations through the server scope. Point it at this
-    // synchronously-populated instance.
-    setServerI18nGetter(() => clientI18n)
-  } else {
-    // At hydration the catalog is already loaded synchronously above, so the
-    // client i18n is active in the same render pass — no async gap that would
-    // throw "No active client i18n instance".
-    setClientI18n(clientI18n)
+declare global {
+  interface Window {
+    __PALAMEDES_LOCALE__?: string
   }
+}
+
+if (typeof window !== "undefined" && locales.isLocale(window.__PALAMEDES_LOCALE__)) {
+  syncClientI18n(window.__PALAMEDES_LOCALE__)
 }

--- a/examples/nextjs-subdomain/src/lib/i18n.server.ts
+++ b/examples/nextjs-subdomain/src/lib/i18n.server.ts
@@ -8,6 +8,10 @@ import { createExampleI18n, type Locale, loadMessages, locales } from "./i18n"
 
 export const serverI18nScope = createServerI18nScope<PalamedesI18n>()
 
+export function runWithServerI18n<Result>(i18n: PalamedesI18n, callback: () => Result): Result {
+  return serverI18nScope.run(i18n, callback)
+}
+
 export async function getSubdomainLocale(): Promise<{
   banner: LocaleSuggestion<Locale> | null
   host: string | null

--- a/examples/nextjs-tld/src/app/page.tsx
+++ b/examples/nextjs-tld/src/app/page.tsx
@@ -6,11 +6,10 @@ import { LocaleSwitcher } from "@/components/LocaleSwitcher"
 import { ProofPanel } from "@/components/ProofPanel"
 import { SuggestionBanner } from "@/components/SuggestionBanner"
 import { TicketPanel } from "@/components/TicketPanel"
-import { createActiveServerI18n, getTldLocale } from "@/lib/i18n.server"
+import { createActiveServerI18n, getTldLocale, runWithServerI18n } from "@/lib/i18n.server"
 import { getLocaleLabel, type Locale } from "@/lib/i18n"
 
-// These functions run only after `createActiveServerI18n()` activated the
-// request-local runtime scope.
+// These functions run only inside `runWithServerI18n()`'s request-local scope.
 function translateEyebrow(): string {
   return t`Localized live with Palamedes`
 }
@@ -41,10 +40,10 @@ function translateSwitchToRecommended(): string {
 
 export default async function TldHome() {
   const { banner, host, locale } = await getTldLocale()
-  await createActiveServerI18n(locale as Locale)
+  const { i18n } = await createActiveServerI18n(locale as Locale)
   const localeLabel = getLocaleLabel(locale)
 
-  return (
+  return runWithServerI18n(i18n, () => (
     <main className="page-shell">
       {banner ? (
         <SuggestionBanner
@@ -92,5 +91,5 @@ export default async function TldHome() {
 
       <ClientReady />
     </main>
-  )
+  ))
 }

--- a/examples/nextjs-tld/src/app/page.tsx
+++ b/examples/nextjs-tld/src/app/page.tsx
@@ -44,52 +44,50 @@ export default async function TldHome() {
   const localeLabel = getLocaleLabel(locale)
 
   return runWithServerI18n(i18n, () => (
-    <main className="page-shell">
-      {banner ? (
-        <SuggestionBanner
-          ctaLabel={translateSwitchToRecommended()}
-          currentLocale={locale}
-          description={banner.description}
-          recommendedLocale={banner.recommendedLocale}
-          recommendedUrl={banner.recommendedUrl}
-        />
-      ) : null}
+    <ClientLocaleBoundary locale={locale}>
+      <main className="page-shell">
+        {banner ? (
+          <SuggestionBanner
+            ctaLabel={translateSwitchToRecommended()}
+            currentLocale={locale}
+            description={banner.description}
+            recommendedLocale={banner.recommendedLocale}
+            recommendedUrl={banner.recommendedUrl}
+          />
+        ) : null}
 
-      <header className="topbar">
-        <div className="brand">
-          <b>Frontend Stage</b>
-          <span className="brand-meta">Berlin · 2026</span>
-        </div>
-        <ClientLocaleBoundary locale={locale}>
+        <header className="topbar">
+          <div className="brand">
+            <b>Frontend Stage</b>
+            <span className="brand-meta">Berlin · 2026</span>
+          </div>
           <LocaleSwitcher host={host} locale={locale} />
-        </ClientLocaleBoundary>
-      </header>
+        </header>
 
-      <section className="hero">
-        <p className="eyebrow">
-          <span className="dot" aria-hidden="true" />
-          {translateEyebrow()}
-        </p>
-        <h1>{translateHeadline()}</h1>
-        <p className="greet">{translateGreeting(EVENT.attendeeName)}</p>
-        <p className="lede">{translateLede()}</p>
-      </section>
+        <section className="hero">
+          <p className="eyebrow">
+            <span className="dot" aria-hidden="true" />
+            {translateEyebrow()}
+          </p>
+          <h1>{translateHeadline()}</h1>
+          <p className="greet">{translateGreeting(EVENT.attendeeName)}</p>
+          <p className="lede">{translateLede()}</p>
+        </section>
 
-      <ClientLocaleBoundary locale={locale}>
         <div className="grid">
           <TicketPanel locale={locale} />
           <ProofPanel locale={locale} />
         </div>
-      </ClientLocaleBoundary>
 
-      <footer className="foot">
-        <span className="foot-badge">Palamedes</span>
-        {translateRenderedWith()}
-        {" · "}
-        {translateServerLocale()} <strong data-testid="server-locale-value">{localeLabel}</strong>
-      </footer>
+        <footer className="foot">
+          <span className="foot-badge">Palamedes</span>
+          {translateRenderedWith()}
+          {" · "}
+          {translateServerLocale()} <strong data-testid="server-locale-value">{localeLabel}</strong>
+        </footer>
 
-      <ClientReady />
-    </main>
+        <ClientReady />
+      </main>
+    </ClientLocaleBoundary>
   ))
 }

--- a/examples/nextjs-tld/src/components/ClientLocaleBoundary.tsx
+++ b/examples/nextjs-tld/src/components/ClientLocaleBoundary.tsx
@@ -5,7 +5,7 @@ import type { ReactNode } from "react"
 import { useClientLocale } from "@palamedes/react/client"
 
 import type { Locale } from "@/lib/i18n"
-import { syncClientI18n } from "@/lib/i18n.client"
+import { activateServerClientI18n, syncClientI18n } from "@/lib/i18n.client"
 
 type ClientLocaleBoundaryProps = {
   children: ReactNode
@@ -13,6 +13,19 @@ type ClientLocaleBoundaryProps = {
 }
 
 export function ClientLocaleBoundary({ children, locale }: ClientLocaleBoundaryProps) {
+  if (typeof window === "undefined") {
+    activateServerClientI18n(locale)
+  }
   useClientLocale(locale, syncClientI18n)
-  return <>{children}</>
+  const serializedLocale = JSON.stringify(locale).replaceAll("<", "\\u003c")
+  return (
+    <>
+      <script
+        dangerouslySetInnerHTML={{
+          __html: `window.__PALAMEDES_LOCALE__=${serializedLocale};`,
+        }}
+      />
+      {children}
+    </>
+  )
 }

--- a/examples/nextjs-tld/src/lib/actions.ts
+++ b/examples/nextjs-tld/src/lib/actions.ts
@@ -2,19 +2,19 @@
 
 import { t } from "@palamedes/core/macro"
 import { getLocaleLabel, type Locale, LOCALES } from "./i18n"
-import { createActiveServerI18n } from "./i18n.server"
+import { createActiveServerI18n, runWithServerI18n } from "./i18n.server"
 
 export async function getServerActionProof(locale: Locale) {
   if (!LOCALES.includes(locale)) {
     throw new Error(`Invalid locale: ${locale}`)
   }
 
-  await createActiveServerI18n(locale)
+  const { i18n } = await createActiveServerI18n(locale)
 
-  return {
+  return runWithServerI18n(i18n, () => ({
     locale,
     localeLabel: getLocaleLabel(locale),
     handledAt: new Date().toISOString(),
     message: t`Server action confirmed locale ${locale}.`,
-  }
+  }))
 }

--- a/examples/nextjs-tld/src/lib/i18n.client.ts
+++ b/examples/nextjs-tld/src/lib/i18n.client.ts
@@ -1,5 +1,6 @@
 import type { CatalogMessages } from "@palamedes/core"
 import { activateServerI18n, setClientI18n } from "@palamedes/runtime"
+import { cache } from "react"
 import { createExampleI18n, locales, type Locale } from "./i18n"
 import { messages as enMessages } from "../locales/en.po"
 import { messages as deMessages } from "../locales/de.po"
@@ -20,11 +21,15 @@ const CATALOGS: Record<Locale, CatalogMessages> = {
 
 const clientI18n = createExampleI18n()
 
-export function activateServerClientI18n(locale: Locale) {
+const getServerClientI18n = cache((locale: Locale) => {
   const i18n = createExampleI18n()
   i18n.load(locale, CATALOGS[locale])
   i18n.activate(locale)
-  activateServerI18n(i18n)
+  return i18n
+})
+
+export function activateServerClientI18n(locale: Locale) {
+  activateServerI18n(getServerClientI18n(locale))
 }
 
 export function syncClientI18n(locale: Locale) {

--- a/examples/nextjs-tld/src/lib/i18n.client.ts
+++ b/examples/nextjs-tld/src/lib/i18n.client.ts
@@ -1,6 +1,6 @@
 import type { CatalogMessages } from "@palamedes/core"
-import { setClientI18n, setServerI18nGetter } from "@palamedes/runtime"
-import { createExampleI18n, type Locale } from "./i18n"
+import { activateServerI18n, setClientI18n } from "@palamedes/runtime"
+import { createExampleI18n, locales, type Locale } from "./i18n"
 import { messages as enMessages } from "../locales/en.po"
 import { messages as deMessages } from "../locales/de.po"
 import { messages as esMessages } from "../locales/es.po"
@@ -20,19 +20,29 @@ const CATALOGS: Record<Locale, CatalogMessages> = {
 
 const clientI18n = createExampleI18n()
 
+export function activateServerClientI18n(locale: Locale) {
+  const i18n = createExampleI18n()
+  i18n.load(locale, CATALOGS[locale])
+  i18n.activate(locale)
+  activateServerI18n(i18n)
+}
+
 export function syncClientI18n(locale: Locale) {
+  if (typeof window === "undefined") {
+    return
+  }
+
   clientI18n.load(locale, CATALOGS[locale])
   clientI18n.activate(locale)
+  setClientI18n(clientI18n)
+}
 
-  if (typeof window === "undefined") {
-    // During SSR the client components still render on the server, so they
-    // resolve translations through the server scope. Point it at this
-    // synchronously-populated instance.
-    setServerI18nGetter(() => clientI18n)
-  } else {
-    // At hydration the catalog is already loaded synchronously above, so the
-    // client i18n is active in the same render pass — no async gap that would
-    // throw "No active client i18n instance".
-    setClientI18n(clientI18n)
+declare global {
+  interface Window {
+    __PALAMEDES_LOCALE__?: string
   }
+}
+
+if (typeof window !== "undefined" && locales.isLocale(window.__PALAMEDES_LOCALE__)) {
+  syncClientI18n(window.__PALAMEDES_LOCALE__)
 }

--- a/examples/nextjs-tld/src/lib/i18n.server.ts
+++ b/examples/nextjs-tld/src/lib/i18n.server.ts
@@ -8,6 +8,10 @@ import { createExampleI18n, type Locale, loadMessages, locales } from "./i18n"
 
 export const serverI18nScope = createServerI18nScope<PalamedesI18n>()
 
+export function runWithServerI18n<Result>(i18n: PalamedesI18n, callback: () => Result): Result {
+  return serverI18nScope.run(i18n, callback)
+}
+
 export async function getTldLocale(): Promise<{
   banner: LocaleSuggestion<Locale> | null
   host: string | null

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -58,6 +58,10 @@ primitives that repeat across apps:
 - keeping the active client locale synchronized
 - building render-ready locale switch models for buttons, links, or forms
 
+`useClientLocale` does not run its sync callback during SSR. If the initial HTML
+contains translated client components, initialize `setClientI18n()` before
+hydration; subsequent locale changes are synchronized after commit.
+
 ```tsx
 import { buildLocaleSwitchItems } from "@palamedes/react"
 import { useClientLocale } from "@palamedes/react/client"

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -60,7 +60,7 @@ primitives that repeat across apps:
 
 `useClientLocale` does not run its sync callback during SSR. If the initial HTML
 contains translated client components, initialize `setClientI18n()` before
-hydration; subsequent locale changes are synchronized after commit.
+hydration; all hook-driven locale synchronization happens after commit.
 
 ```tsx
 import { buildLocaleSwitchItems } from "@palamedes/react"

--- a/packages/react/src/client.tsx
+++ b/packages/react/src/client.tsx
@@ -1,6 +1,46 @@
+import { useEffect, useRef, useSyncExternalStore } from "react"
+import {
+  getClientI18nSnapshot,
+  subscribeClientI18n,
+  type ClientI18nSnapshot,
+} from "@palamedes/runtime"
+
+const SERVER_CLIENT_I18N_SNAPSHOT: ClientI18nSnapshot = {
+  i18n: undefined,
+  revision: 0,
+}
+
 export function useClientLocale<TLocale>(
   locale: TLocale,
   sync: (locale: TLocale) => unknown
 ): void {
-  void sync(locale)
+  const snapshot = useSyncExternalStore(
+    subscribeClientI18n,
+    getClientI18nSnapshot,
+    () => SERVER_CLIENT_I18N_SNAPSHOT
+  )
+  const renderSync = useRef<{ locale: TLocale; sync: typeof sync } | null>(null)
+
+  // Backward-compatible bootstrap for apps that have not initialized their
+  // client runtime before hydration. This branch never runs during SSR. New
+  // integrations should initialize before hydration, as the Next.js examples
+  // do, so all synchronization happens after commit.
+  if (typeof window !== "undefined" && !snapshot.i18n) {
+    renderSync.current = { locale, sync }
+    void sync(locale)
+  }
+
+  useEffect(() => {
+    const synchronousBootstrap = renderSync.current
+    renderSync.current = null
+    if (
+      synchronousBootstrap &&
+      synchronousBootstrap.sync === sync &&
+      Object.is(synchronousBootstrap.locale, locale)
+    ) {
+      return
+    }
+
+    void sync(locale)
+  }, [locale, sync])
 }

--- a/packages/react/src/client.tsx
+++ b/packages/react/src/client.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useSyncExternalStore } from "react"
+import { useEffect, useSyncExternalStore } from "react"
 import {
   getClientI18nSnapshot,
   subscribeClientI18n,
@@ -14,33 +14,13 @@ export function useClientLocale<TLocale>(
   locale: TLocale,
   sync: (locale: TLocale) => unknown
 ): void {
-  const snapshot = useSyncExternalStore(
+  useSyncExternalStore(
     subscribeClientI18n,
     getClientI18nSnapshot,
     () => SERVER_CLIENT_I18N_SNAPSHOT
   )
-  const renderSync = useRef<{ locale: TLocale; sync: typeof sync } | null>(null)
-
-  // Backward-compatible bootstrap for apps that have not initialized their
-  // client runtime before hydration. This branch never runs during SSR. New
-  // integrations should initialize before hydration, as the Next.js examples
-  // do, so all synchronization happens after commit.
-  if (typeof window !== "undefined" && !snapshot.i18n) {
-    renderSync.current = { locale, sync }
-    void sync(locale)
-  }
 
   useEffect(() => {
-    const synchronousBootstrap = renderSync.current
-    renderSync.current = null
-    if (
-      synchronousBootstrap &&
-      synchronousBootstrap.sync === sync &&
-      Object.is(synchronousBootstrap.locale, locale)
-    ) {
-      return
-    }
-
     void sync(locale)
   }, [locale, sync])
 }

--- a/packages/react/src/index.test.tsx
+++ b/packages/react/src/index.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 
 import { createI18n } from "@palamedes/core"
 import { resetI18nRuntime, setClientI18n } from "@palamedes/runtime"
+import { createServerI18nScope } from "@palamedes/runtime/server"
 
 import { Plural, Select, SelectOrdinal, Trans, buildLocaleSwitchItems } from "./index"
 import { useClientLocale } from "./client"
@@ -12,6 +13,7 @@ import { useClientLocale } from "./client"
 describe("@palamedes/react", () => {
   afterEach(() => {
     resetI18nRuntime()
+    vi.unstubAllGlobals()
   })
 
   it("renders Trans without a provider by reading the active runtime instance", () => {
@@ -136,17 +138,59 @@ describe("@palamedes/react", () => {
   })
 
   it("syncs the active client locale through useClientLocale", () => {
-    const sync = vi.fn()
+    const i18n = createI18n()
+    i18n.load("en", { greeting: "Hello" })
+    i18n.load("de", { greeting: "Hallo" })
+    i18n.activate("en")
+    setClientI18n(i18n)
+    const sync = vi.fn((locale: "en" | "de") => {
+      i18n.activate(locale)
+      setClientI18n(i18n)
+    })
 
     function Probe({ locale }: { locale: "en" | "de" }) {
       useClientLocale(locale, sync)
-      return null
+      return <Trans id="greeting" message="Greeting" />
     }
 
     const view = render(<Probe locale="en" />)
     expect(sync).toHaveBeenCalledWith("en")
+    expect(view.container.textContent).toBe("Hello")
 
     view.rerender(<Probe locale="de" />)
     expect(sync).toHaveBeenLastCalledWith("de")
+    expect(view.container.textContent).toBe("Hallo")
+  })
+
+  it("does not mutate client state during server rendering", async () => {
+    vi.stubGlobal("window", undefined)
+    const scope = createServerI18nScope<ReturnType<typeof createI18n>>()
+    const deI18n = createI18n()
+    const enI18n = createI18n()
+    deI18n.load("de", { greeting: "Hallo" })
+    enI18n.load("en", { greeting: "Hello" })
+    deI18n.activate("de")
+    enI18n.activate("en")
+    const sync = vi.fn()
+
+    function Probe({ locale }: { locale: "en" | "de" }) {
+      useClientLocale(locale, sync)
+      return <Trans id="greeting" message="Greeting" />
+    }
+
+    const [deHtml, enHtml] = await Promise.all([
+      scope.run(deI18n, async () => {
+        await Promise.resolve()
+        return renderToStaticMarkup(<Probe locale="de" />)
+      }),
+      scope.run(enI18n, async () => {
+        await Promise.resolve()
+        return renderToStaticMarkup(<Probe locale="en" />)
+      }),
+    ])
+
+    expect(deHtml).toBe("Hallo")
+    expect(enHtml).toBe("Hello")
+    expect(sync).not.toHaveBeenCalled()
   })
 })

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -97,8 +97,10 @@ For a fuller walkthrough, including Hono and Express examples, see:
 ## API
 
 - `getI18n()`
+- `getClientI18nSnapshot()`
 - `setClientI18n(i18n)`
 - `subscribeClientI18n(listener)`
+- `activateServerI18n(i18n)`
 - `setServerI18nGetter(getter)`
 - `resetI18nRuntime()`
 - `createServerI18nScope()` from `@palamedes/runtime/server` for Node runtimes
@@ -110,9 +112,17 @@ The `@palamedes/runtime/server` implementation imports Node `async_hooks`. In
 non-Node bundles, the subpath resolves to a small fallback module that throws an
 actionable Node-only error when called.
 
+Isomorphic SSR client-component bundles can use `activateServerI18n(i18n)` from
+the main entry point to enter an existing request scope without importing the
+Node-only subpath. The server entry point must first configure the shared scope
+with `createServerI18nScope()`. The helper does not make a shared i18n singleton
+request-safe, so pass a fresh request-local instance.
+
 `subscribeClientI18n(listener)` is intended for framework bindings such as the
 Solid reactivity bridge. It fires when `setClientI18n()` is called and returns
-an unsubscribe function.
+an unsubscribe function. `getClientI18nSnapshot()` pairs the active instance
+with a monotonic revision so external-store bindings can also observe
+re-activation of the same mutable instance.
 
 ## Related Packages
 

--- a/packages/runtime/src/index.test.ts
+++ b/packages/runtime/src/index.test.ts
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it } from "vitest"
 
 import {
   type I18nInstance,
+  getClientI18nSnapshot,
   getI18n,
   resetI18nRuntime,
   setClientI18n,
@@ -47,15 +48,20 @@ describe("@palamedes/runtime", () => {
 
     const i18n = createTestI18n("en")
     setClientI18n(i18n)
+    const firstSnapshot = getClientI18nSnapshot()
 
     // Same instance, re-activated in place: still notifies so bindings re-render.
     i18n.locale = "de"
     setClientI18n(i18n)
+    const secondSnapshot = getClientI18nSnapshot()
 
     unsubscribe()
     setClientI18n(createTestI18n("es"))
 
     expect(seen).toStrictEqual(["en", "de"])
+    expect(firstSnapshot.i18n).toBe(i18n)
+    expect(secondSnapshot.i18n).toBe(i18n)
+    expect(secondSnapshot.revision).toBe(firstSnapshot.revision + 1)
   })
 
   it("resolves the request-local server instance", () => {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -101,7 +101,11 @@ export function activateServerI18n<T extends I18nInstance>(i18n: T): T {
       "No server i18n scope is configured. Create one with createServerI18nScope() from @palamedes/runtime/server before activating SSR client components."
     )
   }
-  serverI18nGetter = () => scopeState.active.getStore()
+  serverI18nGetter ??= () => scopeState.active.getStore()
+  const activeI18n = scopeState.active.getStore()
+  if (activeI18n === i18n) {
+    return i18n
+  }
   scopeState.active.enterWith(i18n)
   return i18n
 }

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -6,16 +6,38 @@ export type I18nInstance = {
 type ServerI18nGetter<T extends I18nInstance = I18nInstance> = () => T | undefined
 
 const CLIENT_I18N_KEY = Symbol.for("palamedes.runtime.clientI18n")
+const CLIENT_I18N_SNAPSHOT_KEY = Symbol.for("palamedes.runtime.clientI18nSnapshot")
+const SERVER_SCOPE_STATE_KEY = Symbol.for("palamedes.runtime.serverI18nScopeState")
 
 let clientI18n: I18nInstance | undefined
+let clientI18nSnapshot: ClientI18nSnapshot = {
+  i18n: undefined,
+  revision: 0,
+}
 let serverI18nGetter: ServerI18nGetter | undefined
 
 type ClientI18nListener = (i18n: I18nInstance) => void
 
 const clientI18nListeners = new Set<ClientI18nListener>()
 
-function globalClientState(): typeof globalThis & { [CLIENT_I18N_KEY]?: I18nInstance } {
-  return globalThis as typeof globalThis & { [CLIENT_I18N_KEY]?: I18nInstance }
+export type ClientI18nSnapshot = Readonly<{
+  i18n: I18nInstance | undefined
+  revision: number
+}>
+
+type GlobalRuntimeState = typeof globalThis & {
+  [CLIENT_I18N_KEY]?: I18nInstance
+  [CLIENT_I18N_SNAPSHOT_KEY]?: ClientI18nSnapshot
+  [SERVER_SCOPE_STATE_KEY]?: {
+    active: {
+      enterWith(i18n: I18nInstance): void
+      getStore(): I18nInstance | undefined
+    }
+  }
+}
+
+function globalRuntimeState(): GlobalRuntimeState {
+  return globalThis as GlobalRuntimeState
 }
 
 function isServerEnvironment(): boolean {
@@ -23,12 +45,28 @@ function isServerEnvironment(): boolean {
 }
 
 export function setClientI18n<T extends I18nInstance>(i18n: T): T {
+  const state = globalRuntimeState()
+  const previousSnapshot = state[CLIENT_I18N_SNAPSHOT_KEY] ?? clientI18nSnapshot
   clientI18n = i18n
-  globalClientState()[CLIENT_I18N_KEY] = i18n
+  clientI18nSnapshot = {
+    i18n,
+    revision: previousSnapshot.revision + 1,
+  }
+  state[CLIENT_I18N_KEY] = i18n
+  state[CLIENT_I18N_SNAPSHOT_KEY] = clientI18nSnapshot
   for (const listener of clientI18nListeners) {
     listener(i18n)
   }
   return i18n
+}
+
+/**
+ * Return a stable snapshot of the active client instance and its activation
+ * revision. Framework bindings use the revision to observe re-activation of the
+ * same mutable i18n instance.
+ */
+export function getClientI18nSnapshot(): ClientI18nSnapshot {
+  return globalRuntimeState()[CLIENT_I18N_SNAPSHOT_KEY] ?? clientI18nSnapshot
 }
 
 /**
@@ -52,6 +90,22 @@ export function setServerI18nGetter<T extends I18nInstance>(getter: ServerI18nGe
   serverI18nGetter = getter as ServerI18nGetter
 }
 
+/**
+ * Enter the request scope created by `@palamedes/runtime/server` from an
+ * isomorphic SSR bundle that cannot import the Node-only server subpath.
+ */
+export function activateServerI18n<T extends I18nInstance>(i18n: T): T {
+  const scopeState = globalRuntimeState()[SERVER_SCOPE_STATE_KEY]
+  if (!scopeState) {
+    throw new Error(
+      "No server i18n scope is configured. Create one with createServerI18nScope() from @palamedes/runtime/server before activating SSR client components."
+    )
+  }
+  serverI18nGetter = () => scopeState.active.getStore()
+  scopeState.active.enterWith(i18n)
+  return i18n
+}
+
 export function getI18n<T extends I18nInstance = I18nInstance>(): T {
   if (isServerEnvironment()) {
     const i18n = serverI18nGetter?.()
@@ -63,7 +117,7 @@ export function getI18n<T extends I18nInstance = I18nInstance>(): T {
     return i18n as T
   }
 
-  const activeClientI18n = globalClientState()[CLIENT_I18N_KEY] ?? clientI18n
+  const activeClientI18n = globalRuntimeState()[CLIENT_I18N_KEY] ?? clientI18n
   if (!activeClientI18n) {
     throw new Error(
       "No active client i18n instance. Initialize @palamedes/runtime with setClientI18n() before translated code runs."
@@ -75,6 +129,12 @@ export function getI18n<T extends I18nInstance = I18nInstance>(): T {
 
 export function resetI18nRuntime(): void {
   clientI18n = undefined
+  clientI18nSnapshot = {
+    i18n: undefined,
+    revision: 0,
+  }
+  const state = globalRuntimeState()
+  delete state[CLIENT_I18N_KEY]
+  delete state[CLIENT_I18N_SNAPSHOT_KEY]
   serverI18nGetter = undefined
-  delete globalClientState()[CLIENT_I18N_KEY]
 }

--- a/packages/runtime/src/server.test.ts
+++ b/packages/runtime/src/server.test.ts
@@ -72,6 +72,22 @@ describe("@palamedes/runtime/server", () => {
     isolatedRuntime.resetI18nRuntime()
   })
 
+  it("reuses an active instance when an SSR boundary render is retried", async () => {
+    const scope = createServerI18nScope<I18nInstance>()
+    const outerI18n = createTestI18n("en")
+    const clientComponentI18n = createTestI18n("de")
+    vi.resetModules()
+    const isolatedRuntime = await import("./index")
+
+    scope.run(outerI18n, () => {
+      expect(isolatedRuntime.activateServerI18n(clientComponentI18n)).toBe(clientComponentI18n)
+      expect(isolatedRuntime.activateServerI18n(clientComponentI18n)).toBe(clientComponentI18n)
+      expect(isolatedRuntime.getI18n()).toBe(clientComponentI18n)
+    })
+
+    isolatedRuntime.resetI18nRuntime()
+  })
+
   it("keeps isolated SSR bundle activations request-local under concurrency", async () => {
     const scope = createServerI18nScope<I18nInstance>()
     const deI18n = createTestI18n("de")

--- a/packages/runtime/src/server.test.ts
+++ b/packages/runtime/src/server.test.ts
@@ -1,6 +1,6 @@
 import { AsyncLocalStorage } from "node:async_hooks"
 
-import { describe, expect, it, afterEach } from "vitest"
+import { describe, expect, it, afterEach, vi } from "vitest"
 
 import { type I18nInstance, getI18n, resetI18nRuntime } from "./index"
 import { createServerI18nScope } from "./server"
@@ -54,6 +54,45 @@ describe("@palamedes/runtime/server", () => {
       expect(firstScope.get()).toBe(i18n)
       expect(getI18n()).toBe(i18n)
     })
+  })
+
+  it("connects an isolated SSR bundle to the active request scope", async () => {
+    const scope = createServerI18nScope<I18nInstance>()
+    const outerI18n = createTestI18n("en")
+    const clientComponentI18n = createTestI18n("de")
+    vi.resetModules()
+    const isolatedRuntime = await import("./index")
+
+    scope.run(outerI18n, () => {
+      expect(isolatedRuntime.activateServerI18n(clientComponentI18n)).toBe(clientComponentI18n)
+      expect(isolatedRuntime.getI18n()).toBe(clientComponentI18n)
+      expect(getI18n()).toBe(clientComponentI18n)
+    })
+
+    isolatedRuntime.resetI18nRuntime()
+  })
+
+  it("keeps isolated SSR bundle activations request-local under concurrency", async () => {
+    const scope = createServerI18nScope<I18nInstance>()
+    const deI18n = createTestI18n("de")
+    const enI18n = createTestI18n("en")
+    vi.resetModules()
+    const isolatedRuntime = await import("./index")
+
+    await Promise.all([
+      scope.run(enI18n, async () => {
+        isolatedRuntime.activateServerI18n(deI18n)
+        await Promise.resolve()
+        expect(isolatedRuntime.getI18n()).toBe(deI18n)
+      }),
+      scope.run(deI18n, async () => {
+        isolatedRuntime.activateServerI18n(enI18n)
+        await Promise.resolve()
+        expect(isolatedRuntime.getI18n()).toBe(enI18n)
+      }),
+    ])
+
+    isolatedRuntime.resetI18nRuntime()
   })
 
   it("keeps concurrent async server scopes isolated", async () => {


### PR DESCRIPTION
## Summary

- prevent `useClientLocale` from invoking client synchronization during server rendering
- bridge React locale updates through `useSyncExternalStore`, including re-activation of the same mutable i18n instance
- connect Turbopack's isolated client-component SSR runtime to the existing request-local `AsyncLocalStorage` scope
- update all four Next.js examples to use fresh request-local SSR instances and pre-hydration client initialization
- keep server component and server action translations inside explicit request scopes

## Verification

- `CI=true pnpm format:check`
- `CI=true pnpm lint`
- `CI=true RUSTUP_TOOLCHAIN=1.95 pnpm check-types`
- `CI=true RUSTUP_TOOLCHAIN=1.95 pnpm build`
- `CI=true RUSTUP_TOOLCHAIN=1.95 pnpm test`
- `RUSTUP_TOOLCHAIN=1.95 cargo fmt --all -- --check`
- `RUSTUP_TOOLCHAIN=1.95 cargo clippy --workspace --all-targets --locked -- -D warnings`
- `RUSTUP_TOOLCHAIN=1.95 cargo test --workspace --locked`
- production builds for the cookie, route, subdomain, and TLD Next.js examples
- `CI=true RUSTUP_TOOLCHAIN=1.95 node scripts/verify-examples-browser.mjs --framework nextjs`

Fixes #402