### PR TITLE
fix: share runtime state across module graphs

### DIFF
--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -23,8 +23,14 @@
         "import": "./dist/server.mjs",
         "require": "./dist/server.cjs"
       },
-      "browser": "./dist/server-unavailable.mjs",
-      "default": "./dist/server-unavailable.mjs"
+      "browser": {
+        "import": "./dist/server-unavailable.mjs",
+        "require": "./dist/server-unavailable.cjs"
+      },
+      "default": {
+        "import": "./dist/server-unavailable.mjs",
+        "require": "./dist/server-unavailable.cjs"
+      }
     }
   },
   "main": "./dist/index.cjs",

--- a/packages/runtime/src/index.test.ts
+++ b/packages/runtime/src/index.test.ts
@@ -83,6 +83,16 @@ describe("@palamedes/runtime", () => {
     }
   })
 
+  it("clears client listeners when the runtime is reset", () => {
+    const listener = vi.fn()
+    subscribeClientI18n(listener)
+
+    resetI18nRuntime()
+    setClientI18n(createTestI18n())
+
+    expect(listener).not.toHaveBeenCalled()
+  })
+
   it("resolves the request-local server instance", () => {
     const i18n = createTestI18n()
     setServerI18nGetter(() => i18n)

--- a/packages/runtime/src/index.test.ts
+++ b/packages/runtime/src/index.test.ts
@@ -1,6 +1,6 @@
 import { AsyncLocalStorage } from "node:async_hooks"
 
-import { afterEach, describe, expect, it } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 
 import {
   type I18nInstance,
@@ -62,6 +62,25 @@ describe("@palamedes/runtime", () => {
     expect(firstSnapshot.i18n).toBe(i18n)
     expect(secondSnapshot.i18n).toBe(i18n)
     expect(secondSnapshot.revision).toBe(firstSnapshot.revision + 1)
+  })
+
+  it("shares client snapshots and listeners across isolated module graphs", async () => {
+    ;(globalThis as Record<string, unknown>).window = {}
+    const seen: string[] = []
+    const unsubscribe = subscribeClientI18n((clientI18n) => seen.push(clientI18n.locale))
+    vi.resetModules()
+    const isolatedRuntime = await import("./index")
+    const i18n = createTestI18n("de")
+
+    try {
+      isolatedRuntime.setClientI18n(i18n)
+
+      expect(seen).toStrictEqual(["de"])
+      expect(getClientI18nSnapshot()).toBe(isolatedRuntime.getClientI18nSnapshot())
+      expect(getI18n()).toBe(i18n)
+    } finally {
+      unsubscribe()
+    }
   })
 
   it("resolves the request-local server instance", () => {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -161,5 +161,6 @@ export function resetI18nRuntime(): void {
   const state = globalRuntimeState()
   delete state[CLIENT_I18N_KEY]
   delete state[CLIENT_I18N_SNAPSHOT_KEY]
+  delete state[CLIENT_I18N_LISTENERS_KEY]
   delete state[SERVER_I18N_GETTER_KEY]
 }

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -7,27 +7,28 @@ type ServerI18nGetter<T extends I18nInstance = I18nInstance> = () => T | undefin
 
 const CLIENT_I18N_KEY = Symbol.for("palamedes.runtime.clientI18n")
 const CLIENT_I18N_SNAPSHOT_KEY = Symbol.for("palamedes.runtime.clientI18nSnapshot")
+const CLIENT_I18N_LISTENERS_KEY = Symbol.for("palamedes.runtime.clientI18nListeners")
+const SERVER_I18N_GETTER_KEY = Symbol.for("palamedes.runtime.serverI18nGetter")
 const SERVER_SCOPE_STATE_KEY = Symbol.for("palamedes.runtime.serverI18nScopeState")
 
-let clientI18n: I18nInstance | undefined
-let clientI18nSnapshot: ClientI18nSnapshot = {
-  i18n: undefined,
-  revision: 0,
-}
-let serverI18nGetter: ServerI18nGetter | undefined
-
 type ClientI18nListener = (i18n: I18nInstance) => void
-
-const clientI18nListeners = new Set<ClientI18nListener>()
 
 export type ClientI18nSnapshot = Readonly<{
   i18n: I18nInstance | undefined
   revision: number
 }>
 
+export type ServerI18nScope<T extends I18nInstance = I18nInstance> = {
+  run<Result>(i18n: T, callback: () => Result): Result
+  activate(i18n: T): T
+  get(): T | undefined
+}
+
 type GlobalRuntimeState = typeof globalThis & {
   [CLIENT_I18N_KEY]?: I18nInstance
   [CLIENT_I18N_SNAPSHOT_KEY]?: ClientI18nSnapshot
+  [CLIENT_I18N_LISTENERS_KEY]?: Set<ClientI18nListener>
+  [SERVER_I18N_GETTER_KEY]?: ServerI18nGetter
   [SERVER_SCOPE_STATE_KEY]?: {
     active: {
       enterWith(i18n: I18nInstance): void
@@ -40,21 +41,31 @@ function globalRuntimeState(): GlobalRuntimeState {
   return globalThis as GlobalRuntimeState
 }
 
+function getClientI18nListeners(state = globalRuntimeState()): Set<ClientI18nListener> {
+  const existing = state[CLIENT_I18N_LISTENERS_KEY]
+  if (existing) {
+    return existing
+  }
+
+  const listeners = new Set<ClientI18nListener>()
+  state[CLIENT_I18N_LISTENERS_KEY] = listeners
+  return listeners
+}
+
 function isServerEnvironment(): boolean {
   return typeof window === "undefined"
 }
 
 export function setClientI18n<T extends I18nInstance>(i18n: T): T {
   const state = globalRuntimeState()
-  const previousSnapshot = state[CLIENT_I18N_SNAPSHOT_KEY] ?? clientI18nSnapshot
-  clientI18n = i18n
-  clientI18nSnapshot = {
+  const previousSnapshot = getClientI18nSnapshot()
+  const nextSnapshot: ClientI18nSnapshot = {
     i18n,
     revision: previousSnapshot.revision + 1,
   }
   state[CLIENT_I18N_KEY] = i18n
-  state[CLIENT_I18N_SNAPSHOT_KEY] = clientI18nSnapshot
-  for (const listener of clientI18nListeners) {
+  state[CLIENT_I18N_SNAPSHOT_KEY] = nextSnapshot
+  for (const listener of getClientI18nListeners(state)) {
     listener(i18n)
   }
   return i18n
@@ -66,7 +77,18 @@ export function setClientI18n<T extends I18nInstance>(i18n: T): T {
  * same mutable i18n instance.
  */
 export function getClientI18nSnapshot(): ClientI18nSnapshot {
-  return globalRuntimeState()[CLIENT_I18N_SNAPSHOT_KEY] ?? clientI18nSnapshot
+  const state = globalRuntimeState()
+  const existing = state[CLIENT_I18N_SNAPSHOT_KEY]
+  if (existing) {
+    return existing
+  }
+
+  const snapshot: ClientI18nSnapshot = {
+    i18n: undefined,
+    revision: 0,
+  }
+  state[CLIENT_I18N_SNAPSHOT_KEY] = snapshot
+  return snapshot
 }
 
 /**
@@ -80,14 +102,15 @@ export function getClientI18nSnapshot(): ClientI18nSnapshot {
  * Returns an unsubscribe function.
  */
 export function subscribeClientI18n(listener: ClientI18nListener): () => void {
-  clientI18nListeners.add(listener)
+  const listeners = getClientI18nListeners()
+  listeners.add(listener)
   return () => {
-    clientI18nListeners.delete(listener)
+    listeners.delete(listener)
   }
 }
 
 export function setServerI18nGetter<T extends I18nInstance>(getter: ServerI18nGetter<T>): void {
-  serverI18nGetter = getter as ServerI18nGetter
+  globalRuntimeState()[SERVER_I18N_GETTER_KEY] = getter as ServerI18nGetter
 }
 
 /**
@@ -95,13 +118,14 @@ export function setServerI18nGetter<T extends I18nInstance>(getter: ServerI18nGe
  * isomorphic SSR bundle that cannot import the Node-only server subpath.
  */
 export function activateServerI18n<T extends I18nInstance>(i18n: T): T {
-  const scopeState = globalRuntimeState()[SERVER_SCOPE_STATE_KEY]
+  const state = globalRuntimeState()
+  const scopeState = state[SERVER_SCOPE_STATE_KEY]
   if (!scopeState) {
     throw new Error(
       "No server i18n scope is configured. Create one with createServerI18nScope() from @palamedes/runtime/server before activating SSR client components."
     )
   }
-  serverI18nGetter ??= () => scopeState.active.getStore()
+  state[SERVER_I18N_GETTER_KEY] ??= () => scopeState.active.getStore()
   const activeI18n = scopeState.active.getStore()
   if (activeI18n === i18n) {
     return i18n
@@ -112,7 +136,9 @@ export function activateServerI18n<T extends I18nInstance>(i18n: T): T {
 
 export function getI18n<T extends I18nInstance = I18nInstance>(): T {
   if (isServerEnvironment()) {
-    const i18n = serverI18nGetter?.()
+    const state = globalRuntimeState()
+    const i18n =
+      state[SERVER_I18N_GETTER_KEY]?.() ?? state[SERVER_SCOPE_STATE_KEY]?.active.getStore()
     if (!i18n) {
       throw new Error(
         "No active server i18n instance. Configure @palamedes/runtime with setServerI18nGetter() before translated code runs."
@@ -121,7 +147,7 @@ export function getI18n<T extends I18nInstance = I18nInstance>(): T {
     return i18n as T
   }
 
-  const activeClientI18n = globalRuntimeState()[CLIENT_I18N_KEY] ?? clientI18n
+  const activeClientI18n = globalRuntimeState()[CLIENT_I18N_KEY]
   if (!activeClientI18n) {
     throw new Error(
       "No active client i18n instance. Initialize @palamedes/runtime with setClientI18n() before translated code runs."
@@ -132,13 +158,8 @@ export function getI18n<T extends I18nInstance = I18nInstance>(): T {
 }
 
 export function resetI18nRuntime(): void {
-  clientI18n = undefined
-  clientI18nSnapshot = {
-    i18n: undefined,
-    revision: 0,
-  }
   const state = globalRuntimeState()
   delete state[CLIENT_I18N_KEY]
   delete state[CLIENT_I18N_SNAPSHOT_KEY]
-  serverI18nGetter = undefined
+  delete state[SERVER_I18N_GETTER_KEY]
 }

--- a/packages/runtime/src/server-unavailable.test.ts
+++ b/packages/runtime/src/server-unavailable.test.ts
@@ -1,9 +1,34 @@
+import { readFileSync } from "node:fs"
+
 import { describe, expect, it } from "vitest"
 
+import type { I18nInstance } from "./index"
 import { createServerI18nScope } from "./server-unavailable"
 
 describe("@palamedes/runtime/server fallback", () => {
   it("throws an actionable error outside Node server runtimes", () => {
-    expect(() => createServerI18nScope()).toThrow(/only available in Node\.js server runtimes/)
+    expect(() => createServerI18nScope<I18nInstance>()).toThrow(
+      /only available in Node\.js server runtimes/
+    )
+  })
+
+  it("provides matching ESM and CJS fallbacks for non-Node conditions", () => {
+    const packageJson = JSON.parse(
+      readFileSync(new URL("../package.json", import.meta.url), "utf8")
+    ) as {
+      exports: {
+        "./server": {
+          browser: unknown
+          default: unknown
+        }
+      }
+    }
+    const fallback = {
+      import: "./dist/server-unavailable.mjs",
+      require: "./dist/server-unavailable.cjs",
+    }
+
+    expect(packageJson.exports["./server"].browser).toStrictEqual(fallback)
+    expect(packageJson.exports["./server"].default).toStrictEqual(fallback)
   })
 })

--- a/packages/runtime/src/server-unavailable.ts
+++ b/packages/runtime/src/server-unavailable.ts
@@ -1,12 +1,10 @@
+import type { I18nInstance, ServerI18nScope } from "./index"
+
+export type { ServerI18nScope } from "./index"
+
 const SERVER_RUNTIME_UNAVAILABLE_MESSAGE =
   "@palamedes/runtime/server is only available in Node.js server runtimes. Import it from server-only Node code, not Client Components or Edge runtime code."
 
-export type ServerI18nScope<T = unknown> = {
-  run<Result>(i18n: T, callback: () => Result): Result
-  activate(i18n: T): T
-  get(): T | undefined
-}
-
-export function createServerI18nScope(): never {
+export function createServerI18nScope<T extends I18nInstance = I18nInstance>(): ServerI18nScope<T> {
   throw new Error(SERVER_RUNTIME_UNAVAILABLE_MESSAGE)
 }

--- a/packages/runtime/src/server.test.ts
+++ b/packages/runtime/src/server.test.ts
@@ -31,6 +31,19 @@ describe("@palamedes/runtime/server", () => {
     expect(scope.get()).toBeUndefined()
   })
 
+  it("shares the active request scope with isolated module graphs", async () => {
+    const scope = createServerI18nScope<I18nInstance>()
+    const i18n = createTestI18n("de")
+    vi.resetModules()
+    const isolatedRuntime = await import("./index")
+
+    scope.run(i18n, () => {
+      expect(isolatedRuntime.getI18n()).toBe(i18n)
+    })
+
+    isolatedRuntime.resetI18nRuntime()
+  })
+
   it("activates an i18n instance for the current async server context", async () => {
     const scope = createServerI18nScope<I18nInstance>()
     const i18n = createTestI18n()

--- a/packages/runtime/src/server.ts
+++ b/packages/runtime/src/server.ts
@@ -1,17 +1,13 @@
 import { AsyncLocalStorage } from "node:async_hooks"
 
-import { type I18nInstance, setServerI18nGetter } from "./index"
+import { type I18nInstance, type ServerI18nScope, setServerI18nGetter } from "./index"
+
+export type { ServerI18nScope } from "./index"
 
 const SERVER_SCOPE_STATE_KEY = Symbol.for("palamedes.runtime.serverI18nScopeState")
 
 type ServerScopeState = {
   active: AsyncLocalStorage<I18nInstance>
-}
-
-export type ServerI18nScope<T extends I18nInstance = I18nInstance> = {
-  run<Result>(i18n: T, callback: () => Result): Result
-  activate(i18n: T): T
-  get(): T | undefined
 }
 
 function getServerScopeState(): ServerScopeState {

--- a/packages/solid/src/index.test.tsx
+++ b/packages/solid/src/index.test.tsx
@@ -32,6 +32,16 @@ describe("@palamedes/solid", () => {
     // Pretend we are on the client so `getI18n` reads the client instance.
     ;(globalThis as { window?: unknown }).window = {}
 
+    const previousI18n = createI18n()
+    previousI18n.activate("en")
+    setClientI18n(previousI18n)
+    const previousRender = Trans({
+      id: "title",
+      message: "Book your seat",
+    }) as unknown as () => unknown
+    previousRender()
+    resetI18nRuntime()
+
     const i18n = createI18n()
     i18n.load("en", { title: "Book your seat" })
     i18n.load("de", { title: "Sichere dir deinen Platz" })

--- a/packages/solid/src/runtime.ts
+++ b/packages/solid/src/runtime.ts
@@ -14,19 +14,17 @@ import { getI18n as getRuntimeI18n, subscribeClientI18n } from "@palamedes/runti
 // change detection would never fire.
 const [trackClientI18n, notifyClientI18n] = createSignal(undefined, { equals: false })
 
-// Subscribe lazily on first use rather than at module load: this package sets
+// Subscribe lazily on use rather than at module load: this package sets
 // `sideEffects: false`, so a top-level subscription could be dropped by a bundler
-// that considers it dead code. Registering from inside `getI18n` keeps it alive.
-let subscribed = false
+// that considers it dead code. The runtime stores listeners in a Set, making
+// repeated registration of this stable callback idempotent. Registering on every
+// read also reconnects the bridge after resetI18nRuntime clears shared listeners.
+const notifyClientLocaleChanged = () => {
+  notifyClientI18n()
+}
 
 function ensureSubscribed(): void {
-  if (subscribed) {
-    return
-  }
-  subscribed = true
-  subscribeClientI18n(() => {
-    notifyClientI18n()
-  })
+  subscribeClientI18n(notifyClientLocaleChanged)
 }
 
 /**


### PR DESCRIPTION
Closes #423

## Summary
- store the client listener set and server getter under `Symbol.for` global runtime keys alongside the existing shared instance/scope state
- let server lookups fall back directly to the shared async-local scope for mixed module graphs
- add isolated-module regression tests for server scope resolution and client subscriptions/snapshots
- share the `ServerI18nScope` type between Node and unavailable-server entries
- provide mode-correct ESM and CJS browser/default fallbacks for `@palamedes/runtime/server`

## Validation
- `CI=true RUSTUP_TOOLCHAIN=1.95 pnpm build`
- `CI=true RUSTUP_TOOLCHAIN=1.95 pnpm format:check`
- `CI=true RUSTUP_TOOLCHAIN=1.95 pnpm lint`
- `CI=true RUSTUP_TOOLCHAIN=1.95 pnpm check-types`
- `CI=true RUSTUP_TOOLCHAIN=1.95 pnpm test`
- `RUSTUP_TOOLCHAIN=1.95 cargo fmt --all --check`
- `RUSTUP_TOOLCHAIN=1.95 cargo clippy --workspace --all-targets --locked -- -D warnings`
- `RUSTUP_TOOLCHAIN=1.95 cargo test --workspace --locked`
- built ESM/CJS smoke test covering cross-format client notifications and server scope resolution