### PR TITLE
fix(i18n): support plural offsets end to end

### DIFF
--- a/crates/palamedes/src/choice.rs
+++ b/crates/palamedes/src/choice.rs
@@ -1,0 +1,70 @@
+const PLURAL_CATEGORIES: [&str; 6] = ["zero", "one", "two", "few", "many", "other"];
+const MAX_SAFE_INTEGER: f64 = 9_007_199_254_740_991.0;
+
+pub(crate) fn is_plural_format(format: &str) -> bool {
+    matches!(format, "plural" | "selectordinal")
+}
+
+pub(crate) fn normalize_choice_option_key(format: &str, key: &str) -> Option<String> {
+    if !is_plural_format(format) {
+        return Some(key.to_string());
+    }
+
+    if PLURAL_CATEGORIES.contains(&key) {
+        return Some(key.to_string());
+    }
+
+    let exact = key.strip_prefix('_').or_else(|| key.strip_prefix('='))?;
+    is_non_negative_integer(exact).then(|| format!("={exact}"))
+}
+
+pub(crate) fn normalize_string_offset(value: &str) -> Option<String> {
+    let value = value.trim();
+    let parsed = value.parse::<u64>().ok()?;
+    ((parsed as f64) <= MAX_SAFE_INTEGER).then(|| value.to_string())
+}
+
+pub(crate) fn normalize_numeric_offset(value: f64) -> Option<String> {
+    (value.is_finite() && (0.0..=MAX_SAFE_INTEGER).contains(&value) && value.fract() == 0.0)
+        .then(|| format!("{value:.0}"))
+}
+
+fn is_non_negative_integer(value: &str) -> bool {
+    !value.is_empty() && value.bytes().all(|byte| byte.is_ascii_digit())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{normalize_choice_option_key, normalize_numeric_offset, normalize_string_offset};
+
+    #[test]
+    fn validates_plural_categories_and_exact_keys() {
+        assert_eq!(
+            normalize_choice_option_key("plural", "one").as_deref(),
+            Some("one")
+        );
+        assert_eq!(
+            normalize_choice_option_key("selectordinal", "_2").as_deref(),
+            Some("=2")
+        );
+        assert_eq!(
+            normalize_choice_option_key("plural", "=0").as_deref(),
+            Some("=0")
+        );
+        assert_eq!(normalize_choice_option_key("plural", "invalid"), None);
+        assert_eq!(
+            normalize_choice_option_key("select", "invalid").as_deref(),
+            Some("invalid")
+        );
+    }
+
+    #[test]
+    fn validates_static_offsets() {
+        assert_eq!(normalize_string_offset(" 12 ").as_deref(), Some("12"));
+        assert_eq!(normalize_string_offset("-1"), None);
+        assert_eq!(normalize_string_offset("1.5"), None);
+        assert_eq!(normalize_numeric_offset(1.0).as_deref(), Some("1"));
+        assert_eq!(normalize_numeric_offset(-1.0), None);
+        assert_eq!(normalize_numeric_offset(1.5), None);
+    }
+}

--- a/crates/palamedes/src/choice.rs
+++ b/crates/palamedes/src/choice.rs
@@ -1,3 +1,7 @@
+use oxc_ast::ast::{Expression, JSXAttributeValue, JSXExpression};
+
+use crate::error::PalamedesError;
+
 const PLURAL_CATEGORIES: [&str; 6] = ["zero", "one", "two", "few", "many", "other"];
 const MAX_SAFE_INTEGER: f64 = 9_007_199_254_740_991.0;
 
