### PR TITLE
fix(benchmarks): author the Palamedes lane with the post-1.5.0 macro surface

### DIFF
--- a/benchmarks/e2e-workflow/results/latest.md
+++ b/benchmarks/e2e-workflow/results/latest.md
@@ -16,6 +16,16 @@ Machine-local: yes
 - i18next-parser CLI: 9.4.0
 - i18next-cli: 1.66.2
 
+> **Stale corpus provenance — regenerate before quoting these as reproducible.**
+> This report was recorded before the Palamedes corpus lane was corrected in
+> #445. It was generated with CLI v1.3.0, against a corpus that authored the
+> Palamedes lane with `defineMessage` — a macro 1.5.0 removed. The measured
+> inventory and the ratios are internally consistent and still match what
+> `site/app/data/bench.ts` quotes, so nothing published is wrong; but
+> re-running the harness today produces a slightly different Palamedes source
+> shape than the one measured here. A fresh run on the reference machine
+> (darwin/arm64, warmup 3, runs 7) replaces this note.
+
 ## Methodology
 
 - Scope: scan sources, extract messages, update catalogs, and write catalog files

--- a/benchmarks/e2e-workflow/src/corpus.mjs
+++ b/benchmarks/e2e-workflow/src/corpus.mjs
@@ -339,8 +339,8 @@ function renderFillerModule(fileIndex, lineCount) {
   return `${fillerLines(fileIndex, lineCount).join("\n")}\n`
 }
 
-function renderPalamedesSource(fileIndex, messages, extension, targetLines) {
-  const imports = ['import { defineMessage, t } from "@palamedes/core/macro"']
+export function renderPalamedesSource(fileIndex, messages, extension, targetLines) {
+  const imports = ['import { t } from "@palamedes/core/macro"']
   if (extension === "tsx") {
     imports.push('import { Trans } from "@palamedes/react/macro"')
   }
@@ -352,10 +352,11 @@ function renderPalamedesSource(fileIndex, messages, extension, targetLines) {
     extension,
     fileIndex,
     targetLines,
+    authorMessage: authorPalamedesMessage,
   })
 }
 
