### PR TITLE
fix(extract): align accessor placeholder names

### DIFF
--- a/crates/palamedes/src/extract.rs
+++ b/crates/palamedes/src/extract.rs
@@ -11,6 +11,7 @@ use crate::jsx_entities::decode_jsx_entities;
 use crate::jsx_message::{
     clean_jsx_text, join_jsx_message_parts, JoinedJsxMessage, JsxMessagePart,
 };
+use crate::placeholder_name::{expression_name, jsx_expression_name};
 use crate::translation_scope::validate_translation_macro_scopes;
 use oxc_allocator::Allocator;
 use oxc_ast::ast::{
@@ -1065,26 +1066,6 @@ fn extract_jsx_choice_value(
     Ok(None)
 }
 
-fn jsx_expression_name(expr: &JSXExpression<'_>) -> Option<String> {
-    match expr {
-        JSXExpression::Identifier(identifier) => Some(identifier.name.to_string()),
-        JSXExpression::StaticMemberExpression(member) => Some(member.property.name.to_string()),
-        JSXExpression::ComputedMemberExpression(member) => member
-            .static_property_name()
-            .map(|name| name.to_string())
-            .or_else(|| expression_name(&member.expression)),
-        JSXExpression::CallExpression(call) => getter_name(call.callee_name()?),
-        JSXExpression::LogicalExpression(logical) if logical.operator.is_coalesce() => {
-            expression_name(&logical.left).or_else(|| expression_name(&logical.right))
-        }
-        JSXExpression::LogicalExpression(logical) if logical.operator.is_or() => {
-            expression_name(&logical.left).or_else(|| expression_name(&logical.right))
-        }
-        JSXExpression::ParenthesizedExpression(expr) => expression_name(&expr.expression),
-        _ => None,
-    }
-}
-
 fn extract_jsx_children_as_message(
     children: &[JSXChild<'_>],
     _source: &str,
@@ -1230,69 +1211,7 @@ fn build_icu_message(
 }
 
 fn argument_expression_name(arg: &Argument<'_>) -> Option<String> {
-    match arg {
-        Argument::Identifier(identifier) => Some(identifier.name.to_string()),
-        Argument::StaticMemberExpression(member) => Some(member.property.name.to_string()),
-        Argument::ComputedMemberExpression(member) => member
-            .static_property_name()
-            .map(|name| name.to_string())
-            .or_else(|| expression_name(&member.expression)),
-        Argument::CallExpression(call) => getter_name(call.callee_name()?),
-        Argument::LogicalExpression(logical) if logical.operator.is_coalesce() => {
-            expression_name(&logical.left).or_else(|| expression_name(&logical.right))
-        }
-        Argument::LogicalExpression(logical) if logical.operator.is_or() => {
-            expression_name(&logical.left).or_else(|| expression_name(&logical.right))
-        }
-        Argument::ParenthesizedExpression(expr) => expression_name(&expr.expression),
-        _ => None,
-    }
-}
-
-fn expression_name(expr: &Expression<'_>) -> Option<String> {
-    let expr = expr.without_parentheses();
-
-    if let Expression::Identifier(identifier) = expr {
-        return Some(identifier.name.to_string());
-    }
-
-    if let Some(member) = expr.as_member_expression() {
-        return match member {
-            MemberExpression::ComputedMemberExpression(member) => member
-                .static_property_name()
-                .map(|name| name.to_string())
-                .or_else(|| expression_name(&member.expression)),
-            MemberExpression::StaticMemberExpression(member) => {
-                Some(member.property.name.to_string())
-            }
-            MemberExpression::PrivateFieldExpression(_) => None,
-        };
-    }
-
-    if let Expression::CallExpression(call) = expr {
-        return getter_name(call.callee_name()?);
-    }
-
-    if let Expression::LogicalExpression(logical) = expr {
-        if logical.operator.is_coalesce() || logical.operator.is_or() {
-            return expression_name(&logical.left).or_else(|| expression_name(&logical.right));
-        }
-    }
-
-    None
-}
-
-fn getter_name(name: &str) -> Option<String> {
-    if !name.starts_with("get") || name.len() <= 3 {
-        return None;
-    }
-    let suffix = &name[3..];
-    let first = suffix.chars().next()?;
-    first.is_ascii_uppercase().then(|| {
-        let mut result = first.to_ascii_lowercase().to_string();
-        result.push_str(&suffix[first.len_utf8()..]);
-        result
-    })
+    arg.as_expression().and_then(expression_name)
 }
 
 /// Extracts source-string-first messages from a JavaScript or TypeScript module.
@@ -1685,6 +1604,43 @@ function choices() {
         assert_eq!(
             placeholders.get("locale").map(String::as_str),
             Some("resolved.locale")
+        );
+    }
+
+    #[test]
+    fn extracts_zero_argument_accessor_placeholder_names() {
+        let messages = extract_messages(
+            r##"
+              import { plural, t } from "@palamedes/core/macro"
+              import { Plural, Trans } from "@palamedes/react/macro"
+
+              const tagged = t`You have ${count()} items`
+              const rich = <Trans>There are {props.quantity()} tasks</Trans>
+              const choice = plural(count(), { one: "# item", other: "# items" })
+              const richChoice = <Plural value={props.quantity()} one="# task" other="# tasks" />
+            "##,
+            "test.tsx",
+        )
+        .expect("zero-argument accessors should extract");
+
+        assert_eq!(
+            messages
+                .iter()
+                .map(|message| message.message.as_str())
+                .collect::<Vec<_>>(),
+            vec![
+                "You have {count} items",
+                "There are {quantity} tasks",
+                "{count, plural, one {# item} other {# items}}",
+                "{quantity, plural, one {# task} other {# tasks}}",
+            ]
+        );
+        assert_eq!(
+            messages[0].placeholders,
+            Some(BTreeMap::from([(
+                "count".to_string(),
+                "count()".to_string()
+            )]))
         );
     }
 

--- a/crates/palamedes/src/lib.rs
+++ b/crates/palamedes/src/lib.rs
@@ -29,6 +29,7 @@ mod extract;
 mod jsx_entities;
 mod jsx_message;
 mod message_metadata;
+mod placeholder_name;
 #[cfg(test)]
 mod test_support;
 mod transform;

--- a/crates/palamedes/src/placeholder_name.rs
+++ b/crates/palamedes/src/placeholder_name.rs
@@ -1,0 +1,59 @@
+use oxc_ast::ast::{CallExpression, Expression, JSXExpression};
+
+fn getter_name(name: &str) -> Option<String> {
+    if !name.starts_with("get") || name.len() <= 3 {
+        return None;
+    }
+
+    let suffix = &name[3..];
+    let first = suffix.chars().next()?;
+    first.is_ascii_uppercase().then(|| {
+        let mut result = first.to_ascii_lowercase().to_string();
+        result.push_str(&suffix[first.len_utf8()..]);
+        result
+    })
+}
+
+fn call_expression_name(call: &CallExpression<'_>) -> Option<String> {
+    let callee = call.callee_name()?;
+    getter_name(callee).or_else(|| call.arguments.is_empty().then(|| callee.to_string()))
+}
+
+pub(crate) fn expression_name(expr: &Expression<'_>) -> Option<String> {
+    match expr.without_parentheses() {
+        Expression::Identifier(identifier) => Some(identifier.name.to_string()),
+        Expression::StaticMemberExpression(member) => Some(member.property.name.to_string()),
+        Expression::ComputedMemberExpression(member) => member
+            .static_property_name()
+            .map(|name| name.to_string())
+            .or_else(|| expression_name(&member.expression)),
+        Expression::CallExpression(call) => call_expression_name(call),
+        Expression::LogicalExpression(logical) if logical.operator.is_coalesce() => {
+            expression_name(&logical.left).or_else(|| expression_name(&logical.right))
+        }
+        Expression::LogicalExpression(logical) if logical.operator.is_or() => {
+            expression_name(&logical.left).or_else(|| expression_name(&logical.right))
+        }
+        _ => None,
+    }
+}
+
+pub(crate) fn jsx_expression_name(expr: &JSXExpression<'_>) -> Option<String> {
+    match expr {
+        JSXExpression::Identifier(identifier) => Some(identifier.name.to_string()),
+        JSXExpression::StaticMemberExpression(member) => Some(member.property.name.to_string()),
+        JSXExpression::ComputedMemberExpression(member) => member
+            .static_property_name()
+            .map(|name| name.to_string())
+            .or_else(|| expression_name(&member.expression)),
+        JSXExpression::CallExpression(call) => call_expression_name(call),
+        JSXExpression::LogicalExpression(logical) if logical.operator.is_coalesce() => {
+            expression_name(&logical.left).or_else(|| expression_name(&logical.right))
+        }
+        JSXExpression::LogicalExpression(logical) if logical.operator.is_or() => {
+            expression_name(&logical.left).or_else(|| expression_name(&logical.right))
+        }
+        JSXExpression::ParenthesizedExpression(expr) => expression_name(&expr.expression),
+        _ => None,
+    }
+}

--- a/crates/palamedes/src/transform/messages.rs
+++ b/crates/palamedes/src/transform/messages.rs
@@ -1,8 +1,8 @@
 use std::collections::HashMap;
 
 use oxc_ast::ast::{
-    Argument, CallExpression, Expression, JSXAttributeValue, JSXChild, JSXExpression,
-    JSXOpeningElement, ObjectExpression, ObjectPropertyKind, TemplateLiteral,
+    Argument, Expression, JSXAttributeValue, JSXChild, JSXExpression, JSXOpeningElement,
+    ObjectExpression, ObjectPropertyKind, TemplateLiteral,
 };
 use oxc_span::GetSpan;
 
@@ -11,6 +11,7 @@ use crate::jsx_entities::decode_jsx_entities;
 use crate::jsx_message::{
     clean_jsx_text, join_jsx_message_parts, JoinedJsxMessage, JsxMessagePart,
 };
+use crate::placeholder_name::{expression_name, jsx_expression_name};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct ValueBinding {
@@ -133,48 +134,6 @@ pub(super) fn extract_jsx_value_binding(
     }
 
     Ok(None)
-}
-
-pub(super) fn jsx_expression_name(expr: &JSXExpression<'_>) -> Option<String> {
-    match expr {
-        JSXExpression::Identifier(identifier) => Some(identifier.name.to_string()),
-        JSXExpression::StaticMemberExpression(member) => Some(member.property.name.to_string()),
-        JSXExpression::ComputedMemberExpression(member) => member
-            .static_property_name()
-            .map(|name| name.to_string())
-            .or_else(|| expression_name(&member.expression)),
-        JSXExpression::CallExpression(call) => call_expression_name(call),
-        JSXExpression::LogicalExpression(logical) if logical.operator.is_coalesce() => {
-            expression_name(&logical.left).or_else(|| expression_name(&logical.right))
-        }
-        JSXExpression::LogicalExpression(logical) if logical.operator.is_or() => {
-            expression_name(&logical.left).or_else(|| expression_name(&logical.right))
-        }
-        JSXExpression::ParenthesizedExpression(expr) => expression_name(&expr.expression),
-        _ => None,
-    }
-}
-
-fn getter_name(name: &str) -> Option<String> {
-    if !name.starts_with("get") || name.len() <= 3 {
-        return None;
-    }
-    let suffix = &name[3..];
-    let first = suffix.chars().next()?;
-    first.is_ascii_uppercase().then(|| {
-        let mut result = first.to_ascii_lowercase().to_string();
-        result.push_str(&suffix[first.len_utf8()..]);
-        result
-    })
-}
-
-// Derive a placeholder name from a call expression. Prefer the unwrapped
-// getter name (`getCount()` -> `count`), but fall back to the bare callee for
-// argument-less accessor calls so reactive signal reads (`count()`, Solid's
-// `props.quantity()`) keep their own name instead of collapsing to "value".
-fn call_expression_name(call: &CallExpression<'_>) -> Option<String> {
-    let callee = call.callee_name()?;
-    getter_name(callee).or_else(|| call.arguments.is_empty().then(|| callee.to_string()))
 }
 
 pub(super) fn extract_choice_options_from_jsx(
@@ -399,27 +358,6 @@ pub(super) fn append_unique_bindings(
 ) {
     for binding in incoming {
         push_unique_binding(bindings, binding);
-    }
-}
-
-pub(super) fn expression_name(expr: &Expression<'_>) -> Option<String> {
-    let expr = expr.without_parentheses();
-
-    match expr {
-        Expression::Identifier(identifier) => Some(identifier.name.to_string()),
-        Expression::StaticMemberExpression(member) => Some(member.property.name.to_string()),
-        Expression::ComputedMemberExpression(member) => member
-            .static_property_name()
-            .map(|name| name.to_string())
-            .or_else(|| expression_name(&member.expression)),
-        Expression::CallExpression(call) => call_expression_name(call),
-        Expression::LogicalExpression(logical) if logical.operator.is_coalesce() => {
-            expression_name(&logical.left).or_else(|| expression_name(&logical.right))
-        }
-        Expression::LogicalExpression(logical) if logical.operator.is_or() => {
-            expression_name(&logical.left).or_else(|| expression_name(&logical.right))
-        }
-        _ => None,
     }
 }
 

--- a/crates/palamedes/src/transform/tests.rs
+++ b/crates/palamedes/src/transform/tests.rs
@@ -312,6 +312,29 @@ fn transforms_plural_choice_with_signal_accessor() {
 }
 
 #[test]
+fn extractor_and_transform_share_zero_argument_accessor_names() {
+    let source = r##"import { plural, t } from "@palamedes/core/macro";
+import { Plural, Trans } from "@palamedes/react/macro";
+
+const tagged = t`You have ${count()} items`;
+const rich = <Trans>There are {props.quantity()} tasks</Trans>;
+const choice = plural(count(), { one: "# item", other: "# items" });
+const richChoice = <Plural value={props.quantity()} one="# task" other="# tasks" />;
+"##;
+    let scoped_source = scope_macro_test_source(source, "test.tsx");
+    let extracted = crate::extract::extract_messages(&scoped_source, "test.tsx")
+        .expect("zero-argument accessors should extract");
+    let transformed = transform_macros(source, "test.tsx", None)
+        .expect("zero-argument accessors should transform");
+    let extracted_ids = extracted
+        .iter()
+        .map(|message| compiled_key(&message.message, message.context.as_deref()))
+        .collect::<Vec<_>>();
+
+    assert_eq!(transformed.compiled_ids, extracted_ids);
+}
+
+#[test]
 fn transforms_select_ordinal_choice_macros() {
     let result = transform_macros(
         "import { selectOrdinal } from \"@palamedes/core/macro\";\nconst msg = selectOrdinal(count, { one: \"#st\", other: \"#th\" });\n",


### PR DESCRIPTION
## Summary

- derive placeholder names through one shared implementation used by extraction and transformation
- preserve zero-argument accessor names such as `count()` and `props.quantity()` across templates, rich messages, and choice macros
- add an end-to-end regression assertion that extracted catalog keys match transformed runtime IDs

## Root cause

The transformer supported zero-argument reactive accessors, while the extractor only recognized `getX()` calls. That produced different source patterns and compiled IDs, or rejected otherwise transformable messages.

## Validation

- `RUSTUP_TOOLCHAIN=1.95 cargo fmt --all --check`
- `RUSTUP_TOOLCHAIN=1.95 cargo clippy --workspace --all-targets --locked -- -D warnings`
- `RUSTUP_TOOLCHAIN=1.95 cargo test --workspace --locked`
- `CI=true pnpm format:check`
- `CI=true pnpm lint`
- `CI=true RUSTUP_TOOLCHAIN=1.95 pnpm build`
- `CI=true RUSTUP_TOOLCHAIN=1.95 pnpm check-types`
- `CI=true RUSTUP_TOOLCHAIN=1.95 pnpm test`
- production JS wrapper reproduction for `plural(count(), …)` and ``t`…${count()}…` ``

Closes #406
