### PR TITLE
feat(cli): binary plugin protocol host support (ADR 002)

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -11,6 +11,7 @@ expected to use directly.
 - [`@palamedes/config`](./config.md)
 - [`@palamedes/cli`](./cli.md)
 - [`@palamedes/cli/plugin`](./cli-plugin.md)
+- [`pmds` binary plugin protocol](./cli-binary-plugin.md)
 - [`@palamedes/vite-plugin`](./vite-plugin.md)
 - [`@palamedes/next-plugin`](./next-plugin.md)
 - [`@palamedes/core-node`](./core-node.md)

--- a/docs/api/cli-binary-plugin.md
+++ b/docs/api/cli-binary-plugin.md
@@ -53,7 +53,12 @@ object to stdin, then closes it:
 `describe` must answer with exactly one manifest event on stdout:
 
 ```json
-{ "event": "manifest", "name": "acme", "protocolVersion": 1, "commands": { "inspect": { "description": "Inspect configured catalogs." } } }
+{
+  "event": "manifest",
+  "name": "acme",
+  "protocolVersion": 1,
+  "commands": { "inspect": { "description": "Inspect configured catalogs." } }
+}
 ```
 
 Manifests are validated like ESM plugin definitions: lowercase kebab-case
@@ -73,7 +78,15 @@ A `run` request carries the invocation and resolved project context:
   "json": false,
   "interactive": false,
   "config": { "…": "resolved LoadedPalamedesConfig" },
