### PR TITLE
fix: transform macros in Trans component attributes

### DIFF
--- a/crates/palamedes/src/transform/messages.rs
+++ b/crates/palamedes/src/transform/messages.rs
@@ -17,6 +17,8 @@ use crate::jsx_message::{
 };
 use crate::placeholder_name::{expression_name, jsx_expression_name};
 
+use super::Replacement;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct ValueBinding {
     pub expression: String,
@@ -224,13 +226,14 @@ pub(super) fn extract_choice_options_from_jsx(
 pub(super) fn opening_element_to_component(
     opening_element: &JSXOpeningElement<'_>,
     source: &str,
+    replacements: &[Replacement],
 ) -> String {
     let start = opening_element.span.start as usize;
     let end = opening_element.span.end as usize;
-    let markup = &source[start..end];
+    let markup = source_range_with_replacements(source, start, end, replacements);
 
     if markup.trim_end().ends_with("/>") {
-        return markup.to_string();
+        return markup;
     }
 
     if let Some(prefix) = markup.strip_suffix('>') {
@@ -243,10 +246,13 @@ pub(super) fn opening_element_to_component(
 pub(super) fn opening_element_to_component_wrapper(
     opening_element: &JSXOpeningElement<'_>,
     source: &str,
+    replacements: &[Replacement],
 ) -> String {
     let start = opening_element.span.start as usize;
     let end = opening_element.span.end as usize;
-    let markup = source[start..end].trim().to_string();
+    let markup = source_range_with_replacements(source, start, end, replacements)
+        .trim()
+        .to_string();
     let name_span = opening_element.name.span();
     let name = source[name_span.start as usize..name_span.end as usize].to_string();
 
@@ -261,10 +267,34 @@ pub(super) fn opening_element_to_component_wrapper(
     format!("(children) => {opening}{{children}}</{name}>")
 }
 
+fn source_range_with_replacements(
+    source: &str,
+    start: usize,
+    end: usize,
+    replacements: &[Replacement],
+) -> String {
+    let mut text = source[start..end].to_string();
+    let mut contained = replacements
+        .iter()
+        .filter(|replacement| replacement.start >= start && replacement.end <= end)
+        .collect::<Vec<_>>();
+    contained.sort_by(|left, right| right.start.cmp(&left.start).then(right.end.cmp(&left.end)));
+
+    for replacement in contained {
+        text.replace_range(
+            replacement.start - start..replacement.end - start,
+            &replacement.text,
+        );
+    }
+
+    text
+}
+
 pub(super) fn extract_jsx_children_parts(
     children: &[JSXChild<'_>],
     source: &str,
     solid_wrappers: bool,
+    replacements: &[Replacement],
 ) -> PalamedesResult<(String, Vec<ValueBinding>, Vec<ValueBinding>)> {
     let mut used_value_names = HashMap::<String, String>::new();
     let mut next_component_index = 0usize;
@@ -273,6 +303,7 @@ pub(super) fn extract_jsx_children_parts(
         children,
         source,
         solid_wrappers,
+        replacements,
         &mut used_value_names,
         &mut next_component_index,
     )?;
@@ -284,6 +315,7 @@ fn extract_jsx_children_parts_with_state(
     children: &[JSXChild<'_>],
     source: &str,
     solid_wrappers: bool,
+    replacements: &[Replacement],
     used_value_names: &mut HashMap<String, String>,
     next_component_index: &mut usize,
 ) -> PalamedesResult<(JoinedJsxMessage, Vec<ValueBinding>, Vec<ValueBinding>)> {
@@ -316,9 +348,13 @@ fn extract_jsx_children_parts_with_state(
             },
             JSXChild::Element(element) => {
                 let component_expression = if solid_wrappers {
-                    opening_element_to_component_wrapper(&element.opening_element, source)
+                    opening_element_to_component_wrapper(
+                        &element.opening_element,
+                        source,
+                        replacements,
+                    )
                 } else {
-                    opening_element_to_component(&element.opening_element, source)
+                    opening_element_to_component(&element.opening_element, source, replacements)
                 };
                 let component_name = next_component_index.to_string();
                 *next_component_index += 1;
@@ -328,6 +364,7 @@ fn extract_jsx_children_parts_with_state(
                         &element.children,
                         source,
                         solid_wrappers,
+                        replacements,
                         used_value_names,
                         next_component_index,
                     )?;
@@ -354,6 +391,7 @@ fn extract_jsx_children_parts_with_state(
                         &fragment.children,
                         source,
                         solid_wrappers,
+                        replacements,
                         used_value_names,
                         next_component_index,
                     )?;

--- a/crates/palamedes/src/transform/messages.rs
+++ b/crates/palamedes/src/transform/messages.rs
@@ -279,6 +279,12 @@ fn source_range_with_replacements(
         .filter(|replacement| replacement.start >= start && replacement.end <= end)
         .collect::<Vec<_>>();
     contained.sort_by(|left, right| right.start.cmp(&left.start).then(right.end.cmp(&left.end)));
+    debug_assert!(
+        contained
+            .windows(2)
+            .all(|pair| pair[0].start >= pair[1].end),
+        "component source replacements must not overlap"
+    );
 
     for replacement in contained {
         text.replace_range(

--- a/crates/palamedes/src/transform/mod.rs
+++ b/crates/palamedes/src/transform/mod.rs
@@ -19,7 +19,14 @@ use crate::error::{PalamedesError, PalamedesResult};
 use crate::translation_scope::{source_location, validate_translation_macro_scopes};
 
 use self::imports::ImportCollector;
-use self::visitor::{Replacement, TransformVisitor};
+use self::visitor::TransformVisitor;
+
+#[derive(Debug, Clone)]
+pub(super) struct Replacement {
+    pub start: usize,
+    pub end: usize,
+    pub text: String,
+}
 
 /// Options controlling how macro transforms emit runtime code.
 #[derive(Debug, Default, Deserialize)]

--- a/crates/palamedes/src/transform/runtime.rs
+++ b/crates/palamedes/src/transform/runtime.rs
@@ -363,6 +363,7 @@ pub(super) fn transform_trans_element(
     element: &JSXElement<'_>,
     source: &str,
     jsx_runtime_module: &str,
+    replacements: &[super::Replacement],
 ) -> PalamedesResult<Option<(String, String)>> {
     let attrs = jsx_attributes(&element.opening_element);
     if attrs.contains_key("id") {
@@ -372,7 +373,7 @@ pub(super) fn transform_trans_element(
     let solid_wrappers = jsx_runtime_module == "@palamedes/solid";
 
     let (children_message, values, components) =
-        extract_jsx_children_parts(&element.children, source, solid_wrappers)?;
+        extract_jsx_children_parts(&element.children, source, solid_wrappers, replacements)?;
     let message = attrs
         .get("message")
         .cloned()

--- a/crates/palamedes/src/transform/tests.rs
+++ b/crates/palamedes/src/transform/tests.rs
@@ -800,7 +800,7 @@ fn transforms_nested_jsx_message_macros_inside_render_prop_attributes() {
 fn transforms_trans_macros_inside_component_attributes() {
     for module in ["react", "solid"] {
         let source = format!(
-            "import {{ Trans }} from \"@palamedes/{module}/macro\";\nconst el = <Trans>Click <Button title={{<Trans>Tooltip</Trans>}} /> now</Trans>;\n"
+            "import {{ Trans }} from \"@palamedes/{module}/macro\";\nconst el = <Trans>Click <Button title={{<Trans>Tooltip</Trans>}} description={{<Trans>Details</Trans>}} /> now</Trans>;\n"
         );
         let result = transform_macros(&source, "test.tsx", None)
             .expect("Trans macros in component attributes should transform");
@@ -808,10 +808,24 @@ fn transforms_trans_macros_inside_component_attributes() {
         assert!(result.code.contains("message={\"Click <0/> now\"}"));
         assert!(result.code.contains("title={<Trans id=\""));
         assert!(result.code.contains("message={\"Tooltip\"}"));
-        assert_eq!(result.code.matches("<Trans id=").count(), 2);
-        assert_eq!(result.compiled_ids.len(), 2);
+        assert!(result.code.contains("description={<Trans id=\""));
+        assert!(result.code.contains("message={\"Details\"}"));
+        assert_eq!(result.code.matches("<Trans id=").count(), 3);
+        assert_eq!(result.compiled_ids.len(), 3);
         assert!(!result.code.contains(&format!("@palamedes/{module}/macro")));
     }
+}
+
+#[test]
+fn rejects_component_attribute_macros_inside_trans_expression_children() {
+    let error = transform_macros(
+        "import { Trans } from \"@palamedes/react/macro\";\nconst el = <Trans>{cond && <Button title={<Trans>Tooltip</Trans>} />}</Trans>;\n",
+        "test.tsx",
+        None,
+    )
+    .expect_err("complex JSX child expressions should remain unsupported");
+
+    assert!(error.to_string().contains("stable placeholder name"));
 }
 
 #[test]

--- a/crates/palamedes/src/transform/tests.rs
+++ b/crates/palamedes/src/transform/tests.rs
@@ -783,16 +783,35 @@ fn rejects_nested_jsx_message_macros_inside_map_callbacks() {
 }
 
 #[test]
-fn allows_nested_jsx_message_macros_inside_render_prop_attributes() {
+fn transforms_nested_jsx_message_macros_inside_render_prop_attributes() {
     let result = transform_macros(
         "import { Plural, Trans } from \"@palamedes/react/macro\";\nconst el = <Trans><List renderItem={() => <Plural value={count} one=\"one\" other=\"other\" />} /></Trans>;\n",
         "test.tsx",
         None,
     )
-    .expect("nested message macros in render prop attributes should not fail");
+    .expect("nested message macros in render prop attributes should transform");
 
     assert!(result.code.contains("message={\"<0/>\"}"));
-    assert!(result.code.contains("renderItem={() => <Plural"));
+    assert!(result.code.contains("renderItem={() => getI18n()._(\""));
+    assert!(!result.code.contains("<Plural"));
+}
+
+#[test]
+fn transforms_trans_macros_inside_component_attributes() {
+    for module in ["react", "solid"] {
+        let source = format!(
+            "import {{ Trans }} from \"@palamedes/{module}/macro\";\nconst el = <Trans>Click <Button title={{<Trans>Tooltip</Trans>}} /> now</Trans>;\n"
+        );
+        let result = transform_macros(&source, "test.tsx", None)
+            .expect("Trans macros in component attributes should transform");
+
+        assert!(result.code.contains("message={\"Click <0/> now\"}"));
+        assert!(result.code.contains("title={<Trans id=\""));
+        assert!(result.code.contains("message={\"Tooltip\"}"));
+        assert_eq!(result.code.matches("<Trans id=").count(), 2);
+        assert_eq!(result.compiled_ids.len(), 2);
+        assert!(!result.code.contains(&format!("@palamedes/{module}/macro")));
+    }
 }
 
 #[test]

--- a/crates/palamedes/src/transform/visitor.rs
+++ b/crates/palamedes/src/transform/visitor.rs
@@ -14,14 +14,7 @@ use super::runtime::{
     transform_choice_call, transform_choice_jsx_element, transform_descriptor_call,
     transform_tagged_template, transform_trans_element,
 };
-use super::NativeTransformOptions;
-
-#[derive(Debug, Clone)]
-pub(super) struct Replacement {
-    pub start: usize,
-    pub end: usize,
-    pub text: String,
-}
+use super::{NativeTransformOptions, Replacement};
 
 pub(super) struct TransformVisitor<'a> {
     filename: &'a str,
@@ -88,6 +81,25 @@ impl<'a> TransformVisitor<'a> {
                 *start == element.span.start as usize && *end == element.span.end as usize
             })
     }
+
+    fn visit_preserved_attribute_macros(&mut self, children: &[JSXChild<'a>]) {
+        for child in children {
+            if self.error.is_some() {
+                return;
+            }
+
+            match child {
+                JSXChild::Element(element) => {
+                    walk::walk_jsx_opening_element(self, &element.opening_element);
+                    self.visit_preserved_attribute_macros(&element.children);
+                }
+                JSXChild::Fragment(fragment) => {
+                    self.visit_preserved_attribute_macros(&fragment.children);
+                }
+                _ => {}
+            }
+        }
+    }
 }
 
 impl<'a> Visit<'a> for TransformVisitor<'a> {
@@ -120,6 +132,15 @@ impl<'a> Visit<'a> for TransformVisitor<'a> {
             }
         }
 
+        let attribute_replacement_start = self.replacements.len();
+        if macro_info.imported_name == "Trans" {
+            self.visit_preserved_attribute_macros(&it.children);
+            if self.error.is_some() {
+                return;
+            }
+        }
+        let attribute_replacements = self.replacements.split_off(attribute_replacement_start);
+
         let replacement = match macro_info.imported_name.as_str() {
             "Trans" => transform_trans_element(
                 it,
@@ -128,6 +149,7 @@ impl<'a> Visit<'a> for TransformVisitor<'a> {
                     .source
                     .strip_suffix("/macro")
                     .unwrap_or("@palamedes/react"),
+                &attribute_replacements,
             ),
             "Plural" | "Select" | "SelectOrdinal" => transform_choice_jsx_element(
                 it,

--- a/crates/palamedes/src/transform/visitor.rs
+++ b/crates/palamedes/src/transform/visitor.rs
@@ -96,6 +96,9 @@ impl<'a> TransformVisitor<'a> {
                 JSXChild::Fragment(fragment) => {
                     self.visit_preserved_attribute_macros(&fragment.children);
                 }
+                JSXChild::ExpressionContainer(container) => {
+                    walk::walk_jsx_expression_container(self, container);
+                }
                 _ => {}
             }
         }

--- a/packages/transform/src/transform.test.ts
+++ b/packages/transform/src/transform.test.ts
@@ -582,18 +582,29 @@ const el = <Trans><List renderItem={() => <Plural value={count} one="one" other=
     (framework) => {
       const code = `
 import { Trans } from "@palamedes/${framework}/macro";
-const el = <Trans>Click <Button title={<Trans>Tooltip</Trans>} /> now</Trans>;
+const el = <Trans>Click <Button title={<Trans>Tooltip</Trans>} description={<Trans>Details</Trans>} /> now</Trans>;
 `
       const result = transformPalamedesMacros(code, "test.tsx")
 
       expect(result.code).toContain('message={"Click <0/> now"}')
       expect(result.code).toContain('title={<Trans id="')
       expect(result.code).toContain('message={"Tooltip"}')
-      expect(result.code.match(/<Trans id=/g)).toHaveLength(2)
-      expect(result.compiledIds).toHaveLength(2)
+      expect(result.code).toContain('description={<Trans id="')
+      expect(result.code).toContain('message={"Details"}')
+      expect(result.code.match(/<Trans id=/g)).toHaveLength(3)
+      expect(result.compiledIds).toHaveLength(3)
       expect(result.code).not.toContain(`@palamedes/${framework}/macro`)
     }
   )
+
+  it("rejects component attribute macros inside Trans expression children", () => {
+    const code = `
+import { Trans } from "@palamedes/react/macro";
+const el = <Trans>{cond && <Button title={<Trans>Tooltip</Trans>} />}</Trans>;
+`
+
+    expect(() => transformPalamedesMacros(code, "test.tsx")).toThrow(/stable placeholder name/)
+  })
 
   it("accepts computed, defaulted, and literal choice values", () => {
     const code = `

--- a/packages/transform/src/transform.test.ts
+++ b/packages/transform/src/transform.test.ts
@@ -565,7 +565,7 @@ const el = <Trans>Hello {firstName + lastName}</Trans>;
     }
   })
 
-  it("allows nested JSX message macros in render prop attributes", () => {
+  it("transforms nested JSX message macros in render prop attributes", () => {
     const code = `
 import { Plural, Trans } from "@palamedes/react/macro";
 const el = <Trans><List renderItem={() => <Plural value={count} one="one" other="other" />} /></Trans>;
@@ -573,8 +573,27 @@ const el = <Trans><List renderItem={() => <Plural value={count} one="one" other=
     const result = transformPalamedesMacros(code, "test.tsx")
 
     expect(result.code).toContain('message={"<0/>"}')
-    expect(result.code).toContain("renderItem={() => <Plural")
+    expect(result.code).toContain('renderItem={() => getI18n()._("')
+    expect(result.code).not.toContain("<Plural")
   })
+
+  it.each(["react", "solid"])(
+    "transforms Trans macros inside %s component attributes",
+    (framework) => {
+      const code = `
+import { Trans } from "@palamedes/${framework}/macro";
+const el = <Trans>Click <Button title={<Trans>Tooltip</Trans>} /> now</Trans>;
+`
+      const result = transformPalamedesMacros(code, "test.tsx")
+
+      expect(result.code).toContain('message={"Click <0/> now"}')
+      expect(result.code).toContain('title={<Trans id="')
+      expect(result.code).toContain('message={"Tooltip"}')
+      expect(result.code.match(/<Trans id=/g)).toHaveLength(2)
+      expect(result.compiledIds).toHaveLength(2)
+      expect(result.code).not.toContain(`@palamedes/${framework}/macro`)
+    }
+  )
 
   it("accepts computed, defaulted, and literal choice values", () => {
     const code = `


### PR DESCRIPTION
Closes #420

## Summary
- traverse independent JSX attribute/render-prop contexts before replacing an outer `<Trans>` subtree
- fold nested macro replacements into the preserved component markup instead of emitting dead macro components
- preserve React and Solid component wrapper behavior
- add regression coverage for nested `<Trans>` attributes and nested choice macros in render props

## Validation
- `RUSTUP_TOOLCHAIN=1.95 cargo fmt --all --check`
- `RUSTUP_TOOLCHAIN=1.95 cargo clippy --workspace --all-targets --locked -- -D warnings`
- `RUSTUP_TOOLCHAIN=1.95 cargo test --workspace --locked`
- `CI=true RUSTUP_TOOLCHAIN=1.95 pnpm build`
- `CI=true RUSTUP_TOOLCHAIN=1.95 pnpm format:check`
- `CI=true RUSTUP_TOOLCHAIN=1.95 pnpm lint`
- `CI=true RUSTUP_TOOLCHAIN=1.95 pnpm check-types`
- `CI=true RUSTUP_TOOLCHAIN=1.95 pnpm test`