### PR TITLE
fix: ignore JSX comments inside Trans

### DIFF
--- a/crates/palamedes/src/extract.rs
+++ b/crates/palamedes/src/extract.rs
@@ -1132,6 +1132,7 @@ fn extract_jsx_children_as_message_with_state(
                 }
             }
             JSXChild::ExpressionContainer(container) => match &container.expression {
+                JSXExpression::EmptyExpression(_) => {}
                 JSXExpression::StringLiteral(literal) => {
                     parts.push(JsxMessagePart::Text(literal.value.to_string()));
                 }
@@ -1700,6 +1701,22 @@ function choices() {
                 "count()".to_string()
             )]))
         );
+    }
+
+    #[test]
+    fn ignores_jsx_comments_inside_trans() {
+        let messages = extract_messages(
+            r#"
+              import { Trans } from "@palamedes/react/macro"
+              const message = <Trans>Hello {/* translator note */} world</Trans>
+            "#,
+            "test.tsx",
+        )
+        .expect("JSX comments should be ignored");
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].message, "Hello world");
+        assert_eq!(messages[0].placeholders, None);
     }
 
     #[test]

--- a/crates/palamedes/src/transform/messages.rs
+++ b/crates/palamedes/src/transform/messages.rs
@@ -300,6 +300,7 @@ fn extract_jsx_children_parts_with_state(
                 }
             }
             JSXChild::ExpressionContainer(container) => match &container.expression {
+                JSXExpression::EmptyExpression(_) => {}
                 JSXExpression::StringLiteral(literal) => {
                     parts.push(JsxMessagePart::Text(literal.value.to_string()));
                 }

--- a/crates/palamedes/src/transform/tests.rs
+++ b/crates/palamedes/src/transform/tests.rs
@@ -369,6 +369,20 @@ fn transforms_trans_jsx_macro() {
 }
 
 #[test]
+fn ignores_jsx_comments_inside_trans() {
+    let result = transform_macros(
+        "import { Trans } from \"@palamedes/react/macro\";\nconst el = <Trans>Hello {/* translator note */} world</Trans>;\n",
+        "test.tsx",
+        None,
+    )
+    .expect("JSX comments should be ignored");
+
+    assert!(result.code.contains("message={\"Hello world\"}"));
+    assert!(!result.code.contains("translator note"));
+    assert!(!result.code.contains("values="));
+}
+
+#[test]
 fn transforms_solid_trans_jsx_macro() {
     let result = transform_macros(
         "import { Trans } from \"@palamedes/solid/macro\";\nconst el = <Trans>Hello <strong>{name}</strong></Trans>;\n",

--- a/packages/extractor/src/extractMessages.test.ts
+++ b/packages/extractor/src/extractMessages.test.ts
@@ -65,6 +65,18 @@ describe("extractMessages", () => {
       expect(messages[0].message).toBe("Hello World")
     })
 
+    it("ignores JSX comments inside Trans", () => {
+      const code = `
+        import { Trans } from "@palamedes/react/macro"
+        const x = <Trans>Hello {/* translator note */} world</Trans>
+      `
+      const messages = extract(code)
+      expect(messages).toHaveLength(1)
+      expect(messages[0]).toMatchObject({
+        message: "Hello world",
+      })
+    })
+
     it("extracts Trans with interpolation", () => {
       const code = `
         import { Trans } from "@palamedes/react/macro"

--- a/packages/transform/src/transform.test.ts
+++ b/packages/transform/src/transform.test.ts
@@ -215,6 +215,18 @@ const el = <Trans>Hello {name}</Trans>;
     expect(result.code).toContain("values={{ name }}")
   })
 
+  it("ignores JSX comments inside <Trans>", () => {
+    const code = `
+import { Trans } from "@palamedes/react/macro";
+const el = <Trans>Hello {/* translator note */} world</Trans>;
+`
+    const result = transformPalamedesMacros(code, "test.tsx")
+
+    expect(result.code).toContain('message={"Hello world"}')
+    expect(result.code).not.toContain("translator note")
+    expect(result.code).not.toContain("values=")
+  })
+
   it("applies native UTF-8 byte edit offsets to JavaScript strings", () => {
     const code = `import { Trans } from "@palamedes/react/macro";
 const x = "äöü";


### PR DESCRIPTION
Closes #419

## Summary
- ignore JSX empty expressions produced by `{/* ... */}` comments during `<Trans>` extraction
- apply the same behavior during macro transformation
- add Rust and package-level regression coverage for extraction and transformation

## Validation
- `RUSTUP_TOOLCHAIN=1.95 cargo fmt --all --check`
- `RUSTUP_TOOLCHAIN=1.95 cargo clippy --workspace --all-targets --locked -- -D warnings`
- `RUSTUP_TOOLCHAIN=1.95 cargo test --workspace --locked`
- `CI=true RUSTUP_TOOLCHAIN=1.95 pnpm build`
- `CI=true pnpm format:check`
- `CI=true pnpm lint`
- `CI=true RUSTUP_TOOLCHAIN=1.95 pnpm check-types`
- `CI=true RUSTUP_TOOLCHAIN=1.95 pnpm test`