@@ -27,6 +31,54 @@ pub(crate) fn normalize_string_offset(value: &str) -> Option<String> {
 pub(crate) fn normalize_numeric_offset(value: f64) -> Option<String> {
     (value.is_finite() && (0.0..=MAX_SAFE_INTEGER).contains(&value) && value.fract() == 0.0)
         .then(|| format!("{value:.0}"))
+}
+
+pub(crate) fn expression_offset_value(expression: &Expression<'_>) -> Option<String> {
+    match expression.without_parentheses() {
+        Expression::StringLiteral(literal) => normalize_string_offset(literal.value.as_str()),
+        Expression::TemplateLiteral(template) => template
+            .single_quasi()
+            .and_then(|value| normalize_string_offset(value.as_str())),
+        Expression::NumericLiteral(literal) => normalize_numeric_offset(literal.value),
+        _ => None,
+    }
+}
+
+pub(crate) fn jsx_offset_value(value: &JSXAttributeValue<'_>) -> Option<String> {
+    match value {
+        JSXAttributeValue::StringLiteral(literal) => {
+            normalize_string_offset(literal.value.as_str())
+        }
+        JSXAttributeValue::ExpressionContainer(container) => match &container.expression {
+            JSXExpression::StringLiteral(literal) => {
+                normalize_string_offset(literal.value.as_str())
+            }
+            JSXExpression::TemplateLiteral(template) => template
+                .single_quasi()
+                .and_then(|value| normalize_string_offset(value.as_str())),
+            JSXExpression::NumericLiteral(literal) => normalize_numeric_offset(literal.value),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+pub(crate) fn invalid_offset(macro_name: &str, location: &str) -> PalamedesError {
+    PalamedesError::UnsupportedMacroSyntax {
+        macro_name: macro_name.to_string(),
+        location: location.to_string(),
+        detail: "`offset` must be a static non-negative integer".to_string(),
+    }
+}
+
+pub(crate) fn invalid_choice_option(macro_name: &str, location: &str, key: &str) -> PalamedesError {
+    PalamedesError::UnsupportedMacroSyntax {
+        macro_name: macro_name.to_string(),
+        location: location.to_string(),
+        detail: format!(
+            "`{key}` is not a valid plural category; use zero, one, two, few, many, other, or an exact _N key"
+        ),
+    }
 }
 
 fn is_non_negative_integer(value: &str) -> bool {

--- a/crates/palamedes/src/extract.rs
+++ b/crates/palamedes/src/extract.rs
@@ -4,8 +4,8 @@ use std::path::{Path, PathBuf};
 
 use crate::catalog_update::{CatalogUpdateMessage, CatalogUpdateOrigin};
 use crate::choice::{
-    is_plural_format, normalize_choice_option_key, normalize_numeric_offset,
-    normalize_string_offset,
+    expression_offset_value, invalid_choice_option, invalid_offset, is_plural_format,
+    jsx_offset_value, normalize_choice_option_key,
 };
 use crate::descriptor::{
     descriptor_property_value, descriptor_static_property, unsupported_macro_syntax,
@@ -1248,54 +1248,6 @@ fn extract_choice_options_from_jsx(
         placeholders,
         offset,
     })
-}
-
-fn expression_offset_value(expression: &Expression<'_>) -> Option<String> {
-    match expression.without_parentheses() {
-        Expression::StringLiteral(literal) => normalize_string_offset(literal.value.as_str()),
-        Expression::TemplateLiteral(template) => template
-            .single_quasi()
-            .and_then(|value| normalize_string_offset(value.as_str())),
-        Expression::NumericLiteral(literal) => normalize_numeric_offset(literal.value),
-        _ => None,
-    }
-}
-
-fn jsx_offset_value(value: &JSXAttributeValue<'_>) -> Option<String> {
-    match value {
-        JSXAttributeValue::StringLiteral(literal) => {
-            normalize_string_offset(literal.value.as_str())
-        }
-        JSXAttributeValue::ExpressionContainer(container) => match &container.expression {
-            JSXExpression::StringLiteral(literal) => {
-                normalize_string_offset(literal.value.as_str())
-            }
-            JSXExpression::TemplateLiteral(template) => template
-                .single_quasi()
-                .and_then(|value| normalize_string_offset(value.as_str())),
-            JSXExpression::NumericLiteral(literal) => normalize_numeric_offset(literal.value),
-            _ => None,
-        },
-        _ => None,
-    }
-}
-
-fn invalid_offset(macro_name: &str, location: &str) -> PalamedesError {
-    PalamedesError::UnsupportedMacroSyntax {
-        macro_name: macro_name.to_string(),
-        location: location.to_string(),
-        detail: "`offset` must be a static non-negative integer".to_string(),
-    }
-}
-
-fn invalid_choice_option(macro_name: &str, location: &str, key: &str) -> PalamedesError {
-    PalamedesError::UnsupportedMacroSyntax {
-        macro_name: macro_name.to_string(),
-        location: location.to_string(),
-        detail: format!(
-            "`{key}` is not a valid plural category; use zero, one, two, few, many, other, or an exact _N key"
-        ),
-    }
 }
 
 fn build_icu_message(

--- a/crates/palamedes/src/extract.rs
+++ b/crates/palamedes/src/extract.rs
@@ -3,6 +3,10 @@ use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 
 use crate::catalog_update::{CatalogUpdateMessage, CatalogUpdateOrigin};
+use crate::choice::{
+    is_plural_format, normalize_choice_option_key, normalize_numeric_offset,
+    normalize_string_offset,
+};
 use crate::descriptor::{
     descriptor_property_value, descriptor_static_property, unsupported_macro_syntax,
 };
@@ -32,6 +36,12 @@ const PALAMEDES_MACRO_PACKAGES: [&str; 3] = [
 ];
 type ChoiceOptions = Vec<(String, String)>;
 const CHOICE_VALUE_FALLBACK_NAME: &str = "value";
+
+struct ExtractedChoiceOptions {
+    options: ChoiceOptions,
+    placeholders: BTreeMap<String, String>,
+    offset: Option<String>,
+}
 
 #[derive(Debug, Clone)]
 struct ImportedMacro {
@@ -317,6 +327,7 @@ impl<'a> Visit<'a> for ExtractionVisitor<'a> {
                 self.origin(it.span.start as usize),
                 self.current_scope(),
                 self.source,
+                &self.location(it.span.start as usize),
             ) {
                 Ok(Some(message)) => self.push(message),
                 Ok(None) => {
@@ -400,6 +411,7 @@ impl<'a> Visit<'a> for ExtractionVisitor<'a> {
                         self.origin(it.span.start as usize),
                         self.current_scope(),
                         self.source,
+                        &self.location(it.span.start as usize),
                     ),
                     _ => extract_from_descriptor_call(
                         it,
@@ -565,9 +577,13 @@ fn extract_choice_options_from_object(
     object: &ObjectExpression<'_>,
     source: &str,
     used_value_names: &mut HashMap<String, String>,
-) -> PalamedesResult<(ChoiceOptions, BTreeMap<String, String>)> {
+    format: &str,
+    macro_name: &str,
+    location: &str,
+) -> PalamedesResult<ExtractedChoiceOptions> {
     let mut options = Vec::new();
     let mut placeholders = BTreeMap::new();
+    let mut offset = None;
 
     for property in &object.properties {
         let ObjectPropertyKind::ObjectProperty(property) = property else {
@@ -575,6 +591,17 @@ fn extract_choice_options_from_object(
         };
         let Some(key) = property.key.static_name() else {
             continue;
+        };
+        let key = key.into_owned();
+        if is_plural_format(format) && key == "offset" {
+            offset = Some(
+                expression_offset_value(&property.value)
+                    .ok_or_else(|| invalid_offset(macro_name, location))?,
+            );
+            continue;
+        }
+        let Some(normalized_key) = normalize_choice_option_key(format, &key) else {
+            return Err(invalid_choice_option(macro_name, location, &key));
         };
         let (value, option_placeholders) = match property.value.without_parentheses() {
             Expression::StringLiteral(literal) => (literal.value.to_string(), BTreeMap::new()),
@@ -587,16 +614,15 @@ fn extract_choice_options_from_object(
             _ => continue,
         };
 
-        let key = key.into_owned();
-        if let Some(exact) = key.strip_prefix('_') {
-            options.push((format!("={exact}"), value));
-        } else {
-            options.push((key, value));
-        }
+        options.push((normalized_key, value));
         placeholders.extend(option_placeholders);
     }
 
-    Ok((options, placeholders))
+    Ok(ExtractedChoiceOptions {
+        options,
+        placeholders,
+        offset,
+    })
 }
 
 fn extract_from_jsx_element(
@@ -605,6 +631,7 @@ fn extract_from_jsx_element(
     origin: (String, usize, Option<usize>),
     scope: Option<String>,
     source: &str,
+    location: &str,
 ) -> PalamedesResult<Option<ExtractedMessageRecord>> {
     let attrs = jsx_attributes(&element.opening_element);
 
@@ -645,28 +672,30 @@ fn extract_from_jsx_element(
         else {
             return Ok(None);
         };
-        let mut used_value_names = HashMap::from([(value_name.clone(), value_expression)]);
-        let (options, placeholders) = extract_choice_options_from_jsx(
-            &element.opening_element,
-            source,
-            &mut used_value_names,
-        )?;
-        if options.is_empty() {
-            return Ok(None);
-        }
-
         let format = match macro_name {
             "Plural" => "plural",
             "Select" => "select",
             "SelectOrdinal" => "selectordinal",
             _ => return Ok(None),
         };
+        let mut used_value_names = HashMap::from([(value_name.clone(), value_expression)]);
+        let extracted_options = extract_choice_options_from_jsx(
+            &element.opening_element,
+            source,
+            &mut used_value_names,
+            format,
+            macro_name,
+            location,
+        )?;
+        if extracted_options.options.is_empty() {
+            return Ok(None);
+        }
 
         let message = build_icu_message(
             format,
             &value_name,
-            &options,
-            attrs.get("offset").map(String::as_str),
+            &extracted_options.options,
+            extracted_options.offset.as_deref(),
         );
         let context = attrs.get("context").cloned();
 
@@ -674,7 +703,8 @@ fn extract_from_jsx_element(
             message,
             comment: attrs.get("comment").cloned(),
             context,
-            placeholders: (!placeholders.is_empty()).then_some(placeholders),
+            placeholders: (!extracted_options.placeholders.is_empty())
+                .then_some(extracted_options.placeholders),
             origin,
             scope,
         }));
@@ -770,6 +800,7 @@ fn extract_from_choice_call(
     origin: (String, usize, Option<usize>),
     scope: Option<String>,
     source: &str,
+    location: &str,
 ) -> PalamedesResult<Option<ExtractedMessageRecord>> {
     let Some(value_arg) = call.arguments.first() else {
         return Ok(None);
@@ -788,26 +819,37 @@ fn extract_from_choice_call(
         .and_then(|expression| expression_source(expression, source))
         .unwrap_or_else(|| value_name.clone());
     let mut used_value_names = HashMap::from([(value_name.clone(), value_expression)]);
-    let (options, placeholders) =
-        extract_choice_options_from_object(object, source, &mut used_value_names)?;
-    if options.is_empty() {
-        return Ok(None);
-    }
-
     let format = match macro_name {
         "plural" => "plural",
         "select" => "select",
         "selectOrdinal" => "selectordinal",
         _ => return Ok(None),
     };
+    let extracted_options = extract_choice_options_from_object(
+        object,
+        source,
+        &mut used_value_names,
+        format,
+        macro_name,
+        location,
+    )?;
+    if extracted_options.options.is_empty() {
+        return Ok(None);
+    }
 
-    let message = build_icu_message(format, &value_name, &options, None);
+    let message = build_icu_message(
+        format,
+        &value_name,
+        &extracted_options.options,
+        extracted_options.offset.as_deref(),
+    );
 
     Ok(Some(ExtractedMessageRecord {
         message,
         comment: None,
         context: None,
-        placeholders: (!placeholders.is_empty()).then_some(placeholders),
+        placeholders: (!extracted_options.placeholders.is_empty())
+            .then_some(extracted_options.placeholders),
         origin,
         scope,
     }))
@@ -1144,9 +1186,13 @@ fn extract_choice_options_from_jsx(
     opening_element: &JSXOpeningElement<'_>,
     source: &str,
     used_value_names: &mut HashMap<String, String>,
-) -> PalamedesResult<(ChoiceOptions, BTreeMap<String, String>)> {
+    format: &str,
+    macro_name: &str,
+    location: &str,
+) -> PalamedesResult<ExtractedChoiceOptions> {
     let mut options = Vec::new();
     let mut placeholders = BTreeMap::new();
+    let mut offset = None;
 
     for attr in &opening_element.attributes {
         let Some(attr) = attr.as_attribute() else {
@@ -1155,10 +1201,22 @@ fn extract_choice_options_from_jsx(
         let key = attr.name.get_identifier().name.to_string();
         if matches!(
             key.as_str(),
-            "id" | "message" | "comment" | "context" | "value" | "offset"
+            "id" | "message" | "comment" | "context" | "value"
         ) {
             continue;
         }
+        if is_plural_format(format) && key == "offset" {
+            offset = Some(
+                attr.value
+                    .as_ref()
+                    .and_then(jsx_offset_value)
+                    .ok_or_else(|| invalid_offset(macro_name, location))?,
+            );
+            continue;
+        }
+        let Some(normalized_key) = normalize_choice_option_key(format, &key) else {
+            return Err(invalid_choice_option(macro_name, location, &key));
+        };
         let Some(attr_value) = attr.value.as_ref() else {
             continue;
         };
@@ -1181,15 +1239,63 @@ fn extract_choice_options_from_jsx(
             _ => continue,
         };
 
-        if let Some(exact) = key.strip_prefix('_') {
-            options.push((format!("={exact}"), value));
-        } else {
-            options.push((key, value));
-        }
+        options.push((normalized_key, value));
         placeholders.extend(option_placeholders);
     }
 
-    Ok((options, placeholders))
+    Ok(ExtractedChoiceOptions {
+        options,
+        placeholders,
+        offset,
+    })
+}
+
+fn expression_offset_value(expression: &Expression<'_>) -> Option<String> {
+    match expression.without_parentheses() {
+        Expression::StringLiteral(literal) => normalize_string_offset(literal.value.as_str()),
+        Expression::TemplateLiteral(template) => template
+            .single_quasi()
+            .and_then(|value| normalize_string_offset(value.as_str())),
+        Expression::NumericLiteral(literal) => normalize_numeric_offset(literal.value),
+        _ => None,
+    }
+}
+
+fn jsx_offset_value(value: &JSXAttributeValue<'_>) -> Option<String> {
+    match value {
+        JSXAttributeValue::StringLiteral(literal) => {
+            normalize_string_offset(literal.value.as_str())
+        }
+        JSXAttributeValue::ExpressionContainer(container) => match &container.expression {
+            JSXExpression::StringLiteral(literal) => {
+                normalize_string_offset(literal.value.as_str())
+            }
+            JSXExpression::TemplateLiteral(template) => template
+                .single_quasi()
+                .and_then(|value| normalize_string_offset(value.as_str())),
+            JSXExpression::NumericLiteral(literal) => normalize_numeric_offset(literal.value),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+fn invalid_offset(macro_name: &str, location: &str) -> PalamedesError {
+    PalamedesError::UnsupportedMacroSyntax {
+        macro_name: macro_name.to_string(),
+        location: location.to_string(),
+        detail: "`offset` must be a static non-negative integer".to_string(),
+    }
+}
+
+fn invalid_choice_option(macro_name: &str, location: &str, key: &str) -> PalamedesError {
+    PalamedesError::UnsupportedMacroSyntax {
+        macro_name: macro_name.to_string(),
+        location: location.to_string(),
+        detail: format!(
+            "`{key}` is not a valid plural category; use zero, one, two, few, many, other, or an exact _N key"
+        ),
+    }
 }
 
 fn build_icu_message(
@@ -1642,6 +1748,57 @@ function choices() {
                 "count()".to_string()
             )]))
         );
+    }
+
+    #[test]
+    fn extracts_plural_offsets_from_calls_and_jsx() {
+        let messages = extract_messages(
+            r##"
+              import { plural } from "@palamedes/core/macro"
+              import { Plural } from "@palamedes/react/macro"
+
+              const call = plural(count, { offset: 1, one: "# item", other: "# items" })
+              const stringCall = plural(count, { offset: "2", one: "# item", other: "# items" })
+              const jsx = <Plural value={count} offset={1} one="# item" other="# items" />
+            "##,
+            "test.tsx",
+        )
+        .expect("static plural offsets should extract");
+
+        assert_eq!(
+            messages
+                .iter()
+                .map(|message| message.message.as_str())
+                .collect::<Vec<_>>(),
+            vec![
+                "{count, plural, offset:1 one {# item} other {# items}}",
+                "{count, plural, offset:2 one {# item} other {# items}}",
+                "{count, plural, offset:1 one {# item} other {# items}}",
+            ]
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_plural_offsets_and_categories() {
+        let cases = [
+            r##"
+              import { plural } from "@palamedes/core/macro"
+              const message = plural(count, { offset: dynamicOffset, one: "# item", other: "# items" })
+            "##,
+            r##"
+              import { plural } from "@palamedes/core/macro"
+              const message = plural(count, { invalid: "broken", other: "# items" })
+            "##,
+            r##"
+              import { Plural } from "@palamedes/react/macro"
+              const message = <Plural value={count} offset={-1} one="# item" other="# items" />
+            "##,
+        ];
+
+        for source in cases {
+            let error = extract_messages(source, "test.tsx").expect_err("invalid plural metadata");
+            assert!(error.to_string().contains("Unsupported"));
+        }
     }
 
     #[test]

--- a/crates/palamedes/src/lib.rs
+++ b/crates/palamedes/src/lib.rs
@@ -22,6 +22,7 @@ mod catalog_artifact;
 mod catalog_audit;
 mod catalog_combine;
 mod catalog_update;
+mod choice;
 mod descriptor;
 mod diagnostic;
 mod error;

--- a/crates/palamedes/src/transform/messages.rs
+++ b/crates/palamedes/src/transform/messages.rs
@@ -7,8 +7,8 @@ use oxc_ast::ast::{
 use oxc_span::GetSpan;
 
 use crate::choice::{
-    is_plural_format, normalize_choice_option_key, normalize_numeric_offset,
-    normalize_string_offset,
+    expression_offset_value, invalid_choice_option, invalid_offset, is_plural_format,
+    jsx_offset_value, normalize_choice_option_key,
 };
 use crate::error::{PalamedesError, PalamedesResult};
 use crate::jsx_entities::decode_jsx_entities;
@@ -219,54 +219,6 @@ pub(super) fn extract_choice_options_from_jsx(
         values,
         offset,
     })
-}
-
-fn expression_offset_value(expression: &Expression<'_>) -> Option<String> {
-    match expression.without_parentheses() {
-        Expression::StringLiteral(literal) => normalize_string_offset(literal.value.as_str()),
-        Expression::TemplateLiteral(template) => template
-            .single_quasi()
-            .and_then(|value| normalize_string_offset(value.as_str())),
-        Expression::NumericLiteral(literal) => normalize_numeric_offset(literal.value),
-        _ => None,
-    }
-}
-
-fn jsx_offset_value(value: &JSXAttributeValue<'_>) -> Option<String> {
-    match value {
-        JSXAttributeValue::StringLiteral(literal) => {
-            normalize_string_offset(literal.value.as_str())
-        }
-        JSXAttributeValue::ExpressionContainer(container) => match &container.expression {
-            JSXExpression::StringLiteral(literal) => {
-                normalize_string_offset(literal.value.as_str())
-            }
-            JSXExpression::TemplateLiteral(template) => template
-                .single_quasi()
-                .and_then(|value| normalize_string_offset(value.as_str())),
-            JSXExpression::NumericLiteral(literal) => normalize_numeric_offset(literal.value),
-            _ => None,
-        },
-        _ => None,
-    }
-}
-
-fn invalid_offset(macro_name: &str, location: &str) -> PalamedesError {
-    PalamedesError::UnsupportedMacroSyntax {
-        macro_name: macro_name.to_string(),
-        location: location.to_string(),
-        detail: "`offset` must be a static non-negative integer".to_string(),
-    }
-}
-
-fn invalid_choice_option(macro_name: &str, location: &str, key: &str) -> PalamedesError {
-    PalamedesError::UnsupportedMacroSyntax {
-        macro_name: macro_name.to_string(),
-        location: location.to_string(),
-        detail: format!(
-            "`{key}` is not a valid plural category; use zero, one, two, few, many, other, or an exact _N key"
-        ),
-    }
 }
 
 pub(super) fn opening_element_to_component(

--- a/crates/palamedes/src/transform/messages.rs
+++ b/crates/palamedes/src/transform/messages.rs
@@ -6,6 +6,10 @@ use oxc_ast::ast::{
 };
 use oxc_span::GetSpan;
 
+use crate::choice::{
+    is_plural_format, normalize_choice_option_key, normalize_numeric_offset,
+    normalize_string_offset,
+};
 use crate::error::{PalamedesError, PalamedesResult};
 use crate::jsx_entities::decode_jsx_entities;
 use crate::jsx_message::{
@@ -22,6 +26,7 @@ pub(super) struct ValueBinding {
 pub(super) struct ExtractedChoiceOptions {
     pub options: Vec<(String, String)>,
     pub values: Vec<ValueBinding>,
+    pub offset: Option<String>,
 }
 
 const CHOICE_VALUE_FALLBACK_NAME: &str = "value";
@@ -37,9 +42,13 @@ pub(super) fn extract_choice_options(
     object: &ObjectExpression<'_>,
     source: &str,
     used_value_names: &mut HashMap<String, String>,
+    format: &str,
+    macro_name: &str,
+    location: &str,
 ) -> PalamedesResult<ExtractedChoiceOptions> {
     let mut options = Vec::new();
     let mut values = Vec::new();
+    let mut offset = None;
 
     for property in &object.properties {
         let ObjectPropertyKind::ObjectProperty(property) = property else {
@@ -47,6 +56,17 @@ pub(super) fn extract_choice_options(
         };
         let Some(key) = property.key.static_name() else {
             continue;
+        };
+        let key = key.into_owned();
+        if is_plural_format(format) && key == "offset" {
+            offset = Some(
+                expression_offset_value(&property.value)
+                    .ok_or_else(|| invalid_offset(macro_name, location))?,
+            );
+            continue;
+        }
+        let Some(normalized_key) = normalize_choice_option_key(format, &key) else {
+            return Err(invalid_choice_option(macro_name, location, &key));
         };
         let (value, option_values) = match property.value.without_parentheses() {
             Expression::StringLiteral(literal) => (literal.value.to_string(), Vec::new()),
@@ -59,16 +79,15 @@ pub(super) fn extract_choice_options(
             _ => continue,
         };
 
-        let normalized_key = if let Some(exact) = key.strip_prefix('_') {
-            format!("={exact}")
-        } else {
-            key.into_owned()
-        };
         options.push((normalized_key, value));
         append_unique_bindings(&mut values, option_values);
     }
 
-    Ok(ExtractedChoiceOptions { options, values })
+    Ok(ExtractedChoiceOptions {
+        options,
+        values,
+        offset,
+    })
 }
 
 pub(super) fn jsx_attribute_string_value(value: &JSXAttributeValue<'_>) -> Option<String> {
@@ -140,9 +159,13 @@ pub(super) fn extract_choice_options_from_jsx(
     opening_element: &JSXOpeningElement<'_>,
     source: &str,
     used_value_names: &mut HashMap<String, String>,
+    format: &str,
+    macro_name: &str,
+    location: &str,
 ) -> PalamedesResult<ExtractedChoiceOptions> {
     let mut options = Vec::new();
     let mut values = Vec::new();
+    let mut offset = None;
 
     for attr in &opening_element.attributes {
         let Some(attr) = attr.as_attribute() else {
@@ -151,10 +174,22 @@ pub(super) fn extract_choice_options_from_jsx(
         let key = attr.name.get_identifier().name.to_string();
         if matches!(
             key.as_str(),
-            "id" | "message" | "comment" | "context" | "value" | "offset"
+            "id" | "message" | "comment" | "context" | "value"
         ) {
             continue;
         }
+        if is_plural_format(format) && key == "offset" {
+            offset = Some(
+                attr.value
+                    .as_ref()
+                    .and_then(jsx_offset_value)
+                    .ok_or_else(|| invalid_offset(macro_name, location))?,
+            );
+            continue;
+        }
+        let Some(normalized_key) = normalize_choice_option_key(format, &key) else {
+            return Err(invalid_choice_option(macro_name, location, &key));
+        };
         let Some(attr_value) = attr.value.as_ref() else {
             continue;
         };
@@ -175,15 +210,63 @@ pub(super) fn extract_choice_options_from_jsx(
             _ => continue,
         };
 
-        if let Some(exact) = key.strip_prefix('_') {
-            options.push((format!("={exact}"), value));
-        } else {
-            options.push((key, value));
-        }
+        options.push((normalized_key, value));
         append_unique_bindings(&mut values, option_values);
     }
 
-    Ok(ExtractedChoiceOptions { options, values })
+    Ok(ExtractedChoiceOptions {
+        options,
+        values,
+        offset,
+    })
+}
+
+fn expression_offset_value(expression: &Expression<'_>) -> Option<String> {
+    match expression.without_parentheses() {
+        Expression::StringLiteral(literal) => normalize_string_offset(literal.value.as_str()),
+        Expression::TemplateLiteral(template) => template
+            .single_quasi()
+            .and_then(|value| normalize_string_offset(value.as_str())),
+        Expression::NumericLiteral(literal) => normalize_numeric_offset(literal.value),
+        _ => None,
+    }
+}
+
+fn jsx_offset_value(value: &JSXAttributeValue<'_>) -> Option<String> {
+    match value {
+        JSXAttributeValue::StringLiteral(literal) => {
+            normalize_string_offset(literal.value.as_str())
+        }
+        JSXAttributeValue::ExpressionContainer(container) => match &container.expression {
+            JSXExpression::StringLiteral(literal) => {
+                normalize_string_offset(literal.value.as_str())
+            }
+            JSXExpression::TemplateLiteral(template) => template
+                .single_quasi()
+                .and_then(|value| normalize_string_offset(value.as_str())),
+            JSXExpression::NumericLiteral(literal) => normalize_numeric_offset(literal.value),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+fn invalid_offset(macro_name: &str, location: &str) -> PalamedesError {
+    PalamedesError::UnsupportedMacroSyntax {
+        macro_name: macro_name.to_string(),
+        location: location.to_string(),
+        detail: "`offset` must be a static non-negative integer".to_string(),
+    }
+}
+
+fn invalid_choice_option(macro_name: &str, location: &str, key: &str) -> PalamedesError {
+    PalamedesError::UnsupportedMacroSyntax {
+        macro_name: macro_name.to_string(),
+        location: location.to_string(),
+        detail: format!(
+            "`{key}` is not a valid plural category; use zero, one, two, few, many, other, or an exact _N key"
+        ),
+    }
 }
 
 pub(super) fn opening_element_to_component(

--- a/crates/palamedes/src/transform/runtime.rs
+++ b/crates/palamedes/src/transform/runtime.rs
@@ -299,6 +299,7 @@ pub(super) fn transform_choice_call(
     call: &CallExpression<'_>,
     source: &str,
     macro_name: &str,
+    location: &str,
     options: &NativeTransformOptions,
 ) -> PalamedesResult<Option<(String, String)>> {
     let Some(value_arg) = call.arguments.first() else {
@@ -318,18 +319,30 @@ pub(super) fn transform_choice_call(
     let mut used_value_names = std::collections::HashMap::new();
     let value_binding = choice_expression_binding(value_expr, source, &mut used_value_names);
     let value_name = value_binding.name.clone();
-    let extracted_options = extract_choice_options(choice_object, source, &mut used_value_names)?;
-
-    if extracted_options.options.is_empty() {
-        return Ok(None);
-    }
-
     let format = if macro_name == "selectOrdinal" {
         "selectordinal"
     } else {
         macro_name
     };
-    let message = build_icu_message(format, &value_name, &extracted_options.options, None);
+    let extracted_options = extract_choice_options(
+        choice_object,
+        source,
+        &mut used_value_names,
+        format,
+        macro_name,
+        location,
+    )?;
+
+    if extracted_options.options.is_empty() {
+        return Ok(None);
+    }
+
+    let message = build_icu_message(
+        format,
+        &value_name,
+        &extracted_options.options,
+        extracted_options.offset.as_deref(),
+    );
     let lookup_key = compiled_key(&message, None);
     let mut values = vec![value_binding];
     append_unique_bindings(&mut values, extracted_options.values);
@@ -393,6 +406,7 @@ pub(super) fn transform_choice_jsx_element(
     element: &JSXElement<'_>,
     source: &str,
     macro_name: &str,
+    location: &str,
     options: &NativeTransformOptions,
 ) -> PalamedesResult<Option<(String, String)>> {
     let attrs = jsx_attributes(&element.opening_element);
@@ -408,24 +422,30 @@ pub(super) fn transform_choice_jsx_element(
         return Ok(None);
     };
     let value_name = value_binding.name.clone();
-    let extracted_options =
-        extract_choice_options_from_jsx(&element.opening_element, source, &mut used_value_names)?;
-
-    if extracted_options.options.is_empty() {
-        return Ok(None);
-    }
-
     let format = match macro_name {
         "Plural" => "plural",
         "Select" => "select",
         "SelectOrdinal" => "selectordinal",
         _ => return Ok(None),
     };
+    let extracted_options = extract_choice_options_from_jsx(
+        &element.opening_element,
+        source,
+        &mut used_value_names,
+        format,
+        macro_name,
+        location,
+    )?;
+
+    if extracted_options.options.is_empty() {
+        return Ok(None);
+    }
+
     let message = build_icu_message(
         format,
         &value_name,
         &extracted_options.options,
-        attrs.get("offset").map(String::as_str),
+        extracted_options.offset.as_deref(),
     );
     let lookup_key = compiled_key(&message, context.as_deref());
     let mut values = vec![value_binding];

--- a/crates/palamedes/src/transform/tests.rs
+++ b/crates/palamedes/src/transform/tests.rs
@@ -534,6 +534,56 @@ fn transforms_plural_jsx_macro() {
 }
 
 #[test]
+fn transforms_plural_offsets_from_calls_and_jsx() {
+    let result = transform_macros(
+        r##"import { plural } from "@palamedes/core/macro";
+import { Plural } from "@palamedes/react/macro";
+const call = plural(count, { offset: 1, one: "# item", other: "# items" });
+const stringCall = plural(count, { offset: "2", one: "# item", other: "# items" });
+const jsx = <Plural value={count} offset={1} one="# item" other="# items" />;
+"##,
+        "test.tsx",
+        None,
+    )
+    .expect("static plural offsets should transform");
+
+    assert!(result
+        .code
+        .contains("message: \"{count, plural, offset:1 one {# item} other {# items}}\""));
+    assert!(result
+        .code
+        .contains("message: \"{count, plural, offset:2 one {# item} other {# items}}\""));
+    assert_eq!(
+        result
+            .code
+            .matches("message: \"{count, plural, offset:1 one {# item} other {# items}}\"")
+            .count(),
+        2
+    );
+}
+
+#[test]
+fn rejects_invalid_plural_offsets_and_categories() {
+    let cases = [
+        r##"import { plural } from "@palamedes/core/macro";
+const message = plural(count, { offset: dynamicOffset, one: "# item", other: "# items" });
+"##,
+        r##"import { plural } from "@palamedes/core/macro";
+const message = plural(count, { invalid: "broken", other: "# items" });
+"##,
+        r##"import { Plural } from "@palamedes/react/macro";
+const message = <Plural value={count} offset={-1} one="# item" other="# items" />;
+"##,
+    ];
+
+    for source in cases {
+        let error = transform_macros(source, "test.tsx", None)
+            .expect_err("invalid plural metadata should fail");
+        assert!(error.to_string().contains("Unsupported"));
+    }
+}
+
+#[test]
 fn transforms_plural_jsx_branch_interpolations() {
     let result = transform_macros(
         r##"import { Plural } from "@palamedes/react/macro";

--- a/crates/palamedes/src/transform/visitor.rs
+++ b/crates/palamedes/src/transform/visitor.rs
@@ -133,6 +133,7 @@ impl<'a> Visit<'a> for TransformVisitor<'a> {
                 it,
                 self.source,
                 &macro_info.imported_name,
+                &source_location(self.source, self.filename, it.span.start as usize),
                 self.options,
             ),
             _ => Ok(None),
@@ -277,6 +278,7 @@ impl<'a> Visit<'a> for TransformVisitor<'a> {
                     it,
                     self.source,
                     &macro_info.imported_name,
+                    &location,
                     self.options,
                 ) {
                     Ok(Some((text, compiled_id))) => {

--- a/packages/core/src/messageFormat.test.ts
+++ b/packages/core/src/messageFormat.test.ts
@@ -42,6 +42,25 @@ describe("parseMessagePattern", () => {
       },
     ])
   })
+
+  it("parses plural offsets separately from choice keys", () => {
+    expect(
+      parseMessagePattern(
+        "{count, plural, offset:1 one {you and one other} other {you and # others}}"
+      )
+    ).toStrictEqual([
+      {
+        type: "choice",
+        variable: "count",
+        kind: "plural",
+        offset: 1,
+        options: {
+          one: [{ type: "text", value: "you and one other" }],
+          other: [{ type: "text", value: "you and # others" }],
+        },
+      },
+    ])
+  })
 })
 
 describe("formatMessagePattern", () => {
@@ -75,5 +94,24 @@ describe("formatMessagePattern", () => {
 
   it("renders a self-closing placeholder as empty text", () => {
     expect(formatMessagePattern("Line one<0/>Line two")).toBe("Line oneLine two")
+  })
+
+  it("applies plural offsets to category selection and pound replacement", () => {
+    const message =
+      "{n, plural, offset:1 =0 {nobody} =3 {exactly #} one {you and one other} other {you and # others}}"
+
+    expect(formatMessagePattern(message, { n: 0 }, "en")).toBe("nobody")
+    expect(formatMessagePattern(message, { n: 2 }, "en")).toBe("you and one other")
+    expect(formatMessagePattern(message, { n: 3 }, "en")).toBe("exactly 2")
+    expect(formatMessagePattern(message, { n: 4 }, "en")).toBe("you and 3 others")
+  })
+
+  it("rejects malformed plural offsets", () => {
+    expect(() =>
+      formatMessagePattern("{n, plural, offset:-1 other {# items}}", { n: 2 }, "en")
+    ).toThrow(/non-negative integer plural offset/)
+    expect(() =>
+      formatMessagePattern("{n, plural, offset:1.5 other {# items}}", { n: 2 }, "en")
+    ).toThrow(/non-negative integer plural offset/)
   })
 })

--- a/packages/core/src/messageFormat.ts
+++ b/packages/core/src/messageFormat.ts
@@ -24,6 +24,7 @@ export type MessageChoiceNode = {
   type: "choice"
   variable: string
   kind: "plural" | "select" | "selectordinal"
+  offset?: number
   options: Record<string, MessageNode[]>
 }
 
@@ -174,6 +175,7 @@ function parseBraceExpression(state: ParserState, poundIsSyntax: boolean): Messa
   }
 
   expectChar(state, ",")
+  const offset = kind === "plural" || kind === "selectordinal" ? readPluralOffset(state) : undefined
 
   const options: Record<string, MessageNode[]> = {}
   while (state.index < state.input.length) {
@@ -195,8 +197,34 @@ function parseBraceExpression(state: ParserState, poundIsSyntax: boolean): Messa
     type: "choice",
     variable: name,
     kind: kind as MessageChoiceNode["kind"],
+    ...(offset === undefined ? {} : { offset }),
     options,
   }
+}
+
+function readPluralOffset(state: ParserState): number | undefined {
+  skipWhitespace(state)
+  if (!state.input.startsWith("offset:", state.index)) {
+    return undefined
+  }
+
+  state.index += "offset:".length
+  skipWhitespace(state)
+  const start = state.index
+  while (/\d/.test(state.input[state.index] ?? "")) {
+    state.index += 1
+  }
+
+  const offset = Number(state.input.slice(start, state.index))
+  if (
+    state.index === start ||
+    !Number.isSafeInteger(offset) ||
+    !/\s/.test(state.input[state.index] ?? "")
+  ) {
+    throw new Error("Expected a non-negative integer plural offset while parsing message pattern.")
+  }
+
+  return offset
 }
 
 function isFormattedArgumentKind(kind: string): kind is MessageFormattedArgumentNode["format"] {
@@ -419,7 +447,8 @@ function renderNodeToString(
     }
     case "choice": {
       const value = values[node.variable]
-      const nextPluralValue = node.kind === "select" ? pluralValue : normalizeNumericValue(value)
+      const nextPluralValue =
+        node.kind === "select" ? pluralValue : pluralOperand(node, normalizeNumericValue(value))
       return renderNodesToString(selectChoice(node, value, locale), values, locale, nextPluralValue)
     }
   }
@@ -550,6 +579,7 @@ function selectChoice(node: MessageChoiceNode, value: unknown, locale?: string):
     return node.options[exactKey]
   }
 
+  const operand = pluralOperand(node, numericValue)
   const pluralRules = new Intl.PluralRules(undefined, {
     localeMatcher: "best fit",
     type: node.kind === "selectordinal" ? "ordinal" : "cardinal",
@@ -557,8 +587,12 @@ function selectChoice(node: MessageChoiceNode, value: unknown, locale?: string):
   const resolvedRules = locale
     ? new Intl.PluralRules(locale, { type: node.kind === "selectordinal" ? "ordinal" : "cardinal" })
     : pluralRules
-  const category = resolvedRules.select(numericValue)
+  const category = resolvedRules.select(operand)
   return node.options[category] ?? node.options.other ?? []
+}
+
+function pluralOperand(node: MessageChoiceNode, numericValue: number): number {
+  return numericValue - (node.offset ?? 0)
 }
 
 function normalizeNumericValue(value: unknown): number {

--- a/packages/extractor/src/extractMessages.test.ts
+++ b/packages/extractor/src/extractMessages.test.ts
@@ -257,6 +257,35 @@ const descriptor = t({ message })
       expect(messages[1].message).toBe("{gender, select, male {He} female {She} other {They}}")
     })
 
+    it("extracts static plural offsets and rejects invalid choice metadata", () => {
+      const code = `
+        import { plural } from "@palamedes/core/macro"
+        import { Plural } from "@palamedes/react/macro"; function messages() {
+        const call = plural(count, { offset: 1, one: "# item", other: "# items" })
+        const jsx = <Plural value={count} offset={1} one="# item" other="# items" />
+        }
+      `
+
+      expect(extract(code).map((message) => message.message)).toStrictEqual([
+        "{count, plural, offset:1 one {# item} other {# items}}",
+        "{count, plural, offset:1 one {# item} other {# items}}",
+      ])
+      expect(() =>
+        extract(`
+          import { plural } from "@palamedes/core/macro"; function messages() {
+          plural(count, { offset: dynamicOffset, one: "# item", other: "# items" })
+          }
+        `)
+      ).toThrow(/`offset` must be a static non-negative integer/)
+      expect(() =>
+        extract(`
+          import { plural } from "@palamedes/core/macro"; function messages() {
+          plural(count, { invalid: "broken", other: "# items" })
+          }
+        `)
+      ).toThrow(/`invalid` is not a valid plural category/)
+    })
+
     it("extracts interpolated plural branches with placeholder metadata", () => {
       const code = `
         import { plural } from "@palamedes/core/macro"

--- a/packages/react/src/index.test.tsx
+++ b/packages/react/src/index.test.tsx
@@ -73,6 +73,17 @@ describe("@palamedes/react", () => {
     expect(rich).toBe("you and <strong>2</strong> others")
   })
 
+  it("rejects invalid offsets at the direct component boundary", () => {
+    const i18n = createI18n()
+    setClientI18n(i18n)
+
+    for (const offset of [Number.NaN, -1, 1.5, Number.MAX_SAFE_INTEGER + 1]) {
+      expect(() =>
+        renderToStaticMarkup(<Plural value={2} offset={offset} one="# item" other="# items" />)
+      ).toThrow("Plural offset must be a non-negative safe integer.")
+    }
+  })
+
   it("formats direct choice components without reporting missing catalog entries", () => {
     const onMissing = vi.fn()
     const i18n = createI18n({ onMissing })

--- a/packages/react/src/index.test.tsx
+++ b/packages/react/src/index.test.tsx
@@ -52,6 +52,27 @@ describe("@palamedes/react", () => {
     expect(html).toBe("2 items")
   })
 
+  it("applies plural offsets in direct and rich messages", () => {
+    const i18n = createI18n()
+    i18n.activate("en")
+    setClientI18n(i18n)
+
+    const direct = renderToStaticMarkup(
+      <Plural value={2} offset={1} one="# item" other="# items" />
+    )
+    const rich = renderToStaticMarkup(
+      <Trans
+        id="companions"
+        message="{count, plural, offset:1 one {you and <0>one</0> other} other {you and <0>#</0> others}}"
+        values={{ count: 3 }}
+        components={{ 0: <strong /> }}
+      />
+    )
+
+    expect(direct).toBe("1 item")
+    expect(rich).toBe("you and <strong>2</strong> others")
+  })
+
   it("formats direct choice components without reporting missing catalog entries", () => {
     const onMissing = vi.fn()
     const i18n = createI18n({ onMissing })

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -90,11 +90,18 @@ function buildChoiceMessage(
   choices: Record<string, string | number | undefined>,
   offset?: number
 ): string {
+  validatePluralOffset(offset)
   const parts = Object.entries(choices)
     .filter((entry): entry is [string, string] => typeof entry[1] === "string")
     .map(([key, value]) => `${key} {${value}}`)
   const offsetPart = offset === undefined ? "" : ` offset:${offset}`
   return `{${variable}, ${kind},${offsetPart} ${parts.join(" ")}}`
+}
+
+function validatePluralOffset(offset: number | undefined): void {
+  if (offset !== undefined && (!Number.isSafeInteger(offset) || offset < 0)) {
+    throw new RangeError("Plural offset must be a non-negative safe integer.")
+  }
 }
 
 function renderNodes(

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -34,9 +34,13 @@ type ChoiceComponentProps = {
   other: string
 }
 
-export type PluralProps = {} & ChoiceComponentProps
+export type PluralProps = ChoiceComponentProps & {
+  offset?: number
+}
 
-export type SelectOrdinalProps = {} & ChoiceComponentProps
+export type SelectOrdinalProps = ChoiceComponentProps & {
+  offset?: number
+}
 
 export type SelectProps = {
   value: string | number
@@ -62,15 +66,15 @@ export function Trans({
   return <>{renderNodes(nodes, values ?? {}, components ?? {}, i18n.locale)}</>
 }
 
-export function Plural({ value, ...choices }: PluralProps): ReactNode {
+export function Plural({ value, offset, ...choices }: PluralProps): ReactNode {
   const i18n = getI18n<PalamedesI18n>()
-  const message = buildChoiceMessage("value", "plural", choices)
+  const message = buildChoiceMessage("value", "plural", choices, offset)
   return <>{formatMessagePattern(message, { value }, i18n.locale)}</>
 }
 
-export function SelectOrdinal({ value, ...choices }: SelectOrdinalProps): ReactNode {
+export function SelectOrdinal({ value, offset, ...choices }: SelectOrdinalProps): ReactNode {
   const i18n = getI18n<PalamedesI18n>()
-  const message = buildChoiceMessage("value", "selectordinal", choices)
+  const message = buildChoiceMessage("value", "selectordinal", choices, offset)
   return <>{formatMessagePattern(message, { value }, i18n.locale)}</>
 }
 
@@ -83,12 +87,14 @@ export function Select({ value, ...choices }: SelectProps): ReactNode {
 function buildChoiceMessage(
   variable: string,
   kind: "plural" | "select" | "selectordinal",
-  choices: Record<string, string | number | undefined>
+  choices: Record<string, string | number | undefined>,
+  offset?: number
 ): string {
   const parts = Object.entries(choices)
     .filter((entry): entry is [string, string] => typeof entry[1] === "string")
     .map(([key, value]) => `${key} {${value}}`)
-  return `{${variable}, ${kind}, ${parts.join(" ")}}`
+  const offsetPart = offset === undefined ? "" : ` offset:${offset}`
+  return `{${variable}, ${kind},${offsetPart} ${parts.join(" ")}}`
 }
 
 function renderNodes(
@@ -138,7 +144,8 @@ function renderNode(
     }
     case "choice": {
       const value = values[node.variable]
-      const nextPluralValue = node.kind === "select" ? pluralValue : normalizeNumericValue(value)
+      const nextPluralValue =
+        node.kind === "select" ? pluralValue : pluralOperand(node, normalizeNumericValue(value))
       const choice = selectChoice(node, value, locale)
       return renderNodes(choice, values, components, locale, nextPluralValue)
     }
@@ -163,11 +170,16 @@ function selectChoice(node: MessageChoiceNode, value: unknown, locale: string): 
     return node.options[exactKey]
   }
 
+  const operand = pluralOperand(node, numericValue)
   const pluralRules = new Intl.PluralRules(locale, {
     type: node.kind === "selectordinal" ? "ordinal" : "cardinal",
   })
-  const category = pluralRules.select(numericValue)
+  const category = pluralRules.select(operand)
   return node.options[category] ?? node.options.other ?? []
+}
+
+function pluralOperand(node: MessageChoiceNode, numericValue: number): number {
+  return numericValue - (node.offset ?? 0)
 }
 
 function renderVariable(value: unknown): ReactNode {

--- a/packages/solid/src/index.test.tsx
+++ b/packages/solid/src/index.test.tsx
@@ -74,6 +74,24 @@ describe("@palamedes/solid", () => {
     expect(html).toBe("2 items")
   })
 
+  it("applies plural offsets in direct and rich messages", () => {
+    const i18n = createI18n()
+    i18n.activate("en")
+    setServerI18nGetter(() => i18n)
+
+    const direct = renderToString(() => (
+      <Plural value={2} offset={1} one="# item" other="# items" />
+    ))
+    const rich = Trans({
+      id: "companions",
+      message: "{count, plural, offset:1 one {you and one other} other {you and # others}}",
+      values: { count: 3 },
+    }) as unknown as () => unknown
+
+    expect(direct).toBe("1 item")
+    expect([rich()].flat().join("")).toBe("you and 2 others")
+  })
+
   it("formats direct choice components without reporting missing catalog entries", () => {
     const onMissing = vi.fn()
     const i18n = createI18n({ onMissing })

--- a/packages/solid/src/index.test.tsx
+++ b/packages/solid/src/index.test.tsx
@@ -92,6 +92,17 @@ describe("@palamedes/solid", () => {
     expect([rich()].flat().join("")).toBe("you and 2 others")
   })
 
+  it("rejects invalid offsets at the direct component boundary", () => {
+    const i18n = createI18n()
+    setServerI18nGetter(() => i18n)
+
+    for (const offset of [Number.NaN, -1, 1.5, Number.MAX_SAFE_INTEGER + 1]) {
+      expect(() =>
+        renderToString(() => <Plural value={2} offset={offset} one="# item" other="# items" />)
+      ).toThrow("Plural offset must be a non-negative safe integer.")
+    }
+  })
+
   it("formats direct choice components without reporting missing catalog entries", () => {
     const onMissing = vi.fn()
     const i18n = createI18n({ onMissing })

--- a/packages/solid/src/index.tsx
+++ b/packages/solid/src/index.tsx
@@ -43,9 +43,13 @@ type ChoiceComponentProps = {
   other: string
 }
 
-export type PluralProps = {} & ChoiceComponentProps
+export type PluralProps = ChoiceComponentProps & {
+  offset?: number
+}
 
-export type SelectOrdinalProps = {} & ChoiceComponentProps
+export type SelectOrdinalProps = ChoiceComponentProps & {
+  offset?: number
+}
 
 export type SelectProps = {
   value: string | number
@@ -77,18 +81,18 @@ export function Trans({
   }) as unknown as JSX.Element
 }
 
-export function Plural({ value, ...choices }: PluralProps): JSX.Element {
+export function Plural({ value, offset, ...choices }: PluralProps): JSX.Element {
   return (() => {
     const i18n = useReactiveI18n()
-    const message = buildChoiceMessage("value", "plural", choices)
+    const message = buildChoiceMessage("value", "plural", choices, offset)
     return formatMessagePattern(message, { value }, i18n.locale)
   }) as unknown as JSX.Element
 }
 
-export function SelectOrdinal({ value, ...choices }: SelectOrdinalProps): JSX.Element {
+export function SelectOrdinal({ value, offset, ...choices }: SelectOrdinalProps): JSX.Element {
   return (() => {
     const i18n = useReactiveI18n()
-    const message = buildChoiceMessage("value", "selectordinal", choices)
+    const message = buildChoiceMessage("value", "selectordinal", choices, offset)
     return formatMessagePattern(message, { value }, i18n.locale)
   }) as unknown as JSX.Element
 }
@@ -104,12 +108,14 @@ export function Select({ value, ...choices }: SelectProps): JSX.Element {
 function buildChoiceMessage(
   variable: string,
   kind: "plural" | "select" | "selectordinal",
-  choices: Record<string, string | number | undefined>
+  choices: Record<string, string | number | undefined>,
+  offset?: number
 ): string {
   const parts = Object.entries(choices)
     .filter((entry): entry is [string, string] => typeof entry[1] === "string")
     .map(([key, value]) => `${key} {${value}}`)
-  return `{${variable}, ${kind}, ${parts.join(" ")}}`
+  const offsetPart = offset === undefined ? "" : ` offset:${offset}`
+  return `{${variable}, ${kind},${offsetPart} ${parts.join(" ")}}`
 }
 
 function renderNodes(
@@ -165,7 +171,8 @@ function renderNode(
     }
     case "choice": {
       const value = values[node.variable]
-      const nextPluralValue = node.kind === "select" ? pluralValue : normalizeNumericValue(value)
+      const nextPluralValue =
+        node.kind === "select" ? pluralValue : pluralOperand(node, normalizeNumericValue(value))
       const choice = selectChoice(node, value, locale)
       return renderNodes(choice, values, components, locale, nextPluralValue)
     }
@@ -190,11 +197,16 @@ function selectChoice(node: MessageChoiceNode, value: unknown, locale: string): 
     return node.options[exactKey]
   }
 
+  const operand = pluralOperand(node, numericValue)
   const pluralRules = new Intl.PluralRules(locale, {
     type: node.kind === "selectordinal" ? "ordinal" : "cardinal",
   })
-  const category = pluralRules.select(numericValue)
+  const category = pluralRules.select(operand)
   return node.options[category] ?? node.options.other ?? []
+}
+
+function pluralOperand(node: MessageChoiceNode, numericValue: number): number {
+  return numericValue - (node.offset ?? 0)
 }
 
 function renderVariable(value: unknown): JSX.Element {

--- a/packages/solid/src/index.tsx
+++ b/packages/solid/src/index.tsx
@@ -111,11 +111,18 @@ function buildChoiceMessage(
   choices: Record<string, string | number | undefined>,
   offset?: number
 ): string {
+  validatePluralOffset(offset)
   const parts = Object.entries(choices)
     .filter((entry): entry is [string, string] => typeof entry[1] === "string")
     .map(([key, value]) => `${key} {${value}}`)
   const offsetPart = offset === undefined ? "" : ` offset:${offset}`
   return `{${variable}, ${kind},${offsetPart} ${parts.join(" ")}}`
+}
+
+function validatePluralOffset(offset: number | undefined): void {
+  if (offset !== undefined && (!Number.isSafeInteger(offset) || offset < 0)) {
+    throw new RangeError("Plural offset must be a non-negative safe integer.")
+  }
 }
 
 function renderNodes(

--- a/packages/transform/src/transform.test.ts
+++ b/packages/transform/src/transform.test.ts
@@ -603,6 +603,41 @@ const jsx = <Plural
     expect(result.code.split("{ count, planLabel, max }")).toHaveLength(3)
   })
 
+  it("transforms static plural offsets and rejects invalid choice metadata", () => {
+    const code = `
+import { plural } from "@palamedes/core/macro";
+import { Plural } from "@palamedes/react/macro"; function messages() {
+const call = plural(count, { offset: 1, one: "# item", other: "# items" });
+const jsx = <Plural value={count} offset={1} one="# item" other="# items" />;
+}
+`
+
+    const result = transformPalamedesMacros(code, "test.tsx")
+    expect(
+      result.code.match(/message: "\{count, plural, offset:1 one \{# item\} other \{# items\}\}"/g)
+    ).toHaveLength(2)
+    expect(() =>
+      transformPalamedesMacros(
+        `
+import { plural } from "@palamedes/core/macro"; function messages() {
+plural(count, { offset: dynamicOffset, one: "# item", other: "# items" });
+}
+`,
+        "test.ts"
+      )
+    ).toThrow(/`offset` must be a static non-negative integer/)
+    expect(() =>
+      transformPalamedesMacros(
+        `
+import { plural } from "@palamedes/core/macro"; function messages() {
+plural(count, { invalid: "broken", other: "# items" });
+}
+`,
+        "test.ts"
+      )
+    ).toThrow(/`invalid` is not a valid plural category/)
+  })
+
   it("accepts defaulted JSX choice values", () => {
     const code = `
 import { Plural } from "@palamedes/react/macro"; function message() {


### PR DESCRIPTION
## Summary

- parse ICU plural offsets into the runtime AST and apply them to category selection and `#` replacement while keeping exact matches on the original value
- preserve static numeric and string offsets in call and JSX macro extraction/transformation
- reject dynamic offsets and invalid plural categories instead of silently dropping or corrupting them
- keep direct and rich-message rendering aligned across Core, React, and Solid

## Root cause

The compiler could emit `offset:N`, but the runtime parsed it as part of an option key and selected plural branches using the unadjusted value. Separately, the macro pipeline ignored numeric offsets and treated string offsets as ordinary categories in call expressions.

## Validation

- `RUSTUP_TOOLCHAIN=1.95 cargo fmt --all --check`
- `RUSTUP_TOOLCHAIN=1.95 cargo clippy --workspace --all-targets --locked -- -D warnings`
- `RUSTUP_TOOLCHAIN=1.95 cargo test --workspace --locked`
- `CI=true RUSTUP_TOOLCHAIN=1.95 pnpm build`
- `CI=true RUSTUP_TOOLCHAIN=1.95 pnpm test`
- `CI=true pnpm format:check`
- `CI=true pnpm lint`
- `CI=true RUSTUP_TOOLCHAIN=1.95 pnpm check-types`
- `CI=true pnpm check:published-types`

Closes #407