-  "catalogs": [{ "path": "…", "format": "po", "include": ["src"], "exclude": [], "locales": [{ "locale": "en", "path": "/abs/path" }] }]
+  "catalogs": [
+    {
+      "path": "…",
+      "format": "po",
+      "include": ["src"],
+      "exclude": [],
+      "locales": [{ "locale": "en", "path": "/abs/path" }]
+    }
+  ]
 }
 ```
 

--- a/docs/api/cli-binary-plugin.md
+++ b/docs/api/cli-binary-plugin.md
@@ -1,0 +1,114 @@
+# `pmds` Binary Plugin Protocol
+
+Binary plugins are standalone executables that extend `pmds` with namespaced
+commands, following [ADR 002](../adr/002-binary-plugin-protocol.md). They speak
+a versioned newline-delimited JSON protocol over stdio, so Rust-first
+extensions can link the `palamedes` crates directly without maintaining Node
+bindings. The [ESM plugin API](./cli-plugin.md) remains fully supported; both
+kinds share one configuration, one registry, and the same output contract.
+
+## Declare A Binary Plugin
+
+Configuration keeps the familiar tuple form. The plugin kind is a property of
+the resolved package: a binary plugin package declares `palamedes.pluginBinary`
+in its `package.json`, pointing at the executable relative to the package root.
+
+```yaml
+plugins:
+  - ["@acme/palamedes-plus", { license: "…" }]
+```
+
+```json
+{
+  "name": "@acme/palamedes-plus",
+  "palamedes": { "pluginBinary": "./bin/palamedes-plus" }
+}
+```
+
+Per-platform binaries follow the same `optionalDependencies` pattern the CLI
+itself uses for `pmds-native`. For local development, a config-relative path to
+a directory containing such a `package.json` — or directly to a non-JavaScript
+executable file — is accepted. A `pluginBinary` ending in `.js`, `.mjs`, or
+`.cjs` is spawned through the current Node executable, which keeps fixtures and
+prototypes cross-platform. Packages without `palamedes.pluginBinary` are
+loaded as ESM plugins as before. Nothing is ever discovered via `PATH` or
+executed merely because it is installed.
+
+## Protocol
+
+Protocol version `1` must match exactly. It is versioned independently of both
+the package version and the ESM plugin API major.
+
+The host spawns the executable once per request and writes a single JSON
+object to stdin, then closes it:
+
+```json
+{
+  "palamedesBinaryPluginProtocol": 1,
+  "hostVersion": "1.5.1",
+  "kind": "describe"
+}
+```
+
+`describe` must answer with exactly one manifest event on stdout:
+
+```json
+{ "event": "manifest", "name": "acme", "protocolVersion": 1, "commands": { "inspect": { "description": "Inspect configured catalogs." } } }
+```
+
+Manifests are validated like ESM plugin definitions: lowercase kebab-case
+names, no built-in namespaces (`extract`, `audit`, `report`, `catalog`,
+`version`), no duplicates across configured plugins.
+
+A `run` request carries the invocation and resolved project context:
+
+```json
+{
+  "palamedesBinaryPluginProtocol": 1,
+  "hostVersion": "1.5.1",
+  "kind": "run",
+  "command": "inspect",
+  "args": ["one", "two"],
+  "options": { "license": "…" },
+  "json": false,
+  "interactive": false,
+  "config": { "…": "resolved LoadedPalamedesConfig" },
+  "catalogs": [{ "path": "…", "format": "po", "include": ["src"], "exclude": [], "locales": [{ "locale": "en", "path": "/abs/path" }] }]
+}
+```
+
+The plugin answers with newline-delimited events on stdout — zero or more
+`diagnostic` and `output` events, then at most one `result` event:
+
+```json
+{ "event": "diagnostic", "severity": "info", "code": "ACME_INSPECTED", "message": "Inspected 2 catalogs." }
+{ "event": "output", "text": "inspecting" }
+{ "event": "result", "text": "done", "data": { "count": 2 }, "exitCode": 0 }
+```
+
+- stdout is reserved for protocol events; free-form progress belongs on
+  stderr, which passes through to the terminal.
+- Diagnostics use the same `severity`/`code`/`message`/`details` shape and
+  rendering as the ESM API. With `--json`, everything is folded into the same
+  single host envelope.
+- Without an explicit `exitCode`, error diagnostics produce `1` and other
+  results produce `0`. Exit codes must be integers from 0 through 255.
+- If no valid `result` event arrives, the process exit code is the
+  authoritative fallback and the host reports a `PLUGIN_BINARY_PROTOCOL`
+  diagnostic.
+- `SIGINT` and `SIGTERM` are forwarded to the child; cooperative cancellation
+  maps to exit codes 130 and 143.
+
+## Built-In Commands And Trust
+
+Instead of a bidirectional channel, the host exports the resolved
+`pmds-native` executable path as the `PALAMEDES_NATIVE` environment variable.
+Binary plugins are trusted local code — the trust model from
+[ADR 001](../adr/001-cli-plugin-execution-boundary.md) applies unchanged — so
+they may invoke documented built-in commands directly as subprocesses. In JSON
+mode a plugin should capture that output rather than let it corrupt the single
+envelope on its own stdout.
+
+Built-in commands bypass configuration and plugin loading entirely, so a
+missing, incompatible, or crashing binary plugin never affects `pmds extract`,
+`audit`, `report`, `catalog`, or `version`.

--- a/docs/api/cli-plugin.md
+++ b/docs/api/cli-plugin.md
@@ -2,6 +2,9 @@
 
 The versioned CLI plugin API defines explicit, namespaced workflow commands. It
 does not provide lifecycle hooks and does not expose Rust or N-API internals.
+Plugins that are standalone executables instead of Node modules use the
+[binary plugin protocol](./cli-binary-plugin.md) with the same configuration
+and output contract.
 
 ## Define A Plugin
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -19,8 +19,9 @@ pmds <plugin> <command> --config ./palamedes.yaml [...args]
 fall back to the native CLI's normal unknown-command diagnostic.
 
 Plugin loading is explicit and applies only to non-built-in namespaces. See the
-[configuration field](./configuration.md#cli-plugins) and
-[`@palamedes/cli/plugin` API](./api/cli-plugin.md).
+[configuration field](./configuration.md#cli-plugins), the
+[`@palamedes/cli/plugin` API](./api/cli-plugin.md), and the
+[binary plugin protocol](./api/cli-binary-plugin.md) for executable plugins.
 
 ## `pmds extract`
 

--- a/packages/cli/fixtures/plugin-project/binary-plugin-future/package.json
+++ b/packages/cli/fixtures/plugin-project/binary-plugin-future/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "palamedes-binary-plugin-future-fixture",
+  "private": true,
+  "type": "module",
+  "palamedes": {
+    "pluginBinary": "./plugin.mjs"
+  }
+}

--- a/packages/cli/fixtures/plugin-project/binary-plugin-future/plugin.mjs
+++ b/packages/cli/fixtures/plugin-project/binary-plugin-future/plugin.mjs
@@ -1,0 +1,4 @@
+process.stdout.write(
+  `${JSON.stringify({ event: "manifest", name: "future", protocolVersion: 2, commands: {} })}\n`
+)
+process.exit(0)

--- a/packages/cli/fixtures/plugin-project/binary-plugin/package.json
+++ b/packages/cli/fixtures/plugin-project/binary-plugin/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "palamedes-binary-plugin-fixture",
+  "private": true,
+  "type": "module",
+  "palamedes": {
+    "pluginBinary": "./plugin.mjs"
+  }
+}

--- a/packages/cli/fixtures/plugin-project/binary-plugin/plugin.mjs
+++ b/packages/cli/fixtures/plugin-project/binary-plugin/plugin.mjs
@@ -1,0 +1,70 @@
+const request = JSON.parse(await readStdin())
+
+if (request.kind === "describe") {
+  emit({
+    event: "manifest",
+    name: "binary",
+    protocolVersion: 1,
+    commands: {
+      inspect: { description: "Inspect the project through the binary protocol." },
+      fail: { description: "Report a failing workflow result." },
+      crash: { description: "Exit without emitting a result event." },
+    },
+  })
+  process.exit(0)
+}
+
+if (request.command === "inspect") {
+  emit({
+    event: "diagnostic",
+    severity: "info",
+    code: "BINARY_INSPECTED",
+    message: `Inspected ${request.catalogs.length} catalog definitions.`,
+  })
+  emit({ event: "output", text: "inspecting" })
+  emit({
+    event: "result",
+    text: "done",
+    data: {
+      args: request.args,
+      options: request.options,
+      rootDir: request.config.rootDir,
+      locales: request.catalogs[0].locales.map((entry) => entry.locale),
+      native: process.env.PALAMEDES_NATIVE ?? null,
+      json: request.json,
+      interactive: request.interactive,
+    },
+    exitCode: 0,
+  })
+  process.exit(0)
+}
+
+if (request.command === "fail") {
+  emit({
+    event: "diagnostic",
+    severity: "error",
+    code: "BINARY_FAILED",
+    message: "Binary workflow failed.",
+  })
+  emit({ event: "result", exitCode: 9 })
+  process.exit(0)
+}
+
+if (request.command === "crash") {
+  process.exit(5)
+}
+
+process.exit(2)
+
+function emit(event) {
+  process.stdout.write(`${JSON.stringify(event)}\n`)
+}
+
+async function readStdin() {
+  let input = ""
+  process.stdin.setEncoding("utf8")
+  for await (const chunk of process.stdin) {
+    input += chunk
+  }
+  return input
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -38,7 +38,7 @@
   "scripts": {
     "build": "node ./scripts/build.mjs",
     "postinstall": "node ./scripts/install.mjs",
-    "test": "node --test ./scripts/plugin-host.test.mjs && node ./scripts/smoke.mjs"
+    "test": "node --test ./scripts/plugin-host.test.mjs ./scripts/binary-plugin.test.mjs && node ./scripts/smoke.mjs"
   },
   "engines": {
     "node": ">=22.0.0"

--- a/packages/cli/scripts/binary-plugin.mjs
+++ b/packages/cli/scripts/binary-plugin.mjs
@@ -1,0 +1,275 @@
+import { spawn } from "node:child_process"
+import fs from "node:fs"
+import { createRequire } from "node:module"
+import path from "node:path"
+
+import { PALAMEDES_PLUGIN_API_VERSION } from "../plugin-api.mjs"
+
+export const PALAMEDES_BINARY_PLUGIN_PROTOCOL_VERSION = 1
+
+// Script binaries keep the fixture and local-dev story cross-platform: a
+// pluginBinary ending in .js/.mjs/.cjs is spawned through the current Node
+// executable instead of directly.
+const SCRIPT_EXTENSIONS = new Set([".js", ".mjs", ".cjs"])
+
+const HOST_VERSION = createRequire(import.meta.url)("../package.json").version
+
+export function resolveBinaryPlugin(specifier, configPath) {
+  const configDir = path.dirname(configPath)
+  const packageDir = locatePackageDir(specifier, configPath, configDir)
+  if (packageDir) {
+    const declared = readPackageManifest(packageDir)?.palamedes?.pluginBinary
+    if (typeof declared !== "string" || declared.length === 0) {
+      return
+    }
+    return { specifier, binaryPath: path.resolve(packageDir, declared) }
+  }
+  if (isPathSpecifier(specifier)) {
+    const resolved = path.resolve(configDir, specifier)
+    if (isFile(resolved) && !SCRIPT_EXTENSIONS.has(path.extname(resolved))) {
+      return { specifier, binaryPath: resolved }
+    }
+  }
+  return
+}
+
+export async function loadBinaryPlugin(resolved, context = {}) {
+  const invocation = await invokeBinary(resolved, describeRequest(), context)
+  if (invocation.exitCode !== 0) {
+    throw protocolError(resolved, `describe failed with exit code ${invocation.exitCode}`)
+  }
+  const manifests = invocation.events.filter((event) => event.event === "manifest")
+  if (manifests.length !== 1) {
+    throw protocolError(resolved, "describe must emit exactly one manifest event")
+  }
+  const manifest = manifests[0]
+  if (manifest.protocolVersion !== PALAMEDES_BINARY_PLUGIN_PROTOCOL_VERSION) {
+    throw codedError(
+      "PLUGIN_PROTOCOL_INCOMPATIBLE",
+      `Binary plugin "${resolved.specifier}" requires binary plugin protocol ${String(manifest.protocolVersion)}; this CLI supports ${PALAMEDES_BINARY_PLUGIN_PROTOCOL_VERSION}.`
+    )
+  }
+  if (
+    !manifest.commands ||
+    typeof manifest.commands !== "object" ||
+    Array.isArray(manifest.commands)
+  ) {
+    throw protocolError(resolved, "manifest must declare a commands object")
+  }
+
+  const commands = {}
+  for (const [commandName, declaration] of Object.entries(manifest.commands)) {
+    commands[commandName] = {
+      ...(typeof declaration?.description === "string"
+        ? { description: declaration.description }
+        : {}),
+      run: (payload) => runBinaryCommand(resolved, commandName, payload, context),
+    }
+  }
+  return { name: manifest.name, apiVersion: PALAMEDES_PLUGIN_API_VERSION, commands }
+}
+
+async function runBinaryCommand(resolved, commandName, payload, context) {
+  const request = {
+    palamedesBinaryPluginProtocol: PALAMEDES_BINARY_PLUGIN_PROTOCOL_VERSION,
+    hostVersion: HOST_VERSION,
+    kind: "run",
+    command: commandName,
+    args: payload.args,
+    options: payload.options ?? null,
+    json: payload.json,
+    interactive: payload.interactive,
+    config: payload.host.config,
+    catalogs: payload.host.catalogs(),
+  }
+  const invocation = await invokeBinary(resolved, request, context, payload.signal)
+  if (payload.signal?.aborted) {
+    throw payload.signal.reason
+  }
+
+  const outputs = []
+  let result
+  for (const event of invocation.events) {
+    if (event.event === "diagnostic") {
+      payload.host.reportDiagnostic({
+        severity: event.severity,
+        message: event.message,
+        ...(event.code ? { code: event.code } : {}),
+        ...(Object.hasOwn(event, "details") ? { details: event.details } : {}),
+      })
+    } else if (event.event === "output") {
+      outputs.push(String(event.text ?? ""))
+    } else if (event.event === "result") {
+      if (result) {
+        throw protocolError(resolved, "run must emit at most one result event")
+      }
+      result = event
+    } else {
+      throw protocolError(resolved, `unknown event "${String(event.event)}"`)
+    }
+  }
+
+  if (!result) {
+    return {
+      exitCode: invocation.exitCode === 0 ? 1 : invocation.exitCode,
+      diagnostics: [
+        {
+          severity: "error",
+          code: "PLUGIN_BINARY_PROTOCOL",
+          message: `Binary plugin "${resolved.specifier}" exited with code ${invocation.exitCode} without emitting a result event.`,
+        },
+      ],
+    }
+  }
+
+  const text = [...outputs, ...(result.text !== undefined ? [String(result.text)] : [])].join("\n")
+  return {
+    ...(text.length > 0 ? { text } : {}),
+    ...(Object.hasOwn(result, "data") ? { data: result.data } : {}),
+    ...(Object.hasOwn(result, "exitCode") ? { exitCode: result.exitCode } : {}),
+  }
+}
+
+function describeRequest() {
+  return {
+    palamedesBinaryPluginProtocol: PALAMEDES_BINARY_PLUGIN_PROTOCOL_VERSION,
+    hostVersion: HOST_VERSION,
+    kind: "describe",
+  }
+}
+
+async function invokeBinary(resolved, request, context = {}, signal) {
+  if (signal?.aborted) {
+    throw signal.reason
+  }
+  const isScript = SCRIPT_EXTENSIONS.has(path.extname(resolved.binaryPath))
+  const executable = isScript ? process.execPath : resolved.binaryPath
+  const executableArgs = isScript ? [resolved.binaryPath] : []
+
+  return new Promise((resolvePromise, reject) => {
+    const child = spawn(executable, executableArgs, {
+      cwd: context.cwd,
+      env: {
+        ...process.env,
+        ...(context.nativeExecutable ? { PALAMEDES_NATIVE: context.nativeExecutable } : {}),
+      },
+      stdio: ["pipe", "pipe", "inherit"],
+    })
+    let stdout = ""
+    child.stdout.setEncoding("utf8")
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk
+    })
+    const onAbort = () => child.kill(signal?.reason?.signal ?? "SIGTERM")
+    const cleanup = () => signal?.removeEventListener("abort", onAbort)
+    signal?.addEventListener("abort", onAbort, { once: true })
+    child.once("error", (error) => {
+      cleanup()
+      reject(
+        codedError(
+          "PLUGIN_BINARY_SPAWN_FAILED",
+          `Could not run binary plugin "${resolved.specifier}": ${error.message}`
+        )
+      )
+    })
+    child.once("exit", (code, exitSignal) => {
+      cleanup()
+      const exitCode = exitSignal
+        ? exitSignal === "SIGINT"
+          ? 130
+          : exitSignal === "SIGTERM"
+            ? 143
+            : 1
+        : (code ?? 1)
+      try {
+        resolvePromise({ exitCode, events: parseEvents(stdout, resolved) })
+      } catch (error) {
+        reject(error)
+      }
+    })
+    // The child may exit before consuming its request; a closed pipe must not
+    // surface as an unrelated stream error.
+    child.stdin.on("error", () => {})
+    child.stdin.end(`${JSON.stringify(request)}\n`)
+  })
+}
+
+function parseEvents(stdout, resolved) {
+  const events = []
+  for (const line of stdout.split("\n")) {
+    if (line.trim().length === 0) {
+      continue
+    }
+    let event
+    try {
+      event = JSON.parse(line)
+    } catch {
+      throw protocolError(resolved, `invalid JSON event line: ${line}`)
+    }
+    if (!event || typeof event !== "object" || typeof event.event !== "string") {
+      throw protocolError(resolved, `event lines must be objects with an "event" kind`)
+    }
+    events.push(event)
+  }
+  return events
+}
+
+function locatePackageDir(specifier, configPath, configDir) {
+  if (isPathSpecifier(specifier)) {
+    const resolved = path.resolve(configDir, specifier)
+    return isFile(path.join(resolved, "package.json")) ? resolved : undefined
+  }
+  const packageSegments = bareSpecifierSegments(specifier)
+  if (!packageSegments) {
+    return
+  }
+  const require = createRequire(configPath)
+  for (const candidateRoot of require.resolve.paths(specifier) ?? []) {
+    const candidate = path.join(candidateRoot, ...packageSegments)
+    if (isFile(path.join(candidate, "package.json"))) {
+      return candidate
+    }
+  }
+  return
+}
+
+function bareSpecifierSegments(specifier) {
+  const segments = specifier.split("/")
+  if (specifier.startsWith("@")) {
+    return segments.length === 2 ? segments : undefined
+  }
+  return segments.length === 1 ? segments : undefined
+}
+
+function readPackageManifest(packageDir) {
+  try {
+    return JSON.parse(fs.readFileSync(path.join(packageDir, "package.json"), "utf8"))
+  } catch {
+    return
+  }
+}
+
+function isPathSpecifier(specifier) {
+  return specifier.startsWith("./") || specifier.startsWith("../") || path.isAbsolute(specifier)
+}
+
+function isFile(candidate) {
+  try {
+    return fs.statSync(candidate).isFile()
+  } catch {
+    return false
+  }
+}
+
+function protocolError(resolved, detail) {
+  return codedError(
+    "PLUGIN_BINARY_PROTOCOL",
+    `Binary plugin "${resolved.specifier}" violated the binary plugin protocol: ${detail}.`
+  )
+}
+
+function codedError(code, message) {
+  const error = new Error(message)
+  error.code = code
+  return error
+}

--- a/packages/cli/scripts/binary-plugin.test.mjs
+++ b/packages/cli/scripts/binary-plugin.test.mjs
@@ -1,0 +1,174 @@
+import assert from "node:assert/strict"
+import path from "node:path"
+import test from "node:test"
+
+import { resolveBinaryPlugin } from "./binary-plugin.mjs"
+import { tryRunPluginCommand } from "./plugin-host.mjs"
+
+const fixtureRoot = path.resolve(import.meta.dirname, "../fixtures/plugin-project")
+const fixtureConfigPath = path.join(fixtureRoot, "palamedes.config.mjs")
+
+test("binary plugins register manifest commands and answer through the JSON envelope", async () => {
+  const io = captureIo()
+  const result = await tryRunPluginCommand(["binary", "inspect", "--json", "one", "two"], {
+    io,
+    loadConfig: async () => loadedConfig([["./binary-plugin", { policy: "strict" }]]),
+    installSignalHandlers: false,
+    nativeExecutable: "/fixture/pmds-native",
+  })
+
+  assert.deepEqual(result, { handled: true, exitCode: 0 })
+  assert.equal(io.stderrText(), "")
+  const output = JSON.parse(io.stdoutText())
+  assert.equal(output.ok, true)
+  assert.equal(output.plugin, "binary")
+  assert.equal(output.command, "inspect")
+  assert.deepEqual(output.result.args, ["one", "two"])
+  assert.deepEqual(output.result.options, { policy: "strict" })
+  assert.equal(output.result.rootDir, fixtureRoot)
+  assert.deepEqual(output.result.locales, ["en", "de"])
+  assert.equal(output.result.native, "/fixture/pmds-native")
+  assert.equal(output.result.json, true)
+  assert.equal(output.result.interactive, false)
+  assert.deepEqual(output.diagnostics, [
+    {
+      severity: "info",
+      code: "BINARY_INSPECTED",
+      message: "Inspected 1 catalog definitions.",
+    },
+  ])
+})
+
+test("binary plugin output and result text use the stable text contract", async () => {
+  const io = captureIo()
+  const result = await tryRunPluginCommand(["binary", "inspect"], {
+    io,
+    loadConfig: async () => loadedConfig(["./binary-plugin"]),
+    installSignalHandlers: false,
+    interactive: false,
+  })
+
+  assert.deepEqual(result, { handled: true, exitCode: 0 })
+  assert.equal(io.stdoutText(), "inspecting\ndone\n")
+  assert.equal(io.stderrText(), "[info BINARY_INSPECTED] Inspected 1 catalog definitions.\n")
+})
+
+test("binary plugin failure results keep their diagnostics and exit code", async () => {
+  const io = captureIo()
+  const result = await tryRunPluginCommand(["binary", "fail", "--json"], {
+    io,
+    loadConfig: async () => loadedConfig(["./binary-plugin"]),
+    installSignalHandlers: false,
+  })
+
+  assert.deepEqual(result, { handled: true, exitCode: 9 })
+  const output = JSON.parse(io.stdoutText())
+  assert.equal(output.ok, false)
+  assert.equal(output.exitCode, 9)
+  assert.deepEqual(output.diagnostics, [
+    {
+      severity: "error",
+      code: "BINARY_FAILED",
+      message: "Binary workflow failed.",
+    },
+  ])
+})
+
+test("a binary plugin exiting without a result falls back to its process exit code", async () => {
+  const io = captureIo()
+  const result = await tryRunPluginCommand(["binary", "crash"], {
+    io,
+    loadConfig: async () => loadedConfig(["./binary-plugin"]),
+    installSignalHandlers: false,
+  })
+
+  assert.deepEqual(result, { handled: true, exitCode: 5 })
+  assert.match(
+    io.stderrText(),
+    /PLUGIN_BINARY_PROTOCOL.*exited with code 5 without emitting a result event/u
+  )
+})
+
+test("incompatible binary plugin protocol versions fail clearly", async () => {
+  const io = captureIo()
+  const result = await tryRunPluginCommand(["future", "sync"], {
+    io,
+    loadConfig: async () => loadedConfig(["./binary-plugin-future"]),
+    installSignalHandlers: false,
+  })
+
+  assert.equal(result.exitCode, 1)
+  assert.match(
+    io.stderrText(),
+    /PLUGIN_PROTOCOL_INCOMPATIBLE.*requires binary plugin protocol 2.*supports 1/u
+  )
+})
+
+test("binary and ESM plugins share one registry with collision detection", async (t) => {
+  await t.test("both kinds dispatch from the same configuration", async () => {
+    const plugins = [["./example-plugin.mjs", { greeting: "hello" }], "./binary-plugin"]
+    const esmIo = captureIo()
+    const esmResult = await tryRunPluginCommand(["example", "inspect"], {
+      io: esmIo,
+      loadConfig: async () => loadedConfig(plugins),
+      installSignalHandlers: false,
+    })
+    assert.equal(esmResult.exitCode, 0)
+    assert.match(esmIo.stdoutText(), /hello from/u)
+
+    const binaryIo = captureIo()
+    const binaryResult = await tryRunPluginCommand(["binary", "inspect"], {
+      io: binaryIo,
+      loadConfig: async () => loadedConfig(plugins),
+      installSignalHandlers: false,
+    })
+    assert.equal(binaryResult.exitCode, 0)
+    assert.match(binaryIo.stdoutText(), /inspecting/u)
+  })
+
+  await t.test("duplicate namespaces across kinds are rejected", async () => {
+    const io = captureIo()
+    const result = await tryRunPluginCommand(["binary", "inspect"], {
+      io,
+      loadConfig: async () => loadedConfig(["./binary-plugin", "./binary-plugin"]),
+      installSignalHandlers: false,
+    })
+    assert.equal(result.exitCode, 1)
+    assert.match(io.stderrText(), /PLUGIN_NAMESPACE_COLLISION.*Multiple configured plugins/u)
+  })
+})
+
+test("binary plugin resolution only claims packages that declare pluginBinary", () => {
+  const resolved = resolveBinaryPlugin("./binary-plugin", fixtureConfigPath)
+  assert.equal(resolved.binaryPath, path.join(fixtureRoot, "binary-plugin", "plugin.mjs"))
+
+  assert.equal(resolveBinaryPlugin("./example-plugin.mjs", fixtureConfigPath), undefined)
+  assert.equal(
+    resolveBinaryPlugin("palamedes-import-only-plugin-fixture", fixtureConfigPath),
+    undefined
+  )
+  assert.equal(resolveBinaryPlugin("./does-not-exist", fixtureConfigPath), undefined)
+})
+
+function loadedConfig(plugins) {
+  return {
+    configPath: fixtureConfigPath,
+    rootDir: fixtureRoot,
+    sourceReferenceRoot: fixtureRoot,
+    locales: ["en", "de"],
+    sourceLocale: "en",
+    catalogs: [{ path: "locales/{locale}/messages", include: ["src"] }],
+    plugins,
+  }
+}
+
+function captureIo() {
+  const stdout = []
+  const stderr = []
+  return {
+    stdout: (value) => stdout.push(value),
+    stderr: (value) => stderr.push(value),
+    stdoutText: () => stdout.join(""),
+    stderrText: () => stderr.join(""),
+  }
+}

--- a/packages/cli/scripts/plugin-host.mjs
+++ b/packages/cli/scripts/plugin-host.mjs
@@ -4,6 +4,7 @@ import { pathToFileURL } from "node:url"
 import { resolve as resolveImport } from "import-meta-resolve"
 
 import { PALAMEDES_PLUGIN_API_VERSION } from "../plugin-api.mjs"
+import { loadBinaryPlugin, resolveBinaryPlugin } from "./binary-plugin.mjs"
 import { spawnNative } from "./native.mjs"
 
 const BUILT_IN_NAMESPACES = new Set(["extract", "audit", "report", "catalog", "version"])
@@ -48,7 +49,10 @@ export async function tryRunPluginCommand(argv, options = {}) {
 
   let plugins
   try {
-    plugins = await loadPlugins(config, options.importPlugin)
+    plugins = await loadPlugins(config, options.importPlugin, {
+      cwd: options.cwd ?? process.cwd(),
+      nativeExecutable: options.nativeExecutable,
+    })
   } catch (error) {
     return emitHostFailure(invocation, io, error.code ?? "PLUGIN_LOAD_FAILED", error)
   }
@@ -134,22 +138,27 @@ export async function tryRunPluginCommand(argv, options = {}) {
   }
 }
 
-export async function loadPlugins(config, importPlugin = importPluginFromConfig) {
+export async function loadPlugins(config, importPlugin = importPluginFromConfig, context = {}) {
   const registry = new Map()
 
   for (const declaration of config.plugins ?? []) {
     const [specifier, pluginOptions] = normalizeDeclaration(declaration)
-    let imported
-    try {
-      imported = await importPlugin(specifier, config.configPath)
-    } catch (error) {
-      throw codedError(
-        "PLUGIN_MISSING",
-        `Could not load configured Palamedes plugin "${specifier}": ${errorMessage(error)}`
-      )
+    let plugin
+    const binary = resolveBinaryPlugin(specifier, config.configPath)
+    if (binary) {
+      plugin = await loadBinaryPlugin(binary, context)
+    } else {
+      let imported
+      try {
+        imported = await importPlugin(specifier, config.configPath)
+      } catch (error) {
+        throw codedError(
+          "PLUGIN_MISSING",
+          `Could not load configured Palamedes plugin "${specifier}": ${errorMessage(error)}`
+        )
+      }
+      plugin = imported?.default ?? imported?.plugin ?? imported
     }
-
-    const plugin = imported?.default ?? imported?.plugin ?? imported
     validatePlugin(plugin, specifier)
 
     if (registry.has(plugin.name)) {


### PR DESCRIPTION
## Summary

Implements the binary plugin protocol accepted in ADR 002 (#441). Packages that declare `palamedes.pluginBinary` in their `package.json` are now loaded as **binary plugins**: standalone executables the host spawns per invocation and drives over a versioned newline-delimited JSON stdio protocol. Rust-first extensions can link the `palamedes` crates directly and integrate into `pmds` without any Node bindings.

- New `packages/cli/scripts/binary-plugin.mjs`: deterministic package resolution (config-relative paths and bare package names, no `PATH` discovery), `describe`/`run` requests over stdin, `manifest`/`diagnostic`/`output`/`result` events on stdout, protocol version `1` with exact-match validation, and the `PALAMEDES_NATIVE` environment-variable handoff for invoking built-ins.
- `plugin-host.mjs`: binary and ESM plugins share one registry, namespace validation, collision detection, cancellation semantics (130/143), and the single `--json` envelope. Packages without `palamedes.pluginBinary` load as ESM plugins exactly as before.
- Exit semantics per ADR 002: a `result` event drives the exit code; without one, the child process exit code is the authoritative fallback with a `PLUGIN_BINARY_PROTOCOL` diagnostic. Child stderr passes through for free-form progress.
- A `pluginBinary` ending in `.js`/`.mjs`/`.cjs` is spawned through the current Node executable, keeping fixtures and local prototypes cross-platform.
- Fixtures: a protocol-speaking binary plugin (inspect/fail/crash commands) and a future-protocol variant; 8 new tests cover the JSON envelope, text contract, failure results, missing-result fallback, protocol incompatibility, mixed ESM+binary registries, collisions, and resolution rules.
- Docs: new `docs/api/cli-binary-plugin.md` protocol reference, cross-linked from `docs/api/cli-plugin.md`, `docs/cli.md`, and the API index.

Intentionally not in this PR: the `palamedes-plugin` Rust SDK crate and moving dispatch into `pmds-native` (both noted in ADR 002 as follow-ups).

## Issue

No issue exists; this implements ADR 002, which was merged in #441.

## Validation

- `node --test scripts/plugin-host.test.mjs scripts/binary-plugin.test.mjs` — 29 pass, 0 fail (all existing plugin-host tests unchanged and green).
- `oxlint --deny-warnings`, `eslint --max-warnings=0`, and `oxfmt --check` clean on all changed files.
- The npm smoke test (`scripts/smoke.mjs`) needs the native binary and runs in CI as usual.

## Follow-up

- `palamedes-plugin` Rust SDK crate wrapping the protocol (command registration, typed config/catalog access, diagnostics).
- Optionally re-base the ESM plugin API onto the same protocol via a generic shim, and evaluate moving binary-plugin dispatch into `pmds-native` for a Node-free distribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MMxCrkGeyQ2SYq5R5XicFe

---
_Generated by [Claude Code](https://claude.ai/code/session_01MMxCrkGeyQ2SYq5R5XicFe)_