### PR TITLE
Fix formatting-correctness cluster: plural coercion, Date hydration, runtime choice components, canonical URL scheme (#414, #416, #417, #418)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,384 +9,358 @@
 - Custom `I18nInstance` implementations must expose an initialized
   `locale: string`; implementations that omitted the property or declared it as
   optional need to update.
+- Plural and selectordinal arguments now require a present, numeric value
+  (numeric strings still work). A missing or non-finite value throws instead of
+  silently coercing to `0` and matching `=0`/`zero` branches; inside
+  `_()`/`getMessage()` the error is reported through `onError` and rendering
+  falls back to the source message.
+- Host-carrying URLs from `canonicalUrl()` and `suggest()` are now
+  protocol-relative (`//host/path`) instead of hardcoding `http://`. Set the
+  new `protocol` option in `defineLocaleControls` for absolute URLs.
+- The runtime `Plural`/`Select`/`SelectOrdinal` components in
+  `@palamedes/react` and `@palamedes/solid` now resolve through the active
+  i18n instance (catalog entries keyed by the synthesized source pattern are
+  honored), normalize `_N` exact-match props to ICU `=N` like the macro
+  transform, and reject invalid option props or option text with unbalanced
+  braces instead of silently misrendering.
+- `<Trans>` variable values that are `Date` instances now render as
+  deterministic ISO strings (matching `i18n._`), fixing SSR hydration
+  mismatches across time zones.
 
 ## [1.6.0](https://github.com/sebastian-software/palamedes/compare/palamedes-v1.5.1...palamedes-v1.6.0) (2026-07-25)
 
-
 ### Features
 
-* **cli:** add binary plugin protocol host support ([fe519b9](https://github.com/sebastian-software/palamedes/commit/fe519b9c641da1c5989d1af0f225ebda99fe41fd))
-* **cli:** binary plugin protocol host support (ADR 002) ([c4aeb3b](https://github.com/sebastian-software/palamedes/commit/c4aeb3ba5b4b0475368ee83e905856400ff039d5))
-* **core:** initialize every i18n locale ([#432](https://github.com/sebastian-software/palamedes/issues/432)) ([57b6ecd](https://github.com/sebastian-software/palamedes/commit/57b6ecd2eb347d49d1c27b52b757c1da17ad910f))
-
+- **cli:** add binary plugin protocol host support ([fe519b9](https://github.com/sebastian-software/palamedes/commit/fe519b9c641da1c5989d1af0f225ebda99fe41fd))
+- **cli:** binary plugin protocol host support (ADR 002) ([c4aeb3b](https://github.com/sebastian-software/palamedes/commit/c4aeb3ba5b4b0475368ee83e905856400ff039d5))
+- **core:** initialize every i18n locale ([#432](https://github.com/sebastian-software/palamedes/issues/432)) ([57b6ecd](https://github.com/sebastian-software/palamedes/commit/57b6ecd2eb347d49d1c27b52b757c1da17ad910f))
 
 ### Bug Fixes
 
-* add reactive React runtime bridge ([5770cda](https://github.com/sebastian-software/palamedes/commit/5770cda2a66a3b14fbd2e643e6e53a1ee9a2450e))
-* clear shared runtime listeners on reset ([8c72577](https://github.com/sebastian-software/palamedes/commit/8c725777be95c300a077c692461ba935cfa4afa7))
-* **cli:** fail safely on extraction errors ([3f58b2f](https://github.com/sebastian-software/palamedes/commit/3f58b2fe24b7b6b176a7578c8e7c2faf904d66b4))
-* **cli:** fail safely on extraction errors ([3b4557e](https://github.com/sebastian-software/palamedes/commit/3b4557ea8445a8f8490e033a60b826768166ec95))
-* **cli:** keep watch mode alive after parse errors ([44829e4](https://github.com/sebastian-software/palamedes/commit/44829e437f76a8a863a294af2130f7e29a73ea2b))
-* **core:** export message text nodes ([39398f9](https://github.com/sebastian-software/palamedes/commit/39398f93a48e7b5437436ce75d03841ecb1bb65e))
-* **core:** preserve PO translator metadata ([37294b0](https://github.com/sebastian-software/palamedes/commit/37294b01748082c4f22ee99de0336138b458d112))
-* **core:** preserve PO translator metadata ([5b69165](https://github.com/sebastian-software/palamedes/commit/5b69165f1f74b11e26b82f5dd429591e12b3b2c9))
-* **core:** support ICU apostrophe quoting ([30a3e98](https://github.com/sebastian-software/palamedes/commit/30a3e983a61decb79f3a991224c691e3567e2ea0))
-* **core:** support ICU apostrophe quoting ([42d64a8](https://github.com/sebastian-software/palamedes/commit/42d64a81c29f084138f1abc212501ecb794ffce2))
-* **deps:** replace dependency @base-ui-components/react with @base-ui/react 1.0.0 ([#397](https://github.com/sebastian-software/palamedes/issues/397)) ([6e7970b](https://github.com/sebastian-software/palamedes/commit/6e7970b527a544dfbdae030e49972de80b21a620))
-* **deps:** update lucide monorepo to v1 ([ab70673](https://github.com/sebastian-software/palamedes/commit/ab70673b373834a838cf9922ea20abf4be2a1a59))
-* **deps:** update testing-library monorepo to v7 ([6f31062](https://github.com/sebastian-software/palamedes/commit/6f31062dcbe35778529b2eb961dc6212b8b8e27a))
-* **extract:** align accessor placeholder names ([91a49e4](https://github.com/sebastian-software/palamedes/commit/91a49e462bcc4a9b6504fa0a306971faa3638576))
-* **extract:** align accessor placeholder names ([a3c7692](https://github.com/sebastian-software/palamedes/commit/a3c76922ba54eef7796d4722e0ebcfdae2486681))
-* **i18n:** support plural offsets end to end ([7898d2a](https://github.com/sebastian-software/palamedes/commit/7898d2a139f8edcb6aa00c94df4a0feadbbe1f85))
-* **i18n:** support plural offsets end to end ([f2dcf9d](https://github.com/sebastian-software/palamedes/commit/f2dcf9d036ea8bb352f004b99933fcecb7c9b0ef))
-* **i18n:** validate direct plural offsets ([02ceb31](https://github.com/sebastian-software/palamedes/commit/02ceb31dec06ece1f4e45f00596eb075a5c91f77))
-* ignore JSX comments inside Trans ([860ea94](https://github.com/sebastian-software/palamedes/commit/860ea943fd8a74fa096938c9797e6020113f6664))
-* ignore JSX comments inside Trans ([c9e1bf3](https://github.com/sebastian-software/palamedes/commit/c9e1bf33c63800733b78a33204f2cd75d382d6ad))
-* **react:** add reactive runtime bridge ([#440](https://github.com/sebastian-software/palamedes/issues/440)) ([92a1c45](https://github.com/sebastian-software/palamedes/commit/92a1c451ca6e8d66084af41ecc0e63a492cc28dd)), closes [#415](https://github.com/sebastian-software/palamedes/issues/415)
-* **react:** expose server-specific types ([0a95160](https://github.com/sebastian-software/palamedes/commit/0a95160c4d7bbc745a18b3213c25cda3710375b0))
-* reconnect Solid runtime after reset ([31fba43](https://github.com/sebastian-software/palamedes/commit/31fba43ea04666d62511e14d7ab87c160f25cfda))
-* **runtime:** address SSR review feedback ([c32c45c](https://github.com/sebastian-software/palamedes/commit/c32c45c4544f81f24b22a73e3fdb599ec8b41de6))
-* **runtime:** isolate SSR client locale activation ([587fa45](https://github.com/sebastian-software/palamedes/commit/587fa454b8f176346d6fcd6fd10455eb627931f5))
-* **runtime:** isolate SSR client locale activation ([82e4cdc](https://github.com/sebastian-software/palamedes/commit/82e4cdcf3d82d9ce8aec882369ab62b2b05fb61e))
-* share runtime state across module graphs ([a085f34](https://github.com/sebastian-software/palamedes/commit/a085f34bc9d7cf9884618cb5adfcd301f4666dce))
-* share runtime state across module graphs ([52a7e46](https://github.com/sebastian-software/palamedes/commit/52a7e465b0ef1386d2ed6f160b6c65e3b3227374))
-* **site:** derive quoted numbers from repo data and repair page metadata ([0cb1eaa](https://github.com/sebastian-software/palamedes/commit/0cb1eaa83932e392c339629bb8026cdee5ee5eda))
-* **site:** keep tld matrix cells in provisioning and derive frameworks-page counts ([9405053](https://github.com/sebastian-software/palamedes/commit/9405053fd8c7a8052ce5d482c2d603effbec941f))
-* **site:** register route for new cli-binary-plugin API doc ([14695b0](https://github.com/sebastian-software/palamedes/commit/14695b0e61ad1063924310b7d347804b0b5b4179))
-* transform macros in Trans component attributes ([5488c13](https://github.com/sebastian-software/palamedes/commit/5488c1374ffda82a6c3c491fbc964d854b4dcfeb))
-* transform macros in Trans component attributes ([f7c0df0](https://github.com/sebastian-software/palamedes/commit/f7c0df06222eaea491ce605ef17cfbb5ff82ba77))
-* **ui:** make Trans catalog parsing resilient ([f5c5e87](https://github.com/sebastian-software/palamedes/commit/f5c5e87cb1c0e69b445e0a34fb2d593759e1f0af))
-* **ui:** make Trans catalog parsing resilient ([9d57535](https://github.com/sebastian-software/palamedes/commit/9d57535c6a941ad08a678e0c56cef8029c13c80c))
+- add reactive React runtime bridge ([5770cda](https://github.com/sebastian-software/palamedes/commit/5770cda2a66a3b14fbd2e643e6e53a1ee9a2450e))
+- clear shared runtime listeners on reset ([8c72577](https://github.com/sebastian-software/palamedes/commit/8c725777be95c300a077c692461ba935cfa4afa7))
+- **cli:** fail safely on extraction errors ([3f58b2f](https://github.com/sebastian-software/palamedes/commit/3f58b2fe24b7b6b176a7578c8e7c2faf904d66b4))
+- **cli:** fail safely on extraction errors ([3b4557e](https://github.com/sebastian-software/palamedes/commit/3b4557ea8445a8f8490e033a60b826768166ec95))
+- **cli:** keep watch mode alive after parse errors ([44829e4](https://github.com/sebastian-software/palamedes/commit/44829e437f76a8a863a294af2130f7e29a73ea2b))
+- **core:** export message text nodes ([39398f9](https://github.com/sebastian-software/palamedes/commit/39398f93a48e7b5437436ce75d03841ecb1bb65e))
+- **core:** preserve PO translator metadata ([37294b0](https://github.com/sebastian-software/palamedes/commit/37294b01748082c4f22ee99de0336138b458d112))
+- **core:** preserve PO translator metadata ([5b69165](https://github.com/sebastian-software/palamedes/commit/5b69165f1f74b11e26b82f5dd429591e12b3b2c9))
+- **core:** support ICU apostrophe quoting ([30a3e98](https://github.com/sebastian-software/palamedes/commit/30a3e983a61decb79f3a991224c691e3567e2ea0))
+- **core:** support ICU apostrophe quoting ([42d64a8](https://github.com/sebastian-software/palamedes/commit/42d64a81c29f084138f1abc212501ecb794ffce2))
+- **deps:** replace dependency @base-ui-components/react with @base-ui/react 1.0.0 ([#397](https://github.com/sebastian-software/palamedes/issues/397)) ([6e7970b](https://github.com/sebastian-software/palamedes/commit/6e7970b527a544dfbdae030e49972de80b21a620))
+- **deps:** update lucide monorepo to v1 ([ab70673](https://github.com/sebastian-software/palamedes/commit/ab70673b373834a838cf9922ea20abf4be2a1a59))
+- **deps:** update testing-library monorepo to v7 ([6f31062](https://github.com/sebastian-software/palamedes/commit/6f31062dcbe35778529b2eb961dc6212b8b8e27a))
+- **extract:** align accessor placeholder names ([91a49e4](https://github.com/sebastian-software/palamedes/commit/91a49e462bcc4a9b6504fa0a306971faa3638576))
+- **extract:** align accessor placeholder names ([a3c7692](https://github.com/sebastian-software/palamedes/commit/a3c76922ba54eef7796d4722e0ebcfdae2486681))
+- **i18n:** support plural offsets end to end ([7898d2a](https://github.com/sebastian-software/palamedes/commit/7898d2a139f8edcb6aa00c94df4a0feadbbe1f85))
+- **i18n:** support plural offsets end to end ([f2dcf9d](https://github.com/sebastian-software/palamedes/commit/f2dcf9d036ea8bb352f004b99933fcecb7c9b0ef))
+- **i18n:** validate direct plural offsets ([02ceb31](https://github.com/sebastian-software/palamedes/commit/02ceb31dec06ece1f4e45f00596eb075a5c91f77))
+- ignore JSX comments inside Trans ([860ea94](https://github.com/sebastian-software/palamedes/commit/860ea943fd8a74fa096938c9797e6020113f6664))
+- ignore JSX comments inside Trans ([c9e1bf3](https://github.com/sebastian-software/palamedes/commit/c9e1bf33c63800733b78a33204f2cd75d382d6ad))
+- **react:** add reactive runtime bridge ([#440](https://github.com/sebastian-software/palamedes/issues/440)) ([92a1c45](https://github.com/sebastian-software/palamedes/commit/92a1c451ca6e8d66084af41ecc0e63a492cc28dd)), closes [#415](https://github.com/sebastian-software/palamedes/issues/415)
+- **react:** expose server-specific types ([0a95160](https://github.com/sebastian-software/palamedes/commit/0a95160c4d7bbc745a18b3213c25cda3710375b0))
+- reconnect Solid runtime after reset ([31fba43](https://github.com/sebastian-software/palamedes/commit/31fba43ea04666d62511e14d7ab87c160f25cfda))
+- **runtime:** address SSR review feedback ([c32c45c](https://github.com/sebastian-software/palamedes/commit/c32c45c4544f81f24b22a73e3fdb599ec8b41de6))
+- **runtime:** isolate SSR client locale activation ([587fa45](https://github.com/sebastian-software/palamedes/commit/587fa454b8f176346d6fcd6fd10455eb627931f5))
+- **runtime:** isolate SSR client locale activation ([82e4cdc](https://github.com/sebastian-software/palamedes/commit/82e4cdcf3d82d9ce8aec882369ab62b2b05fb61e))
+- share runtime state across module graphs ([a085f34](https://github.com/sebastian-software/palamedes/commit/a085f34bc9d7cf9884618cb5adfcd301f4666dce))
+- share runtime state across module graphs ([52a7e46](https://github.com/sebastian-software/palamedes/commit/52a7e465b0ef1386d2ed6f160b6c65e3b3227374))
+- **site:** derive quoted numbers from repo data and repair page metadata ([0cb1eaa](https://github.com/sebastian-software/palamedes/commit/0cb1eaa83932e392c339629bb8026cdee5ee5eda))
+- **site:** keep tld matrix cells in provisioning and derive frameworks-page counts ([9405053](https://github.com/sebastian-software/palamedes/commit/9405053fd8c7a8052ce5d482c2d603effbec941f))
+- **site:** register route for new cli-binary-plugin API doc ([14695b0](https://github.com/sebastian-software/palamedes/commit/14695b0e61ad1063924310b7d347804b0b5b4179))
+- transform macros in Trans component attributes ([5488c13](https://github.com/sebastian-software/palamedes/commit/5488c1374ffda82a6c3c491fbc964d854b4dcfeb))
+- transform macros in Trans component attributes ([f7c0df0](https://github.com/sebastian-software/palamedes/commit/f7c0df06222eaea491ce605ef17cfbb5ff82ba77))
+- **ui:** make Trans catalog parsing resilient ([f5c5e87](https://github.com/sebastian-software/palamedes/commit/f5c5e87cb1c0e69b445e0a34fb2d593759e1f0af))
+- **ui:** make Trans catalog parsing resilient ([9d57535](https://github.com/sebastian-software/palamedes/commit/9d57535c6a941ad08a678e0c56cef8029c13c80c))
 
 ## [1.5.1](https://github.com/sebastian-software/palamedes/compare/palamedes-v1.5.0...palamedes-v1.5.1) (2026-07-24)
 
-
 ### Bug Fixes
 
-* correct published TypeScript declarations ([335aae5](https://github.com/sebastian-software/palamedes/commit/335aae57e668f371cdd3978f5a031d301fa512e1))
-* correct published TypeScript declarations ([abdf985](https://github.com/sebastian-software/palamedes/commit/abdf9851ace033d33014f01ab56427df68b9fc1e))
-* preserve legacy TypeScript resolution ([684f438](https://github.com/sebastian-software/palamedes/commit/684f438354f68cdb7fa05e017ec69b31451eab6f))
+- correct published TypeScript declarations ([335aae5](https://github.com/sebastian-software/palamedes/commit/335aae57e668f371cdd3978f5a031d301fa512e1))
+- correct published TypeScript declarations ([abdf985](https://github.com/sebastian-software/palamedes/commit/abdf9851ace033d33014f01ab56427df68b9fc1e))
+- preserve legacy TypeScript resolution ([684f438](https://github.com/sebastian-software/palamedes/commit/684f438354f68cdb7fa05e017ec69b31451eab6f))
 
 ## [1.5.0](https://github.com/sebastian-software/palamedes/compare/palamedes-v1.4.0...palamedes-v1.5.0) (2026-07-23)
 
-
 ### Features
 
-* remove deferred messages and enforce eager macro scope ([e4ae4ef](https://github.com/sebastian-software/palamedes/commit/e4ae4ef9d05a02d903a5c5b90930ceb1a63d38c1))
-
+- remove deferred messages and enforce eager macro scope ([e4ae4ef](https://github.com/sebastian-software/palamedes/commit/e4ae4ef9d05a02d903a5c5b90930ceb1a63d38c1))
 
 ### Bug Fixes
 
-* support interpolated descriptor templates ([cb3e893](https://github.com/sebastian-software/palamedes/commit/cb3e893212cb338d7753d4132461a013d5f41ef0))
-* validate interpolated descriptor values ([9bb6eb0](https://github.com/sebastian-software/palamedes/commit/9bb6eb05d0eea17f86b0779211e7331272b6af23))
+- support interpolated descriptor templates ([cb3e893](https://github.com/sebastian-software/palamedes/commit/cb3e893212cb338d7753d4132461a013d5f41ef0))
+- validate interpolated descriptor values ([9bb6eb0](https://github.com/sebastian-software/palamedes/commit/9bb6eb05d0eea17f86b0779211e7331272b6af23))
 
 ## [1.4.0](https://github.com/sebastian-software/palamedes/compare/palamedes-v1.3.0...palamedes-v1.4.0) (2026-07-22)
 
-
 ### Features
 
-* add Remix locale catalog flow ([cb111bd](https://github.com/sebastian-software/palamedes/commit/cb111bdd20167151fe86b1de721d9a9de9450c9a))
-* add Remix request i18n scope ([aa71708](https://github.com/sebastian-software/palamedes/commit/aa71708a16641795c7fc8f5208a804337b344d80))
-* add Remix v3 register hook ([d52e876](https://github.com/sebastian-software/palamedes/commit/d52e876abacd5a6a83ca4fbcf7ce0f75efb12a17))
-* **benchmarks:** model realistic extract-time parse volume ([5ec2430](https://github.com/sebastian-software/palamedes/commit/5ec24305c20bfc9ae45d22e59b56b09ec2fae52d))
-* **cli:** add explicit namespaced plugin commands ([#368](https://github.com/sebastian-software/palamedes/issues/368)) ([c2bb14e](https://github.com/sebastian-software/palamedes/commit/c2bb14e04c08d7119b95a885c5a4add1504ebf45)), closes [#365](https://github.com/sebastian-software/palamedes/issues/365)
-* **remix:** add server API and locale strategy examples ([ed1426e](https://github.com/sebastian-software/palamedes/commit/ed1426e873b446ce20769568adb74d411d2144a0))
-* **remix:** load PO catalogs through node hooks ([56d1cc0](https://github.com/sebastian-software/palamedes/commit/56d1cc08b3b85e80bb368ea0fca09404c26c2a1f))
-* **site:** polish homepage and add realistic 10k-message benchmark ([cc47a75](https://github.com/sebastian-software/palamedes/commit/cc47a7551aec64b46858c318799814b579bccfb9))
-
+- add Remix locale catalog flow ([cb111bd](https://github.com/sebastian-software/palamedes/commit/cb111bdd20167151fe86b1de721d9a9de9450c9a))
+- add Remix request i18n scope ([aa71708](https://github.com/sebastian-software/palamedes/commit/aa71708a16641795c7fc8f5208a804337b344d80))
+- add Remix v3 register hook ([d52e876](https://github.com/sebastian-software/palamedes/commit/d52e876abacd5a6a83ca4fbcf7ce0f75efb12a17))
+- **benchmarks:** model realistic extract-time parse volume ([5ec2430](https://github.com/sebastian-software/palamedes/commit/5ec24305c20bfc9ae45d22e59b56b09ec2fae52d))
+- **cli:** add explicit namespaced plugin commands ([#368](https://github.com/sebastian-software/palamedes/issues/368)) ([c2bb14e](https://github.com/sebastian-software/palamedes/commit/c2bb14e04c08d7119b95a885c5a4add1504ebf45)), closes [#365](https://github.com/sebastian-software/palamedes/issues/365)
+- **remix:** add server API and locale strategy examples ([ed1426e](https://github.com/sebastian-software/palamedes/commit/ed1426e873b446ce20769568adb74d411d2144a0))
+- **remix:** load PO catalogs through node hooks ([56d1cc0](https://github.com/sebastian-software/palamedes/commit/56d1cc08b3b85e80bb368ea0fca09404c26c2a1f))
+- **site:** polish homepage and add realistic 10k-message benchmark ([cc47a75](https://github.com/sebastian-software/palamedes/commit/cc47a7551aec64b46858c318799814b579bccfb9))
 
 ### Bug Fixes
 
-* address Remix review feedback ([18ec453](https://github.com/sebastian-software/palamedes/commit/18ec453b81861980a6cdf3840033bddac6c1db83))
-* **benchmarks:** read multiline PO msgids ([a207ed2](https://github.com/sebastian-software/palamedes/commit/a207ed2d3dfef9af49a995f6e09a570f6b6ec641))
-* extract interpolated plural branches ([#366](https://github.com/sebastian-software/palamedes/issues/366)) ([306fe64](https://github.com/sebastian-software/palamedes/commit/306fe648b67d11fd344c7164770d895edae4857c)), closes [#363](https://github.com/sebastian-software/palamedes/issues/363)
-* **remix:** address server parity review comments ([4ab7db3](https://github.com/sebastian-software/palamedes/commit/4ab7db3ae63d21836249726e59cf525412f66f4d))
-* satisfy Remix example lint ([8ea7741](https://github.com/sebastian-software/palamedes/commit/8ea77410b3346c8b77c5fcb5f8c48a1ddefeb6e3))
+- address Remix review feedback ([18ec453](https://github.com/sebastian-software/palamedes/commit/18ec453b81861980a6cdf3840033bddac6c1db83))
+- **benchmarks:** read multiline PO msgids ([a207ed2](https://github.com/sebastian-software/palamedes/commit/a207ed2d3dfef9af49a995f6e09a570f6b6ec641))
+- extract interpolated plural branches ([#366](https://github.com/sebastian-software/palamedes/issues/366)) ([306fe64](https://github.com/sebastian-software/palamedes/commit/306fe648b67d11fd344c7164770d895edae4857c)), closes [#363](https://github.com/sebastian-software/palamedes/issues/363)
+- **remix:** address server parity review comments ([4ab7db3](https://github.com/sebastian-software/palamedes/commit/4ab7db3ae63d21836249726e59cf525412f66f4d))
+- satisfy Remix example lint ([8ea7741](https://github.com/sebastian-software/palamedes/commit/8ea77410b3346c8b77c5fcb5f8c48a1ddefeb6e3))
 
 ## [1.3.0](https://github.com/sebastian-software/palamedes/compare/palamedes-v1.2.0...palamedes-v1.3.0) (2026-07-06)
 
-
 ### Features
 
-* **site:** adopt ARDO generated routes ([d31343a](https://github.com/sebastian-software/palamedes/commit/d31343af7a2b650ad58081a39b1eea72d7174e2b))
-* **site:** live smoke-test after Pages deploys and canonical palamedes.dev metadata ([43210df](https://github.com/sebastian-software/palamedes/commit/43210df0b4445a03d782671db14571b7cd1b813a))
-* **site:** marry the Swiss spec grid with the Palamedes Greek identity ([6577f00](https://github.com/sebastian-software/palamedes/commit/6577f00a5409005023f8dd3f6565d226f1bc568c))
-* **site:** route docs links internally ([ee0a074](https://github.com/sebastian-software/palamedes/commit/ee0a074e16f6a6ee25eea13e1dfe3a568ae89c6d))
-
+- **site:** adopt ARDO generated routes ([d31343a](https://github.com/sebastian-software/palamedes/commit/d31343af7a2b650ad58081a39b1eea72d7174e2b))
+- **site:** live smoke-test after Pages deploys and canonical palamedes.dev metadata ([43210df](https://github.com/sebastian-software/palamedes/commit/43210df0b4445a03d782671db14571b7cd1b813a))
+- **site:** marry the Swiss spec grid with the Palamedes Greek identity ([6577f00](https://github.com/sebastian-software/palamedes/commit/6577f00a5409005023f8dd3f6565d226f1bc568c))
+- **site:** route docs links internally ([ee0a074](https://github.com/sebastian-software/palamedes/commit/ee0a074e16f6a6ee25eea13e1dfe3a568ae89c6d))
 
 ### Bug Fixes
 
-* **site:** address ARDO review comments ([8b73468](https://github.com/sebastian-software/palamedes/commit/8b7346845ae88dadf6b3e28b844193facd8eecda))
-* **site:** address ARDO-coupling review notes on the wordmark and meander ([b248f03](https://github.com/sebastian-software/palamedes/commit/b248f0387913e1cede4dd5f4c4b993266f51bc89))
-* **site:** anchor lede removal by offsets and skip headings inside blocks ([d97704c](https://github.com/sebastian-software/palamedes/commit/d97704c2f773048fac10fd02ed4335146aab7cbc))
-* **site:** reconcile ARDO chrome with the Swiss-spec-grid design ([948a606](https://github.com/sebastian-software/palamedes/commit/948a606dbb82f9fbddc84962f47fc9693606f453))
-* **site:** set hero and CTA headlines in capitals to surface the Hellenic glyphs ([53c66c1](https://github.com/sebastian-software/palamedes/commit/53c66c1b05a0eec7b146c8380388b1354f1591b2))
+- **site:** address ARDO review comments ([8b73468](https://github.com/sebastian-software/palamedes/commit/8b7346845ae88dadf6b3e28b844193facd8eecda))
+- **site:** address ARDO-coupling review notes on the wordmark and meander ([b248f03](https://github.com/sebastian-software/palamedes/commit/b248f0387913e1cede4dd5f4c4b993266f51bc89))
+- **site:** anchor lede removal by offsets and skip headings inside blocks ([d97704c](https://github.com/sebastian-software/palamedes/commit/d97704c2f773048fac10fd02ed4335146aab7cbc))
+- **site:** reconcile ARDO chrome with the Swiss-spec-grid design ([948a606](https://github.com/sebastian-software/palamedes/commit/948a606dbb82f9fbddc84962f47fc9693606f453))
+- **site:** set hero and CTA headlines in capitals to surface the Hellenic glyphs ([53c66c1](https://github.com/sebastian-software/palamedes/commit/53c66c1b05a0eec7b146c8380388b1354f1591b2))
 
 ## [1.2.0](https://github.com/sebastian-software/palamedes/compare/palamedes-v1.1.2...palamedes-v1.2.0) (2026-07-05)
 
-
 ### Features
 
-* **site:** build the Palamedes website — Swiss spec grid with CLI-first hero ([4a98e23](https://github.com/sebastian-software/palamedes/commit/4a98e2387f97b6964322c662b7d29e35d4a39879))
-* **site:** deploy the website to GitHub Pages ([11f028d](https://github.com/sebastian-software/palamedes/commit/11f028de6f5d57413c8c772b4d40b672707339e3))
-* **site:** scaffold @palamedes/site workspace with prerendered React Router app ([b2d9528](https://github.com/sebastian-software/palamedes/commit/b2d95283b0168b2700f758a687999d24748fef59))
-* **site:** serve corrected llms.txt context files from the site root ([a5f0dd2](https://github.com/sebastian-software/palamedes/commit/a5f0dd2301629b753f6ee6da69d60b6893f0c99c)), closes [#309](https://github.com/sebastian-software/palamedes/issues/309)
-
+- **site:** build the Palamedes website — Swiss spec grid with CLI-first hero ([4a98e23](https://github.com/sebastian-software/palamedes/commit/4a98e2387f97b6964322c662b7d29e35d4a39879))
+- **site:** deploy the website to GitHub Pages ([11f028d](https://github.com/sebastian-software/palamedes/commit/11f028de6f5d57413c8c772b4d40b672707339e3))
+- **site:** scaffold @palamedes/site workspace with prerendered React Router app ([b2d9528](https://github.com/sebastian-software/palamedes/commit/b2d95283b0168b2700f758a687999d24748fef59))
+- **site:** serve corrected llms.txt context files from the site root ([a5f0dd2](https://github.com/sebastian-software/palamedes/commit/a5f0dd2301629b753f6ee6da69d60b6893f0c99c)), closes [#309](https://github.com/sebastian-software/palamedes/issues/309)
 
 ### Bug Fixes
 
-* render and compile-validate self-closing component placeholders ([#330](https://github.com/sebastian-software/palamedes/issues/330)) ([4441284](https://github.com/sebastian-software/palamedes/commit/4441284d8013fdbba835bf0806b5c413e2bcbee3)), closes [#328](https://github.com/sebastian-software/palamedes/issues/328)
+- render and compile-validate self-closing component placeholders ([#330](https://github.com/sebastian-software/palamedes/issues/330)) ([4441284](https://github.com/sebastian-software/palamedes/commit/4441284d8013fdbba835bf0806b5c413e2bcbee3)), closes [#328](https://github.com/sebastian-software/palamedes/issues/328)
 
 ## [1.1.2](https://github.com/sebastian-software/palamedes/compare/palamedes-v1.1.1...palamedes-v1.1.2) (2026-07-05)
 
-
 ### Bug Fixes
 
-* **release:** build musl core-node cdylib with a musl-native toolchain ([#325](https://github.com/sebastian-software/palamedes/issues/325)) ([e1c9e64](https://github.com/sebastian-software/palamedes/commit/e1c9e6473f02bf5d10e9c887a78a5f0006755228))
+- **release:** build musl core-node cdylib with a musl-native toolchain ([#325](https://github.com/sebastian-software/palamedes/issues/325)) ([e1c9e64](https://github.com/sebastian-software/palamedes/commit/e1c9e6473f02bf5d10e9c887a78a5f0006755228))
 
 ## [1.1.1](https://github.com/sebastian-software/palamedes/compare/palamedes-v1.1.0...palamedes-v1.1.1) (2026-07-04)
 
-
 ### Bug Fixes
 
-* **release:** build musl node addon with the default self-contained linker ([#300](https://github.com/sebastian-software/palamedes/issues/300)) ([530a778](https://github.com/sebastian-software/palamedes/commit/530a778cdcfdd69a07677c7e76cef09675f705b7))
+- **release:** build musl node addon with the default self-contained linker ([#300](https://github.com/sebastian-software/palamedes/issues/300)) ([530a778](https://github.com/sebastian-software/palamedes/commit/530a778cdcfdd69a07677c7e76cef09675f705b7))
 
 ## [1.1.0](https://github.com/sebastian-software/palamedes/compare/palamedes-v1.0.0...palamedes-v1.1.0) (2026-07-04)
 
-
 ### Features
 
-* **examples:** map the .com tld to en for the tld demos ([#299](https://github.com/sebastian-software/palamedes/issues/299)) ([e4ebbd4](https://github.com/sebastian-software/palamedes/commit/e4ebbd41ee205fc1b07bf2094ff6e7227878a5f4))
-
+- **examples:** map the .com tld to en for the tld demos ([#299](https://github.com/sebastian-software/palamedes/issues/299)) ([e4ebbd4](https://github.com/sebastian-software/palamedes/commit/e4ebbd41ee205fc1b07bf2094ff6e7227878a5f4))
 
 ### Bug Fixes
 
-* **release:** build musl cdylib addon via target-scoped RUSTFLAGS ([#296](https://github.com/sebastian-software/palamedes/issues/296)) ([c1dcdee](https://github.com/sebastian-software/palamedes/commit/c1dcdee5a14b76500c8c4f08dcd11fd44df3700b))
+- **release:** build musl cdylib addon via target-scoped RUSTFLAGS ([#296](https://github.com/sebastian-software/palamedes/issues/296)) ([c1dcdee](https://github.com/sebastian-software/palamedes/commit/c1dcdee5a14b76500c8c4f08dcd11fd44df3700b))
 
 ## [1.0.0](https://github.com/sebastian-software/palamedes/compare/palamedes-v0.11.4...palamedes-v1.0.0) (2026-07-04)
 
-
 ### ⚠ BREAKING CHANGES
 
-* Palamedes 1.0 documents the Ferrocat 2 catalog migration, removes NDJSON migration paths, and promotes stable app-facing surfaces to SemVer.
+- Palamedes 1.0 documents the Ferrocat 2 catalog migration, removes NDJSON migration paths, and promotes stable app-facing surfaces to SemVer.
 
 ### Features
 
-* **benchmarks:** add end-to-end workflow comparison ([7888450](https://github.com/sebastian-software/palamedes/commit/788845048a30cf33477cd0959239a1599d81e5a0))
-* **cli:** add FCL catalog workflows ([4f9c05d](https://github.com/sebastian-software/palamedes/commit/4f9c05daba2b6b7426172f2b06cd5854dfc3a821))
-* **core:** migrate catalogs to Ferrocat FCL ([640ffdd](https://github.com/sebastian-software/palamedes/commit/640ffdd66faee4c2cab47ceee8aca219e4582eba))
-* **examples:** add authoritative subdomain locale strategy across all frameworks ([#291](https://github.com/sebastian-software/palamedes/issues/291)) ([1494a0a](https://github.com/sebastian-software/palamedes/commit/1494a0a63fe43762b723f2aa757639bc1b3fc53c))
-* **extract:** emit stable origin scopes ([18245db](https://github.com/sebastian-software/palamedes/commit/18245db52863a45a06b4cfbf8e3bb8810014c89b))
-* **locale:** add top-level-domain (tld) locale strategy with examples ([#293](https://github.com/sebastian-software/palamedes/issues/293)) ([995a7c1](https://github.com/sebastian-software/palamedes/commit/995a7c102ea9c3b2a73948c4d2b1978f87f63f98))
-* **node:** expose FCL catalog formats ([60d5707](https://github.com/sebastian-software/palamedes/commit/60d5707030b12a8e0bb7a365f217e44f0acfaaa4))
-
+- **benchmarks:** add end-to-end workflow comparison ([7888450](https://github.com/sebastian-software/palamedes/commit/788845048a30cf33477cd0959239a1599d81e5a0))
+- **cli:** add FCL catalog workflows ([4f9c05d](https://github.com/sebastian-software/palamedes/commit/4f9c05daba2b6b7426172f2b06cd5854dfc3a821))
+- **core:** migrate catalogs to Ferrocat FCL ([640ffdd](https://github.com/sebastian-software/palamedes/commit/640ffdd66faee4c2cab47ceee8aca219e4582eba))
+- **examples:** add authoritative subdomain locale strategy across all frameworks ([#291](https://github.com/sebastian-software/palamedes/issues/291)) ([1494a0a](https://github.com/sebastian-software/palamedes/commit/1494a0a63fe43762b723f2aa757639bc1b3fc53c))
+- **extract:** emit stable origin scopes ([18245db](https://github.com/sebastian-software/palamedes/commit/18245db52863a45a06b4cfbf8e3bb8810014c89b))
+- **locale:** add top-level-domain (tld) locale strategy with examples ([#293](https://github.com/sebastian-software/palamedes/issues/293)) ([995a7c1](https://github.com/sebastian-software/palamedes/commit/995a7c102ea9c3b2a73948c4d2b1978f87f63f98))
+- **node:** expose FCL catalog formats ([60d5707](https://github.com/sebastian-software/palamedes/commit/60d5707030b12a8e0bb7a365f217e44f0acfaaa4))
 
 ### Bug Fixes
 
-* **release:** bump minor instead of major for pre-1.0 breaking changes ([#294](https://github.com/sebastian-software/palamedes/issues/294)) ([c19d831](https://github.com/sebastian-software/palamedes/commit/c19d83163f5b2f625cf2321ced1d7b8202ee1f32))
-
+- **release:** bump minor instead of major for pre-1.0 breaking changes ([#294](https://github.com/sebastian-software/palamedes/issues/294)) ([c19d831](https://github.com/sebastian-software/palamedes/commit/c19d83163f5b2f625cf2321ced1d7b8202ee1f32))
 
 ### Documentation
 
-* prepare Palamedes 1.0 migration ([724067c](https://github.com/sebastian-software/palamedes/commit/724067ca20e9825a6552095508b21cf5aed6d3fb))
+- prepare Palamedes 1.0 migration ([724067c](https://github.com/sebastian-software/palamedes/commit/724067ca20e9825a6552095508b21cf5aed6d3fb))
 
 ## [0.11.4](https://github.com/sebastian-software/palamedes/compare/palamedes-v0.11.3...palamedes-v0.11.4) (2026-07-03)
 
-
 ### Bug Fixes
 
-* **ci:** repair main pipeline formatting and musl addon build ([372dc4f](https://github.com/sebastian-software/palamedes/commit/372dc4f05ac3392c0d1039851147854ff78e33a6))
-* **ci:** repair main pipeline formatting and musl addon build ([b1bf8e4](https://github.com/sebastian-software/palamedes/commit/b1bf8e4b13c3106e6706f35640bad64c2e3f885b))
+- **ci:** repair main pipeline formatting and musl addon build ([372dc4f](https://github.com/sebastian-software/palamedes/commit/372dc4f05ac3392c0d1039851147854ff78e33a6))
+- **ci:** repair main pipeline formatting and musl addon build ([b1bf8e4](https://github.com/sebastian-software/palamedes/commit/b1bf8e4b13c3106e6706f35640bad64c2e3f885b))
 
 ## [0.11.3](https://github.com/sebastian-software/palamedes/compare/palamedes-v0.11.2...palamedes-v0.11.3) (2026-07-02)
 
-
 ### Bug Fixes
 
-* **ci:** unblock native package publish on Windows and musl ([#278](https://github.com/sebastian-software/palamedes/issues/278)) ([bb65f13](https://github.com/sebastian-software/palamedes/commit/bb65f13ea857533109ae5a5ab038e15c4315fccf))
+- **ci:** unblock native package publish on Windows and musl ([#278](https://github.com/sebastian-software/palamedes/issues/278)) ([bb65f13](https://github.com/sebastian-software/palamedes/commit/bb65f13ea857533109ae5a5ab038e15c4315fccf))
 
 ## [0.11.2](https://github.com/sebastian-software/palamedes/compare/palamedes-v0.11.1...palamedes-v0.11.2) (2026-07-02)
 
-
 ### Bug Fixes
 
-* **examples:** allow deployed preview host for tanstack examples ([#276](https://github.com/sebastian-software/palamedes/issues/276)) ([58878fe](https://github.com/sebastian-software/palamedes/commit/58878fe848530c88511d096b4a021a937d124759))
+- **examples:** allow deployed preview host for tanstack examples ([#276](https://github.com/sebastian-software/palamedes/issues/276)) ([58878fe](https://github.com/sebastian-software/palamedes/commit/58878fe848530c88511d096b4a021a937d124759))
 
 ## [0.11.1](https://github.com/sebastian-software/palamedes/compare/palamedes-v0.11.0...palamedes-v0.11.1) (2026-07-02)
 
-
 ### Bug Fixes
 
-* **ci:** build examples container for amd64 (x86_64 target host) ([#274](https://github.com/sebastian-software/palamedes/issues/274)) ([efdf6da](https://github.com/sebastian-software/palamedes/commit/efdf6da74ef49ad51c2d89bbf20849e44b038843))
+- **ci:** build examples container for amd64 (x86_64 target host) ([#274](https://github.com/sebastian-software/palamedes/issues/274)) ([efdf6da](https://github.com/sebastian-software/palamedes/commit/efdf6da74ef49ad51c2d89bbf20849e44b038843))
 
 ## [0.11.0](https://github.com/sebastian-software/palamedes/compare/palamedes-v0.10.0...palamedes-v0.11.0) (2026-07-02)
 
-
 ### Features
 
-* **core:** add headless @palamedes/core/locale controls ([5b78fad](https://github.com/sebastian-software/palamedes/commit/5b78fad685990acae23d77e4714c57640db1242f))
-* **examples:** run all examples side by side in one container ([#272](https://github.com/sebastian-software/palamedes/issues/272)) ([ba54ef4](https://github.com/sebastian-software/palamedes/commit/ba54ef42774b3cffd5e3dd0f9380b4a5f0a8cfd7))
-* **examples:** stop the locale banner from nagging after an explicit choice ([af03646](https://github.com/sebastian-software/palamedes/commit/af03646bcc00669d895bc94abb59dd71f445d495))
-* **examples:** unify the example matrix on one shared design ([47a42ab](https://github.com/sebastian-software/palamedes/commit/47a42abbad2607ddc2ab2d3d39719712e15be3cd))
-
+- **core:** add headless @palamedes/core/locale controls ([5b78fad](https://github.com/sebastian-software/palamedes/commit/5b78fad685990acae23d77e4714c57640db1242f))
+- **examples:** run all examples side by side in one container ([#272](https://github.com/sebastian-software/palamedes/issues/272)) ([ba54ef4](https://github.com/sebastian-software/palamedes/commit/ba54ef42774b3cffd5e3dd0f9380b4a5f0a8cfd7))
+- **examples:** stop the locale banner from nagging after an explicit choice ([af03646](https://github.com/sebastian-software/palamedes/commit/af03646bcc00669d895bc94abb59dd71f445d495))
+- **examples:** unify the example matrix on one shared design ([47a42ab](https://github.com/sebastian-software/palamedes/commit/47a42abbad2607ddc2ab2d3d39719712e15be3cd))
 
 ### Bug Fixes
 
-* **cli:** match dot-path includes and warn on empty catalogs ([b2ae950](https://github.com/sebastian-software/palamedes/commit/b2ae95047cbe963ac932f12e660aff4128f40e36))
-* **examples:** render route locale switchers as links, style both elements ([2296ebb](https://github.com/sebastian-software/palamedes/commit/2296ebbdb9120b733c9f5f9a459d3d1e195c62d2))
-* **release:** handle follow-up native publish failures ([1825938](https://github.com/sebastian-software/palamedes/commit/182593847e22bfd26f5c46230cfdfb6d5c2fb4be))
-* **release:** handle follow-up native publish failures ([1345842](https://github.com/sebastian-software/palamedes/commit/1345842e751e8225a7cab9c2801aaa7457e209a0))
-* **release:** repair native publish reruns ([0346cef](https://github.com/sebastian-software/palamedes/commit/0346cef61922a7a16f8584d63d34df1a86c95540))
-* **release:** repair native publish reruns ([682539c](https://github.com/sebastian-software/palamedes/commit/682539c27b6bdf95e67122c14cdd98024b4a8432))
-* **solid:** make Trans and t/plural follow client-side locale switches ([8e5f21e](https://github.com/sebastian-software/palamedes/commit/8e5f21e16084dfab6b205b2c7fcf6656d1b5f1f2))
+- **cli:** match dot-path includes and warn on empty catalogs ([b2ae950](https://github.com/sebastian-software/palamedes/commit/b2ae95047cbe963ac932f12e660aff4128f40e36))
+- **examples:** render route locale switchers as links, style both elements ([2296ebb](https://github.com/sebastian-software/palamedes/commit/2296ebbdb9120b733c9f5f9a459d3d1e195c62d2))
+- **release:** handle follow-up native publish failures ([1825938](https://github.com/sebastian-software/palamedes/commit/182593847e22bfd26f5c46230cfdfb6d5c2fb4be))
+- **release:** handle follow-up native publish failures ([1345842](https://github.com/sebastian-software/palamedes/commit/1345842e751e8225a7cab9c2801aaa7457e209a0))
+- **release:** repair native publish reruns ([0346cef](https://github.com/sebastian-software/palamedes/commit/0346cef61922a7a16f8584d63d34df1a86c95540))
+- **release:** repair native publish reruns ([682539c](https://github.com/sebastian-software/palamedes/commit/682539c27b6bdf95e67122c14cdd98024b4a8432))
+- **solid:** make Trans and t/plural follow client-side locale switches ([8e5f21e](https://github.com/sebastian-software/palamedes/commit/8e5f21e16084dfab6b205b2c7fcf6656d1b5f1f2))
 
 ## [0.10.0](https://github.com/sebastian-software/palamedes/compare/palamedes-v0.9.0...palamedes-v0.10.0) (2026-06-30)
 
-
 ### Features
 
-* **release:** add linux x64 musl native packages ([1d32765](https://github.com/sebastian-software/palamedes/commit/1d32765fb40e9d457ac841b8ca4c7d4b48a2ba9c))
-* **release:** add linux x64 musl native packages ([aa37892](https://github.com/sebastian-software/palamedes/commit/aa37892c5d7f65ce7fcf27794711f6422f49cdec))
-
+- **release:** add linux x64 musl native packages ([1d32765](https://github.com/sebastian-software/palamedes/commit/1d32765fb40e9d457ac841b8ca4c7d4b48a2ba9c))
+- **release:** add linux x64 musl native packages ([aa37892](https://github.com/sebastian-software/palamedes/commit/aa37892c5d7f65ce7fcf27794711f6422f49cdec))
 
 ### Bug Fixes
 
-* make release publishing retryable ([32f4c1f](https://github.com/sebastian-software/palamedes/commit/32f4c1fba1594753922e8b86438a85f774ce6340))
-* make release publishing retryable ([ed7fe73](https://github.com/sebastian-software/palamedes/commit/ed7fe7357ec81292b64e48ff90d50f2215ebda37))
-* **release:** avoid unknown libc musl fallback ([449434a](https://github.com/sebastian-software/palamedes/commit/449434a2f32878f9f659479edb3217a6a02c4069))
-* **release:** tighten native libc selection ([0f78265](https://github.com/sebastian-software/palamedes/commit/0f78265f485c5c7f58cb5464a1a52258e09a29d3))
+- make release publishing retryable ([32f4c1f](https://github.com/sebastian-software/palamedes/commit/32f4c1fba1594753922e8b86438a85f774ce6340))
+- make release publishing retryable ([ed7fe73](https://github.com/sebastian-software/palamedes/commit/ed7fe7357ec81292b64e48ff90d50f2215ebda37))
+- **release:** avoid unknown libc musl fallback ([449434a](https://github.com/sebastian-software/palamedes/commit/449434a2f32878f9f659479edb3217a6a02c4069))
+- **release:** tighten native libc selection ([0f78265](https://github.com/sebastian-software/palamedes/commit/0f78265f485c5c7f58cb5464a1a52258e09a29d3))
 
 ## [0.9.0](https://github.com/sebastian-software/palamedes/compare/palamedes-v0.8.0...palamedes-v0.9.0) (2026-06-28)
 
-
 ### Features
 
-* make pmds a native rust cli ([a6ab3db](https://github.com/sebastian-software/palamedes/commit/a6ab3dbcc4d1e5ffc84f304363ff02afcf35e40c))
-* render vite catalog modules in rust ([07ef4f1](https://github.com/sebastian-software/palamedes/commit/07ef4f148a773c1dea3fecbb29686b144832f762))
+- make pmds a native rust cli ([a6ab3db](https://github.com/sebastian-software/palamedes/commit/a6ab3dbcc4d1e5ffc84f304363ff02afcf35e40c))
+- render vite catalog modules in rust ([07ef4f1](https://github.com/sebastian-software/palamedes/commit/07ef4f148a773c1dea3fecbb29686b144832f762))
 
 ## [0.8.0](https://github.com/sebastian-software/palamedes/compare/palamedes-v0.7.12...palamedes-v0.8.0) (2026-06-27)
 
-
 ### Features
 
-* **config:** default PO origins to git root ([c68950e](https://github.com/sebastian-software/palamedes/commit/c68950e378d16fac29a75fa8939c92f458abf1bb))
-
+- **config:** default PO origins to git root ([c68950e](https://github.com/sebastian-software/palamedes/commit/c68950e378d16fac29a75fa8939c92f458abf1bb))
 
 ### Bug Fixes
 
-* **cli:** keep parent include PO origins relative ([bfe5431](https://github.com/sebastian-software/palamedes/commit/bfe543180b7c24543e0bc775a1c2b5371462f72c))
+- **cli:** keep parent include PO origins relative ([bfe5431](https://github.com/sebastian-software/palamedes/commit/bfe543180b7c24543e0bc775a1c2b5371462f72c))
 
 ## [0.7.12](https://github.com/sebastian-software/palamedes/compare/palamedes-v0.7.11...palamedes-v0.7.12) (2026-06-27)
 
-
 ### Bug Fixes
 
-* **transform:** keep nested choice branches as expressions ([d204513](https://github.com/sebastian-software/palamedes/commit/d204513e14e4af6e3ee6662481029be1fa03784c))
+- **transform:** keep nested choice branches as expressions ([d204513](https://github.com/sebastian-software/palamedes/commit/d204513e14e4af6e3ee6662481029be1fa03784c))
 
 ## [0.7.11](https://github.com/sebastian-software/palamedes/compare/palamedes-v0.7.10...palamedes-v0.7.11) (2026-06-27)
 
-
 ### Bug Fixes
 
-* **transform:** accept fallback choice values ([d261341](https://github.com/sebastian-software/palamedes/commit/d261341da9fc9278a3e03e612edb73a92a61912b))
+- **transform:** accept fallback choice values ([d261341](https://github.com/sebastian-software/palamedes/commit/d261341da9fc9278a3e03e612edb73a92a61912b))
 
 ## [0.7.10](https://github.com/sebastian-software/palamedes/compare/palamedes-v0.7.9...palamedes-v0.7.10) (2026-06-27)
 
-
 ### Bug Fixes
 
-* **transform:** align JSX choice value handling ([7835a58](https://github.com/sebastian-software/palamedes/commit/7835a589c906e8734bd98a8414c70d06b62f9305))
+- **transform:** align JSX choice value handling ([7835a58](https://github.com/sebastian-software/palamedes/commit/7835a589c906e8734bd98a8414c70d06b62f9305))
 
 ## [0.7.9](https://github.com/sebastian-software/palamedes/compare/palamedes-v0.7.8...palamedes-v0.7.9) (2026-06-26)
 
-
 ### Bug Fixes
 
-* **extract:** match Lingui JSX whitespace at expression boundaries ([2826451](https://github.com/sebastian-software/palamedes/commit/28264516f44e91f4ab9d88aa9f6187bb6cbbfe51)), closes [#246](https://github.com/sebastian-software/palamedes/issues/246)
+- **extract:** match Lingui JSX whitespace at expression boundaries ([2826451](https://github.com/sebastian-software/palamedes/commit/28264516f44e91f4ab9d88aa9f6187bb6cbbfe51)), closes [#246](https://github.com/sebastian-software/palamedes/issues/246)
 
 ## [0.7.8](https://github.com/sebastian-software/palamedes/compare/palamedes-v0.7.7...palamedes-v0.7.8) (2026-06-26)
 
-
 ### Bug Fixes
 
-* **extractor:** detect nested macros in JSX expressions ([c529959](https://github.com/sebastian-software/palamedes/commit/c529959b03eefd35836128dfef16f9f7e766d0d3))
-* **extractor:** ignore render prop macros in nested scan ([41d507c](https://github.com/sebastian-software/palamedes/commit/41d507ca6552ab1ec33c74c134bfd64e2b7103d3))
-* **extractor:** reject nested message macros ([488a4fb](https://github.com/sebastian-software/palamedes/commit/488a4fb63edc5c04fb3381f92ca1c55fc20d985c))
-* **transform:** preserve self-closing rich placeholders ([76bf244](https://github.com/sebastian-software/palamedes/commit/76bf244f7be976332622ed188374e4e9e1d50f00))
-* **transform:** preserve spaces around inline empty placeholders ([611c554](https://github.com/sebastian-software/palamedes/commit/611c554135ad1a795f5dc58be8eec56476935a27))
+- **extractor:** detect nested macros in JSX expressions ([c529959](https://github.com/sebastian-software/palamedes/commit/c529959b03eefd35836128dfef16f9f7e766d0d3))
+- **extractor:** ignore render prop macros in nested scan ([41d507c](https://github.com/sebastian-software/palamedes/commit/41d507ca6552ab1ec33c74c134bfd64e2b7103d3))
+- **extractor:** reject nested message macros ([488a4fb](https://github.com/sebastian-software/palamedes/commit/488a4fb63edc5c04fb3381f92ca1c55fc20d985c))
+- **transform:** preserve self-closing rich placeholders ([76bf244](https://github.com/sebastian-software/palamedes/commit/76bf244f7be976332622ed188374e4e9e1d50f00))
+- **transform:** preserve spaces around inline empty placeholders ([611c554](https://github.com/sebastian-software/palamedes/commit/611c554135ad1a795f5dc58be8eec56476935a27))
 
 ## [0.7.7](https://github.com/sebastian-software/palamedes/compare/palamedes-v0.7.6...palamedes-v0.7.7) (2026-06-26)
 
-
 ### Bug Fixes
 
-* **core:** align JSX separator whitespace ([80d87ab](https://github.com/sebastian-software/palamedes/commit/80d87ab1e65ec1b05c330b399afce0ffaacd814b))
-* **core:** preserve literal JSX brace text boundaries ([dd26425](https://github.com/sebastian-software/palamedes/commit/dd26425d7778c49ad185ce88b337f0a180c8fca4))
+- **core:** align JSX separator whitespace ([80d87ab](https://github.com/sebastian-software/palamedes/commit/80d87ab1e65ec1b05c330b399afce0ffaacd814b))
+- **core:** preserve literal JSX brace text boundaries ([dd26425](https://github.com/sebastian-software/palamedes/commit/dd26425d7778c49ad185ce88b337f0a180c8fca4))
 
 ## [0.7.6](https://github.com/sebastian-software/palamedes/compare/palamedes-v0.7.5...palamedes-v0.7.6) (2026-06-26)
 
-
 ### Bug Fixes
 
-* **extractor:** normalize rich-text placeholder whitespace ([65ed86f](https://github.com/sebastian-software/palamedes/commit/65ed86f967763771b3737523f162d66a34c58341))
+- **extractor:** normalize rich-text placeholder whitespace ([65ed86f](https://github.com/sebastian-software/palamedes/commit/65ed86f967763771b3737523f162d66a34c58341))
 
 ## [0.7.5](https://github.com/sebastian-software/palamedes/compare/palamedes-v0.7.4...palamedes-v0.7.5) (2026-06-25)
 
-
 ### Bug Fixes
 
-* **transform:** normalize rich-text placeholder whitespace ([9a5fc5a](https://github.com/sebastian-software/palamedes/commit/9a5fc5a6ae69f6ed8ea44d19b166df41a31dedd1))
+- **transform:** normalize rich-text placeholder whitespace ([9a5fc5a](https://github.com/sebastian-software/palamedes/commit/9a5fc5a6ae69f6ed8ea44d19b166df41a31dedd1))
 
 ## [0.7.4](https://github.com/sebastian-software/palamedes/compare/palamedes-v0.7.3...palamedes-v0.7.4) (2026-06-25)
 
-
 ### Performance Improvements
 
-* **core:** release Ferrocat 1.3.1 catalog optimizations ([706ae81](https://github.com/sebastian-software/palamedes/commit/706ae81d54f1b5524659fbc301ee306a0bc33b90))
+- **core:** release Ferrocat 1.3.1 catalog optimizations ([706ae81](https://github.com/sebastian-software/palamedes/commit/706ae81d54f1b5524659fbc301ee306a0bc33b90))
 
 ## [0.7.3](https://github.com/sebastian-software/palamedes/compare/palamedes-v0.7.2...palamedes-v0.7.3) (2026-06-25)
 
-
 ### Bug Fixes
 
-* **extractor:** decode jsx entities in message keys ([54b1c91](https://github.com/sebastian-software/palamedes/commit/54b1c9105bd120ea93d616798a576498a0f5ec62))
-* **extractor:** preserve raw jsx expression entities ([a681310](https://github.com/sebastian-software/palamedes/commit/a681310a71ccc5d1cfaeae335dcc1e91b51d1ae6))
+- **extractor:** decode jsx entities in message keys ([54b1c91](https://github.com/sebastian-software/palamedes/commit/54b1c9105bd120ea93d616798a576498a0f5ec62))
+- **extractor:** preserve raw jsx expression entities ([a681310](https://github.com/sebastian-software/palamedes/commit/a681310a71ccc5d1cfaeae335dcc1e91b51d1ae6))
 
 ## [0.7.2](https://github.com/sebastian-software/palamedes/compare/palamedes-v0.7.1...palamedes-v0.7.2) (2026-06-24)
 
-
 ### Bug Fixes
 
-* **release:** publish supported native targets only ([5dd4db4](https://github.com/sebastian-software/palamedes/commit/5dd4db4084c12b84beab8c40217d10643a3b7738))
+- **release:** publish supported native targets only ([5dd4db4](https://github.com/sebastian-software/palamedes/commit/5dd4db4084c12b84beab8c40217d10643a3b7738))
 
 ## [0.7.1](https://github.com/sebastian-software/palamedes/compare/palamedes-v0.7.0...palamedes-v0.7.1) (2026-06-24)
 
-
 ### Bug Fixes
 
-* **core:** accept literal apostrophes in catalog audit ([71f7a0d](https://github.com/sebastian-software/palamedes/commit/71f7a0d853a9960f330bfff38626e3c855f36630)), closes [#192](https://github.com/sebastian-software/palamedes/issues/192)
+- **core:** accept literal apostrophes in catalog audit ([71f7a0d](https://github.com/sebastian-software/palamedes/commit/71f7a0d853a9960f330bfff38626e3c855f36630)), closes [#192](https://github.com/sebastian-software/palamedes/issues/192)
 
 ## [0.7.0](https://github.com/sebastian-software/palamedes/compare/palamedes-v0.6.0...palamedes-v0.7.0) (2026-06-12)
 
-
 ### Features
 
-* **cli:** add catalog completeness report ([#179](https://github.com/sebastian-software/palamedes/issues/179)) ([37a0934](https://github.com/sebastian-software/palamedes/commit/37a093453b729057e472aa3594d3f6bd0c500b36))
-* **cli:** add xliff bridge ([#182](https://github.com/sebastian-software/palamedes/issues/182)) ([0338cab](https://github.com/sebastian-software/palamedes/commit/0338cabf37f2bba1eed90be3053bfecc5db549e6))
-* **core-node:** add native target packages ([#174](https://github.com/sebastian-software/palamedes/issues/174)) ([63594e0](https://github.com/sebastian-software/palamedes/commit/63594e068a29a5371ab71bfe1e5fac31267d3058))
-* **core:** add runtime fallback hooks ([#175](https://github.com/sebastian-software/palamedes/issues/175)) ([fd68a24](https://github.com/sebastian-software/palamedes/commit/fd68a244ebc63e7d531413fd9b53f60acd1f7b8b))
-* **core:** format ICU number and date arguments ([#176](https://github.com/sebastian-software/palamedes/issues/176)) ([5a13d1d](https://github.com/sebastian-software/palamedes/commit/5a13d1d8cb3a71deb1a791585318ca27cf3d2cfd))
-
+- **cli:** add catalog completeness report ([#179](https://github.com/sebastian-software/palamedes/issues/179)) ([37a0934](https://github.com/sebastian-software/palamedes/commit/37a093453b729057e472aa3594d3f6bd0c500b36))
+- **cli:** add xliff bridge ([#182](https://github.com/sebastian-software/palamedes/issues/182)) ([0338cab](https://github.com/sebastian-software/palamedes/commit/0338cabf37f2bba1eed90be3053bfecc5db549e6))
+- **core-node:** add native target packages ([#174](https://github.com/sebastian-software/palamedes/issues/174)) ([63594e0](https://github.com/sebastian-software/palamedes/commit/63594e068a29a5371ab71bfe1e5fac31267d3058))
+- **core:** add runtime fallback hooks ([#175](https://github.com/sebastian-software/palamedes/issues/175)) ([fd68a24](https://github.com/sebastian-software/palamedes/commit/fd68a244ebc63e7d531413fd9b53f60acd1f7b8b))
+- **core:** format ICU number and date arguments ([#176](https://github.com/sebastian-software/palamedes/issues/176)) ([5a13d1d](https://github.com/sebastian-software/palamedes/commit/5a13d1d8cb3a71deb1a791585318ca27cf3d2cfd))
 
 ### Bug Fixes
 
-* **cli:** report package version ([ee1ad58](https://github.com/sebastian-software/palamedes/commit/ee1ad583690493777a132f5e614ebb507e436e70))
-* **cli:** report package version ([a5c9405](https://github.com/sebastian-software/palamedes/commit/a5c940570b2ab9bcd465d282de56be5f26964b14))
-* **core:** resolve descriptor ids through active catalog ([#141](https://github.com/sebastian-software/palamedes/issues/141)) ([4447b07](https://github.com/sebastian-software/palamedes/commit/4447b07b7ed80c46fa3dcc21b47c66cb174b312f))
-* **next-plugin:** suppress false apostrophe ICU diagnostics ([#139](https://github.com/sebastian-software/palamedes/issues/139)) ([39f7f8b](https://github.com/sebastian-software/palamedes/commit/39f7f8b2908844733f5afb5d3e054e6a81a602e8))
-* **runtime:** add request-local server i18n scope ([#142](https://github.com/sebastian-software/palamedes/issues/142)) ([2088f81](https://github.com/sebastian-software/palamedes/commit/2088f81261ab2e24c8cc2d95b0eb5985140ab6ec))
-* **transform:** emit valid JSX for macro replacements ([16dfcc4](https://github.com/sebastian-software/palamedes/commit/16dfcc4218a3061029e4d84063aca3b498c4afd0))
-* **transform:** validate descriptor macro values ([#180](https://github.com/sebastian-software/palamedes/issues/180)) ([3b37189](https://github.com/sebastian-software/palamedes/commit/3b371890ef721004e5f8ef50a293d5cf99955cd4))
+- **cli:** report package version ([ee1ad58](https://github.com/sebastian-software/palamedes/commit/ee1ad583690493777a132f5e614ebb507e436e70))
+- **cli:** report package version ([a5c9405](https://github.com/sebastian-software/palamedes/commit/a5c940570b2ab9bcd465d282de56be5f26964b14))
+- **core:** resolve descriptor ids through active catalog ([#141](https://github.com/sebastian-software/palamedes/issues/141)) ([4447b07](https://github.com/sebastian-software/palamedes/commit/4447b07b7ed80c46fa3dcc21b47c66cb174b312f))
+- **next-plugin:** suppress false apostrophe ICU diagnostics ([#139](https://github.com/sebastian-software/palamedes/issues/139)) ([39f7f8b](https://github.com/sebastian-software/palamedes/commit/39f7f8b2908844733f5afb5d3e054e6a81a602e8))
+- **runtime:** add request-local server i18n scope ([#142](https://github.com/sebastian-software/palamedes/issues/142)) ([2088f81](https://github.com/sebastian-software/palamedes/commit/2088f81261ab2e24c8cc2d95b0eb5985140ab6ec))
+- **transform:** emit valid JSX for macro replacements ([16dfcc4](https://github.com/sebastian-software/palamedes/commit/16dfcc4218a3061029e4d84063aca3b498c4afd0))
+- **transform:** validate descriptor macro values ([#180](https://github.com/sebastian-software/palamedes/issues/180)) ([3b37189](https://github.com/sebastian-software/palamedes/commit/3b371890ef721004e5f8ef50a293d5cf99955cd4))
 
 ## [0.6.0](https://github.com/sebastian-software/palamedes/compare/palamedes-v0.5.0...palamedes-v0.6.0) (2026-05-22)
 

--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -9,6 +9,8 @@ package names.
 - `DEFAULT_LOCALE`
 - `formatMessagePattern(pattern, values, locale?)`
 - `parseMessagePattern(pattern)`
+- `resolveChoice(node, value, locale?)` and `ResolvedChoice`
+- `stringifyValue(value)`
 - `parseAcceptLanguage(header)` from `@palamedes/core/locale`
 - `buildLocaleSwitchItems(options)` from `@palamedes/core/locale`
 - `defineLocaleControls(config)` from `@palamedes/core/locale`
@@ -93,8 +95,13 @@ interface MessageMetadata {
   message?: string
   context?: string
   comment?: string
+  reportMissing?: boolean
 }
 ```
+
+`reportMissing: false` suppresses `onMissing` for a single lookup. The runtime
+choice components use it because their synthesized source patterns are
+expected to miss the catalog in apps that never loaded matching entries.
 
 The compiler emits this metadata alongside compact internal lookup ids so the
 runtime can fall back to the source message and report useful diagnostics.
@@ -112,7 +119,9 @@ matrix and reusable in apps:
   labels, active state, locale, and test ids.
 - `defineLocaleControls(config)`: binds locale resolution, deliberate-choice
   cookies, canonical URLs, and suggestion decisions for cookie, route,
-  subdomain, and tld strategies.
+  subdomain, and tld strategies. Host-carrying URLs from `canonicalUrl` and
+  `suggest` are protocol-relative (`//host/path`) unless the config sets
+  `protocol` (e.g. `"https"`), so HTTPS pages never link users to `http://`.
 
 ## Macro Entry Point
 
@@ -152,3 +161,14 @@ Catalog artifact compilation reports `list`, `duration`, `ago`, `name`, and
 other unsupported formatter kinds as errors. Unsupported styles on `number`,
 `date`, and `time` are warnings because the runtime currently falls back to the
 default `Intl` formatter for that argument type.
+
+Plural and selectordinal arguments require a present, numeric value (numeric
+strings are accepted). A missing or non-numeric value throws instead of
+silently coercing to `0` — inside `_()`/`getMessage()` that error is reported
+through `onError` and rendering falls back to the source message.
+
+Two helpers back the host-adapter renderers and are public for custom
+adapters: `resolveChoice(node, value, locale?)` selects the branch of a parsed
+plural/select/selectordinal node (returning the branch nodes plus the operand
+for `#`), and `stringifyValue(value)` is the string renderer's value
+stringification, where `Date` values become deterministic ISO strings.

--- a/examples/nextjs-subdomain/src/components/LocaleSwitcher.tsx
+++ b/examples/nextjs-subdomain/src/components/LocaleSwitcher.tsx
@@ -19,12 +19,10 @@ export function LocaleSwitcher({ host, locale }: LocaleSwitcherProps) {
 
   // Subdomain strategy: switching the locale means loading a different host, so
   // we build the target URL from the request host (the core control swaps the
-  // leftmost label) and let the browser do a full document load. Stripping the
-  // scheme yields a protocol-relative URL that stays correct on both http
-  // (local) and https (deployed).
+  // locale label) and let the browser do a full document load. canonicalUrl
+  // returns protocol-relative URLs, correct on http (local) and https (deployed).
   function hrefFor(target: Locale): string {
-    const url = locales.canonicalUrl({ locale: target, pathname: "/", requestHost: host })
-    return url.replace(/^https?:/, "")
+    return locales.canonicalUrl({ locale: target, pathname: "/", requestHost: host })
   }
 
   return (

--- a/examples/nextjs-subdomain/src/components/SuggestionBanner.tsx
+++ b/examples/nextjs-subdomain/src/components/SuggestionBanner.tsx
@@ -23,7 +23,7 @@ export function SuggestionBanner(props: SuggestionBannerProps) {
       <a
         className="notice-cta"
         data-testid="locale-suggestion-cta"
-        href={props.recommendedUrl.replace(/^https?:/, "")}
+        href={props.recommendedUrl}
         onClick={() => {
           document.cookie = locales.serializeChoice(props.recommendedLocale)
         }}

--- a/examples/nextjs-tld/src/components/LocaleSwitcher.tsx
+++ b/examples/nextjs-tld/src/components/LocaleSwitcher.tsx
@@ -19,12 +19,10 @@ export function LocaleSwitcher({ host, locale }: LocaleSwitcherProps) {
 
   // TLD strategy: switching the locale means loading a different host, so we
   // build the target URL from the request host (the core control swaps the
-  // rightmost label) and let the browser do a full document load. Stripping the
-  // scheme yields a protocol-relative URL that stays correct on both http
-  // (local) and https (deployed).
+  // locale label) and let the browser do a full document load. canonicalUrl
+  // returns protocol-relative URLs, correct on http (local) and https (deployed).
   function hrefFor(target: Locale): string {
-    const url = locales.canonicalUrl({ locale: target, pathname: "/", requestHost: host })
-    return url.replace(/^https?:/, "")
+    return locales.canonicalUrl({ locale: target, pathname: "/", requestHost: host })
   }
 
   return (

--- a/examples/nextjs-tld/src/components/SuggestionBanner.tsx
+++ b/examples/nextjs-tld/src/components/SuggestionBanner.tsx
@@ -23,7 +23,7 @@ export function SuggestionBanner(props: SuggestionBannerProps) {
       <a
         className="notice-cta"
         data-testid="locale-suggestion-cta"
-        href={props.recommendedUrl.replace(/^https?:/, "")}
+        href={props.recommendedUrl}
         onClick={() => {
           document.cookie = locales.serializeChoice(props.recommendedLocale)
         }}

--- a/examples/react-router-subdomain/app/components/LocaleSwitcher.tsx
+++ b/examples/react-router-subdomain/app/components/LocaleSwitcher.tsx
@@ -17,12 +17,10 @@ export function LocaleSwitcher({ host, locale }: LocaleSwitcherProps) {
 
   // Subdomain strategy: switching the locale means loading a different host, so
   // we build the target URL from the request host (the core control swaps the
-  // leftmost label) and let the browser do a full document load. Stripping the
-  // scheme yields a protocol-relative URL that stays correct on both http
-  // (local) and https (deployed).
+  // locale label) and let the browser do a full document load. canonicalUrl
+  // returns protocol-relative URLs, correct on http (local) and https (deployed).
   function hrefFor(target: Locale): string {
-    const url = locales.canonicalUrl({ locale: target, pathname: "/", requestHost: host })
-    return url.replace(/^https?:/, "")
+    return locales.canonicalUrl({ locale: target, pathname: "/", requestHost: host })
   }
 
   return (

--- a/examples/react-router-subdomain/app/components/SuggestionBanner.tsx
+++ b/examples/react-router-subdomain/app/components/SuggestionBanner.tsx
@@ -21,7 +21,7 @@ export function SuggestionBanner(props: SuggestionBannerProps) {
       <a
         className="notice-cta"
         data-testid="locale-suggestion-cta"
-        href={props.recommendedUrl.replace(/^https?:/, "")}
+        href={props.recommendedUrl}
         onClick={() => {
           document.cookie = locales.serializeChoice(props.recommendedLocale)
         }}

--- a/examples/react-router-tld/app/components/LocaleSwitcher.tsx
+++ b/examples/react-router-tld/app/components/LocaleSwitcher.tsx
@@ -18,11 +18,10 @@ export function LocaleSwitcher({ host, locale }: LocaleSwitcherProps) {
   // TLD strategy: switching the locale means loading a different host, so we
   // build the target URL from the request host (the core control swaps the
   // rightmost label / Top-Level-Domain) and let the browser do a full document
-  // load. Stripping the scheme yields a protocol-relative URL that stays
-  // correct on both http (local) and https (deployed).
+  // load. canonicalUrl returns protocol-relative URLs, correct on http (local)
+  // and https (deployed).
   function hrefFor(target: Locale): string {
-    const url = locales.canonicalUrl({ locale: target, pathname: "/", requestHost: host })
-    return url.replace(/^https?:/, "")
+    return locales.canonicalUrl({ locale: target, pathname: "/", requestHost: host })
   }
 
   return (

--- a/examples/react-router-tld/app/components/SuggestionBanner.tsx
+++ b/examples/react-router-tld/app/components/SuggestionBanner.tsx
@@ -21,7 +21,7 @@ export function SuggestionBanner(props: SuggestionBannerProps) {
       <a
         className="notice-cta"
         data-testid="locale-suggestion-cta"
-        href={props.recommendedUrl.replace(/^https?:/, "")}
+        href={props.recommendedUrl}
         onClick={() => {
           document.cookie = locales.serializeChoice(props.recommendedLocale)
         }}

--- a/examples/solidstart-subdomain/src/components/LocaleSwitcher.tsx
+++ b/examples/solidstart-subdomain/src/components/LocaleSwitcher.tsx
@@ -18,12 +18,10 @@ export function LocaleSwitcher(props: LocaleSwitcherProps) {
 
   // Subdomain strategy: switching the locale means loading a different host, so
   // we build the target URL from the request host (the core control swaps the
-  // leftmost label) and let the browser do a full document load. Stripping the
-  // scheme yields a protocol-relative URL that stays correct on both http
-  // (local) and https (deployed).
+  // locale label) and let the browser do a full document load. canonicalUrl
+  // returns protocol-relative URLs, correct on http (local) and https (deployed).
   function hrefFor(target: Locale): string {
-    const url = locales.canonicalUrl({ locale: target, pathname: "/", requestHost: props.host })
-    return url.replace(/^https?:/, "")
+    return locales.canonicalUrl({ locale: target, pathname: "/", requestHost: props.host })
   }
 
   return (

--- a/examples/solidstart-subdomain/src/components/SuggestionBanner.tsx
+++ b/examples/solidstart-subdomain/src/components/SuggestionBanner.tsx
@@ -19,7 +19,7 @@ export function SuggestionBanner(props: SuggestionBannerProps) {
         <a
           class="notice-cta"
           data-testid="locale-suggestion-cta"
-          href={props.recommendedUrl.replace(/^https?:/, "")}
+          href={props.recommendedUrl}
           onClick={() => {
             document.cookie = locales.serializeChoice(props.recommendedLocale)
           }}

--- a/examples/solidstart-tld/src/components/LocaleSwitcher.tsx
+++ b/examples/solidstart-tld/src/components/LocaleSwitcher.tsx
@@ -18,12 +18,10 @@ export function LocaleSwitcher(props: LocaleSwitcherProps) {
 
   // TLD strategy: switching the locale means loading a different host, so
   // we build the target URL from the request host (the core control swaps the
-  // rightmost label) and let the browser do a full document load. Stripping
-  // the scheme yields a protocol-relative URL that stays correct on both http
-  // (local) and https (deployed).
+  // rightmost label) and let the browser do a full document load. canonicalUrl
+  // returns protocol-relative URLs, correct on http (local) and https (deployed).
   function hrefFor(target: Locale): string {
-    const url = locales.canonicalUrl({ locale: target, pathname: "/", requestHost: props.host })
-    return url.replace(/^https?:/, "")
+    return locales.canonicalUrl({ locale: target, pathname: "/", requestHost: props.host })
   }
 
   return (

--- a/examples/solidstart-tld/src/components/SuggestionBanner.tsx
+++ b/examples/solidstart-tld/src/components/SuggestionBanner.tsx
@@ -19,7 +19,7 @@ export function SuggestionBanner(props: SuggestionBannerProps) {
         <a
           class="notice-cta"
           data-testid="locale-suggestion-cta"
-          href={props.recommendedUrl.replace(/^https?:/, "")}
+          href={props.recommendedUrl}
           onClick={() => {
             document.cookie = locales.serializeChoice(props.recommendedLocale)
           }}

--- a/examples/tanstack-subdomain/src/components/LocaleSwitcher.tsx
+++ b/examples/tanstack-subdomain/src/components/LocaleSwitcher.tsx
@@ -17,12 +17,10 @@ export function LocaleSwitcher({ host, locale }: LocaleSwitcherProps) {
 
   // Subdomain strategy: switching the locale means loading a different host, so
   // we build the target URL from the request host (the core control swaps the
-  // leftmost label) and let the browser do a full document load. Stripping the
-  // scheme yields a protocol-relative URL that stays correct on both http
-  // (local) and https (deployed).
+  // locale label) and let the browser do a full document load. canonicalUrl
+  // returns protocol-relative URLs, correct on http (local) and https (deployed).
   function hrefFor(target: Locale): string {
-    const url = locales.canonicalUrl({ locale: target, pathname: "/", requestHost: host })
-    return url.replace(/^https?:/, "")
+    return locales.canonicalUrl({ locale: target, pathname: "/", requestHost: host })
   }
 
   return (

--- a/examples/tanstack-subdomain/src/components/SuggestionBanner.tsx
+++ b/examples/tanstack-subdomain/src/components/SuggestionBanner.tsx
@@ -21,7 +21,7 @@ export function SuggestionBanner(props: SuggestionBannerProps) {
       <a
         className="notice-cta"
         data-testid="locale-suggestion-cta"
-        href={props.recommendedUrl.replace(/^https?:/, "")}
+        href={props.recommendedUrl}
         onClick={() => {
           document.cookie = locales.serializeChoice(props.recommendedLocale)
         }}

--- a/examples/tanstack-tld/src/components/LocaleSwitcher.tsx
+++ b/examples/tanstack-tld/src/components/LocaleSwitcher.tsx
@@ -18,11 +18,10 @@ export function LocaleSwitcher({ host, locale }: LocaleSwitcherProps) {
   // TLD strategy: switching the locale means loading a different host, so
   // we build the target URL from the request host (the core control swaps the
   // rightmost label / TLD) and let the browser do a full document load.
-  // Stripping the scheme yields a protocol-relative URL that stays correct on
-  // both http (local) and https (deployed).
+  // canonicalUrl returns protocol-relative URLs, correct on http (local) and
+  // https (deployed).
   function hrefFor(target: Locale): string {
-    const url = locales.canonicalUrl({ locale: target, pathname: "/", requestHost: host })
-    return url.replace(/^https?:/, "")
+    return locales.canonicalUrl({ locale: target, pathname: "/", requestHost: host })
   }
 
   return (

--- a/examples/tanstack-tld/src/components/SuggestionBanner.tsx
+++ b/examples/tanstack-tld/src/components/SuggestionBanner.tsx
@@ -21,7 +21,7 @@ export function SuggestionBanner(props: SuggestionBannerProps) {
       <a
         className="notice-cta"
         data-testid="locale-suggestion-cta"
-        href={props.recommendedUrl.replace(/^https?:/, "")}
+        href={props.recommendedUrl}
         onClick={() => {
           document.cookie = locales.serializeChoice(props.recommendedLocale)
         }}

--- a/examples/waku-subdomain/src/components/LocaleSwitcher.tsx
+++ b/examples/waku-subdomain/src/components/LocaleSwitcher.tsx
@@ -20,12 +20,10 @@ export function LocaleSwitcher({ host, locale }: LocaleSwitcherProps) {
 
   // Subdomain strategy: switching the locale means loading a different host, so
   // we build the target URL from the request host (the core control swaps the
-  // leftmost label) and let the browser do a full document load. Stripping the
-  // scheme yields a protocol-relative URL that stays correct on both http
-  // (local) and https (deployed).
+  // locale label) and let the browser do a full document load. canonicalUrl
+  // returns protocol-relative URLs, correct on http (local) and https (deployed).
   function hrefFor(target: Locale): string {
-    const url = locales.canonicalUrl({ locale: target, pathname: "/", requestHost: host })
-    return url.replace(/^https?:/, "")
+    return locales.canonicalUrl({ locale: target, pathname: "/", requestHost: host })
   }
 
   return (

--- a/examples/waku-subdomain/src/components/SuggestionBanner.tsx
+++ b/examples/waku-subdomain/src/components/SuggestionBanner.tsx
@@ -25,7 +25,7 @@ export function SuggestionBanner(props: SuggestionBannerProps) {
       <a
         className="notice-cta"
         data-testid="locale-suggestion-cta"
-        href={props.recommendedUrl.replace(/^https?:/, "")}
+        href={props.recommendedUrl}
         onClick={() => {
           document.cookie = locales.serializeChoice(props.recommendedLocale)
         }}

--- a/examples/waku-tld/src/components/LocaleSwitcher.tsx
+++ b/examples/waku-tld/src/components/LocaleSwitcher.tsx
@@ -20,12 +20,10 @@ export function LocaleSwitcher({ host, locale }: LocaleSwitcherProps) {
 
   // TLD strategy: switching the locale means loading a different host, so
   // we build the target URL from the request host (the core control swaps the
-  // rightmost label) and let the browser do a full document load. Stripping the
-  // scheme yields a protocol-relative URL that stays correct on both http
-  // (local) and https (deployed).
+  // locale label) and let the browser do a full document load. canonicalUrl
+  // returns protocol-relative URLs, correct on http (local) and https (deployed).
   function hrefFor(target: Locale): string {
-    const url = locales.canonicalUrl({ locale: target, pathname: "/", requestHost: host })
-    return url.replace(/^https?:/, "")
+    return locales.canonicalUrl({ locale: target, pathname: "/", requestHost: host })
   }
 
   return (

--- a/examples/waku-tld/src/components/SuggestionBanner.tsx
+++ b/examples/waku-tld/src/components/SuggestionBanner.tsx
@@ -25,7 +25,7 @@ export function SuggestionBanner(props: SuggestionBannerProps) {
       <a
         className="notice-cta"
         data-testid="locale-suggestion-cta"
-        href={props.recommendedUrl.replace(/^https?:/, "")}
+        href={props.recommendedUrl}
         onClick={() => {
           document.cookie = locales.serializeChoice(props.recommendedLocale)
         }}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,6 +4,12 @@ export type MessageMetadata = {
   message?: string
   context?: string
   comment?: string
+  /**
+   * Suppress `onMissing` for this lookup. Used by the runtime choice
+   * components, whose synthesized source patterns are expected to miss the
+   * catalog in apps that never loaded matching entries.
+   */
+  reportMissing?: boolean
 }
 
 export type CatalogMessages = Record<string, string>
@@ -77,11 +83,13 @@ export function createI18n(options: CreateI18nOptions = {}): PalamedesI18n {
       }
     }
 
-    notifyMissing({
-      id,
-      locale: activeLocale,
-      metadata,
-    })
+    if (metadata?.reportMissing !== false) {
+      notifyMissing({
+        id,
+        locale: activeLocale,
+        metadata,
+      })
+    }
 
     return {
       pattern: fallback,
@@ -185,6 +193,7 @@ function normalizeError(error: unknown): Error {
 }
 
 export { formatMessagePattern, parseMessagePattern }
+export { resolveChoice, stringifyValue, type ResolvedChoice } from "./messageFormat"
 export type {
   MessageNode,
   MessageChoiceNode,

--- a/packages/core/src/locale.test.ts
+++ b/packages/core/src/locale.test.ts
@@ -110,7 +110,24 @@ describe("locale controls", () => {
         requestHost: "de.lvh.me:4100",
         search: "?probe=1",
       })
-    ).toBe("http://es.lvh.me:4100/es/docs?probe=1")
+    ).toBe("//es.lvh.me:4100/es/docs?probe=1")
+  })
+
+  it("emits absolute urls when a protocol is configured", () => {
+    const secured = defineLocaleControls({
+      locales: ["en", "de", "es"] as const,
+      defaultLocale: "en",
+      protocol: "https",
+      hosts: { mode: "subdomain" },
+    })
+
+    expect(
+      secured.canonicalUrl({
+        locale: "es",
+        pathname: "/",
+        requestHost: "de.example.com",
+      })
+    ).toBe("https://es.example.com/")
   })
 
   it("suggests on accept-language and host mismatch", () => {
@@ -210,7 +227,7 @@ describe("subdomain strategy", () => {
         requestHost: "de.nextjs-subdomain.examples.palamedes.dev",
         search: "?seat=1",
       })
-    ).toBe("http://en.nextjs-subdomain.examples.palamedes.dev/checkout?seat=1")
+    ).toBe("//en.nextjs-subdomain.examples.palamedes.dev/checkout?seat=1")
   })
 
   it("preserves the request port in switch urls", () => {
@@ -220,7 +237,7 @@ describe("subdomain strategy", () => {
         pathname: "/",
         requestHost: "de.lvh.me:4012",
       })
-    ).toBe("http://es.lvh.me:4012/")
+    ).toBe("//es.lvh.me:4012/")
   })
 
   it("prepends the locale label when the host has none yet", () => {
@@ -230,7 +247,7 @@ describe("subdomain strategy", () => {
         pathname: "/",
         requestHost: "nextjs-subdomain.examples.palamedes.dev",
       })
-    ).toBe("http://de.nextjs-subdomain.examples.palamedes.dev/")
+    ).toBe("//de.nextjs-subdomain.examples.palamedes.dev/")
   })
 
   it("returns a bare path when no request host is available", () => {
@@ -261,7 +278,7 @@ describe("subdomain strategy", () => {
     })
     expect(suggestion?.reason).toBe("accept-language")
     expect(suggestion?.recommendedLocale).toBe("es")
-    expect(suggestion?.recommendedUrl).toBe("http://es.lvh.me:4012/")
+    expect(suggestion?.recommendedUrl).toBe("//es.lvh.me:4012/")
   })
 })
 
@@ -351,7 +368,7 @@ describe("tld strategy", () => {
         requestHost: "nextjs.palamedes-i18n.de",
         search: "?seat=1",
       })
-    ).toBe("http://nextjs.palamedes-i18n.fr/checkout?seat=1")
+    ).toBe("//nextjs.palamedes-i18n.fr/checkout?seat=1")
   })
 
   it("routes the default locale to defaultTld (.com), which has no authoritative tld", () => {
@@ -361,7 +378,7 @@ describe("tld strategy", () => {
         pathname: "/",
         requestHost: "nextjs.palamedes-i18n.de",
       })
-    ).toBe("http://nextjs.palamedes-i18n.com/")
+    ).toBe("//nextjs.palamedes-i18n.com/")
   })
 
   it("preserves the request port in switch urls", () => {
@@ -371,7 +388,7 @@ describe("tld strategy", () => {
         pathname: "/",
         requestHost: "palamedes-i18n.de:4013",
       })
-    ).toBe("http://palamedes-i18n.es:4013/")
+    ).toBe("//palamedes-i18n.es:4013/")
   })
 
   it("returns a bare path when no request host is available", () => {
@@ -405,6 +422,6 @@ describe("tld strategy", () => {
     })
     expect(suggestion?.reason).toBe("host")
     expect(suggestion?.recommendedLocale).toBe("fr")
-    expect(suggestion?.recommendedUrl).toBe("http://nextjs.palamedes-i18n.fr/")
+    expect(suggestion?.recommendedUrl).toBe("//nextjs.palamedes-i18n.fr/")
   })
 })

--- a/packages/core/src/locale.ts
+++ b/packages/core/src/locale.ts
@@ -71,6 +71,12 @@ export type LocaleControlsConfig<TLocale extends string> = {
   }
   /** Optional host strategy (locale per host). */
   hosts?: HostLocaleConfig<TLocale>
+  /**
+   * Scheme for host-carrying URLs from `canonicalUrl` and `suggest` (e.g.
+   * `"https"`). Without it those URLs are protocol-relative (`//host/path`),
+   * which stays correct on http (local) and https (deployed) alike.
+   */
+  protocol?: string
 }
 
 export type LocaleSwitchItem<TLocale extends string = string> = {
@@ -516,7 +522,10 @@ export function defineLocaleControls<TLocale extends string>(
         ? `${canonicalHost}:${requestPort}`
         : canonicalHost
 
-    return `http://${hostWithPort}${canonicalPath}${options.search ?? ""}`
+    // Protocol-relative by default so an HTTPS page never links users to
+    // http://; an explicit `protocol` config produces absolute URLs.
+    const scheme = config.protocol ? `${config.protocol.replace(/:$/, "")}:` : ""
+    return `${scheme}//${hostWithPort}${canonicalPath}${options.search ?? ""}`
   }
 
   const suggest = (options: {

--- a/packages/core/src/messageFormat.test.ts
+++ b/packages/core/src/messageFormat.test.ts
@@ -114,4 +114,24 @@ describe("formatMessagePattern", () => {
       formatMessagePattern("{n, plural, offset:1.5 other {# items}}", { n: 2 }, "en")
     ).toThrow(/non-negative integer plural offset/)
   })
+
+  it("rejects absent or non-numeric plural values instead of coercing to 0", () => {
+    const message = "{n, plural, =0 {none} one {one} other {# items}}"
+
+    expect(() => formatMessagePattern(message, {}, "en")).toThrow(/Missing or non-numeric value/)
+    expect(() => formatMessagePattern(message, { n: undefined }, "en")).toThrow(
+      /received undefined/
+    )
+    expect(() => formatMessagePattern(message, { n: Number.NaN }, "en")).toThrow(/received NaN/)
+    expect(() =>
+      formatMessagePattern("{n, selectordinal, other {#th}}", { n: "abc" }, "en")
+    ).toThrow(/received "abc"/)
+  })
+
+  it("still accepts numeric strings for plural values", () => {
+    const message = "{n, plural, =0 {none} other {# items}}"
+
+    expect(formatMessagePattern(message, { n: "0" }, "en")).toBe("none")
+    expect(formatMessagePattern(message, { n: "4" }, "en")).toBe("4 items")
+  })
 })

--- a/packages/core/src/messageFormat.test.ts
+++ b/packages/core/src/messageFormat.test.ts
@@ -134,4 +134,11 @@ describe("formatMessagePattern", () => {
     expect(formatMessagePattern(message, { n: "0" }, "en")).toBe("none")
     expect(formatMessagePattern(message, { n: "4" }, "en")).toBe("4 items")
   })
+
+  it("renders Date values as ISO strings and degrades invalid Dates", () => {
+    const when = new Date(Date.UTC(2026, 6, 24, 2, 0, 0))
+
+    expect(formatMessagePattern("At {when}", { when })).toBe(`At ${when.toISOString()}`)
+    expect(formatMessagePattern("At {when}", { when: new Date("garbage") })).toBe("At Invalid Date")
+  })
 })

--- a/packages/core/src/messageFormat.ts
+++ b/packages/core/src/messageFormat.ts
@@ -446,10 +446,9 @@ function renderNodeToString(
       return renderNodesToString(node.children, values, locale, pluralValue)
     }
     case "choice": {
-      const value = values[node.variable]
-      const nextPluralValue =
-        node.kind === "select" ? pluralValue : pluralOperand(node, normalizeNumericValue(value))
-      return renderNodesToString(selectChoice(node, value, locale), values, locale, nextPluralValue)
+      const resolved = resolveChoice(node, values[node.variable], locale)
+      const nextPluralValue = node.kind === "select" ? pluralValue : resolved.pluralValue
+      return renderNodesToString(resolved.nodes, values, locale, nextPluralValue)
     }
   }
 }
@@ -567,41 +566,71 @@ function normalizeDateTimeStyle(
   return format === "time" ? "short" : undefined
 }
 
-function selectChoice(node: MessageChoiceNode, value: unknown, locale?: string): MessageNode[] {
+export type ResolvedChoice = {
+  nodes: MessageNode[]
+  /** Operand rendered for `#` inside the branch; undefined for `select`. */
+  pluralValue?: number
+}
+
+/**
+ * Selects the branch of a plural/select/selectordinal node for a value.
+ *
+ * Shared by the string renderer and the host-adapter rich renderers so exact
+ * matches, offsets, and missing-value handling cannot drift between them.
+ * Throws when a plural/selectordinal value is absent or non-numeric instead of
+ * silently coercing to 0 (which used to match `=0`/`zero` branches).
+ */
+export function resolveChoice(
+  node: MessageChoiceNode,
+  value: unknown,
+  locale?: string
+): ResolvedChoice {
   if (node.kind === "select") {
     const exact = value == null ? undefined : node.options[String(value)]
-    return exact ?? node.options.other ?? []
+    return { nodes: exact ?? node.options.other ?? [] }
   }
 
-  const numericValue = normalizeNumericValue(value)
+  const numericValue = requireChoiceNumericValue(node, value)
+  const operand = numericValue - (node.offset ?? 0)
   const exactKey = `=${numericValue}`
   if (node.options[exactKey]) {
-    return node.options[exactKey]
+    return { nodes: node.options[exactKey], pluralValue: operand }
   }
 
-  const operand = pluralOperand(node, numericValue)
-  const pluralRules = new Intl.PluralRules(undefined, {
-    localeMatcher: "best fit",
+  const pluralRules = new Intl.PluralRules(locale, {
     type: node.kind === "selectordinal" ? "ordinal" : "cardinal",
   })
-  const resolvedRules = locale
-    ? new Intl.PluralRules(locale, { type: node.kind === "selectordinal" ? "ordinal" : "cardinal" })
-    : pluralRules
-  const category = resolvedRules.select(operand)
-  return node.options[category] ?? node.options.other ?? []
+  const category = pluralRules.select(operand)
+  return { nodes: node.options[category] ?? node.options.other ?? [], pluralValue: operand }
 }
 
-function pluralOperand(node: MessageChoiceNode, numericValue: number): number {
-  return numericValue - (node.offset ?? 0)
-}
-
-function normalizeNumericValue(value: unknown): number {
+function requireChoiceNumericValue(node: MessageChoiceNode, value: unknown): number {
   if (typeof value === "number" && Number.isFinite(value)) {
     return value
   }
 
-  const parsed = Number(value)
-  return Number.isFinite(parsed) ? parsed : 0
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value)
+    if (Number.isFinite(parsed)) {
+      return parsed
+    }
+  }
+
+  throw new Error(
+    `Missing or non-numeric value for {${node.variable}, ${node.kind}, …}: received ${describeValue(
+      value
+    )}.`
+  )
+}
+
+function describeValue(value: unknown): string {
+  if (value === undefined) {
+    return "undefined"
+  }
+  if (value === null) {
+    return "null"
+  }
+  return typeof value === "string" ? `"${value}"` : String(value)
 }
 
 function normalizeFormattedNumberValue(value: unknown): number | undefined {
@@ -637,7 +666,7 @@ function replacePound(value: string, numericValue: number, locale?: string): str
   return value.replaceAll("#", new Intl.NumberFormat(locale).format(numericValue))
 }
 
-function stringifyValue(value: unknown): string {
+export function stringifyValue(value: unknown): string {
   if (value === null || value === undefined) {
     return ""
   }

--- a/packages/core/src/messageFormat.ts
+++ b/packages/core/src/messageFormat.ts
@@ -676,7 +676,9 @@ export function stringifyValue(value: unknown): string {
   }
 
   if (value instanceof Date) {
-    return value.toISOString()
+    // An invalid Date degrades to "Invalid Date" instead of letting
+    // toISOString() throw and abort adapter rendering.
+    return Number.isNaN(value.getTime()) ? String(value) : value.toISOString()
   }
 
   return String(value)

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -58,12 +58,12 @@ example `<0>Palamedes</0>`, while the React component is passed separately.
 
 Besides the macro entry point, the package's main entry exports the runtime
 components `Trans`, `Plural`, `Select`, and `SelectOrdinal` (plus the
-`TransProps` type). These are what macro-transformed JSX renders through.
-`Trans` resolves messages through the active i18n instance; the hand-written
-(non-macro) use of the choice components currently formats the source-language
-props directly without catalog lookup — see
-[#417](https://github.com/sebastian-software/palamedes/issues/417) before
-using them outside macro output.
+`TransProps` type). These are what macro-transformed JSX renders through, and
+all of them resolve messages through the active i18n instance. The choice
+components accept plural categories (`zero` … `other`), exact matches written
+as `_0`/`_1`/… (normalized to ICU `=N`, mirroring the macro transform), and
+`offset`; invalid option props and option text with unbalanced braces are
+rejected with a descriptive error instead of silently misrendering.
 
 ## Headless Frontend Helpers
 

--- a/packages/react/src/index.test.tsx
+++ b/packages/react/src/index.test.tsx
@@ -104,6 +104,78 @@ describe("@palamedes/react", () => {
     expect(onMissing).not.toHaveBeenCalled()
   })
 
+  it("translates direct choice components through the active catalog", () => {
+    const i18n = createI18n()
+    i18n.load("de", {
+      "{value, plural, one {# item} other {# items}}":
+        "{value, plural, one {# Artikel} other {# Artikel}}",
+    })
+    i18n.activate("de")
+    setClientI18n(i18n)
+
+    const html = renderToStaticMarkup(<Plural value={2} one="# item" other="# items" />)
+
+    expect(html).toBe("2 Artikel")
+  })
+
+  it("normalizes _N exact-match props like the macro transform", () => {
+    const i18n = createI18n()
+    i18n.activate("en")
+    setClientI18n(i18n)
+
+    const html = renderToStaticMarkup(
+      <>
+        <Plural value={2} _2="a pair" other="# items" />
+        <Plural value={3} _2="a pair" other="# items" />
+      </>
+    )
+
+    expect(html).toBe("a pair3 items")
+  })
+
+  it("rejects invalid plural option props instead of emitting dead branches", () => {
+    const i18n = createI18n()
+    i18n.activate("en")
+    setClientI18n(i18n)
+
+    expect(() =>
+      renderToStaticMarkup(<Plural value={2} {...{ _pair: "a pair" }} other="# items" />)
+    ).toThrow(/Invalid plural option "_pair"/)
+  })
+
+  it("rejects choice option text with unbalanced braces instead of corrupting the pattern", () => {
+    const i18n = createI18n()
+    i18n.activate("en")
+    setClientI18n(i18n)
+
+    expect(() => renderToStaticMarkup(<Select value="a" a="a } b}" other="other" />)).toThrow(
+      /invalid ICU pattern/
+    )
+  })
+
+  it("renders Date values deterministically like the core string renderer", () => {
+    const i18n = createI18n()
+    i18n.activate("en")
+    setClientI18n(i18n)
+
+    const when = new Date(Date.UTC(2026, 6, 24, 2, 0, 0))
+    const html = renderToStaticMarkup(<Trans id="when" message="At {when}" values={{ when }} />)
+
+    expect(html).toBe(`At ${when.toISOString()}`)
+  })
+
+  it("throws on missing plural values instead of matching zero branches", () => {
+    const i18n = createI18n()
+    i18n.activate("en")
+    setClientI18n(i18n)
+
+    expect(() =>
+      renderToStaticMarkup(
+        <Trans id="items" message="{n, plural, =0 {none} other {# items}}" values={{}} />
+      )
+    ).toThrow(/Missing or non-numeric value/)
+  })
+
   it("renders formatted ICU arguments through Trans", () => {
     const i18n = createI18n()
     i18n.activate("en-US")

--- a/packages/react/src/shared.tsx
+++ b/packages/react/src/shared.tsx
@@ -2,8 +2,13 @@ import * as React from "react"
 import { cloneElement, Fragment, isValidElement } from "react"
 import type { ReactElement, ReactNode } from "react"
 
-import { formatMessagePattern } from "@palamedes/core"
-import type { MessageChoiceNode, MessageNode, PalamedesI18n } from "@palamedes/core"
+import {
+  formatMessagePattern,
+  parseMessagePattern,
+  resolveChoice,
+  stringifyValue,
+} from "@palamedes/core"
+import type { MessageNode, PalamedesI18n } from "@palamedes/core"
 
 export type TransProps = {
   // `id` is optional in authored source: components are written with `message`
@@ -25,7 +30,10 @@ type ChoiceComponentProps = {
   few?: string
   many?: string
   other: string
-}
+} & // Exact matches use the `_N` prop spelling (`_0`, `_1`, …) because JSX
+  // attributes cannot start with `=`; they are normalized to ICU `=N` options,
+  // mirroring the macro transform.
+  Record<`_${number}`, string>
 
 export type PluralProps = ChoiceComponentProps & {
   offset?: number
@@ -53,26 +61,41 @@ export function createRuntimeComponents(useI18n: () => PalamedesI18n) {
     return <>{renderNodes(nodes, values ?? {}, components ?? {}, i18n.locale)}</>
   }
 
+  /*
+   * The choice components resolve through the i18n instance exactly like
+   * Trans: the synthesized ICU pattern is the source message, the catalog can
+   * override it (when an `id` mapping exists), and rendering shares the same
+   * node pipeline. Formatting the source props directly — the previous
+   * behavior — silently skipped translation entirely.
+   */
+  function renderChoice(
+    i18n: PalamedesI18n,
+    kind: "plural" | "select" | "selectordinal",
+    value: string | number,
+    choices: Record<string, string | number | undefined>,
+    offset?: number
+  ): ReactNode {
+    const message = buildChoiceMessage("value", kind, choices, offset)
+    const nodes = i18n.getMessageNodes(message, { message, reportMissing: false })
+    return <>{renderNodes(nodes, { value }, {}, i18n.locale)}</>
+  }
+
   function Plural({ value, offset, ...choices }: PluralProps): ReactNode {
-    const i18n = useI18n()
-    const message = buildChoiceMessage("value", "plural", choices, offset)
-    return <>{formatMessagePattern(message, { value }, i18n.locale)}</>
+    return renderChoice(useI18n(), "plural", value, choices, offset)
   }
 
   function SelectOrdinal({ value, offset, ...choices }: SelectOrdinalProps): ReactNode {
-    const i18n = useI18n()
-    const message = buildChoiceMessage("value", "selectordinal", choices, offset)
-    return <>{formatMessagePattern(message, { value }, i18n.locale)}</>
+    return renderChoice(useI18n(), "selectordinal", value, choices, offset)
   }
 
   function Select({ value, ...choices }: SelectProps): ReactNode {
-    const i18n = useI18n()
-    const message = buildChoiceMessage("value", "select", choices)
-    return <>{formatMessagePattern(message, { value }, i18n.locale)}</>
+    return renderChoice(useI18n(), "select", value, choices)
   }
 
   return { Plural, Select, SelectOrdinal, Trans }
 }
+
+const PLURAL_CATEGORIES = new Set(["zero", "one", "two", "few", "many", "other"])
 
 function buildChoiceMessage(
   variable: string,
@@ -81,11 +104,72 @@ function buildChoiceMessage(
   offset?: number
 ): string {
   validatePluralOffset(offset)
-  const parts = Object.entries(choices)
-    .filter((entry): entry is [string, string] => typeof entry[1] === "string")
-    .map(([key, value]) => `${key} {${value}}`)
+  const entries = Object.entries(choices).filter(
+    (entry): entry is [string, string] => typeof entry[1] === "string"
+  )
+  const keys = entries.map(([key]) => normalizeChoiceKey(kind, key))
+  const parts = entries.map(([key, value], index) => `${keys[index]} {${value}}`)
   const offsetPart = offset === undefined ? "" : ` offset:${offset}`
-  return `{${variable}, ${kind},${offsetPart} ${parts.join(" ")}}`
+  const message = `{${variable}, ${kind},${offsetPart} ${parts.join(" ")}}`
+  assertParseableChoiceMessage(message, kind, keys)
+  return message
+}
+
+/*
+ * Mirrors the macro transform's option-key rules: select keys pass through
+ * verbatim; plural/selectordinal keys must be a plural category or an exact
+ * match written as `_N`/`=N`, which normalizes to ICU `=N`. Anything else was
+ * previously emitted verbatim and could never match at runtime.
+ */
+function normalizeChoiceKey(kind: "plural" | "select" | "selectordinal", key: string): string {
+  if (kind === "select") {
+    return key
+  }
+
+  if (PLURAL_CATEGORIES.has(key)) {
+    return key
+  }
+
+  const exact = key.startsWith("_") || key.startsWith("=") ? key.slice(1) : undefined
+  if (exact !== undefined && /^\d+$/.test(exact)) {
+    return `=${exact}`
+  }
+
+  throw new RangeError(
+    `Invalid ${kind} option "${key}". Use a plural category (zero, one, two, few, many, other) or an exact match such as _0.`
+  )
+}
+
+/*
+ * Guards against option text with unbalanced braces silently corrupting the
+ * synthesized pattern (e.g. `other="a } b"` producing a pattern that parses
+ * into something unrelated).
+ */
+function assertParseableChoiceMessage(message: string, kind: string, expectedKeys: string[]): void {
+  let parsed: MessageNode[]
+  try {
+    parsed = parseMessagePattern(message)
+  } catch (error) {
+    throw new RangeError(
+      `Choice options for the ${kind} component produced an invalid ICU pattern (${message}): ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+      { cause: error }
+    )
+  }
+
+  const node = parsed.length === 1 && parsed[0]?.type === "choice" ? parsed[0] : undefined
+  const parsedKeys = node ? Object.keys(node.options) : []
+  const intact =
+    node !== undefined &&
+    parsedKeys.length === expectedKeys.length &&
+    expectedKeys.every((key) => key in node.options)
+
+  if (!intact) {
+    throw new RangeError(
+      `Choice options for the ${kind} component produced an invalid ICU pattern (${message}). Check option text for unbalanced "{" or "}" characters.`
+    )
+  }
 }
 
 function validatePluralOffset(offset: number | undefined): void {
@@ -126,7 +210,7 @@ function renderNode(
       return [node.value]
     }
     case "variable": {
-      return [renderVariable(values[node.name])]
+      return [renderVariable(values[node.name], key)]
     }
     case "formatted": {
       return [formatMessagePattern(buildFormattedMessage(node), values, locale)]
@@ -140,64 +224,25 @@ function renderNode(
       return children
     }
     case "choice": {
-      const value = values[node.variable]
-      const nextPluralValue =
-        node.kind === "select" ? pluralValue : pluralOperand(node, normalizeNumericValue(value))
-      const choice = selectChoice(node, value, locale)
-      return renderNodes(choice, values, components, locale, nextPluralValue)
+      const resolved = resolveChoice(node, values[node.variable], locale)
+      const nextPluralValue = node.kind === "select" ? pluralValue : resolved.pluralValue
+      return renderNodes(resolved.nodes, values, components, locale, nextPluralValue)
     }
   }
-
-  return []
 }
 
 function buildFormattedMessage(node: Extract<MessageNode, { type: "formatted" }>): string {
   return `{${node.variable}, ${node.format}${node.style ? `, ${node.style}` : ""}}`
 }
 
-function selectChoice(node: MessageChoiceNode, value: unknown, locale: string): MessageNode[] {
-  if (node.kind === "select") {
-    const exact = value == null ? undefined : node.options[String(value)]
-    return exact ?? node.options.other ?? []
-  }
-
-  const numericValue = normalizeNumericValue(value)
-  const exactKey = `=${numericValue}`
-  if (node.options[exactKey]) {
-    return node.options[exactKey]
-  }
-
-  const operand = pluralOperand(node, numericValue)
-  const pluralRules = new Intl.PluralRules(locale, {
-    type: node.kind === "selectordinal" ? "ordinal" : "cardinal",
-  })
-  const category = pluralRules.select(operand)
-  return node.options[category] ?? node.options.other ?? []
-}
-
-function pluralOperand(node: MessageChoiceNode, numericValue: number): number {
-  return numericValue - (node.offset ?? 0)
-}
-
-function renderVariable(value: unknown): ReactNode {
-  if (value === null || value === undefined) {
-    return ""
-  }
-
+function renderVariable(value: unknown, key: number): ReactNode {
   if (isValidElement(value)) {
-    return cloneElement(value, {})
+    return cloneElement(value, { key })
   }
 
-  return String(value)
-}
-
-function normalizeNumericValue(value: unknown): number {
-  if (typeof value === "number" && Number.isFinite(value)) {
-    return value
-  }
-
-  const parsed = Number(value)
-  return Number.isFinite(parsed) ? parsed : 0
+  // Same stringification as the core string renderer (`i18n._`), so Dates
+  // render as deterministic ISO strings on server and client alike.
+  return stringifyValue(value)
 }
 
 function formatNumber(value: number, locale: string): string {

--- a/packages/solid/src/index.test.tsx
+++ b/packages/solid/src/index.test.tsx
@@ -129,6 +129,30 @@ describe("@palamedes/solid", () => {
     expect(onMissing).not.toHaveBeenCalled()
   })
 
+  it("translates direct choice components through the active catalog", () => {
+    const i18n = createI18n()
+    i18n.load("de", {
+      "{value, plural, one {# item} other {# items}}":
+        "{value, plural, one {# Artikel} other {# Artikel}}",
+    })
+    i18n.activate("de")
+    setServerI18nGetter(() => i18n)
+
+    const html = renderToString(() => <Plural value={2} one="# item" other="# items" />)
+
+    expect(html).toBe("2 Artikel")
+  })
+
+  it("normalizes _N exact-match props like the macro transform", () => {
+    const i18n = createI18n()
+    i18n.activate("en")
+    setServerI18nGetter(() => i18n)
+
+    const html = renderToString(() => <Plural value={2} _2="a pair" other="# items" />)
+
+    expect(html).toBe("a pair")
+  })
+
   it("renders ICU-quoted syntax literally through Trans", () => {
     const i18n = createI18n()
     i18n.activate("en")

--- a/packages/solid/src/index.tsx
+++ b/packages/solid/src/index.tsx
@@ -1,7 +1,12 @@
 import type { JSX } from "solid-js"
 
-import { formatMessagePattern } from "@palamedes/core"
-import type { MessageChoiceNode, MessageNode, PalamedesI18n } from "@palamedes/core"
+import {
+  formatMessagePattern,
+  parseMessagePattern,
+  resolveChoice,
+  stringifyValue,
+} from "@palamedes/core"
+import type { MessageNode, PalamedesI18n } from "@palamedes/core"
 
 import { getI18n } from "./runtime"
 
@@ -41,7 +46,10 @@ type ChoiceComponentProps = {
   few?: string
   many?: string
   other: string
-}
+} & // Exact matches use the `_N` prop spelling (`_0`, `_1`, …) because JSX
+  // attributes cannot start with `=`; they are normalized to ICU `=N` options,
+  // mirroring the macro transform.
+  Record<`_${number}`, string>
 
 export type PluralProps = ChoiceComponentProps & {
   offset?: number
@@ -81,29 +89,40 @@ export function Trans({
   }) as unknown as JSX.Element
 }
 
-export function Plural({ value, offset, ...choices }: PluralProps): JSX.Element {
+/*
+ * The choice components resolve through the i18n instance exactly like Trans:
+ * the synthesized ICU pattern is the source message, the catalog can override
+ * it (when an `id` mapping exists), and rendering shares the same node
+ * pipeline. Formatting the source props directly — the previous behavior —
+ * silently skipped translation entirely.
+ */
+function renderChoice(
+  kind: "plural" | "select" | "selectordinal",
+  value: string | number,
+  choices: Record<string, string | number | undefined>,
+  offset?: number
+): JSX.Element {
   return (() => {
     const i18n = useReactiveI18n()
-    const message = buildChoiceMessage("value", "plural", choices, offset)
-    return formatMessagePattern(message, { value }, i18n.locale)
+    const message = buildChoiceMessage("value", kind, choices, offset)
+    const nodes = i18n.getMessageNodes(message, { message, reportMissing: false })
+    return renderNodes(nodes, { value }, {}, i18n.locale)
   }) as unknown as JSX.Element
+}
+
+export function Plural({ value, offset, ...choices }: PluralProps): JSX.Element {
+  return renderChoice("plural", value, choices, offset)
 }
 
 export function SelectOrdinal({ value, offset, ...choices }: SelectOrdinalProps): JSX.Element {
-  return (() => {
-    const i18n = useReactiveI18n()
-    const message = buildChoiceMessage("value", "selectordinal", choices, offset)
-    return formatMessagePattern(message, { value }, i18n.locale)
-  }) as unknown as JSX.Element
+  return renderChoice("selectordinal", value, choices, offset)
 }
 
 export function Select({ value, ...choices }: SelectProps): JSX.Element {
-  return (() => {
-    const i18n = useReactiveI18n()
-    const message = buildChoiceMessage("value", "select", choices)
-    return formatMessagePattern(message, { value }, i18n.locale)
-  }) as unknown as JSX.Element
+  return renderChoice("select", value, choices)
 }
+
+const PLURAL_CATEGORIES = new Set(["zero", "one", "two", "few", "many", "other"])
 
 function buildChoiceMessage(
   variable: string,
@@ -112,11 +131,72 @@ function buildChoiceMessage(
   offset?: number
 ): string {
   validatePluralOffset(offset)
-  const parts = Object.entries(choices)
-    .filter((entry): entry is [string, string] => typeof entry[1] === "string")
-    .map(([key, value]) => `${key} {${value}}`)
+  const entries = Object.entries(choices).filter(
+    (entry): entry is [string, string] => typeof entry[1] === "string"
+  )
+  const keys = entries.map(([key]) => normalizeChoiceKey(kind, key))
+  const parts = entries.map(([key, value], index) => `${keys[index]} {${value}}`)
   const offsetPart = offset === undefined ? "" : ` offset:${offset}`
-  return `{${variable}, ${kind},${offsetPart} ${parts.join(" ")}}`
+  const message = `{${variable}, ${kind},${offsetPart} ${parts.join(" ")}}`
+  assertParseableChoiceMessage(message, kind, keys)
+  return message
+}
+
+/*
+ * Mirrors the macro transform's option-key rules: select keys pass through
+ * verbatim; plural/selectordinal keys must be a plural category or an exact
+ * match written as `_N`/`=N`, which normalizes to ICU `=N`. Anything else was
+ * previously emitted verbatim and could never match at runtime.
+ */
+function normalizeChoiceKey(kind: "plural" | "select" | "selectordinal", key: string): string {
+  if (kind === "select") {
+    return key
+  }
+
+  if (PLURAL_CATEGORIES.has(key)) {
+    return key
+  }
+
+  const exact = key.startsWith("_") || key.startsWith("=") ? key.slice(1) : undefined
+  if (exact !== undefined && /^\d+$/.test(exact)) {
+    return `=${exact}`
+  }
+
+  throw new RangeError(
+    `Invalid ${kind} option "${key}". Use a plural category (zero, one, two, few, many, other) or an exact match such as _0.`
+  )
+}
+
+/*
+ * Guards against option text with unbalanced braces silently corrupting the
+ * synthesized pattern (e.g. `other="a } b"` producing a pattern that parses
+ * into something unrelated).
+ */
+function assertParseableChoiceMessage(message: string, kind: string, expectedKeys: string[]): void {
+  let parsed: MessageNode[]
+  try {
+    parsed = parseMessagePattern(message)
+  } catch (error) {
+    throw new RangeError(
+      `Choice options for the ${kind} component produced an invalid ICU pattern (${message}): ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+      { cause: error }
+    )
+  }
+
+  const node = parsed.length === 1 && parsed[0]?.type === "choice" ? parsed[0] : undefined
+  const parsedKeys = node ? Object.keys(node.options) : []
+  const intact =
+    node !== undefined &&
+    parsedKeys.length === expectedKeys.length &&
+    expectedKeys.every((key) => key in node.options)
+
+  if (!intact) {
+    throw new RangeError(
+      `Choice options for the ${kind} component produced an invalid ICU pattern (${message}). Check option text for unbalanced "{" or "}" characters.`
+    )
+  }
 }
 
 function validatePluralOffset(offset: number | undefined): void {
@@ -177,11 +257,9 @@ function renderNode(
       return children
     }
     case "choice": {
-      const value = values[node.variable]
-      const nextPluralValue =
-        node.kind === "select" ? pluralValue : pluralOperand(node, normalizeNumericValue(value))
-      const choice = selectChoice(node, value, locale)
-      return renderNodes(choice, values, components, locale, nextPluralValue)
+      const resolved = resolveChoice(node, values[node.variable], locale)
+      const nextPluralValue = node.kind === "select" ? pluralValue : resolved.pluralValue
+      return renderNodes(resolved.nodes, values, components, locale, nextPluralValue)
     }
   }
 
@@ -190,30 +268,6 @@ function renderNode(
 
 function buildFormattedMessage(node: Extract<MessageNode, { type: "formatted" }>): string {
   return `{${node.variable}, ${node.format}${node.style ? `, ${node.style}` : ""}}`
-}
-
-function selectChoice(node: MessageChoiceNode, value: unknown, locale: string): MessageNode[] {
-  if (node.kind === "select") {
-    const exact = value == null ? undefined : node.options[String(value)]
-    return exact ?? node.options.other ?? []
-  }
-
-  const numericValue = normalizeNumericValue(value)
-  const exactKey = `=${numericValue}`
-  if (node.options[exactKey]) {
-    return node.options[exactKey]
-  }
-
-  const operand = pluralOperand(node, numericValue)
-  const pluralRules = new Intl.PluralRules(locale, {
-    type: node.kind === "selectordinal" ? "ordinal" : "cardinal",
-  })
-  const category = pluralRules.select(operand)
-  return node.options[category] ?? node.options.other ?? []
-}
-
-function pluralOperand(node: MessageChoiceNode, numericValue: number): number {
-  return numericValue - (node.offset ?? 0)
 }
 
 function renderVariable(value: unknown): JSX.Element {
@@ -225,16 +279,13 @@ function renderVariable(value: unknown): JSX.Element {
     return String(value)
   }
 
-  return value as JSX.Element
-}
-
-function normalizeNumericValue(value: unknown): number {
-  if (typeof value === "number" && Number.isFinite(value)) {
-    return value
+  // Same stringification as the core string renderer (`i18n._`), so Dates
+  // render as deterministic ISO strings on server and client alike.
+  if (value instanceof Date) {
+    return stringifyValue(value)
   }
 
-  const parsed = Number(value)
-  return Number.isFinite(parsed) ? parsed : 0
+  return value as JSX.Element
 }
 
 function formatNumber(value: number, locale: string): string {


### PR DESCRIPTION
Block 1 of the remaining review backlog: the four correctness issues around message formatting and locale URLs. The root cause running through three of them was duplicated rendering logic between `packages/core/src/messageFormat.ts` and the React/Solid renderers — this PR consolidates it in core and has both adapters consume the shared helpers.

## Fixes #414 — missing plural values throw instead of matching `=0`/`zero`

`normalizeNumericValue` coerced absent/non-finite plural values to `0`, so a forgotten `values` entry rendered the semantically loaded "you have no items" branch. Plural/selectordinal arguments now require a present, numeric value (numeric strings still work); a violation throws a descriptive error (`Missing or non-numeric value for {n, plural, …}: received undefined.`). Inside `_()`/`getMessage()` that error is reported through `onError` and rendering falls back to the source message — same resilience contract as before. Branch selection moved into an exported `resolveChoice`, which both adapters now use, deleting the duplicated (and drifted) copies.

## Fixes #416 — `<Trans>` renders `Date` values deterministically

The React/Solid `renderVariable` used `String(date)`, producing timezone-dependent output and guaranteed SSR hydration mismatches. Bare variables now render through core's exported `stringifyValue`, so `Date` values become ISO strings — identical to `i18n._` and identical on server and client.

## Fixes #417 — runtime choice components resolve through the i18n instance

The runtime `Plural`/`Select`/`SelectOrdinal` formatted their source-language props directly. Now they:

- resolve via `getMessageNodes` exactly like `Trans`, so catalog entries keyed by the synthesized source pattern are honored;
- pass a new `reportMissing: false` metadata flag, preserving the deliberate behavior from `b04ad8d` ("Preserve direct choice component behavior") that expected catalog misses don't spam `onMissing` — the existing test locking that in still passes;
- normalize `_N`/`=N` exact-match props to ICU `=N`, mirroring `normalize_choice_option_key` in the transform, and reject invalid plural option props (previously `_male` was emitted verbatim and could never match);
- validate that the synthesized pattern round-trips its option keys, so option text with unbalanced braces raises a descriptive `RangeError` instead of silently rendering something unrelated;
- accept typed `_0`/`_1`/… props (`Record<`_${number}`, string>`) — `offset` was already supported.

## Fixes #418 — canonical URLs no longer hardcode `http://`

Host-carrying URLs from `canonicalUrl()`/`suggest()` are now protocol-relative (`//host/path`) by default — exactly what all twenty subdomain/tld example components produced by manually stripping the scheme; those workarounds are removed. A new `protocol` option on `defineLocaleControls` produces absolute URLs when needed.

## Compatibility

All four are behavior changes and documented under `## Unreleased` in CHANGELOG.md and in `docs/api/core.md` (new exports `resolveChoice`, `ResolvedChoice`, `stringifyValue`, the `MessageMetadata.reportMissing` flag, and the `protocol` option). The react README's runtime-components section is updated accordingly.

## Verification

- `pnpm build` + full `pnpm test`: 262 tests green, including new regression tests for every fix (missing-value throw + numeric-string acceptance, catalog-translated choice components, `_N` normalization, invalid-option and unbalanced-brace rejection, deterministic `Date` rendering, protocol-relative and explicit-protocol URLs).
- `pnpm check-types`, `pnpm lint` (oxlint + eslint), `pnpm format:check` — green.
- Spot-built two affected example apps (`example-tanstack-subdomain`, `example-solidstart-tld`) — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TK4yk5JVr5FURvoKZhCgon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TK4yk5JVr5FURvoKZhCgon)_