### PR TITLE
Next plugin: apply include/exclude under Turbopack, merge user rules, declare next ^16 (#411, #412)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,15 @@
 - `<Trans>` variable values that are `Date` instances now render as
   deterministic ISO strings (matching `i18n._`), fixing SSR hydration
   mismatches across time zones.
+- `@palamedes/next-plugin` now declares `next ^16` as its peer range. The
+  previously declared `^13 || ^14 || ^15` never worked with the emitted
+  top-level `turbopack.rules`/`outputFileTracingRoot` config; on those
+  versions the Turbopack transform silently never ran.
+- The Next plugin's `include`/`exclude` options now also apply under
+  Turbopack (translated into the rule condition), user-supplied
+  `turbopack.rules` for the same glob are appended to instead of overwritten,
+  and the macro content pre-filter is derived from the canonical macro
+  package list (it previously missed `@palamedes/solid/macro`).
 
 ## [1.6.0](https://github.com/sebastian-software/palamedes/compare/palamedes-v1.5.1...palamedes-v1.6.0) (2026-07-25)
 

--- a/docs/api/next-plugin.md
+++ b/docs/api/next-plugin.md
@@ -48,5 +48,13 @@ const { withPalamedes } = require("@palamedes/next-plugin")
 module.exports = withPalamedes({})
 ```
 
-The plugin configures both Turbopack and webpack paths. `workspaceRoot` can be
-set explicitly in monorepos when automatic root detection is not correct.
+The plugin configures both Turbopack and webpack paths, and requires Next.js
+16 (`peerDependencies: next ^16` — the emitted top-level `turbopack.rules`
+conditions and `outputFileTracingRoot` need the Next 16 config surface).
+`include` and `exclude` apply under both bundlers: in the webpack branch as
+loader `test`/`exclude`, under Turbopack translated into the rule condition
+(`{ path: include }` plus `{ not: { path: exclude } }`). User-supplied
+`turbopack.rules` for the same glob are preserved — the Palamedes rules are
+appended to the glob's rule list instead of overwriting it. `workspaceRoot`
+can be set explicitly in monorepos when automatic root detection is not
+correct.

--- a/packages/next-plugin/README.md
+++ b/packages/next-plugin/README.md
@@ -16,6 +16,9 @@ and catalog problems show up while the app is still easy to fix.
 - Recommended for Next.js applications using App Router and Palamedes macros
 - Supports `.po` imports and source-string-first catalog semantics
 - Reports missing translations and ICU compatibility diagnostics during builds
+- Requires Next.js 16 (`peerDependencies: next ^16`); the emitted top-level
+  `turbopack.rules` conditions and `outputFileTracingRoot` need the Next 16
+  config surface
 - Uses Turbopack as the verified default path on Next.js 16.2
 - The shipped example proves both server-rendered i18n and localized `"use server"` action output
 - Also supports webpack as an opt-out / fallback path

--- a/packages/next-plugin/package.json
+++ b/packages/next-plugin/package.json
@@ -63,7 +63,7 @@
     "@palamedes/transform": "workspace:^"
   },
   "peerDependencies": {
-    "next": "^13 || ^14 || ^15 || ^16"
+    "next": "^16"
   },
   "devDependencies": {
     "next": "16.2.11",

--- a/packages/next-plugin/src/index.test.ts
+++ b/packages/next-plugin/src/index.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest"
+
+import { withPalamedes } from "./index"
+
+type RuleItem = {
+  condition?: unknown
+  loaders?: { loader: string; options?: Record<string, unknown> }[]
+  as?: string
+}
+
+function getRules(config: ReturnType<typeof withPalamedes>): Record<string, unknown> {
+  return (config.turbopack?.rules ?? {}) as Record<string, unknown>
+}
+
+function conditionList(rule: RuleItem): unknown[] {
+  return (rule.condition as { all: unknown[] }).all
+}
+
+describe("withPalamedes turbopack config", () => {
+  it("translates include/exclude options into the turbopack rule condition", () => {
+    const include = /\.custom\.tsx?$/
+    const exclude = /[/\\]vendored[/\\]/
+    const config = withPalamedes({}, { include, exclude })
+
+    const rule = getRules(config)["*"] as RuleItem
+    const conditions = conditionList(rule)
+
+    expect(conditions).toContainEqual({ path: include })
+    expect(conditions).toContainEqual({ not: { path: exclude } })
+  })
+
+  it("matches all macro packages in the content pre-filter", () => {
+    const config = withPalamedes()
+    const rule = getRules(config)["*"] as RuleItem
+    const content = (
+      conditionList(rule).find(
+        (condition) => typeof condition === "object" && condition !== null && "content" in condition
+      ) as { content: RegExp }
+    ).content
+
+    expect(content.test('import { t } from "@palamedes/core/macro"')).toBe(true)
+    expect(content.test('import { Trans } from "@palamedes/react/macro"')).toBe(true)
+    expect(content.test('import { Trans } from "@palamedes/solid/macro"')).toBe(true)
+    expect(content.test('import { t } from "other-i18n"')).toBe(false)
+  })
+
+  it("appends to user-supplied turbopack rules instead of overwriting them", () => {
+    const userRule = {
+      condition: { path: /\.svg$/ },
+      loaders: ["user-svg-loader"],
+    }
+    const config = withPalamedes({
+      turbopack: {
+        rules: {
+          "*": userRule,
+          "*.mdx": { loaders: ["user-mdx-loader"] },
+        },
+      },
+    })
+
+    const rules = getRules(config)
+    expect(rules["*.mdx"]).toStrictEqual({ loaders: ["user-mdx-loader"] })
+
+    const starRule = rules["*"] as unknown[]
+    expect(Array.isArray(starRule)).toBe(true)
+    expect(starRule[0]).toBe(userRule)
+    expect((starRule[1] as RuleItem).loaders?.[0]?.loader).toContain("palamedes-loader")
+  })
+
+  it("registers the po loader rule unless disabled", () => {
+    const enabled = getRules(withPalamedes())
+    expect((enabled["*.po"] as RuleItem).as).toBe("*.js")
+
+    const disabled = getRules(withPalamedes({}, { enablePoLoader: false }))
+    expect(disabled["*.po"]).toBeUndefined()
+  })
+})

--- a/packages/next-plugin/src/index.ts
+++ b/packages/next-plugin/src/index.ts
@@ -10,7 +10,38 @@ import path from "node:path"
 import { createRequire } from "node:module"
 import type { NextConfig } from "next"
 
+import { PALAMEDES_MACRO_PACKAGES } from "@palamedes/transform"
+
 const require = createRequire(import.meta.url)
+
+type TurbopackRules = NonNullable<NonNullable<NextConfig["turbopack"]>["rules"]>
+type TurbopackRuleConfigItem = Extract<TurbopackRules[string], { loaders?: unknown }>
+
+/*
+ * Derived from the canonical macro package list so the content pre-filter can
+ * never drift from the transform (it previously omitted @palamedes/solid/macro).
+ */
+const MACRO_CONTENT_PATTERN = new RegExp(
+  PALAMEDES_MACRO_PACKAGES.map((name) => name.replaceAll(/[.*+?^${}()|[\]\\/]/gu, "\\$&")).join("|")
+)
+
+/*
+ * Turbopack rules are keyed by glob; a glob can carry a list of rule configs.
+ * Appending keeps user-supplied rules for the same glob intact instead of
+ * silently overwriting them.
+ */
+function appendTurbopackRule(
+  rules: TurbopackRules,
+  glob: string,
+  rule: TurbopackRuleConfigItem
+): void {
+  const existing = rules[glob]
+  if (existing === undefined) {
+    rules[glob] = rule
+    return
+  }
+  rules[glob] = Array.isArray(existing) ? [...existing, rule] : [existing, rule]
+}
 
 export type WithPalamedesOptions = {
   /**
@@ -161,6 +192,44 @@ export function withPalamedes(
     ...(configPath ? { configPath } : {}),
   }
 
+  const rules: TurbopackRules = { ...baseConfig.turbopack?.rules }
+
+  // Transform local JS/TS files that actually import Palamedes macros. The
+  // include/exclude options translate into the rule condition so they behave
+  // the same under Turbopack as in the webpack branch below.
+  appendTurbopackRule(rules, "*", {
+    condition: {
+      all: [
+        { not: "foreign" },
+        { path: include },
+        { not: { path: exclude } },
+        { content: MACRO_CONTENT_PATTERN },
+      ],
+    },
+    loaders: [
+      {
+        loader: oxcLoaderPath,
+        options: { runtimeModule },
+      },
+    ],
+  })
+
+  // Compile local .po files
+  if (enablePoLoader) {
+    appendTurbopackRule(rules, "*.po", {
+      condition: {
+        not: "foreign",
+      },
+      loaders: [
+        {
+          loader: poLoaderPath,
+          options: poLoaderOptions,
+        },
+      ],
+      as: "*.js",
+    })
+  }
+
   return {
     ...baseConfig,
     ...(outputFileTracingRoot ? { outputFileTracingRoot } : {}),
@@ -169,40 +238,7 @@ export function withPalamedes(
     turbopack: {
       ...baseConfig.turbopack,
       ...(configuredTurbopackRoot ? { root: configuredTurbopackRoot } : {}),
-      rules: {
-        ...baseConfig.turbopack?.rules,
-        // Transform local JS/TS files that actually import Palamedes macros.
-        "*": {
-          condition: {
-            all: [
-              { not: "foreign" },
-              { path: /\.[jt]sx?$/ },
-              { content: /@palamedes\/(?:core|react)\/macro/ },
-            ],
-          },
-          loaders: [
-            {
-              loader: oxcLoaderPath,
-              options: { runtimeModule },
-            },
-          ],
-        },
-        // Compile local .po files
-        ...(enablePoLoader && {
-          "*.po": {
-            condition: {
-              not: "foreign",
-            },
-            loaders: [
-              {
-                loader: poLoaderPath,
-                options: poLoaderOptions,
-              },
-            ],
-            as: "*.js",
-          },
-        }),
-      },
+      rules,
     },
 
     // Webpack configuration


### PR DESCRIPTION
The Next-plugin pair from the review backlog, per the agreed decisions: translate the options into Turbopack conditions, and narrow the peer range to what actually works.

## Fixes #411 — `include`/`exclude` work under Turbopack; user rules survive

- The documented `include`/`exclude` options only reached the webpack branch. They now translate into the Turbopack rule condition — `{ path: include }` plus `{ not: { path: exclude } }` — so both bundlers behave identically (verified by test against Next 16's `TurbopackRuleCondition` schema).
- User-supplied `turbopack.rules` for the same glob were silently overwritten by the plugin's spread. A glob key accepts a rule-config list, so the Palamedes rules are now appended, preserving whatever the user configured.
- The macro content pre-filter is derived from the canonical `PALAMEDES_MACRO_PACKAGES` list instead of a hand-written regex — which also fixes that `@palamedes/solid/macro` was missing from it (Solid apps under Turbopack previously skipped the transform entirely).

## Fixes #412 — peer range narrowed to `next ^16`

The emitted config needs the Next 16 surface (top-level `turbopack.rules` with condition objects, top-level `outputFileTracingRoot`). On the previously declared `^13 || ^14 || ^15`, those keys were unrecognized — and with Turbopack the transform silently never ran, surfacing only as the runtime "macro executed outside the compiler transform" error. 15.x was never tested. Users on older versions now get a clear peer warning at install time instead of silent breakage; the range can be widened later if 15.x is actually verified. README, API doc, and CHANGELOG (compatibility note) state the requirement.

## Verification

- New `withPalamedes` test suite: include/exclude translation, content-filter coverage for all three macro packages, user-rule preservation (same glob and other globs), po-loader rule toggling — 8 next-plugin tests green.
- `pnpm check-types`, `pnpm lint`, `pnpm format:check` green; `example-nextjs-cookie` builds against the changed plugin.
- Lockfile unchanged (installed `next 16.2.11` already satisfies the narrowed range).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TK4yk5JVr5FURvoKZhCgon

---
_Generated by [Claude Code](https://claude.ai/code/session_01TK4yk5JVr5FURvoKZhCgon)_