### PR TITLE
fix(react): add reactive runtime bridge

### DIFF
--- a/docs/api/react.md
+++ b/docs/api/react.md
@@ -28,6 +28,11 @@ The client subpath `@palamedes/react/client` exports:
 
 - `useClientLocale(locale, sync)`
 
+The runtime subpath `@palamedes/react/runtime` exports:
+
+- `getI18n<T>()` — a React-aware transform target backed by
+  `useSyncExternalStore`
+
 The macro subpath `@palamedes/react/macro` exports compile-time macro
 components:
 
@@ -38,8 +43,9 @@ components:
 
 ## Runtime Components
 
-Runtime components read the active i18n instance through
-`@palamedes/runtime`.
+Runtime components subscribe to the client activation snapshot and read the
+active request-local instance during server rendering. They therefore update
+independently when nested below `React.memo` components with unchanged props.
 
 ```tsx
 import { Trans } from "@palamedes/react"
@@ -70,3 +76,24 @@ render in the initial HTML. The hook never invokes the sync callback during
 render; this avoids external-store mutations during both SSR and client render
 retries. The sync function may return a promise; the hook intentionally does
 not own loading UI or routing policy.
+
+## Reactive Macro Runtime
+
+Macro `t` / `plural` calls use the transform's configured `runtimeModule`.
+Point it at the React runtime when a client-side locale switch must update
+memoized translated components:
+
+```ts
+palamedes({ runtimeModule: "@palamedes/react/runtime" })
+```
+
+The bridge observes the activation revision rather than only object identity, so
+mutating and re-activating the same i18n instance still schedules a render. Under
+the `react-server` condition, the subpath resolves to the hook-free
+`@palamedes/runtime` getter so Server Components and server actions retain
+request-local runtime behavior.
+
+The reactive getter is a custom hook. Inline `t` / `plural` macros transformed
+to this runtime must execute unconditionally during a function-component or
+custom-hook render. For conditional translated output, render a child component
+such as `<Trans>` in the branch instead of invoking an inline macro conditionally.

--- a/docs/api/runtime.md
+++ b/docs/api/runtime.md
@@ -53,9 +53,9 @@ Registers a listener invoked on every `setClientI18n()` call, including
 re-activation of the same instance in place. Returns an unsubscribe function.
 
 This is the bridge framework bindings use to connect the framework-agnostic
-client runtime to their own reactivity system. `@palamedes/solid/runtime`, for
-example, feeds it into a Solid signal so translated output re-renders on a live
-locale switch. Application code rarely calls this directly.
+client runtime to their own reactivity system. `@palamedes/react/runtime` feeds
+the snapshot into `useSyncExternalStore`, while `@palamedes/solid/runtime` feeds
+activations into a Solid signal. Application code rarely calls this directly.
 
 ```ts
 const unsubscribe = subscribeClientI18n((i18n) => {

--- a/docs/locale-strategies.md
+++ b/docs/locale-strategies.md
@@ -165,6 +165,29 @@ deliberate, that robustness is almost always worth the small reload UX cost.
 Reach for live only when instant, state-preserving switches are a genuine product
 requirement and the team is prepared to key every locale-derived value.
 
+### Enabling live switching (React)
+
+Live switching in React has two pieces:
+
+- `useClientLocale(locale, syncClientI18n)` pushes committed locale changes into
+  the client runtime
+- point the macro transform at React's external-store bridge so memoized
+  `t` / `plural` output follows every activation:
+
+  ```ts
+  palamedes({ runtimeModule: "@palamedes/react/runtime" })
+  ```
+
+The runtime subpath selects a hook-free implementation under the `react-server`
+condition, so the same transform target remains valid for React Server
+Components and server actions.
+
+`<Trans>` / `<Plural>` / `<Select>` / `<SelectOrdinal>` subscribe on their own
+and follow a live switch even with the default `runtimeModule`. Only inline
+`t` / `plural` calls need the reactive transform target. Those calls are
+hook-backed and therefore must execute unconditionally during a React
+function-component or custom-hook render.
+
 ### Enabling live switching (Solid)
 
 Reload needs nothing beyond a normal server render. Live switching in Solid has

--- a/examples/nextjs-route/next.config.mjs
+++ b/examples/nextjs-route/next.config.mjs
@@ -1,3 +1,3 @@
 import { withPalamedes } from "@palamedes/next-plugin"
 
-export default withPalamedes()
+export default withPalamedes({}, { runtimeModule: "@palamedes/react/runtime" })

--- a/examples/react-router-route/vite.config.ts
+++ b/examples/react-router-route/vite.config.ts
@@ -3,7 +3,7 @@ import { palamedes } from "@palamedes/vite-plugin"
 import { defineConfig } from "vite"
 
 export default defineConfig({
-  plugins: [palamedes(), reactRouter()],
+  plugins: [palamedes({ runtimeModule: "@palamedes/react/runtime" }), reactRouter()],
   resolve: {
     tsconfigPaths: true,
   },

--- a/examples/tanstack-route/vite.config.ts
+++ b/examples/tanstack-route/vite.config.ts
@@ -4,7 +4,7 @@ import { tanstackStart } from "@tanstack/react-start/plugin/vite"
 import { palamedes } from "@palamedes/vite-plugin"
 
 export default defineConfig({
-  plugins: [tanstackStart(), palamedes(), react()],
+  plugins: [tanstackStart(), palamedes({ runtimeModule: "@palamedes/react/runtime" }), react()],
   preview: {
     allowedHosts: [".examples.palamedes.dev", "de.lvh.me", "en.lvh.me", "es.lvh.me"],
   },

--- a/examples/waku-route/waku.config.ts
+++ b/examples/waku-route/waku.config.ts
@@ -4,6 +4,6 @@ import { palamedes } from "@palamedes/vite-plugin"
 
 export default defineConfig({
   vite: {
-    plugins: [palamedes(), react()],
+    plugins: [palamedes({ runtimeModule: "@palamedes/react/runtime" }), react()],
   },
 })

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -33,6 +33,24 @@ export function Footer() {
 }
 ```
 
+For live client-side locale switches, point the macro transform at React's
+external-store bridge:
+
+```ts
+palamedes({ runtimeModule: "@palamedes/react/runtime" })
+```
+
+The `@palamedes/react/runtime` subpath exports a React-aware `getI18n()` that
+subscribes the rendering component to every `setClientI18n()` activation,
+including re-activation of the same mutable instance. React Server Components
+resolve the hook-free server implementation through the `react-server` export
+condition.
+
+`<Trans>`, `<Plural>`, `<Select>`, and `<SelectOrdinal>` use the same subscription
+automatically. The transform override is needed for inline `t` / `plural` macro
+calls. Because the reactive getter is a custom hook, those inline calls must run
+unconditionally during a function-component or custom-hook render.
+
 ## License
 
 [![Sebastian Software](https://sebastian-brand.vercel.app/sebastian-software/logo-software.svg)](https://oss.sebastian-software.com/)

--- a/packages/react/build.config.ts
+++ b/packages/react/build.config.ts
@@ -1,0 +1,21 @@
+import { defineBuildConfig } from "unbuild"
+
+export default defineBuildConfig({
+  entries: [
+    "./src/index",
+    "./src/index-server",
+    "./src/client",
+    "./src/runtime",
+    "./src/runtime-server",
+    "./src/macro",
+  ],
+  declaration: true,
+  failOnWarn: false,
+  rollup: {
+    emitCJS: true,
+    output: {
+      banner: (chunk) =>
+        chunk.name === "index" || chunk.name === "runtime" ? '"use client";' : "",
+    },
+  },
+})

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -19,6 +19,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
+      "react-server": {
+        "import": "./dist/index-server.mjs",
+        "require": "./dist/index-server.cjs"
+      },
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
     },
@@ -26,6 +30,15 @@
       "types": "./dist/client.d.ts",
       "import": "./dist/client.mjs",
       "require": "./dist/client.cjs"
+    },
+    "./runtime": {
+      "types": "./dist/runtime.d.ts",
+      "react-server": {
+        "import": "./dist/runtime-server.mjs",
+        "require": "./dist/runtime-server.cjs"
+      },
+      "import": "./dist/runtime.mjs",
+      "require": "./dist/runtime.cjs"
     },
     "./macro": {
       "types": "./dist/macro.d.ts",
@@ -43,7 +56,7 @@
   ],
   "scripts": {
     "build": "unbuild",
-    "test": "vitest run --globals src/index.test.tsx",
+    "test": "vitest run --globals src/index.test.tsx && node --test scripts/exports.test.mjs",
     "stub": "unbuild --stub"
   },
   "engines": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -20,6 +20,7 @@
     ".": {
       "types": "./dist/index.d.ts",
       "react-server": {
+        "types": "./dist/index-server.d.ts",
         "import": "./dist/index-server.mjs",
         "require": "./dist/index-server.cjs"
       },
@@ -34,6 +35,7 @@
     "./runtime": {
       "types": "./dist/runtime.d.ts",
       "react-server": {
+        "types": "./dist/runtime-server.d.ts",
         "import": "./dist/runtime-server.mjs",
         "require": "./dist/runtime-server.cjs"
       },

--- a/packages/react/scripts/exports.test.mjs
+++ b/packages/react/scripts/exports.test.mjs
@@ -6,10 +6,12 @@ const packageJson = JSON.parse(await readFile(new URL("../package.json", import.
 
 test("uses hook-free package entries in React Server Components", () => {
   assert.deepEqual(packageJson.exports["."]["react-server"], {
+    types: "./dist/index-server.d.ts",
     import: "./dist/index-server.mjs",
     require: "./dist/index-server.cjs",
   })
   assert.deepEqual(packageJson.exports["./runtime"]["react-server"], {
+    types: "./dist/runtime-server.d.ts",
     import: "./dist/runtime-server.mjs",
     require: "./dist/runtime-server.cjs",
   })

--- a/packages/react/scripts/exports.test.mjs
+++ b/packages/react/scripts/exports.test.mjs
@@ -1,0 +1,16 @@
+import { readFile } from "node:fs/promises"
+import assert from "node:assert/strict"
+import test from "node:test"
+
+const packageJson = JSON.parse(await readFile(new URL("../package.json", import.meta.url), "utf8"))
+
+test("uses hook-free package entries in React Server Components", () => {
+  assert.deepEqual(packageJson.exports["."]["react-server"], {
+    import: "./dist/index-server.mjs",
+    require: "./dist/index-server.cjs",
+  })
+  assert.deepEqual(packageJson.exports["./runtime"]["react-server"], {
+    import: "./dist/runtime-server.mjs",
+    require: "./dist/runtime-server.cjs",
+  })
+})

--- a/packages/react/src/index-server.tsx
+++ b/packages/react/src/index-server.tsx
@@ -1,6 +1,5 @@
-"use client"
+import { getI18n } from "@palamedes/runtime"
 
-import { getI18n as useI18n } from "./runtime"
 import { createRuntimeComponents } from "./shared"
 
 export {
@@ -16,4 +15,4 @@ export {
   type TransProps,
 } from "./shared"
 
-export const { Plural, Select, SelectOrdinal, Trans } = createRuntimeComponents(useI18n)
+export const { Plural, Select, SelectOrdinal, Trans } = createRuntimeComponents(getI18n)

--- a/packages/react/src/index.test.tsx
+++ b/packages/react/src/index.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
+import { memo } from "react"
 import { renderToStaticMarkup } from "react-dom/server"
-import { render } from "@testing-library/react"
+import { act, render } from "@testing-library/react"
 import { afterEach, describe, expect, it, vi } from "vitest"
 
 import { createI18n } from "@palamedes/core"
@@ -9,6 +10,7 @@ import { createServerI18nScope } from "@palamedes/runtime/server"
 
 import { Plural, Select, SelectOrdinal, Trans, buildLocaleSwitchItems } from "./index"
 import { useClientLocale } from "./client"
+import { getI18n as getReactiveI18n } from "./runtime"
 
 describe("@palamedes/react", () => {
   afterEach(() => {
@@ -191,6 +193,50 @@ describe("@palamedes/react", () => {
 
     view.rerender(<Probe locale="de" />)
     expect(sync).toHaveBeenLastCalledWith("de")
+    expect(view.container.textContent).toBe("Hallo")
+  })
+
+  it("re-renders memoized macro output after a client locale switch", () => {
+    const i18n = createI18n()
+    i18n.load("en", { greeting: "Hello" })
+    i18n.load("de", { greeting: "Hallo" })
+    i18n.activate("en")
+    setClientI18n(i18n)
+
+    const MacroOutput = memo(function MacroOutput() {
+      return <span>{String(getReactiveI18n<typeof i18n>()._("greeting"))}</span>
+    })
+
+    const view = render(<MacroOutput />)
+    expect(view.container.textContent).toBe("Hello")
+
+    act(() => {
+      i18n.activate("de")
+      setClientI18n(i18n)
+    })
+
+    expect(view.container.textContent).toBe("Hallo")
+  })
+
+  it("re-renders memoized Trans output after a client locale switch", () => {
+    const i18n = createI18n()
+    i18n.load("en", { greeting: "Hello" })
+    i18n.load("de", { greeting: "Hallo" })
+    i18n.activate("en")
+    setClientI18n(i18n)
+
+    const MemoizedTrans = memo(function MemoizedTrans() {
+      return <Trans id="greeting" message="Greeting" />
+    })
+
+    const view = render(<MemoizedTrans />)
+    expect(view.container.textContent).toBe("Hello")
+
+    act(() => {
+      i18n.activate("de")
+      setClientI18n(i18n)
+    })
+
     expect(view.container.textContent).toBe("Hallo")
   })
 

--- a/packages/react/src/runtime-server.ts
+++ b/packages/react/src/runtime-server.ts
@@ -1,0 +1,1 @@
+export { getI18n } from "@palamedes/runtime"

--- a/packages/react/src/runtime.ts
+++ b/packages/react/src/runtime.ts
@@ -1,0 +1,35 @@
+"use client"
+
+import { useSyncExternalStore } from "react"
+
+import {
+  getClientI18nSnapshot,
+  getI18n as getRuntimeI18n,
+  subscribeClientI18n,
+  type ClientI18nSnapshot,
+  type I18nInstance,
+} from "@palamedes/runtime"
+
+const SERVER_CLIENT_I18N_SNAPSHOT: ClientI18nSnapshot = {
+  i18n: undefined,
+  revision: 0,
+}
+
+/**
+ * React-aware replacement for `@palamedes/runtime`'s `getI18n`.
+ *
+ * Configure the Palamedes transform to import this function for translated
+ * client components that must re-render after `setClientI18n()` activates a
+ * locale. The `react-server` export condition resolves to the hook-free server
+ * implementation instead.
+ */
+function useReactiveI18n<T extends I18nInstance = I18nInstance>(): T {
+  useSyncExternalStore(
+    subscribeClientI18n,
+    getClientI18nSnapshot,
+    () => SERVER_CLIENT_I18N_SNAPSHOT
+  )
+  return getRuntimeI18n<T>()
+}
+
+export { useReactiveI18n as getI18n }

--- a/packages/react/src/shared.tsx
+++ b/packages/react/src/shared.tsx
@@ -1,0 +1,207 @@
+import * as React from "react"
+import { cloneElement, Fragment, isValidElement } from "react"
+import type { ReactElement, ReactNode } from "react"
+
+import { formatMessagePattern } from "@palamedes/core"
+import type { MessageChoiceNode, MessageNode, PalamedesI18n } from "@palamedes/core"
+
+export type TransProps = {
+  // `id` is optional in authored source: components are written with `message`
+  // (or choice props) and the Palamedes compiler transform injects the resolved
+  // `id` at build time. Hand-written runtime usage may still pass `id` directly.
+  id?: string
+  message?: string
+  context?: string
+  comment?: string
+  values?: Record<string, unknown>
+  components?: Record<string, ReactElement>
+}
+
+type ChoiceComponentProps = {
+  value: string | number
+  zero?: string
+  one?: string
+  two?: string
+  few?: string
+  many?: string
+  other: string
+}
+
+export type PluralProps = ChoiceComponentProps & {
+  offset?: number
+}
+
+export type SelectOrdinalProps = ChoiceComponentProps & {
+  offset?: number
+}
+
+export type SelectProps = {
+  value: string | number
+  other: string
+  [key: string]: string | number | undefined
+}
+
+export function createRuntimeComponents(useI18n: () => PalamedesI18n) {
+  function Trans({ id, message, values, components, context, comment }: TransProps): ReactNode {
+    const i18n = useI18n()
+    const resolvedId = id ?? message ?? ""
+    const nodes = i18n.getMessageNodes(resolvedId, {
+      message,
+      context,
+      comment,
+    })
+    return <>{renderNodes(nodes, values ?? {}, components ?? {}, i18n.locale)}</>
+  }
+
+  function Plural({ value, offset, ...choices }: PluralProps): ReactNode {
+    const i18n = useI18n()
+    const message = buildChoiceMessage("value", "plural", choices, offset)
+    return <>{formatMessagePattern(message, { value }, i18n.locale)}</>
+  }
+
+  function SelectOrdinal({ value, offset, ...choices }: SelectOrdinalProps): ReactNode {
+    const i18n = useI18n()
+    const message = buildChoiceMessage("value", "selectordinal", choices, offset)
+    return <>{formatMessagePattern(message, { value }, i18n.locale)}</>
+  }
+
+  function Select({ value, ...choices }: SelectProps): ReactNode {
+    const i18n = useI18n()
+    const message = buildChoiceMessage("value", "select", choices)
+    return <>{formatMessagePattern(message, { value }, i18n.locale)}</>
+  }
+
+  return { Plural, Select, SelectOrdinal, Trans }
+}
+
+function buildChoiceMessage(
+  variable: string,
+  kind: "plural" | "select" | "selectordinal",
+  choices: Record<string, string | number | undefined>,
+  offset?: number
+): string {
+  validatePluralOffset(offset)
+  const parts = Object.entries(choices)
+    .filter((entry): entry is [string, string] => typeof entry[1] === "string")
+    .map(([key, value]) => `${key} {${value}}`)
+  const offsetPart = offset === undefined ? "" : ` offset:${offset}`
+  return `{${variable}, ${kind},${offsetPart} ${parts.join(" ")}}`
+}
+
+function validatePluralOffset(offset: number | undefined): void {
+  if (offset !== undefined && (!Number.isSafeInteger(offset) || offset < 0)) {
+    throw new RangeError("Plural offset must be a non-negative safe integer.")
+  }
+}
+
+function renderNodes(
+  nodes: MessageNode[],
+  values: Record<string, unknown>,
+  components: Record<string, ReactElement>,
+  locale: string,
+  pluralValue?: number
+): ReactNode[] {
+  return nodes.flatMap((node, index) =>
+    renderNode(node, values, components, index, locale, pluralValue)
+  )
+}
+
+function renderNode(
+  node: MessageNode,
+  values: Record<string, unknown>,
+  components: Record<string, ReactElement>,
+  key: number,
+  locale: string,
+  pluralValue?: number
+): ReactNode[] {
+  switch (node.type) {
+    case "text": {
+      return [
+        pluralValue === undefined
+          ? node.value
+          : node.value.replaceAll("#", formatNumber(pluralValue, locale)),
+      ]
+    }
+    case "literal": {
+      return [node.value]
+    }
+    case "variable": {
+      return [renderVariable(values[node.name])]
+    }
+    case "formatted": {
+      return [formatMessagePattern(buildFormattedMessage(node), values, locale)]
+    }
+    case "tag": {
+      const children = renderNodes(node.children, values, components, locale, pluralValue)
+      const component = components[node.name]
+      if (component && isValidElement(component)) {
+        return [cloneElement(component, { key }, ...children)]
+      }
+      return children
+    }
+    case "choice": {
+      const value = values[node.variable]
+      const nextPluralValue =
+        node.kind === "select" ? pluralValue : pluralOperand(node, normalizeNumericValue(value))
+      const choice = selectChoice(node, value, locale)
+      return renderNodes(choice, values, components, locale, nextPluralValue)
+    }
+  }
+
+  return []
+}
+
+function buildFormattedMessage(node: Extract<MessageNode, { type: "formatted" }>): string {
+  return `{${node.variable}, ${node.format}${node.style ? `, ${node.style}` : ""}}`
+}
+
+function selectChoice(node: MessageChoiceNode, value: unknown, locale: string): MessageNode[] {
+  if (node.kind === "select") {
+    const exact = value == null ? undefined : node.options[String(value)]
+    return exact ?? node.options.other ?? []
+  }
+
+  const numericValue = normalizeNumericValue(value)
+  const exactKey = `=${numericValue}`
+  if (node.options[exactKey]) {
+    return node.options[exactKey]
+  }
+
+  const operand = pluralOperand(node, numericValue)
+  const pluralRules = new Intl.PluralRules(locale, {
+    type: node.kind === "selectordinal" ? "ordinal" : "cardinal",
+  })
+  const category = pluralRules.select(operand)
+  return node.options[category] ?? node.options.other ?? []
+}
+
+function pluralOperand(node: MessageChoiceNode, numericValue: number): number {
+  return numericValue - (node.offset ?? 0)
+}
+
+function renderVariable(value: unknown): ReactNode {
+  if (value === null || value === undefined) {
+    return ""
+  }
+
+  if (isValidElement(value)) {
+    return cloneElement(value, {})
+  }
+
+  return String(value)
+}
+
+function normalizeNumericValue(value: unknown): number {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value
+  }
+
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : 0
+}
+
+function formatNumber(value: number, locale: string): string {
+  return new Intl.NumberFormat(locale).format(value)
+}
+
+export { Fragment }


### PR DESCRIPTION
Closes #415

## Summary
- add a hook-backed `@palamedes/react/runtime` bridge and reactive runtime components
- add hook-free `react-server` conditional entries for the React package root and runtime
- wire the live route examples and documentation to the reactive transform target

## Validation
- `CI=true pnpm format:check`
- `CI=true pnpm lint`
- `CI=true RUSTUP_TOOLCHAIN=1.95 pnpm check-types`
- `CI=true RUSTUP_TOOLCHAIN=1.95 pnpm test`
- `CI=true RUSTUP_TOOLCHAIN=1.95 pnpm build`
- `CI=true pnpm check:published-types`
- React Router, TanStack, Waku, and Next.js route production builds
- `react-server` ESM smoke tests