### PR TITLE
Fix locale-resolution bugs (#409, #410, #413) and close the remaining docs drift (#424)

### DIFF
--- a/crates/palamedes-node/src/catalog.rs
+++ b/crates/palamedes-node/src/catalog.rs
@@ -394,6 +394,7 @@ pub struct CatalogModuleResult {
     pub code: String,
     pub warnings: Vec<String>,
     pub watch_files: Vec<String>,
+    pub locale: String,
 }
 
 struct CatalogModuleRenderOptions {
@@ -1294,7 +1295,7 @@ pub fn compile_catalog_module(request: CatalogModuleRequest) -> Result<CatalogMo
     let render_options = CatalogModuleRenderOptions {
         locale,
         resource_path: resource_path.clone(),
-        pseudo_locale,
+        pseudo_locale: pseudo_locale.or_else(|| config.pseudo_locale.clone()),
         fail_on_missing: fail_on_missing.unwrap_or(false),
         fail_on_compile_error: fail_on_compile_error.unwrap_or(false),
         missing_failure_hint,
@@ -1332,12 +1333,26 @@ fn create_catalog_module_result(
     artifact: palamedes::CatalogArtifactResult,
     options: &CatalogModuleRenderOptions,
 ) -> Result<CatalogModuleResult> {
-    if options.pseudo_locale.as_deref() != Some(options.locale.as_str())
+    /*
+     * The caller-supplied locale is only a fallback: loaders historically
+     * derived it from the file basename, which is wrong for layouts like
+     * `{locale}/messages.po`. The artifact pipeline resolves the true locale
+     * from the catalog path pattern and reports it as the head of the
+     * fallback chain.
+     */
+    let locale = artifact
+        .resolved_locale_chain
+        .as_ref()
+        .and_then(|chain| chain.first())
+        .cloned()
+        .unwrap_or_else(|| options.locale.clone());
+
+    if options.pseudo_locale.as_deref() != Some(locale.as_str())
         && !artifact.missing.is_empty()
         && options.fail_on_missing
     {
         return Err(napi::Error::from_reason(append_hint(
-            create_missing_error_message(&options.locale, &artifact.missing),
+            create_missing_error_message(&locale, &artifact.missing),
             options.missing_failure_hint.as_deref(),
         )));
     }
@@ -1354,13 +1369,13 @@ fn create_catalog_module_result(
 
         if options.fail_on_compile_error && !error_diagnostics.is_empty() {
             return Err(napi::Error::from_reason(append_hint(
-                create_compile_error_message(&options.locale, &error_diagnostics),
+                create_compile_error_message(&locale, &error_diagnostics),
                 options.compile_failure_hint.as_deref(),
             )));
         }
 
         warnings.push(append_hint(
-            create_diagnostic_message(&options.locale, &artifact.diagnostics),
+            create_diagnostic_message(&locale, &artifact.diagnostics),
             if options.fail_on_compile_error {
                 None
             } else {
@@ -1370,9 +1385,10 @@ fn create_catalog_module_result(
     }
 
     Ok(CatalogModuleResult {
-        code: render_catalog_module(&artifact.messages, &options.locale, &options.resource_path)?,
+        code: render_catalog_module(&artifact.messages, &locale, &options.resource_path)?,
         warnings,
         watch_files: artifact.watch_files,
+        locale,
     })
 }
 

--- a/docs/api/core-node.md
+++ b/docs/api/core-node.md
@@ -29,8 +29,11 @@ Unsupported styles on supported `number`, `date`, and `time` formatters are
 warnings because the runtime falls back to default `Intl` formatting.
 
 `compileCatalogModule(config, resourcePath, options)` renders the compiled
-catalog artifact as a JavaScript module for a selected locale. The first-party
-Vite and Next plugins use it for `.po` imports.
+catalog artifact as a JavaScript module. The locale is resolved from the
+configured catalog path pattern (so layouts like `{locale}/messages.po` work);
+the caller-supplied `options.locale` is only a fallback when resolution is
+unavailable, and the result reports the effective locale as `locale`. The
+first-party Vite and Next plugins use this function for `.po` imports.
 
 ## Stability
 

--- a/docs/migrate-from-lingui.md
+++ b/docs/migrate-from-lingui.md
@@ -88,8 +88,13 @@ After:
 ```ts
 import { getI18n } from "@palamedes/runtime"
 
-const locale = getI18n().locale
+function currentLocale() {
+  return getI18n().locale
+}
 ```
+
+Call `getI18n()` inside a function or component, not at module top level — at
+import time there is no active i18n instance yet.
 
 ### 2. Explicit IDs
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -12,7 +12,7 @@ The important design goal is a calmer i18n model across frameworks:
 - one native core with OXC-powered transforms and extraction
 - thin host adapters for frameworks and bundlers
 
-Verified integrations currently include Next.js, Vite, TanStack Start, SolidStart, Waku, and React Router.
+Verified integrations currently include Next.js, Vite, TanStack Start, SolidStart, Waku, React Router, and server-first Remix v3.
 
 ## How to answer Palamedes questions
 
@@ -167,8 +167,14 @@ Palamedes keeps Lingui-style authoring familiarity where useful:
 ```tsx
 import { t } from "@palamedes/core/macro"
 
-const title = t`Welcome to Palamedes`
+function pageTitle() {
+  return t`Welcome to Palamedes`
+}
 ```
+
+Translation macros are eager: they must run inside a function or callback so
+the active locale is read at call time. A module-top-level `t` call is a
+compile error.
 
 But Palamedes intentionally avoids some historical Lingui surface area:
 

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -27,6 +27,9 @@ catalogs:
 
 - `defineConfig(config)`
 - `loadPalamedesConfig(options?)`
+- `loadPalamedesConfigSync(options?)` — synchronous variant with the same
+  options and return shape, for hosts that cannot await (e.g. synchronous
+  loader hooks)
 - `CONFIG_FILENAMES`
 - `expandFallbackLocales(locales, fallbackLocales?)`
 - `resolveCatalogPath(config, catalogPath, locale)`

--- a/packages/core-node/src/generated/palamedes-node-types.ts
+++ b/packages/core-node/src/generated/palamedes-node-types.ts
@@ -253,6 +253,7 @@ export interface CatalogModuleResult {
   code: string;
   warnings: Array<string>;
   watchFiles: Array<string>;
+  locale: string;
 }
 export interface CatalogArtifactCatalogConfig {
   path: string;

--- a/packages/core-node/src/index.test.ts
+++ b/packages/core-node/src/index.test.ts
@@ -121,6 +121,65 @@ msgstr "Hallo"
     expect(result.code).toContain("Hallo")
     expect(result.warnings).toStrictEqual([])
     expect(result.watchFiles).toContain(path.join(deCatalog, "messages.po"))
+    expect(result.locale).toBe("de")
+  })
+
+  it("resolves the module locale from the catalog path, not the caller-supplied locale", async () => {
+    const rootDir = await createTempDir()
+    const enCatalog = path.join(rootDir, "locales", "en")
+    const deCatalog = path.join(rootDir, "locales", "de")
+
+    await mkdir(enCatalog, { recursive: true })
+    await mkdir(deCatalog, { recursive: true })
+    await writeFile(
+      path.join(enCatalog, "messages.po"),
+      `msgid ""
+msgstr ""
+"Language: en\\n"
+
+msgid "Hello"
+msgstr "Hello"
+`
+    )
+    await writeFile(
+      path.join(deCatalog, "messages.po"),
+      `msgid ""
+msgstr ""
+"Language: de\\n"
+
+msgid "Hello"
+msgstr ""
+`
+    )
+
+    const config = {
+      rootDir,
+      locales: ["en", "de"],
+      sourceLocale: "en",
+      catalogs: [{ path: "locales/{locale}/messages", include: ["src"] }],
+    }
+    const resourcePath = path.join(deCatalog, "messages.po")
+
+    /*
+     * Loaders derive the caller locale from the file basename, which is
+     * "messages" in the {locale}/messages.po layout. The resolved locale
+     * must win for the result and for failure messages.
+     */
+    const result = compileCatalogModule(config, resourcePath, { locale: "messages" })
+    expect(result.locale).toBe("de")
+
+    expect(() =>
+      compileCatalogModule(config, resourcePath, { locale: "messages", failOnMissing: true })
+    ).toThrow(/locale de/)
+
+    /*
+     * A pseudo locale matching the resolved locale must bypass the
+     * missing-translation gate even when the caller locale is wrong.
+     */
+    const pseudoConfig = { ...config, locales: ["en", "de"], pseudoLocale: "de" }
+    expect(() =>
+      compileCatalogModule(pseudoConfig, resourcePath, { locale: "messages", failOnMissing: true })
+    ).not.toThrow()
   })
 
   it("renders catalog modules with the same message order as artifact objects", async () => {

--- a/packages/core/src/locale.test.ts
+++ b/packages/core/src/locale.test.ts
@@ -41,6 +41,16 @@ describe("locale controls", () => {
     ).toStrictEqual({ locale: "es", source: "cookie" })
   })
 
+  it("falls through to accept-language when the cookie locale is unsupported", () => {
+    expect(
+      controls.resolve({
+        strategy: "cookie",
+        acceptLanguageHeader: "de",
+        cookieHeader: "locale=en-US",
+      })
+    ).toStrictEqual({ locale: "de", source: "accept-language" })
+  })
+
   it("resolves the route locale before accept-language", () => {
     expect(controls.resolve({ strategy: "route", routeLocale: "de" })).toStrictEqual({
       locale: "de",

--- a/packages/core/src/locale.ts
+++ b/packages/core/src/locale.ts
@@ -286,7 +286,7 @@ export function defineLocaleControls<TLocale extends string>(
 
   const readCookieLocale = (cookieHeader: string | null | undefined): TLocale | null => {
     const value = readCookie(cookieHeader, localeCookie)
-    return value ? normalizeLocale(value) : null
+    return isLocale(value) ? value : null
   }
 
   const serializeChoice = (locale: TLocale): string =>

--- a/packages/next-plugin/README.md
+++ b/packages/next-plugin/README.md
@@ -123,9 +123,18 @@ module.exports = withPalamedes(
     failOnMissing: false,
     failOnCompileError: false,
     runtimeModule: "@palamedes/runtime",
+    workspaceRoot: undefined,
   }
 )
 ```
+
+`workspaceRoot` pins the monorepo root used for Turbopack and output file
+tracing. When omitted, `withPalamedes` walks upward from the working directory
+looking for workspace markers (`workspaces` in package.json,
+`pnpm-workspace.yaml`, `turbo.json`, or `.git`) and — when it finds one — sets
+`outputFileTracingRoot` and `turbopack.root` on the Next config as a side
+effect. Pass `workspaceRoot` explicitly if that detection picks the wrong
+directory.
 
 ## What This Package Handles
 

--- a/packages/next-plugin/palamedes-po-loader.cjs
+++ b/packages/next-plugin/palamedes-po-loader.cjs
@@ -1,8 +1,38 @@
 "use strict"
 
+const { statSync } = require("node:fs")
 const path = require("node:path")
 const { loadPalamedesConfig } = require("@palamedes/config")
 const { compileCatalogModule } = require("@palamedes/core-node")
+
+/*
+ * Loading the config walks the filesystem upward and parses the file; doing
+ * that once per .po file per rebuild is wasteful. Cache per requested path
+ * and invalidate on config-file mtime changes, so webpack rebuilds triggered
+ * by the addDependency below observe the edited config.
+ */
+const configCache = new Map()
+
+async function loadConfigCached(configPath) {
+  const key = configPath ?? ""
+  const cached = configCache.get(key)
+  if (cached) {
+    try {
+      if (statSync(cached.cfg.configPath).mtimeMs === cached.mtimeMs) {
+        return cached.cfg
+      }
+    } catch {
+      // Config file moved or deleted — fall through to a fresh load.
+    }
+  }
+  const cfg = await loadPalamedesConfig({ configPath })
+  try {
+    configCache.set(key, { cfg, mtimeMs: statSync(cfg.configPath).mtimeMs })
+  } catch {
+    // Config not stat-able (e.g. stubbed in tests) — serve it uncached.
+  }
+  return cfg
+}
 
 module.exports = function palamedesPoLoader() {
   const callback = this.async()
@@ -11,7 +41,7 @@ module.exports = function palamedesPoLoader() {
   const failOnCompileError = options.failOnCompileError === true
 
   ;(async () => {
-    const cfg = await loadPalamedesConfig({ configPath: options.configPath })
+    const cfg = await loadConfigCached(options.configPath)
     const locale = path.basename(this.resourcePath, ".po")
     const result = compileCatalogModule(
       {
@@ -36,11 +66,14 @@ module.exports = function palamedesPoLoader() {
           "You can fail the build on error diagnostics by setting `failOnCompileError=true` in the Palamedes Next plugin configuration.",
       }
     )
-    result.watchFiles.forEach((file) => {
-      if (typeof this.addDependency === "function") {
-        this.addDependency(file)
+    if (typeof this.addDependency === "function") {
+      if (cfg.configPath) {
+        this.addDependency(cfg.configPath)
       }
-    })
+      result.watchFiles.forEach((file) => {
+        this.addDependency(file)
+      })
+    }
 
     result.warnings.forEach((warning) => console.warn(warning))
 

--- a/packages/next-plugin/src/index.ts
+++ b/packages/next-plugin/src/index.ts
@@ -76,7 +76,6 @@ function resolveWorkspaceRoot(explicitRoot?: string) {
     if (
       hasWorkspaces(packageJsonPath) ||
       existsSync(path.join(currentDir, "pnpm-workspace.yaml")) ||
-      existsSync(path.join(currentDir, "pnpm-workspace.yml")) ||
       existsSync(path.join(currentDir, "turbo.json")) ||
       existsSync(path.join(currentDir, ".git"))
     ) {

--- a/packages/next-plugin/src/palamedes-po-loader.test.ts
+++ b/packages/next-plugin/src/palamedes-po-loader.test.ts
@@ -17,6 +17,7 @@ const compileCatalogModule = vi.fn()
 
 beforeEach(() => {
   loadPalamedesConfig.mockResolvedValue({
+    configPath: "/repo/palamedes.yaml",
     rootDir: "/repo",
     locales: ["en", "de", "pseudo"],
     sourceLocale: "en",
@@ -55,7 +56,7 @@ describe("palamedes-po-loader.cjs", () => {
     expect(result.code).toBe(
       'export const messages={"greeting":"Hallo"};export default { messages };'
     )
-    expect(result.dependencies).toStrictEqual(["/repo/src/locales/en.po"])
+    expect(result.dependencies).toStrictEqual(["/repo/palamedes.yaml", "/repo/src/locales/en.po"])
     expect(compileCatalogModule).toHaveBeenCalledWith(
       expect.objectContaining({ rootDir: "/repo", sourceLocale: "en" }),
       "/repo/src/locales/de.po",

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -51,14 +51,19 @@ automatically. The transform override is needed for inline `t` / `plural` macro
 calls. Because the reactive getter is a custom hook, those inline calls must run
 unconditionally during a function-component or custom-hook render.
 
-## License
-
-[![Sebastian Software](https://sebastian-brand.vercel.app/sebastian-software/logo-software.svg)](https://oss.sebastian-software.com/)
-
-MIT © 2026 Sebastian Software
-
 Rich JSX children are transformed to numeric component slots in the message, for
 example `<0>Palamedes</0>`, while the React component is passed separately.
+
+## Runtime Components
+
+Besides the macro entry point, the package's main entry exports the runtime
+components `Trans`, `Plural`, `Select`, and `SelectOrdinal` (plus the
+`TransProps` type). These are what macro-transformed JSX renders through.
+`Trans` resolves messages through the active i18n instance; the hand-written
+(non-macro) use of the choice components currently formats the source-language
+props directly without catalog lookup — see
+[#417](https://github.com/sebastian-software/palamedes/issues/417) before
+using them outside macro output.
 
 ## Headless Frontend Helpers
 
@@ -110,3 +115,9 @@ function LocaleToolbar({
   )
 }
 ```
+
+## License
+
+[![Sebastian Software](https://sebastian-brand.vercel.app/sebastian-software/logo-software.svg)](https://oss.sebastian-software.com/)
+
+MIT © 2026 Sebastian Software

--- a/packages/transform/src/catalogLoader.ts
+++ b/packages/transform/src/catalogLoader.ts
@@ -19,6 +19,8 @@ export type CatalogCompileArtifactResult = {
   messages: Record<string, string>
   missing: MissingCatalogMessage[]
   diagnostics: CatalogDiagnostic[]
+  /** Fallback chain reported by the compiler; the head is the resolved locale. */
+  resolvedLocaleChain?: string[]
 }
 
 export type CatalogLoaderOptions = {
@@ -42,7 +44,6 @@ export function createCatalogLoaderResult(
 ): CatalogLoaderResult {
   const warnings: string[] = []
   const {
-    locale,
     pseudoLocale,
     failOnMissing = false,
     failOnCompileError = false,
@@ -50,6 +51,13 @@ export function createCatalogLoaderResult(
     compileFailureHint,
     diagnosticsWarningHint,
   } = options
+
+  /*
+   * The caller-supplied locale is often derived from the catalog file's
+   * basename, which is wrong for layouts like `{locale}/messages.po`. When
+   * the compiler reports the resolved chain, its head is authoritative.
+   */
+  const locale = result.resolvedLocaleChain?.[0] ?? options.locale
 
   if (locale !== pseudoLocale && result.missing.length > 0 && failOnMissing) {
     throw new Error(

--- a/packages/vite-plugin/README.md
+++ b/packages/vite-plugin/README.md
@@ -92,11 +92,21 @@ palamedes({
   exclude: /node_modules/,
   enablePoLoader: true,
   configPath: "./palamedes.yaml",
+  cwd: process.cwd(),
+  skipValidation: false,
   failOnMissing: false,
   failOnCompileError: false,
   runtimeModule: "@palamedes/runtime",
 })
 ```
+
+`cwd` and `skipValidation` are passed through to `loadPalamedesConfig`: `cwd`
+sets the directory the config search starts from, and `skipValidation` loads
+partially-authored config files without validation (tooling only).
+
+Imports ending in `?palamedes` are treated like `.po` catalog imports — the
+analog of Lingui's `?lingui` query suffix — so bundler-agnostic code can force
+a module through the Palamedes catalog loader.
 
 ## What This Package Handles
 

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -207,12 +207,27 @@ export function palamedes(options: PalamedesPluginOptions = {}): Plugin[] {
     plugins.push({
       name: "palamedes:po-loader",
 
+      /*
+       * Drop the cached config at the start of every build so edits to
+       * palamedes.yaml take effect without a dev-server restart.
+       */
+      buildStart() {
+        config = null
+      },
+
+      watchChange(id) {
+        if (config && path.resolve(id) === path.resolve(config.configPath)) {
+          config = null
+        }
+      },
+
       async transform(src, id) {
         if (!PO_FILE_REGEX.test(id)) {
           return null
         }
 
         const cfg = await getConfigLazy()
+        this.addWatchFile(cfg.configPath)
         const cleanId = stripQuery(id)
         const locale = path.basename(cleanId, ".po")
         const result = compileCatalogModule(


### PR DESCRIPTION
Works through the top of the open-issue backlog from the pre-1.5.1 production-readiness review: the cookie-locale one-liner, the two Lingui-migration-path blockers in the `.po` loader pipeline, and the remainder of the documentation-drift findings.

## Fixes #413 — invalid locale cookie falls through to Accept-Language

`readCookieLocale` mapped any non-empty invalid cookie value through `normalizeLocale` to the default locale, reported as `source: "cookie"` — forever, with nothing correcting it. It now returns `null` for unsupported values (same behavior as `readChoice`), so resolution falls through to Accept-Language negotiation. Regression test added.

## Fixes #409 — catalog module locale comes from the path pattern, not the file basename

With Lingui's default `{locale}/messages.po` layout, every module compiled under locale `"messages"`: diagnostics read "locale messages" and the pseudo-locale guard misfired (`failOnMissing` + `pseudoLocale` failed the build on the pseudo catalog's expected gaps). The napi layer now uses the locale the artifact pipeline already resolves from the catalog path pattern (head of `resolvedLocaleChain`), keeps the caller value only as a fallback, defaults the pseudo-guard to the config's `pseudoLocale` when the caller passes none, and reports the effective locale as a new `locale` field on `CatalogModuleResult` (additive; generated native types regenerated). The JS catalog-loader twin in `@palamedes/transform` honors an optional `resolvedLocaleChain` the same way. Regression test covers the nested layout, the failure-message locale, and the pseudo-guard bypass.

## Fixes #410 — `palamedes.yaml` is now a watch/cache dependency

- **Vite:** the plugin watched only `.po` files and cached the loaded config forever. It now calls `addWatchFile(cfg.configPath)`, drops the cache on `buildStart`, and invalidates it in `watchChange` when the config file changes — config edits take effect without a dev-server restart.
- **Next/webpack:** the loader now declares the config via `this.addDependency(cfg.configPath)` (so webpack's persistent cache can't serve stale compiled modules across builds) and caches the loaded config keyed by config-file mtime instead of re-walking the filesystem once per `.po` file per rebuild.

## Closes #424 — remaining documentation drift

The four P2-grade items plus about half the smaller gaps were already fixed by #443. This PR closes the rest:

- `llms-full.txt`: module-top-level `` t`…` `` authoring sample wrapped in a function with an eager-scope note; "Verified integrations" now includes Remix v3.
- `docs/migrate-from-lingui.md`: the module-scope `getI18n().locale` sample is now a function, with a note about import-time access.
- `packages/config/README.md` documents `loadPalamedesConfigSync`; `packages/vite-plugin/README.md` documents `cwd`, `skipValidation`, and the `?palamedes` import-query suffix; `packages/next-plugin/README.md` documents `workspaceRoot` and the `outputFileTracingRoot`/`turbopack.root` side effect of the workspace-root walk.
- `packages/react/README.md`: the content stranded after the License footer moved back above it, and a Runtime Components section documents `Trans`/`Plural`/`Select`/`SelectOrdinal` + `TransProps` (with a pointer to #417 for the non-macro choice-component caveat).
- The workspace-root walk no longer checks the nonexistent `pnpm-workspace.yml` spelling.

## Verification

- `cargo test --workspace` (177 tests), `cargo clippy --workspace` clean.
- `pnpm build` + full `pnpm test` across all packages (255 tests), `pnpm check-types`, `pnpm check:native-types`, `pnpm lint`, `pnpm format:check` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TK4yk5JVr5FURvoKZhCgon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TK4yk5JVr5FURvoKZhCgon)_