-function renderLinguiSource(fileIndex, messages, extension, targetLines) {
+export function renderLinguiSource(fileIndex, messages, extension, targetLines) {
   const imports = ['import { defineMessage, t } from "@lingui/core/macro"']
   if (extension === "tsx") {
     imports.push('import { Trans } from "@lingui/react/macro"')
@@ -371,20 +372,45 @@ function renderLinguiSource(fileIndex, messages, extension, targetLines) {
   })
 }
 
-/* Variable messages ({name}) are authored with defineMessage — t({ message })
- * would drop the interpolation. Plain messages keep the t/defineMessage mix. */
-function authorMacroMessage(message, index) {
+/* Lingui lane: variable messages ({name}) are authored with defineMessage —
+ * t({ message }) would drop the interpolation there. Plain messages keep the
+ * t/defineMessage mix. */
+function authorLinguiMessage(message, index) {
   if (message.includes("{name}") || index % 3 !== 0) {
     return `    defineMessage({ message: ${JSON.stringify(message)} }).message,`
   }
   return `    t({ message: ${JSON.stringify(message)} }),`
 }
 
-function renderMacroSource({ functionName, imports, messages, extension, fileIndex, targetLines }) {
+/*
+ * Palamedes lane: eager t({ message }) throughout, which is the post-1.5.0
+ * authoring model — deferred message descriptors were removed, so
+ * `defineMessage` no longer exists in @palamedes/core/macro and the extractor
+ * rejects it outright.
+ *
+ * Interpolation is not a reason to reach for a deferred macro here: the
+ * placeholder is part of the message text, and `t({ message: "Hello {name}" })`
+ * lands in the catalog as `msgid "Hello {name}"` unchanged. The two lanes
+ * therefore still produce an identical logical message inventory, which is
+ * what the harness's semantic validation compares.
+ */
+function authorPalamedesMessage(message) {
+  return `    t({ message: ${JSON.stringify(message)} }),`
+}
+
+function renderMacroSource({
+  functionName,
+  imports,
+  messages,
+  extension,
+  fileIndex,
+  targetLines,
+  authorMessage = authorLinguiMessage,
+}) {
   const body = [`export function ${functionName}() {`, "  const values = ["]
 
   for (let index = 0; index < messages.length; index += 1) {
-    body.push(authorMacroMessage(messages[index].current, index))
+    body.push(authorMessage(messages[index].current, index))
   }
 
   body.push("  ]")

--- a/benchmarks/e2e-workflow/src/run.test.mjs
+++ b/benchmarks/e2e-workflow/src/run.test.mjs
@@ -1,8 +1,70 @@
 import assert from "node:assert/strict"
 import test from "node:test"
 
-import { formatJsId, toFormatJsCatalog } from "./corpus.mjs"
+import {
+  formatJsId,
+  renderLinguiSource,
+  renderPalamedesSource,
+  toFormatJsCatalog,
+} from "./corpus.mjs"
 import { parsePoMsgids } from "./po.mjs"
+
+/*
+ * Regression guard for #445. The Palamedes lane used to be rendered with
+ * `defineMessage`, which 1.5.0 removed from @palamedes/core/macro — so
+ * regenerating the corpus with a current CLI failed outright while the checked
+ * report, recorded on an older CLI, kept validating. The mismatch went
+ * unnoticed for months because nothing asserted the generated source against
+ * the macro surface it is supposed to exercise.
+ */
+const REMOVED_PALAMEDES_MACROS = ["defineMessage", "msg"]
+
+const SAMPLE_MESSAGES = [
+  { current: "Plain toolbar message" },
+  { current: "Hello {name}, welcome back" },
+  { current: "Another plain message" },
+  { current: "Queue item for {name} is ready" },
+]
+
+test("Palamedes lane authors messages with the post-1.5.0 macro surface", () => {
+  const source = renderPalamedesSource(1, SAMPLE_MESSAGES, "ts", 0)
+
+  for (const macro of REMOVED_PALAMEDES_MACROS) {
+    assert.ok(
+      !source.includes(macro),
+      `Palamedes corpus must not use the removed \`${macro}\` macro — see issue #445`
+    )
+  }
+  assert.match(source, /import \{ t \} from "@palamedes\/core\/macro"/u)
+  assert.equal(source.match(/t\(\{ message: /gu)?.length, SAMPLE_MESSAGES.length)
+})
+
+test("Palamedes lane keeps interpolated messages intact", () => {
+  const source = renderPalamedesSource(1, SAMPLE_MESSAGES, "ts", 0)
+
+  /*
+   * The placeholder is part of the message text, so an eager t({ message })
+   * carries it into the catalog unchanged. This is what makes dropping the
+   * deferred macro safe rather than lossy.
+   */
+  assert.ok(source.includes('t({ message: "Hello {name}, welcome back" })'))
+})
+
+test("both macro lanes render an identical logical message inventory", () => {
+  /*
+   * The harness compares extracted inventories across tools, so the lanes may
+   * differ in authoring style but never in which messages they contain.
+   */
+  const extract = (source) =>
+    [...source.matchAll(/message: ("(?:[^"\\]|\\.)*")/gu)]
+      .map((match) => JSON.parse(match[1]))
+      .sort()
+
+  assert.deepEqual(
+    extract(renderPalamedesSource(1, SAMPLE_MESSAGES, "ts", 0)),
+    extract(renderLinguiSource(1, SAMPLE_MESSAGES, "ts", 0))
+  )
+})
 
 test("FormatJS baseline catalog uses the CLI content-hash ID convention", () => {
   assert.equal(formatJsId("Hello world"), "t/eDuu")


### PR DESCRIPTION
## Summary

Refs #445. Makes the benchmark corpus re-runnable again for the Palamedes lane.

`benchmarks/e2e-workflow/src/corpus.mjs` rendered the Palamedes lane with `defineMessage`, a macro 1.5.0 removed from `@palamedes/core/macro`. Regenerating the corpus with a current CLI failed outright — reproduced against a release build of `pmds` v1.6.0:

```
Error: Unsupported `defineMessage` macro usage at src/generated/a.ts:1:1:
this deferred message macro has been removed; translate at the point of use with `t`
```

The checked report predates the removal (recorded on CLI v1.3.0), which is why it kept validating while the "re-runnable" half of the claim was quietly broken.

**The fix.** The lane now uses eager `t({ message })` throughout, matching the authoring model `docs/migrate-from-lingui.md` documents. `authorMacroMessage` was shared with the Lingui lane, so it is split: Lingui keeps its `defineMessage`/`t` mix, Palamedes gets its own renderer.

**A claim in the old comment turned out to be wrong.** It stated that variable messages needed a deferred macro because `t({ message })` "would drop the interpolation". Checked against the built CLI, that does not hold — `t({ message: "Hello {name}, welcome back" })` extracts to `msgid "Hello {name}, welcome back"` unchanged, because the placeholder is part of the message text. Both lanes therefore still render an identical logical message inventory, which is exactly what the harness's semantic validation compares.

## Issue

Refs #445 — addresses the corpus half. The issue stays open for the report regeneration, see Follow-up.

## Validation

- Reproduced the original failure against a release `pmds` build, then confirmed the corrected shape extracts cleanly with placeholders intact.
- Three new regression tests in `run.test.mjs`, **checked against the bug rather than only against the fix**: reintroducing `defineMessage` fails two of them, and they pass again once reverted.
- `node --test ./src/run.test.mjs` — 5 passed, 0 failed.
- Full harness run on the small profile: all five tools pass semantic validation (640 active messages per catalog target and tool) with the corrected corpus.
- `node scripts/verify-site-bench-data.mjs` — `bench.ts` still matches `latest.md`, so nothing published moves.
- `pnpm lint`, `pnpm format:check` — clean.

## Follow-up

**The checked report is deliberately not regenerated in this PR.** It would have to be recorded on this container (linux/x64, Node 22) rather than the reference machine (darwin/arm64, Node 24), and every ratio quoted on `/proof`, `/i18n-performance` and each comparison table derives from it. Replacing the whole measurement series is a conscious decision, not a side effect of a bug fix.

A provenance note now sits at the top of `results/latest.md` stating that it predates the corpus change and needs a fresh run, so nobody reads it as reproducible in the meantime. The note disappears automatically when the harness next writes the file.

To close #445 fully: run `pnpm benchmark:e2e-workflow` on the reference machine and commit the refreshed report; the drift guard will then require `bench.ts` to follow.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TK4yk5JVr5FURvoKZhCgon)_