### PR TITLE
Re-record all benchmarks on reference hardware, and fix the catalog-write regression they surfaced

### DIFF
--- a/benchmarks/e2e-workflow/results/latest.json
+++ b/benchmarks/e2e-workflow/results/latest.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "benchmark": "palamedes-e2e-extract-update-workflow",
-  "generatedAt": "2026-07-22T14:44:41.328Z",
+  "generatedAt": "2026-07-27T09:48:40.633Z",
   "machineLocal": true,
   "seed": 20260703,
   "warmup": 3,
@@ -11,15 +11,15 @@
     "nodeVersion": "v24.18.0",
     "platform": "darwin",
     "arch": "arm64",
-    "generatedAt": "2026-07-22T14:44:41.328Z"
+    "generatedAt": "2026-07-27T09:48:40.633Z"
   },
   "versions": {
     "benchmarkPackage": "@palamedes/benchmark-e2e-workflow",
     "palamedes": {
-      "cli": "pmds (Palamedes) v1.3.0"
+      "cli": "pmds (Palamedes) v1.7.0"
     },
     "lingui": {
-      "cli": "6.4.0"
+      "cli": "6.5.0"
     },
     "formatjs": {
       "cli": "6.16.14"
@@ -91,7 +91,7 @@
       "results": [
         {
           "tool": "palamedes",
-          "version": "pmds (Palamedes) v1.3.0",
+          "version": "pmds (Palamedes) v1.7.0",
           "profile": "small",
           "fileCount": 80,
           "sourceMessageCount": 640,
@@ -102,24 +102,30 @@
           "sourceBytes": 23590,
           "warmup": 3,
           "runs": 7,
-          "medianMs": 43.880125,
+          "medianMs": 35.983708,
           "rawSamplesMs": [
-            39.976, 40.147041, 43.821917, 43.880125, 45.077709, 47.800875, 50.331625
+            34.598334,
+            34.790375,
+            35.732708,
+            35.983708,
+            36.451375,
+            37.326917,
+            37.957875
           ],
           "stdoutBytes": 178,
           "stderrBytes": 0,
           "palamedesTiming": {
-            "totalMs": 34,
+            "totalMs": 29,
             "globMs": 0,
-            "extractMs": 5,
-            "writeMs": 26,
+            "extractMs": 3,
+            "writeMs": 24,
             "totalMessages": 640,
             "totalFiles": 80
           }
         },
         {
           "tool": "lingui",
-          "version": "6.4.0",
+          "version": "6.5.0",
           "profile": "small",
           "fileCount": 80,
           "sourceMessageCount": 640,
@@ -130,11 +136,17 @@
           "sourceBytes": 23590,
           "warmup": 3,
           "runs": 7,
-          "medianMs": 1143.36625,
+          "medianMs": 658.16775,
           "rawSamplesMs": [
-            864.300875, 1098.274416, 1113.048875, 1143.36625, 1225.4595, 1254.526584, 1268.349167
+            646.756042,
+            648.989125,
+            652.841584,
+            658.16775,
+            660.727,
+            671.595333,
+            682.756333
           ],
-          "stdoutBytes": 787,
+          "stdoutBytes": 757,
           "stderrBytes": 18
         },
         {
@@ -150,9 +162,15 @@
           "sourceBytes": 23590,
           "warmup": 3,
           "runs": 7,
-          "medianMs": 291.07925,
+          "medianMs": 275.786792,
           "rawSamplesMs": [
-            278.858791, 281.127958, 283.520167, 291.07925, 323.314125, 330.741875, 340.549875
+            264.563791,
+            267.449791,
+            273.649334,
+            275.786792,
+            278.557875,
+            299.340291,
+            324.196666
           ],
           "stdoutBytes": 0,
           "stderrBytes": 0
@@ -170,11 +188,17 @@
           "sourceBytes": 23590,
           "warmup": 3,
           "runs": 7,
-          "medianMs": 512.983542,
+          "medianMs": 506.039167,
           "rawSamplesMs": [
-            502.507792, 505.540459, 512.696958, 512.983542, 513.50425, 522.15825, 537.697875
+            495.936334,
+            501.147667,
+            504.329084,
+            506.039167,
+            506.60175,
+            511.357333,
+            522.901417
           ],
-          "stdoutBytes": 13327,
+          "stdoutBytes": 12457,
           "stderrBytes": 0
         },
         {
@@ -190,9 +214,15 @@
           "sourceBytes": 23590,
           "warmup": 3,
           "runs": 7,
-          "medianMs": 378.206916,
+          "medianMs": 382.8705,
           "rawSamplesMs": [
-            376.857458, 377.031542, 377.584375, 378.206916, 378.313416, 381.742459, 382.741958
+            376.084875,
+            380.097958,
+            380.566708,
+            382.8705,
+            388.436125,
+            390.979625,
+            391.442791
           ],
           "stdoutBytes": 292,
           "stderrBytes": 0
@@ -248,7 +278,7 @@
       "results": [
         {
           "tool": "palamedes",
-          "version": "pmds (Palamedes) v1.3.0",
+          "version": "pmds (Palamedes) v1.7.0",
           "profile": "medium",
           "fileCount": 240,
           "sourceMessageCount": 1920,
@@ -259,14 +289,20 @@
           "sourceBytes": 70681,
           "warmup": 3,
           "runs": 7,
-          "medianMs": 46.933084,
+          "medianMs": 47.676625,
           "rawSamplesMs": [
-            42.264167, 43.577083, 44.305292, 46.933084, 48.387833, 56.753167, 57.601084
+            46.957917,
+            46.9995,
+            47.608334,
+            47.676625,
+            48.009875,
+            48.020125,
+            48.857958
           ],
           "stdoutBytes": 183,
           "stderrBytes": 0,
           "palamedesTiming": {
-            "totalMs": 40,
+            "totalMs": 41,
             "globMs": 1,
             "extractMs": 10,
             "writeMs": 29,
@@ -276,7 +312,7 @@
         },
         {
           "tool": "lingui",
-          "version": "6.4.0",
+          "version": "6.5.0",
           "profile": "medium",
           "fileCount": 240,
           "sourceMessageCount": 1920,
@@ -287,11 +323,17 @@
           "sourceBytes": 70681,
           "warmup": 3,
           "runs": 7,
-          "medianMs": 760.766167,
+          "medianMs": 732.813042,
           "rawSamplesMs": [
-            748.777083, 752.513833, 758.582667, 760.766167, 765.753167, 770.888583, 772.073084
+            726.857334,
+            727.178916,
+            727.719458,
+            732.813042,
+            738.14125,
+            741.17675,
+            750.684333
           ],
-          "stdoutBytes": 787,
+          "stdoutBytes": 757,
           "stderrBytes": 18
         },
         {
@@ -307,9 +349,15 @@
           "sourceBytes": 70681,
           "warmup": 3,
           "runs": 7,
-          "medianMs": 299.824,
+          "medianMs": 293.855542,
           "rawSamplesMs": [
-            298.118416, 298.664583, 299.578167, 299.824, 303.178708, 303.841708, 312.105875
+            290.911916,
+            291.847292,
+            293.179792,
+            293.855542,
+            294.131625,
+            296.855333,
+            303.923333
           ],
           "stdoutBytes": 0,
           "stderrBytes": 0
@@ -327,11 +375,17 @@
           "sourceBytes": 70681,
           "warmup": 3,
           "runs": 7,
-          "medianMs": 569.171083,
+          "medianMs": 565.665833,
           "rawSamplesMs": [
-            566.731667, 566.73475, 568.880541, 569.171083, 570.746583, 575.355334, 687.844958
+            554.557958,
+            558.141,
+            560.730167,
+            565.665833,
+            568.951,
+            568.978334,
+            581.865917
           ],
-          "stdoutBytes": 39223,
+          "stdoutBytes": 36753,
           "stderrBytes": 0
         },
         {
@@ -347,9 +401,15 @@
           "sourceBytes": 70681,
           "warmup": 3,
           "runs": 7,
-          "medianMs": 584.743292,
+          "medianMs": 568.559792,
           "rawSamplesMs": [
-            579.607167, 581.159416, 583.116167, 584.743292, 585.769792, 598.345333, 602.978375
+            561.389875,
+            562.105292,
+            563.42875,
+            568.559792,
+            581.747042,
+            593.304208,
+            654.563625
           ],
           "stdoutBytes": 294,
           "stderrBytes": 0
@@ -405,7 +465,7 @@
       "results": [
         {
           "tool": "palamedes",
-          "version": "pmds (Palamedes) v1.3.0",
+          "version": "pmds (Palamedes) v1.7.0",
           "profile": "realistic",
           "fileCount": 1500,
           "sourceMessageCount": 6000,
@@ -416,24 +476,30 @@
           "sourceBytes": 220653,
           "warmup": 3,
           "runs": 7,
-          "medianMs": 179.868917,
+          "medianMs": 192.94325,
           "rawSamplesMs": [
-            176.729959, 177.828792, 179.729583, 179.868917, 181.29225, 185.296875, 192.285167
+            188.887417,
+            188.971541,
+            191.080042,
+            192.94325,
+            193.073209,
+            194.867,
+            208.091375
           ],
           "stdoutBytes": 188,
           "stderrBytes": 0,
           "palamedesTiming": {
-            "totalMs": 174,
-            "globMs": 8,
-            "extractMs": 125,
-            "writeMs": 38,
+            "totalMs": 185,
+            "globMs": 7,
+            "extractMs": 121,
+            "writeMs": 52,
             "totalMessages": 6000,
             "totalFiles": 1500
           }
         },
         {
           "tool": "lingui",
-          "version": "6.4.0",
+          "version": "6.5.0",
           "profile": "realistic",
           "fileCount": 1500,
           "sourceMessageCount": 6000,
@@ -444,12 +510,17 @@
           "sourceBytes": 220653,
           "warmup": 3,
           "runs": 7,
-          "medianMs": 2238.752541,
+          "medianMs": 2342.49325,
           "rawSamplesMs": [
-            2164.585083, 2174.039333, 2218.360459, 2238.752541, 2272.051625, 2284.020459,
-            2304.347875
+            2263.753292,
+            2272.463917,
+            2279.210916,
+            2342.49325,
+            2359.238041,
+            2512.455625,
+            2522.205541
           ],
-          "stdoutBytes": 787,
+          "stdoutBytes": 757,
           "stderrBytes": 15
         },
         {
@@ -465,9 +536,15 @@
           "sourceBytes": 220653,
           "warmup": 3,
           "runs": 7,
-          "medianMs": 474.618834,
+          "medianMs": 472.18375,
           "rawSamplesMs": [
-            465.178667, 470.405667, 472.895291, 474.618834, 476.289083, 476.482625, 489.966959
+            466.557459,
+            470.609417,
+            472.059625,
+            472.18375,
+            474.374583,
+            477.27925,
+            484.386375
           ],
           "stdoutBytes": 0,
           "stderrBytes": 0
@@ -485,11 +562,17 @@
           "sourceBytes": 220653,
           "warmup": 3,
           "runs": 7,
-          "medianMs": 1641.149,
+          "medianMs": 1540.723583,
           "rawSamplesMs": [
-            1620.186833, 1629.230833, 1638.131084, 1641.149, 1663.696541, 1673.019292, 2026.597667
+            1515.379875,
+            1531.989792,
+            1535.440583,
+            1540.723583,
+            1544.967417,
+            1569.04275,
+            1582.406959
           ],
-          "stdoutBytes": 246760,
+          "stdoutBytes": 231690,
           "stderrBytes": 0
         },
         {
@@ -505,9 +588,15 @@
           "sourceBytes": 220653,
           "warmup": 3,
           "runs": 7,
-          "medianMs": 6612.710542,
+          "medianMs": 5804.345,
           "rawSamplesMs": [
-            6520.209875, 6576.082125, 6596.760042, 6612.710542, 6615.306708, 6638.475625, 7558.43075
+            5775.107625,
+            5782.309125,
+            5800.127958,
+            5804.345,
+            5892.860625,
+            6127.086459,
+            6212.822958
           ],
           "stdoutBytes": 300,
           "stderrBytes": 0
@@ -518,7 +607,7 @@
   "results": [
     {
       "tool": "palamedes",
-      "version": "pmds (Palamedes) v1.3.0",
+      "version": "pmds (Palamedes) v1.7.0",
       "profile": "small",
       "fileCount": 80,
       "sourceMessageCount": 640,
@@ -529,22 +618,30 @@
       "sourceBytes": 23590,
       "warmup": 3,
       "runs": 7,
-      "medianMs": 43.880125,
-      "rawSamplesMs": [39.976, 40.147041, 43.821917, 43.880125, 45.077709, 47.800875, 50.331625],
+      "medianMs": 35.983708,
+      "rawSamplesMs": [
+        34.598334,
+        34.790375,
+        35.732708,
+        35.983708,
+        36.451375,
+        37.326917,
+        37.957875
+      ],
       "stdoutBytes": 178,
       "stderrBytes": 0,
       "palamedesTiming": {
-        "totalMs": 34,
+        "totalMs": 29,
         "globMs": 0,
-        "extractMs": 5,
-        "writeMs": 26,
+        "extractMs": 3,
+        "writeMs": 24,
         "totalMessages": 640,
         "totalFiles": 80
       }
     },
     {
       "tool": "lingui",
-      "version": "6.4.0",
+      "version": "6.5.0",
       "profile": "small",
       "fileCount": 80,
       "sourceMessageCount": 640,
@@ -555,11 +652,17 @@
       "sourceBytes": 23590,
       "warmup": 3,
       "runs": 7,
-      "medianMs": 1143.36625,
+      "medianMs": 658.16775,
       "rawSamplesMs": [
-        864.300875, 1098.274416, 1113.048875, 1143.36625, 1225.4595, 1254.526584, 1268.349167
+        646.756042,
+        648.989125,
+        652.841584,
+        658.16775,
+        660.727,
+        671.595333,
+        682.756333
       ],
-      "stdoutBytes": 787,
+      "stdoutBytes": 757,
       "stderrBytes": 18
     },
     {
@@ -575,9 +678,15 @@
       "sourceBytes": 23590,
       "warmup": 3,
       "runs": 7,
-      "medianMs": 291.07925,
+      "medianMs": 275.786792,
       "rawSamplesMs": [
-        278.858791, 281.127958, 283.520167, 291.07925, 323.314125, 330.741875, 340.549875
+        264.563791,
+        267.449791,
+        273.649334,
+        275.786792,
+        278.557875,
+        299.340291,
+        324.196666
       ],
       "stdoutBytes": 0,
       "stderrBytes": 0
@@ -595,11 +704,17 @@
       "sourceBytes": 23590,
       "warmup": 3,
       "runs": 7,
-      "medianMs": 512.983542,
+      "medianMs": 506.039167,
       "rawSamplesMs": [
-        502.507792, 505.540459, 512.696958, 512.983542, 513.50425, 522.15825, 537.697875
+        495.936334,
+        501.147667,
+        504.329084,
+        506.039167,
+        506.60175,
+        511.357333,
+        522.901417
       ],
-      "stdoutBytes": 13327,
+      "stdoutBytes": 12457,
       "stderrBytes": 0
     },
     {
@@ -615,16 +730,22 @@
       "sourceBytes": 23590,
       "warmup": 3,
       "runs": 7,
-      "medianMs": 378.206916,
+      "medianMs": 382.8705,
       "rawSamplesMs": [
-        376.857458, 377.031542, 377.584375, 378.206916, 378.313416, 381.742459, 382.741958
+        376.084875,
+        380.097958,
+        380.566708,
+        382.8705,
+        388.436125,
+        390.979625,
+        391.442791
       ],
       "stdoutBytes": 292,
       "stderrBytes": 0
     },
     {
       "tool": "palamedes",
-      "version": "pmds (Palamedes) v1.3.0",
+      "version": "pmds (Palamedes) v1.7.0",
       "profile": "medium",
       "fileCount": 240,
       "sourceMessageCount": 1920,
@@ -635,12 +756,20 @@
       "sourceBytes": 70681,
       "warmup": 3,
       "runs": 7,
-      "medianMs": 46.933084,
-      "rawSamplesMs": [42.264167, 43.577083, 44.305292, 46.933084, 48.387833, 56.753167, 57.601084],
+      "medianMs": 47.676625,
+      "rawSamplesMs": [
+        46.957917,
+        46.9995,
+        47.608334,
+        47.676625,
+        48.009875,
+        48.020125,
+        48.857958
+      ],
       "stdoutBytes": 183,
       "stderrBytes": 0,
       "palamedesTiming": {
-        "totalMs": 40,
+        "totalMs": 41,
         "globMs": 1,
         "extractMs": 10,
         "writeMs": 29,
@@ -650,7 +779,7 @@
     },
     {
       "tool": "lingui",
-      "version": "6.4.0",
+      "version": "6.5.0",
       "profile": "medium",
       "fileCount": 240,
       "sourceMessageCount": 1920,
@@ -661,11 +790,17 @@
       "sourceBytes": 70681,
       "warmup": 3,
       "runs": 7,
-      "medianMs": 760.766167,
+      "medianMs": 732.813042,
       "rawSamplesMs": [
-        748.777083, 752.513833, 758.582667, 760.766167, 765.753167, 770.888583, 772.073084
+        726.857334,
+        727.178916,
+        727.719458,
+        732.813042,
+        738.14125,
+        741.17675,
+        750.684333
       ],
-      "stdoutBytes": 787,
+      "stdoutBytes": 757,
       "stderrBytes": 18
     },
     {
@@ -681,9 +816,15 @@
       "sourceBytes": 70681,
       "warmup": 3,
       "runs": 7,
-      "medianMs": 299.824,
+      "medianMs": 293.855542,
       "rawSamplesMs": [
-        298.118416, 298.664583, 299.578167, 299.824, 303.178708, 303.841708, 312.105875
+        290.911916,
+        291.847292,
+        293.179792,
+        293.855542,
+        294.131625,
+        296.855333,
+        303.923333
       ],
       "stdoutBytes": 0,
       "stderrBytes": 0
@@ -701,11 +842,17 @@
       "sourceBytes": 70681,
       "warmup": 3,
       "runs": 7,
-      "medianMs": 569.171083,
+      "medianMs": 565.665833,
       "rawSamplesMs": [
-        566.731667, 566.73475, 568.880541, 569.171083, 570.746583, 575.355334, 687.844958
+        554.557958,
+        558.141,
+        560.730167,
+        565.665833,
+        568.951,
+        568.978334,
+        581.865917
       ],
-      "stdoutBytes": 39223,
+      "stdoutBytes": 36753,
       "stderrBytes": 0
     },
     {
@@ -721,16 +868,22 @@
       "sourceBytes": 70681,
       "warmup": 3,
       "runs": 7,
-      "medianMs": 584.743292,
+      "medianMs": 568.559792,
       "rawSamplesMs": [
-        579.607167, 581.159416, 583.116167, 584.743292, 585.769792, 598.345333, 602.978375
+        561.389875,
+        562.105292,
+        563.42875,
+        568.559792,
+        581.747042,
+        593.304208,
+        654.563625
       ],
       "stdoutBytes": 294,
       "stderrBytes": 0
     },
     {
       "tool": "palamedes",
-      "version": "pmds (Palamedes) v1.3.0",
+      "version": "pmds (Palamedes) v1.7.0",
       "profile": "realistic",
       "fileCount": 1500,
       "sourceMessageCount": 6000,
@@ -741,24 +894,30 @@
       "sourceBytes": 220653,
       "warmup": 3,
       "runs": 7,
-      "medianMs": 179.868917,
+      "medianMs": 192.94325,
       "rawSamplesMs": [
-        176.729959, 177.828792, 179.729583, 179.868917, 181.29225, 185.296875, 192.285167
+        188.887417,
+        188.971541,
+        191.080042,
+        192.94325,
+        193.073209,
+        194.867,
+        208.091375
       ],
       "stdoutBytes": 188,
       "stderrBytes": 0,
       "palamedesTiming": {
-        "totalMs": 174,
-        "globMs": 8,
-        "extractMs": 125,
-        "writeMs": 38,
+        "totalMs": 185,
+        "globMs": 7,
+        "extractMs": 121,
+        "writeMs": 52,
         "totalMessages": 6000,
         "totalFiles": 1500
       }
     },
     {
       "tool": "lingui",
-      "version": "6.4.0",
+      "version": "6.5.0",
       "profile": "realistic",
       "fileCount": 1500,
       "sourceMessageCount": 6000,
@@ -769,11 +928,17 @@
       "sourceBytes": 220653,
       "warmup": 3,
       "runs": 7,
-      "medianMs": 2238.752541,
+      "medianMs": 2342.49325,
       "rawSamplesMs": [
-        2164.585083, 2174.039333, 2218.360459, 2238.752541, 2272.051625, 2284.020459, 2304.347875
+        2263.753292,
+        2272.463917,
+        2279.210916,
+        2342.49325,
+        2359.238041,
+        2512.455625,
+        2522.205541
       ],
-      "stdoutBytes": 787,
+      "stdoutBytes": 757,
       "stderrBytes": 15
     },
     {
@@ -789,9 +954,15 @@
       "sourceBytes": 220653,
       "warmup": 3,
       "runs": 7,
-      "medianMs": 474.618834,
+      "medianMs": 472.18375,
       "rawSamplesMs": [
-        465.178667, 470.405667, 472.895291, 474.618834, 476.289083, 476.482625, 489.966959
+        466.557459,
+        470.609417,
+        472.059625,
+        472.18375,
+        474.374583,
+        477.27925,
+        484.386375
       ],
       "stdoutBytes": 0,
       "stderrBytes": 0
@@ -809,11 +980,17 @@
       "sourceBytes": 220653,
       "warmup": 3,
       "runs": 7,
-      "medianMs": 1641.149,
+      "medianMs": 1540.723583,
       "rawSamplesMs": [
-        1620.186833, 1629.230833, 1638.131084, 1641.149, 1663.696541, 1673.019292, 2026.597667
+        1515.379875,
+        1531.989792,
+        1535.440583,
+        1540.723583,
+        1544.967417,
+        1569.04275,
+        1582.406959
       ],
-      "stdoutBytes": 246760,
+      "stdoutBytes": 231690,
       "stderrBytes": 0
     },
     {
@@ -829,9 +1006,15 @@
       "sourceBytes": 220653,
       "warmup": 3,
       "runs": 7,
-      "medianMs": 6612.710542,
+      "medianMs": 5804.345,
       "rawSamplesMs": [
-        6520.209875, 6576.082125, 6596.760042, 6612.710542, 6615.306708, 6638.475625, 7558.43075
+        5775.107625,
+        5782.309125,
+        5800.127958,
+        5804.345,
+        5892.860625,
+        6127.086459,
+        6212.822958
       ],
       "stdoutBytes": 300,
       "stderrBytes": 0
@@ -843,108 +1026,108 @@
       "baselineTool": "palamedes",
       "comparedTool": "lingui",
       "fasterTool": "palamedes",
-      "palamedesMedianMs": 43.880125,
-      "comparedMedianMs": 1143.36625,
-      "speedupFactor": 26.056585982833916
+      "palamedesMedianMs": 35.983708,
+      "comparedMedianMs": 658.16775,
+      "speedupFactor": 18.29071506471762
     },
     {
       "profile": "small",
       "baselineTool": "palamedes",
       "comparedTool": "formatjs",
       "fasterTool": "palamedes",
-      "palamedesMedianMs": 43.880125,
-      "comparedMedianMs": 291.07925,
-      "speedupFactor": 6.633510045835102
+      "palamedesMedianMs": 35.983708,
+      "comparedMedianMs": 275.786792,
+      "speedupFactor": 7.664212704260494
     },
     {
       "profile": "small",
       "baselineTool": "palamedes",
       "comparedTool": "i18nextParser",
       "fasterTool": "palamedes",
-      "palamedesMedianMs": 43.880125,
-      "comparedMedianMs": 512.983542,
-      "speedupFactor": 11.6905670163884
+      "palamedesMedianMs": 35.983708,
+      "comparedMedianMs": 506.039167,
+      "speedupFactor": 14.063007820094583
     },
     {
       "profile": "small",
       "baselineTool": "palamedes",
       "comparedTool": "i18nextCli",
       "fasterTool": "palamedes",
-      "palamedesMedianMs": 43.880125,
-      "comparedMedianMs": 378.206916,
-      "speedupFactor": 8.61909386083107
+      "palamedesMedianMs": 35.983708,
+      "comparedMedianMs": 382.8705,
+      "speedupFactor": 10.640106906158753
     },
     {
       "profile": "medium",
       "baselineTool": "palamedes",
       "comparedTool": "lingui",
       "fasterTool": "palamedes",
-      "palamedesMedianMs": 46.933084,
-      "comparedMedianMs": 760.766167,
-      "speedupFactor": 16.20959251260795
+      "palamedesMedianMs": 47.676625,
+      "comparedMedianMs": 732.813042,
+      "speedupFactor": 15.370489039440187
     },
     {
       "profile": "medium",
       "baselineTool": "palamedes",
       "comparedTool": "formatjs",
       "fasterTool": "palamedes",
-      "palamedesMedianMs": 46.933084,
-      "comparedMedianMs": 299.824,
-      "speedupFactor": 6.388329392545352
+      "palamedesMedianMs": 47.676625,
+      "comparedMedianMs": 293.855542,
+      "speedupFactor": 6.163513923227578
     },
     {
       "profile": "medium",
       "baselineTool": "palamedes",
       "comparedTool": "i18nextParser",
       "fasterTool": "palamedes",
-      "palamedesMedianMs": 46.933084,
-      "comparedMedianMs": 569.171083,
-      "speedupFactor": 12.127289206053451
+      "palamedesMedianMs": 47.676625,
+      "comparedMedianMs": 565.665833,
+      "speedupFactor": 11.864636664193407
     },
     {
       "profile": "medium",
       "baselineTool": "palamedes",
       "comparedTool": "i18nextCli",
       "fasterTool": "palamedes",
-      "palamedesMedianMs": 46.933084,
-      "comparedMedianMs": 584.743292,
-      "speedupFactor": 12.459085194571914
+      "palamedesMedianMs": 47.676625,
+      "comparedMedianMs": 568.559792,
+      "speedupFactor": 11.925336409613726
     },
     {
       "profile": "realistic",
       "baselineTool": "palamedes",
       "comparedTool": "lingui",
       "fasterTool": "palamedes",
-      "palamedesMedianMs": 179.868917,
-      "comparedMedianMs": 2238.752541,
-      "speedupFactor": 12.446578198944733
+      "palamedesMedianMs": 192.94325,
+      "comparedMedianMs": 2342.49325,
+      "speedupFactor": 12.140840635782801
     },
     {
       "profile": "realistic",
       "baselineTool": "palamedes",
       "comparedTool": "formatjs",
       "fasterTool": "palamedes",
-      "palamedesMedianMs": 179.868917,
-      "comparedMedianMs": 474.618834,
-      "speedupFactor": 2.63869289878473
+      "palamedesMedianMs": 192.94325,
+      "comparedMedianMs": 472.18375,
+      "speedupFactor": 2.4472675255547935
     },
     {
       "profile": "realistic",
       "baselineTool": "palamedes",
       "comparedTool": "i18nextParser",
       "fasterTool": "palamedes",
-      "palamedesMedianMs": 179.868917,
-      "comparedMedianMs": 1641.149,
-      "speedupFactor": 9.124138997289897
+      "palamedesMedianMs": 192.94325,
+      "comparedMedianMs": 1540.723583,
+      "speedupFactor": 7.985371776416122
     },
     {
       "profile": "realistic",
       "baselineTool": "palamedes",
       "comparedTool": "i18nextCli",
       "fasterTool": "palamedes",
-      "palamedesMedianMs": 179.868917,
-      "comparedMedianMs": 6612.710542,
-      "speedupFactor": 36.76405380258113
+      "palamedesMedianMs": 192.94325,
+      "comparedMedianMs": 5804.345,
+      "speedupFactor": 30.08317212444592
     }
   ]
 }

--- a/benchmarks/e2e-workflow/results/latest.md
+++ b/benchmarks/e2e-workflow/results/latest.md
@@ -1,6 +1,6 @@
 # End-to-End Extraction Workflow Benchmark
 
-Generated: 2026-07-22T14:44:41.328Z
+Generated: 2026-07-27T09:48:40.633Z
 Node: v24.18.0
 Platform: darwin/arm64
 Seed: 20260703
@@ -10,21 +10,11 @@ Machine-local: yes
 
 ## Versions
 
-- Palamedes CLI: pmds (Palamedes) v1.3.0
-- Lingui CLI: 6.4.0
+- Palamedes CLI: pmds (Palamedes) v1.7.0
+- Lingui CLI: 6.5.0
 - FormatJS CLI: 6.16.14
 - i18next-parser CLI: 9.4.0
 - i18next-cli: 1.66.2
-
-> **Stale corpus provenance — regenerate before quoting these as reproducible.**
-> This report was recorded before the Palamedes corpus lane was corrected in
-> #445. It was generated with CLI v1.3.0, against a corpus that authored the
-> Palamedes lane with `defineMessage` — a macro 1.5.0 removed. The measured
-> inventory and the ratios are internally consistent and still match what
-> `site/app/data/bench.ts` quotes, so nothing published is wrong; but
-> re-running the harness today produces a slightly different Palamedes source
-> shape than the one measured here. A fresh run on the reference machine
-> (darwin/arm64, warmup 3, runs 7) replaces this note.
 
 ## Methodology
 
@@ -41,20 +31,20 @@ Machine-local: yes
 - Inventory mix: 48 changed, 64 new, 48 removed
 - Semantic validation: 640 active messages per catalog target and tool
 
-| Tool           |     Median | Samples                                                                           |
-| -------------- | ---------: | --------------------------------------------------------------------------------- |
-| Palamedes      |   43.88 ms | 39.98 ms, 40.15 ms, 43.82 ms, 43.88 ms, 45.08 ms, 47.80 ms, 50.33 ms              |
-| Lingui         | 1143.37 ms | 864.30 ms, 1098.27 ms, 1113.05 ms, 1143.37 ms, 1225.46 ms, 1254.53 ms, 1268.35 ms |
-| FormatJS       |  291.08 ms | 278.86 ms, 281.13 ms, 283.52 ms, 291.08 ms, 323.31 ms, 330.74 ms, 340.55 ms       |
-| i18next-parser |  512.98 ms | 502.51 ms, 505.54 ms, 512.70 ms, 512.98 ms, 513.50 ms, 522.16 ms, 537.70 ms       |
-| i18next-cli    |  378.21 ms | 376.86 ms, 377.03 ms, 377.58 ms, 378.21 ms, 378.31 ms, 381.74 ms, 382.74 ms       |
+| Tool | Median | Samples |
+| --- | ---: | --- |
+| Palamedes | 35.98 ms | 34.60 ms, 34.79 ms, 35.73 ms, 35.98 ms, 36.45 ms, 37.33 ms, 37.96 ms |
+| Lingui | 658.17 ms | 646.76 ms, 648.99 ms, 652.84 ms, 658.17 ms, 660.73 ms, 671.60 ms, 682.76 ms |
+| FormatJS | 275.79 ms | 264.56 ms, 267.45 ms, 273.65 ms, 275.79 ms, 278.56 ms, 299.34 ms, 324.20 ms |
+| i18next-parser | 506.04 ms | 495.94 ms, 501.15 ms, 504.33 ms, 506.04 ms, 506.60 ms, 511.36 ms, 522.90 ms |
+| i18next-cli | 382.87 ms | 376.08 ms, 380.10 ms, 380.57 ms, 382.87 ms, 388.44 ms, 390.98 ms, 391.44 ms |
 
-| Comparison                  | Faster    | Speedup |
-| --------------------------- | --------- | ------: |
-| Palamedes vs Lingui         | Palamedes |  26.06x |
-| Palamedes vs FormatJS       | Palamedes |   6.63x |
-| Palamedes vs i18next-parser | Palamedes |  11.69x |
-| Palamedes vs i18next-cli    | Palamedes |   8.62x |
+| Comparison | Faster | Speedup |
+| --- | --- | ---: |
+| Palamedes vs Lingui | Palamedes | 18.29x |
+| Palamedes vs FormatJS | Palamedes | 7.66x |
+| Palamedes vs i18next-parser | Palamedes | 14.06x |
+| Palamedes vs i18next-cli | Palamedes | 10.64x |
 
 ## Medium
 
@@ -62,20 +52,20 @@ Machine-local: yes
 - Inventory mix: 144 changed, 192 new, 144 removed
 - Semantic validation: 1920 active messages per catalog target and tool
 
-| Tool           |    Median | Samples                                                                     |
-| -------------- | --------: | --------------------------------------------------------------------------- |
-| Palamedes      |  46.93 ms | 42.26 ms, 43.58 ms, 44.31 ms, 46.93 ms, 48.39 ms, 56.75 ms, 57.60 ms        |
-| Lingui         | 760.77 ms | 748.78 ms, 752.51 ms, 758.58 ms, 760.77 ms, 765.75 ms, 770.89 ms, 772.07 ms |
-| FormatJS       | 299.82 ms | 298.12 ms, 298.66 ms, 299.58 ms, 299.82 ms, 303.18 ms, 303.84 ms, 312.11 ms |
-| i18next-parser | 569.17 ms | 566.73 ms, 566.73 ms, 568.88 ms, 569.17 ms, 570.75 ms, 575.36 ms, 687.84 ms |
-| i18next-cli    | 584.74 ms | 579.61 ms, 581.16 ms, 583.12 ms, 584.74 ms, 585.77 ms, 598.35 ms, 602.98 ms |
+| Tool | Median | Samples |
+| --- | ---: | --- |
+| Palamedes | 47.68 ms | 46.96 ms, 47.00 ms, 47.61 ms, 47.68 ms, 48.01 ms, 48.02 ms, 48.86 ms |
+| Lingui | 732.81 ms | 726.86 ms, 727.18 ms, 727.72 ms, 732.81 ms, 738.14 ms, 741.18 ms, 750.68 ms |
+| FormatJS | 293.86 ms | 290.91 ms, 291.85 ms, 293.18 ms, 293.86 ms, 294.13 ms, 296.86 ms, 303.92 ms |
+| i18next-parser | 565.67 ms | 554.56 ms, 558.14 ms, 560.73 ms, 565.67 ms, 568.95 ms, 568.98 ms, 581.87 ms |
+| i18next-cli | 568.56 ms | 561.39 ms, 562.11 ms, 563.43 ms, 568.56 ms, 581.75 ms, 593.30 ms, 654.56 ms |
 
-| Comparison                  | Faster    | Speedup |
-| --------------------------- | --------- | ------: |
-| Palamedes vs Lingui         | Palamedes |  16.21x |
-| Palamedes vs FormatJS       | Palamedes |   6.39x |
-| Palamedes vs i18next-parser | Palamedes |  12.13x |
-| Palamedes vs i18next-cli    | Palamedes |  12.46x |
+| Comparison | Faster | Speedup |
+| --- | --- | ---: |
+| Palamedes vs Lingui | Palamedes | 15.37x |
+| Palamedes vs FormatJS | Palamedes | 6.16x |
+| Palamedes vs i18next-parser | Palamedes | 11.86x |
+| Palamedes vs i18next-cli | Palamedes | 11.93x |
 
 ## Realistic
 
@@ -83,20 +73,20 @@ Machine-local: yes
 - Inventory mix: 450 changed, 600 new, 450 removed
 - Semantic validation: 6000 active messages per catalog target and tool
 
-| Tool           |     Median | Samples                                                                            |
-| -------------- | ---------: | ---------------------------------------------------------------------------------- |
-| Palamedes      |  179.87 ms | 176.73 ms, 177.83 ms, 179.73 ms, 179.87 ms, 181.29 ms, 185.30 ms, 192.29 ms        |
-| Lingui         | 2238.75 ms | 2164.59 ms, 2174.04 ms, 2218.36 ms, 2238.75 ms, 2272.05 ms, 2284.02 ms, 2304.35 ms |
-| FormatJS       |  474.62 ms | 465.18 ms, 470.41 ms, 472.90 ms, 474.62 ms, 476.29 ms, 476.48 ms, 489.97 ms        |
-| i18next-parser | 1641.15 ms | 1620.19 ms, 1629.23 ms, 1638.13 ms, 1641.15 ms, 1663.70 ms, 1673.02 ms, 2026.60 ms |
-| i18next-cli    | 6612.71 ms | 6520.21 ms, 6576.08 ms, 6596.76 ms, 6612.71 ms, 6615.31 ms, 6638.48 ms, 7558.43 ms |
+| Tool | Median | Samples |
+| --- | ---: | --- |
+| Palamedes | 192.94 ms | 188.89 ms, 188.97 ms, 191.08 ms, 192.94 ms, 193.07 ms, 194.87 ms, 208.09 ms |
+| Lingui | 2342.49 ms | 2263.75 ms, 2272.46 ms, 2279.21 ms, 2342.49 ms, 2359.24 ms, 2512.46 ms, 2522.21 ms |
+| FormatJS | 472.18 ms | 466.56 ms, 470.61 ms, 472.06 ms, 472.18 ms, 474.37 ms, 477.28 ms, 484.39 ms |
+| i18next-parser | 1540.72 ms | 1515.38 ms, 1531.99 ms, 1535.44 ms, 1540.72 ms, 1544.97 ms, 1569.04 ms, 1582.41 ms |
+| i18next-cli | 5804.35 ms | 5775.11 ms, 5782.31 ms, 5800.13 ms, 5804.35 ms, 5892.86 ms, 6127.09 ms, 6212.82 ms |
 
-| Comparison                  | Faster    | Speedup |
-| --------------------------- | --------- | ------: |
-| Palamedes vs Lingui         | Palamedes |  12.45x |
-| Palamedes vs FormatJS       | Palamedes |   2.64x |
-| Palamedes vs i18next-parser | Palamedes |   9.12x |
-| Palamedes vs i18next-cli    | Palamedes |  36.76x |
+| Comparison | Faster | Speedup |
+| --- | --- | ---: |
+| Palamedes vs Lingui | Palamedes | 12.14x |
+| Palamedes vs FormatJS | Palamedes | 2.45x |
+| Palamedes vs i18next-parser | Palamedes | 7.99x |
+| Palamedes vs i18next-cli | Palamedes | 30.08x |
 
 ## Notes
 

--- a/benchmarks/lingui-v6/results/latest.json
+++ b/benchmarks/lingui-v6/results/latest.json
@@ -1,34 +1,34 @@
 {
   "schemaVersion": 2,
   "benchmark": "palamedes-vs-lingui-v6",
-  "generatedAt": "2026-07-05T20:27:53.982Z",
+  "generatedAt": "2026-07-27T09:45:09.215Z",
   "machineLocal": true,
   "seed": 20260318,
-  "warmup": 1,
-  "runs": 3,
+  "warmup": 5,
+  "runs": 15,
   "validateOnly": false,
   "environment": {
     "nodeVersion": "v24.18.0",
     "platform": "darwin",
     "arch": "arm64",
-    "generatedAt": "2026-07-05T20:27:53.982Z"
+    "generatedAt": "2026-07-27T09:45:09.215Z"
   },
   "versions": {
     "benchmarkPackage": "@palamedes/benchmark-lingui-v6",
     "palamedes": {
-      "engine": "1.1.2",
-      "ferrocat": "2.1.1",
-      "core": "1.1.2"
+      "engine": "1.7.0",
+      "ferrocat": "2.2.0",
+      "core": "1.7.0"
     },
     "tooling": {
       "babelCore": "8.0.1",
-      "swcCore": "1.15.43"
+      "swcCore": "1.15.46"
     },
     "lingui": {
-      "cli": "6.4.0",
-      "babelMacroPlugin": "6.4.0",
-      "swcPlugin": "6.4.0",
-      "formatPo": "6.4.0"
+      "cli": "6.5.0",
+      "babelMacroPlugin": "6.5.0",
+      "swcPlugin": "6.5.1",
+      "formatPo": "6.5.0"
     }
   },
   "trackDefinitions": [
@@ -86,7 +86,7 @@
       "corpus": {
         "fileCount": 100,
         "messageCount": 1000,
-        "sourceBytes": 140216,
+        "sourceBytes": 136466,
         "localeBytes": {
           "en": 181295,
           "de": 181295
@@ -112,63 +112,123 @@
       "tracks": {
         "macroTransformBabel": {
           "palamedes": {
-            "medianMs": 36.645083,
+            "medianMs": 42.073416,
             "samplesMs": [
-              36.471791,
-              36.645083,
-              36.766416
+              41.378583,
+              41.61075,
+              41.660416,
+              41.769458,
+              41.783542,
+              41.877292,
+              41.945208,
+              42.073416,
+              42.074667,
+              42.077791,
+              42.08025,
+              42.126666,
+              42.137542,
+              42.142291,
+              42.430959
             ],
             "lastOutcome": {
               "fileCount": 100,
-              "outputBytes": 177066
+              "outputBytes": 179566
             }
           },
           "lingui": {
-            "medianMs": 103.722417,
+            "medianMs": 83.617625,
             "samplesMs": [
-              93.282458,
-              103.722417,
-              107.371875
+              75.549209,
+              78.036833,
+              78.482458,
+              80.641666,
+              82.786292,
+              82.792291,
+              83.30175,
+              83.617625,
+              84.684583,
+              84.982917,
+              88.3275,
+              90.816708,
+              91.221667,
+              94.595292,
+              97.587625
             ],
             "lastOutcome": {
               "fileCount": 100,
-              "outputBytes": 165466
+              "outputBytes": 167716
             }
           }
         },
         "macroTransformSwc": {
           "palamedes": {
-            "medianMs": 36.645083,
+            "medianMs": 42.073416,
             "samplesMs": [
-              36.471791,
-              36.645083,
-              36.766416
+              41.378583,
+              41.61075,
+              41.660416,
+              41.769458,
+              41.783542,
+              41.877292,
+              41.945208,
+              42.073416,
+              42.074667,
+              42.077791,
+              42.08025,
+              42.126666,
+              42.137542,
+              42.142291,
+              42.430959
             ],
             "lastOutcome": {
               "fileCount": 100,
-              "outputBytes": 177066
+              "outputBytes": 179566
             }
           },
           "lingui": {
-            "medianMs": 50.895542,
+            "medianMs": 40.291834,
             "samplesMs": [
-              50.568084,
-              50.895542,
-              51.328292
+              38.713792,
+              39.004833,
+              39.291958,
+              39.947375,
+              39.991792,
+              40.072625,
+              40.145375,
+              40.291834,
+              40.590917,
+              40.658,
+              41.061333,
+              41.243292,
+              41.40225,
+              42.676042,
+              42.862375
             ],
             "lastOutcome": {
               "fileCount": 100,
-              "outputBytes": 177016
+              "outputBytes": 179516
             }
           }
         },
         "extract": {
           "palamedes": {
-            "medianMs": 22.854834,
+            "medianMs": 22.510375,
             "samplesMs": [
-              22.760584,
-              22.854834,
-              23.277834
+              22.0925,
+              22.212166,
+              22.228833,
+              22.286417,
+              22.429541,
+              22.44875,
+              22.458458,
+              22.510375,
+              22.549958,
+              22.566333,
+              22.628083,
+              22.72025,
+              22.736666,
+              22.766958,
+              23.164375
             ],
             "lastOutcome": {
               "fileCount": 100,
@@ -176,11 +236,23 @@
             }
           },
           "lingui": {
-            "medianMs": 113.144292,
+            "medianMs": 106.627709,
             "samplesMs": [
-              111.42325,
-              113.144292,
-              132.542042
+              95.925834,
+              100.46,
+              101.569291,
+              101.6395,
+              103.308041,
+              105.109709,
+              105.736917,
+              106.627709,
+              107.022917,
+              109.09725,
+              109.121208,
+              109.438375,
+              114.7445,
+              116.952875,
+              141.286542
             ],
             "lastOutcome": {
               "fileCount": 100,
@@ -190,11 +262,23 @@
         },
         "compileFromCatalog": {
           "palamedes": {
-            "medianMs": 36.185375,
+            "medianMs": 36.531791,
             "samplesMs": [
-              36.101417,
-              36.185375,
-              36.943667
+              34.22625,
+              35.699,
+              36.112209,
+              36.113583,
+              36.388542,
+              36.394625,
+              36.500042,
+              36.531791,
+              36.534666,
+              36.64025,
+              36.671875,
+              36.673458,
+              37.113541,
+              37.127625,
+              37.328291
             ],
             "lastOutcome": {
               "messageCount": 1000,
@@ -203,11 +287,23 @@
             }
           },
           "lingui": {
-            "medianMs": 5.8415,
+            "medianMs": 5.36275,
             "samplesMs": [
-              5.444334,
-              5.8415,
-              10.659125
+              4.8985,
+              4.938125,
+              4.958875,
+              5.012458,
+              5.106,
+              5.17075,
+              5.171417,
+              5.36275,
+              5.640833,
+              5.724791,
+              5.807875,
+              5.817583,
+              6.197416,
+              6.482834,
+              10.099583
             ],
             "lastOutcome": {
               "messageCount": 1000,
@@ -222,33 +318,567 @@
           "profile": "small",
           "track": "macro-transform-babel",
           "fasterTool": "palamedes",
-          "speedupFactor": 2.8304593279267505,
-          "palamedesMedianMs": 36.645083,
-          "linguiMedianMs": 103.722417
+          "speedupFactor": 1.9874218199919873,
+          "palamedesMedianMs": 42.073416,
+          "linguiMedianMs": 83.617625
         },
         {
           "profile": "small",
           "track": "macro-transform-swc",
-          "fasterTool": "palamedes",
-          "speedupFactor": 1.3888777929633833,
-          "palamedesMedianMs": 36.645083,
-          "linguiMedianMs": 50.895542
+          "fasterTool": "lingui",
+          "speedupFactor": 1.0442169497670422,
+          "palamedesMedianMs": 42.073416,
+          "linguiMedianMs": 40.291834
         },
         {
           "profile": "small",
           "track": "extract",
           "fasterTool": "palamedes",
-          "speedupFactor": 4.9505628437292515,
-          "palamedesMedianMs": 22.854834,
-          "linguiMedianMs": 113.144292
+          "speedupFactor": 4.7368250862102474,
+          "palamedesMedianMs": 22.510375,
+          "linguiMedianMs": 106.627709
         },
         {
           "profile": "small",
           "track": "compile-from-catalog",
           "fasterTool": "lingui",
-          "speedupFactor": 6.19453479414534,
-          "palamedesMedianMs": 36.185375,
-          "linguiMedianMs": 5.8415
+          "speedupFactor": 6.8121376159619595,
+          "palamedesMedianMs": 36.531791,
+          "linguiMedianMs": 5.36275
+        }
+      ]
+    },
+    {
+      "profile": "medium",
+      "corpus": {
+        "fileCount": 400,
+        "messageCount": 4000,
+        "sourceBytes": 546349,
+        "localeBytes": {
+          "en": 725661,
+          "de": 725661
+        }
+      },
+      "validation": {
+        "transform": {
+          "palamedesFiles": 400,
+          "linguiBabelFiles": 400,
+          "linguiSwcFiles": 400
+        },
+        "extract": {
+          "expectedMessages": 4000,
+          "palamedesMessages": 4000,
+          "linguiMessages": 4000
+        },
+        "compile": {
+          "expectedMessages": 4000,
+          "palamedesMessages": 4000,
+          "linguiMessages": 4000
+        }
+      },
+      "tracks": {
+        "macroTransformBabel": {
+          "palamedes": {
+            "medianMs": 176.009333,
+            "samplesMs": [
+              169.791458,
+              169.890542,
+              171.980958,
+              172.157541,
+              174.193917,
+              175.082042,
+              175.762667,
+              176.009333,
+              176.017083,
+              176.673584,
+              176.706208,
+              176.919125,
+              177.295542,
+              177.609041,
+              179.717334
+            ],
+            "lastOutcome": {
+              "fileCount": 400,
+              "outputBytes": 718749
+            }
+          },
+          "lingui": {
+            "medianMs": 325.952541,
+            "samplesMs": [
+              309.950709,
+              314.200834,
+              315.904333,
+              316.175542,
+              318.150917,
+              321.884292,
+              325.311583,
+              325.952541,
+              328.117667,
+              330.154166,
+              330.346791,
+              332.084917,
+              335.349625,
+              336.258541,
+              341.798125
+            ],
+            "lastOutcome": {
+              "fileCount": 400,
+              "outputBytes": 671349
+            }
+          }
+        },
+        "macroTransformSwc": {
+          "palamedes": {
+            "medianMs": 176.009333,
+            "samplesMs": [
+              169.791458,
+              169.890542,
+              171.980958,
+              172.157541,
+              174.193917,
+              175.082042,
+              175.762667,
+              176.009333,
+              176.017083,
+              176.673584,
+              176.706208,
+              176.919125,
+              177.295542,
+              177.609041,
+              179.717334
+            ],
+            "lastOutcome": {
+              "fileCount": 400,
+              "outputBytes": 718749
+            }
+          },
+          "lingui": {
+            "medianMs": 161.828458,
+            "samplesMs": [
+              156.482625,
+              156.847291,
+              158.025875,
+              158.311292,
+              158.318666,
+              159.362791,
+              159.455125,
+              161.828458,
+              162.0195,
+              163.43,
+              164.037125,
+              164.897667,
+              166.497833,
+              168.029208,
+              172.415916
+            ],
+            "lastOutcome": {
+              "fileCount": 400,
+              "outputBytes": 718549
+            }
+          }
+        },
+        "extract": {
+          "palamedes": {
+            "medianMs": 90.190417,
+            "samplesMs": [
+              88.390708,
+              88.825542,
+              88.891875,
+              88.968791,
+              89.385958,
+              89.564666,
+              89.66775,
+              90.190417,
+              91.179958,
+              91.440833,
+              92.933375,
+              94.537,
+              94.69,
+              95.112458,
+              98.709666
+            ],
+            "lastOutcome": {
+              "fileCount": 400,
+              "messageCount": 4000
+            }
+          },
+          "lingui": {
+            "medianMs": 410.201291,
+            "samplesMs": [
+              393.314458,
+              395.781583,
+              396.966125,
+              402.270417,
+              404.906875,
+              406.053875,
+              406.338875,
+              410.201291,
+              420.945833,
+              472.78325,
+              483.299209,
+              488.966208,
+              497.552625,
+              500.452084,
+              506.7195
+            ],
+            "lastOutcome": {
+              "fileCount": 400,
+              "messageCount": 4000
+            }
+          }
+        },
+        "compileFromCatalog": {
+          "palamedes": {
+            "medianMs": 133.086541,
+            "samplesMs": [
+              132.091875,
+              132.158917,
+              132.325417,
+              132.445583,
+              132.641916,
+              132.88,
+              132.987333,
+              133.086541,
+              133.309584,
+              133.408291,
+              133.634167,
+              133.715083,
+              134.413667,
+              134.82425,
+              134.824417
+            ],
+            "lastOutcome": {
+              "messageCount": 4000,
+              "diagnosticCount": 0,
+              "outputBytes": 299050
+            }
+          },
+          "lingui": {
+            "medianMs": 21.251333,
+            "samplesMs": [
+              18.918666,
+              19.189625,
+              19.604916,
+              19.828625,
+              20.768291,
+              20.907208,
+              21.170833,
+              21.251333,
+              21.537917,
+              21.855167,
+              22.518167,
+              22.807792,
+              23.115833,
+              23.76525,
+              24.004209
+            ],
+            "lastOutcome": {
+              "messageCount": 4000,
+              "errorCount": 0,
+              "outputBytes": 324863
+            }
+          }
+        }
+      },
+      "comparisons": [
+        {
+          "profile": "medium",
+          "track": "macro-transform-babel",
+          "fasterTool": "palamedes",
+          "speedupFactor": 1.8519048702945768,
+          "palamedesMedianMs": 176.009333,
+          "linguiMedianMs": 325.952541
+        },
+        {
+          "profile": "medium",
+          "track": "macro-transform-swc",
+          "fasterTool": "lingui",
+          "speedupFactor": 1.0876290559476256,
+          "palamedesMedianMs": 176.009333,
+          "linguiMedianMs": 161.828458
+        },
+        {
+          "profile": "medium",
+          "track": "extract",
+          "fasterTool": "palamedes",
+          "speedupFactor": 4.548169358170282,
+          "palamedesMedianMs": 90.190417,
+          "linguiMedianMs": 410.201291
+        },
+        {
+          "profile": "medium",
+          "track": "compile-from-catalog",
+          "fasterTool": "lingui",
+          "speedupFactor": 6.262503203916668,
+          "palamedesMedianMs": 133.086541,
+          "linguiMedianMs": 21.251333
+        }
+      ]
+    },
+    {
+      "profile": "large",
+      "corpus": {
+        "fileCount": 1200,
+        "messageCount": 12000,
+        "sourceBytes": 1638622,
+        "localeBytes": {
+          "en": 2175807,
+          "de": 2175807
+        }
+      },
+      "validation": {
+        "transform": {
+          "palamedesFiles": 1200,
+          "linguiBabelFiles": 1200,
+          "linguiSwcFiles": 1200
+        },
+        "extract": {
+          "expectedMessages": 12000,
+          "palamedesMessages": 12000,
+          "linguiMessages": 12000
+        },
+        "compile": {
+          "expectedMessages": 12000,
+          "palamedesMessages": 12000,
+          "linguiMessages": 12000
+        }
+      },
+      "tracks": {
+        "macroTransformBabel": {
+          "palamedes": {
+            "medianMs": 531.813792,
+            "samplesMs": [
+              520.991666,
+              527.143958,
+              528.932625,
+              529.037666,
+              529.829875,
+              530.362917,
+              531.801334,
+              531.813792,
+              531.851375,
+              534.121917,
+              534.747708,
+              535.034334,
+              535.78825,
+              536.5395,
+              587.551583
+            ],
+            "lastOutcome": {
+              "fileCount": 1200,
+              "outputBytes": 2155822
+            }
+          },
+          "lingui": {
+            "medianMs": 937.555875,
+            "samplesMs": [
+              915.4355,
+              928.80475,
+              929.119042,
+              930.269708,
+              930.341375,
+              936.433375,
+              936.945375,
+              937.555875,
+              940.07275,
+              940.853541,
+              944.526958,
+              987.782042,
+              994.832,
+              1002.610917,
+              1005.062917
+            ],
+            "lastOutcome": {
+              "fileCount": 1200,
+              "outputBytes": 2013622
+            }
+          }
+        },
+        "macroTransformSwc": {
+          "palamedes": {
+            "medianMs": 531.813792,
+            "samplesMs": [
+              520.991666,
+              527.143958,
+              528.932625,
+              529.037666,
+              529.829875,
+              530.362917,
+              531.801334,
+              531.813792,
+              531.851375,
+              534.121917,
+              534.747708,
+              535.034334,
+              535.78825,
+              536.5395,
+              587.551583
+            ],
+            "lastOutcome": {
+              "fileCount": 1200,
+              "outputBytes": 2155822
+            }
+          },
+          "lingui": {
+            "medianMs": 504.64175,
+            "samplesMs": [
+              497.590583,
+              499.450292,
+              499.708834,
+              500.777583,
+              501.483166,
+              503.707834,
+              503.835417,
+              504.64175,
+              506.604209,
+              509.236209,
+              514.769375,
+              516.441666,
+              526.63425,
+              527.719125,
+              548.880709
+            ],
+            "lastOutcome": {
+              "fileCount": 1200,
+              "outputBytes": 2155222
+            }
+          }
+        },
+        "extract": {
+          "palamedes": {
+            "medianMs": 271.19875,
+            "samplesMs": [
+              268.917,
+              269.016667,
+              269.116583,
+              269.354208,
+              269.672083,
+              269.720208,
+              270.777417,
+              271.19875,
+              271.319125,
+              272.12075,
+              272.131208,
+              272.777459,
+              273.05575,
+              273.115333,
+              275.913167
+            ],
+            "lastOutcome": {
+              "fileCount": 1200,
+              "messageCount": 12000
+            }
+          },
+          "lingui": {
+            "medianMs": 1271.117333,
+            "samplesMs": [
+              1238.338791,
+              1253.886083,
+              1259.64675,
+              1260.910291,
+              1263.490334,
+              1268.088167,
+              1271.027708,
+              1271.117333,
+              1273.886,
+              1281.968959,
+              1283.082167,
+              1284.048042,
+              1285.460708,
+              1288.0655,
+              1290.851833
+            ],
+            "lastOutcome": {
+              "fileCount": 1200,
+              "messageCount": 12000
+            }
+          }
+        },
+        "compileFromCatalog": {
+          "palamedes": {
+            "medianMs": 404.353667,
+            "samplesMs": [
+              400.236125,
+              401.190333,
+              401.758625,
+              402.953666,
+              403.187625,
+              404.044,
+              404.137709,
+              404.353667,
+              404.377417,
+              404.777833,
+              404.89675,
+              404.998458,
+              405.31125,
+              405.376,
+              495.331792
+            ],
+            "lastOutcome": {
+              "messageCount": 12000,
+              "diagnosticCount": 0,
+              "outputBytes": 896723
+            }
+          },
+          "lingui": {
+            "medianMs": 68.661334,
+            "samplesMs": [
+              65.011208,
+              66.503917,
+              67.217666,
+              67.586292,
+              67.807958,
+              68.330541,
+              68.605334,
+              68.661334,
+              69.554709,
+              69.749666,
+              69.825167,
+              70.13475,
+              70.896708,
+              70.969,
+              93.238584
+            ],
+            "lastOutcome": {
+              "messageCount": 12000,
+              "errorCount": 0,
+              "outputBytes": 974136
+            }
+          }
+        }
+      },
+      "comparisons": [
+        {
+          "profile": "large",
+          "track": "macro-transform-babel",
+          "fasterTool": "palamedes",
+          "speedupFactor": 1.7629401288637507,
+          "palamedesMedianMs": 531.813792,
+          "linguiMedianMs": 937.555875
+        },
+        {
+          "profile": "large",
+          "track": "macro-transform-swc",
+          "fasterTool": "lingui",
+          "speedupFactor": 1.053844221172743,
+          "palamedesMedianMs": 531.813792,
+          "linguiMedianMs": 504.64175
+        },
+        {
+          "profile": "large",
+          "track": "extract",
+          "fasterTool": "palamedes",
+          "speedupFactor": 4.6870324181066465,
+          "palamedesMedianMs": 271.19875,
+          "linguiMedianMs": 1271.117333
+        },
+        {
+          "profile": "large",
+          "track": "compile-from-catalog",
+          "fasterTool": "lingui",
+          "speedupFactor": 5.889102984803645,
+          "palamedesMedianMs": 404.353667,
+          "linguiMedianMs": 68.661334
         }
       ]
     }
@@ -256,158 +886,758 @@
   "results": [
     {
       "tool": "palamedes",
-      "version": "1.1.2",
-      "engineVersion": "1.1.2",
+      "version": "1.7.0",
+      "engineVersion": "1.7.0",
       "track": "macro-transform-babel",
       "profile": "small",
       "fileCount": 100,
       "messageCount": 1000,
-      "sourceBytes": 140216,
-      "warmup": 1,
-      "runs": 3,
-      "medianMs": 36.645083,
+      "sourceBytes": 136466,
+      "warmup": 5,
+      "runs": 15,
+      "medianMs": 42.073416,
       "rawSamplesMs": [
-        36.471791,
-        36.645083,
-        36.766416
+        41.378583,
+        41.61075,
+        41.660416,
+        41.769458,
+        41.783542,
+        41.877292,
+        41.945208,
+        42.073416,
+        42.074667,
+        42.077791,
+        42.08025,
+        42.126666,
+        42.137542,
+        42.142291,
+        42.430959
       ],
-      "outputBytes": 177066,
+      "outputBytes": 179566,
       "note": "Palamedes has a single native macro transform path, so the same measured baseline is intentionally reported against both Lingui transform lanes."
     },
     {
       "tool": "lingui",
-      "version": "6.4.0",
+      "version": "6.5.0",
       "engineVersion": "8.0.1",
       "track": "macro-transform-babel",
       "profile": "small",
       "fileCount": 100,
       "messageCount": 1000,
-      "sourceBytes": 140216,
-      "warmup": 1,
-      "runs": 3,
-      "medianMs": 103.722417,
+      "sourceBytes": 136466,
+      "warmup": 5,
+      "runs": 15,
+      "medianMs": 83.617625,
       "rawSamplesMs": [
-        93.282458,
-        103.722417,
-        107.371875
+        75.549209,
+        78.036833,
+        78.482458,
+        80.641666,
+        82.786292,
+        82.792291,
+        83.30175,
+        83.617625,
+        84.684583,
+        84.982917,
+        88.3275,
+        90.816708,
+        91.221667,
+        94.595292,
+        97.587625
       ],
-      "outputBytes": 165466
+      "outputBytes": 167716
     },
     {
       "tool": "palamedes",
-      "version": "1.1.2",
-      "engineVersion": "1.1.2",
+      "version": "1.7.0",
+      "engineVersion": "1.7.0",
       "track": "macro-transform-swc",
       "profile": "small",
       "fileCount": 100,
       "messageCount": 1000,
-      "sourceBytes": 140216,
-      "warmup": 1,
-      "runs": 3,
-      "medianMs": 36.645083,
+      "sourceBytes": 136466,
+      "warmup": 5,
+      "runs": 15,
+      "medianMs": 42.073416,
       "rawSamplesMs": [
-        36.471791,
-        36.645083,
-        36.766416
+        41.378583,
+        41.61075,
+        41.660416,
+        41.769458,
+        41.783542,
+        41.877292,
+        41.945208,
+        42.073416,
+        42.074667,
+        42.077791,
+        42.08025,
+        42.126666,
+        42.137542,
+        42.142291,
+        42.430959
       ],
-      "outputBytes": 177066,
+      "outputBytes": 179566,
       "note": "Palamedes has a single native macro transform path, so the same measured baseline is intentionally reported against both Lingui transform lanes."
     },
     {
       "tool": "lingui",
-      "version": "6.4.0",
-      "engineVersion": "1.15.43",
+      "version": "6.5.1",
+      "engineVersion": "1.15.46",
       "track": "macro-transform-swc",
       "profile": "small",
       "fileCount": 100,
       "messageCount": 1000,
-      "sourceBytes": 140216,
-      "warmup": 1,
-      "runs": 3,
-      "medianMs": 50.895542,
+      "sourceBytes": 136466,
+      "warmup": 5,
+      "runs": 15,
+      "medianMs": 40.291834,
       "rawSamplesMs": [
-        50.568084,
-        50.895542,
-        51.328292
+        38.713792,
+        39.004833,
+        39.291958,
+        39.947375,
+        39.991792,
+        40.072625,
+        40.145375,
+        40.291834,
+        40.590917,
+        40.658,
+        41.061333,
+        41.243292,
+        41.40225,
+        42.676042,
+        42.862375
       ],
-      "outputBytes": 177016
+      "outputBytes": 179516
     },
     {
       "tool": "palamedes",
-      "version": "1.1.2",
-      "engineVersion": "1.1.2",
+      "version": "1.7.0",
+      "engineVersion": "1.7.0",
       "track": "extract",
       "profile": "small",
       "fileCount": 100,
       "messageCount": 1000,
-      "sourceBytes": 140216,
-      "warmup": 1,
-      "runs": 3,
-      "medianMs": 22.854834,
+      "sourceBytes": 136466,
+      "warmup": 5,
+      "runs": 15,
+      "medianMs": 22.510375,
       "rawSamplesMs": [
-        22.760584,
-        22.854834,
-        23.277834
+        22.0925,
+        22.212166,
+        22.228833,
+        22.286417,
+        22.429541,
+        22.44875,
+        22.458458,
+        22.510375,
+        22.549958,
+        22.566333,
+        22.628083,
+        22.72025,
+        22.736666,
+        22.766958,
+        23.164375
       ]
     },
     {
       "tool": "lingui",
-      "version": "6.4.0",
+      "version": "6.5.0",
       "engineVersion": "8.0.1",
       "track": "extract",
       "profile": "small",
       "fileCount": 100,
       "messageCount": 1000,
-      "sourceBytes": 140216,
-      "warmup": 1,
-      "runs": 3,
-      "medianMs": 113.144292,
+      "sourceBytes": 136466,
+      "warmup": 5,
+      "runs": 15,
+      "medianMs": 106.627709,
       "rawSamplesMs": [
-        111.42325,
-        113.144292,
-        132.542042
+        95.925834,
+        100.46,
+        101.569291,
+        101.6395,
+        103.308041,
+        105.109709,
+        105.736917,
+        106.627709,
+        107.022917,
+        109.09725,
+        109.121208,
+        109.438375,
+        114.7445,
+        116.952875,
+        141.286542
       ]
     },
     {
       "tool": "palamedes",
-      "version": "1.1.2",
-      "engineVersion": "1.1.2",
+      "version": "1.7.0",
+      "engineVersion": "1.7.0",
       "track": "compile-from-catalog",
       "profile": "small",
       "fileCount": 100,
       "messageCount": 1000,
-      "sourceBytes": 140216,
+      "sourceBytes": 136466,
       "catalogBytes": 181295,
-      "warmup": 1,
-      "runs": 3,
-      "medianMs": 36.185375,
+      "warmup": 5,
+      "runs": 15,
+      "medianMs": 36.531791,
       "rawSamplesMs": [
-        36.101417,
-        36.185375,
-        36.943667
+        34.22625,
+        35.699,
+        36.112209,
+        36.113583,
+        36.388542,
+        36.394625,
+        36.500042,
+        36.531791,
+        36.534666,
+        36.64025,
+        36.671875,
+        36.673458,
+        37.113541,
+        37.127625,
+        37.328291
       ],
       "outputBytes": 74642,
       "locale": "de"
     },
     {
       "tool": "lingui",
-      "version": "6.4.0",
-      "engineVersion": "6.4.0",
+      "version": "6.5.0",
+      "engineVersion": "6.5.0",
       "track": "compile-from-catalog",
       "profile": "small",
       "fileCount": 100,
       "messageCount": 1000,
-      "sourceBytes": 140216,
+      "sourceBytes": 136466,
       "catalogBytes": 181295,
-      "warmup": 1,
-      "runs": 3,
-      "medianMs": 5.8415,
+      "warmup": 5,
+      "runs": 15,
+      "medianMs": 5.36275,
       "rawSamplesMs": [
-        5.444334,
-        5.8415,
-        10.659125
+        4.8985,
+        4.938125,
+        4.958875,
+        5.012458,
+        5.106,
+        5.17075,
+        5.171417,
+        5.36275,
+        5.640833,
+        5.724791,
+        5.807875,
+        5.817583,
+        6.197416,
+        6.482834,
+        10.099583
       ],
       "outputBytes": 81105,
+      "locale": "de"
+    },
+    {
+      "tool": "palamedes",
+      "version": "1.7.0",
+      "engineVersion": "1.7.0",
+      "track": "macro-transform-babel",
+      "profile": "medium",
+      "fileCount": 400,
+      "messageCount": 4000,
+      "sourceBytes": 546349,
+      "warmup": 5,
+      "runs": 15,
+      "medianMs": 176.009333,
+      "rawSamplesMs": [
+        169.791458,
+        169.890542,
+        171.980958,
+        172.157541,
+        174.193917,
+        175.082042,
+        175.762667,
+        176.009333,
+        176.017083,
+        176.673584,
+        176.706208,
+        176.919125,
+        177.295542,
+        177.609041,
+        179.717334
+      ],
+      "outputBytes": 718749,
+      "note": "Palamedes has a single native macro transform path, so the same measured baseline is intentionally reported against both Lingui transform lanes."
+    },
+    {
+      "tool": "lingui",
+      "version": "6.5.0",
+      "engineVersion": "8.0.1",
+      "track": "macro-transform-babel",
+      "profile": "medium",
+      "fileCount": 400,
+      "messageCount": 4000,
+      "sourceBytes": 546349,
+      "warmup": 5,
+      "runs": 15,
+      "medianMs": 325.952541,
+      "rawSamplesMs": [
+        309.950709,
+        314.200834,
+        315.904333,
+        316.175542,
+        318.150917,
+        321.884292,
+        325.311583,
+        325.952541,
+        328.117667,
+        330.154166,
+        330.346791,
+        332.084917,
+        335.349625,
+        336.258541,
+        341.798125
+      ],
+      "outputBytes": 671349
+    },
+    {
+      "tool": "palamedes",
+      "version": "1.7.0",
+      "engineVersion": "1.7.0",
+      "track": "macro-transform-swc",
+      "profile": "medium",
+      "fileCount": 400,
+      "messageCount": 4000,
+      "sourceBytes": 546349,
+      "warmup": 5,
+      "runs": 15,
+      "medianMs": 176.009333,
+      "rawSamplesMs": [
+        169.791458,
+        169.890542,
+        171.980958,
+        172.157541,
+        174.193917,
+        175.082042,
+        175.762667,
+        176.009333,
+        176.017083,
+        176.673584,
+        176.706208,
+        176.919125,
+        177.295542,
+        177.609041,
+        179.717334
+      ],
+      "outputBytes": 718749,
+      "note": "Palamedes has a single native macro transform path, so the same measured baseline is intentionally reported against both Lingui transform lanes."
+    },
+    {
+      "tool": "lingui",
+      "version": "6.5.1",
+      "engineVersion": "1.15.46",
+      "track": "macro-transform-swc",
+      "profile": "medium",
+      "fileCount": 400,
+      "messageCount": 4000,
+      "sourceBytes": 546349,
+      "warmup": 5,
+      "runs": 15,
+      "medianMs": 161.828458,
+      "rawSamplesMs": [
+        156.482625,
+        156.847291,
+        158.025875,
+        158.311292,
+        158.318666,
+        159.362791,
+        159.455125,
+        161.828458,
+        162.0195,
+        163.43,
+        164.037125,
+        164.897667,
+        166.497833,
+        168.029208,
+        172.415916
+      ],
+      "outputBytes": 718549
+    },
+    {
+      "tool": "palamedes",
+      "version": "1.7.0",
+      "engineVersion": "1.7.0",
+      "track": "extract",
+      "profile": "medium",
+      "fileCount": 400,
+      "messageCount": 4000,
+      "sourceBytes": 546349,
+      "warmup": 5,
+      "runs": 15,
+      "medianMs": 90.190417,
+      "rawSamplesMs": [
+        88.390708,
+        88.825542,
+        88.891875,
+        88.968791,
+        89.385958,
+        89.564666,
+        89.66775,
+        90.190417,
+        91.179958,
+        91.440833,
+        92.933375,
+        94.537,
+        94.69,
+        95.112458,
+        98.709666
+      ]
+    },
+    {
+      "tool": "lingui",
+      "version": "6.5.0",
+      "engineVersion": "8.0.1",
+      "track": "extract",
+      "profile": "medium",
+      "fileCount": 400,
+      "messageCount": 4000,
+      "sourceBytes": 546349,
+      "warmup": 5,
+      "runs": 15,
+      "medianMs": 410.201291,
+      "rawSamplesMs": [
+        393.314458,
+        395.781583,
+        396.966125,
+        402.270417,
+        404.906875,
+        406.053875,
+        406.338875,
+        410.201291,
+        420.945833,
+        472.78325,
+        483.299209,
+        488.966208,
+        497.552625,
+        500.452084,
+        506.7195
+      ]
+    },
+    {
+      "tool": "palamedes",
+      "version": "1.7.0",
+      "engineVersion": "1.7.0",
+      "track": "compile-from-catalog",
+      "profile": "medium",
+      "fileCount": 400,
+      "messageCount": 4000,
+      "sourceBytes": 546349,
+      "catalogBytes": 725661,
+      "warmup": 5,
+      "runs": 15,
+      "medianMs": 133.086541,
+      "rawSamplesMs": [
+        132.091875,
+        132.158917,
+        132.325417,
+        132.445583,
+        132.641916,
+        132.88,
+        132.987333,
+        133.086541,
+        133.309584,
+        133.408291,
+        133.634167,
+        133.715083,
+        134.413667,
+        134.82425,
+        134.824417
+      ],
+      "outputBytes": 299050,
+      "locale": "de"
+    },
+    {
+      "tool": "lingui",
+      "version": "6.5.0",
+      "engineVersion": "6.5.0",
+      "track": "compile-from-catalog",
+      "profile": "medium",
+      "fileCount": 400,
+      "messageCount": 4000,
+      "sourceBytes": 546349,
+      "catalogBytes": 725661,
+      "warmup": 5,
+      "runs": 15,
+      "medianMs": 21.251333,
+      "rawSamplesMs": [
+        18.918666,
+        19.189625,
+        19.604916,
+        19.828625,
+        20.768291,
+        20.907208,
+        21.170833,
+        21.251333,
+        21.537917,
+        21.855167,
+        22.518167,
+        22.807792,
+        23.115833,
+        23.76525,
+        24.004209
+      ],
+      "outputBytes": 324863,
+      "locale": "de"
+    },
+    {
+      "tool": "palamedes",
+      "version": "1.7.0",
+      "engineVersion": "1.7.0",
+      "track": "macro-transform-babel",
+      "profile": "large",
+      "fileCount": 1200,
+      "messageCount": 12000,
+      "sourceBytes": 1638622,
+      "warmup": 5,
+      "runs": 15,
+      "medianMs": 531.813792,
+      "rawSamplesMs": [
+        520.991666,
+        527.143958,
+        528.932625,
+        529.037666,
+        529.829875,
+        530.362917,
+        531.801334,
+        531.813792,
+        531.851375,
+        534.121917,
+        534.747708,
+        535.034334,
+        535.78825,
+        536.5395,
+        587.551583
+      ],
+      "outputBytes": 2155822,
+      "note": "Palamedes has a single native macro transform path, so the same measured baseline is intentionally reported against both Lingui transform lanes."
+    },
+    {
+      "tool": "lingui",
+      "version": "6.5.0",
+      "engineVersion": "8.0.1",
+      "track": "macro-transform-babel",
+      "profile": "large",
+      "fileCount": 1200,
+      "messageCount": 12000,
+      "sourceBytes": 1638622,
+      "warmup": 5,
+      "runs": 15,
+      "medianMs": 937.555875,
+      "rawSamplesMs": [
+        915.4355,
+        928.80475,
+        929.119042,
+        930.269708,
+        930.341375,
+        936.433375,
+        936.945375,
+        937.555875,
+        940.07275,
+        940.853541,
+        944.526958,
+        987.782042,
+        994.832,
+        1002.610917,
+        1005.062917
+      ],
+      "outputBytes": 2013622
+    },
+    {
+      "tool": "palamedes",
+      "version": "1.7.0",
+      "engineVersion": "1.7.0",
+      "track": "macro-transform-swc",
+      "profile": "large",
+      "fileCount": 1200,
+      "messageCount": 12000,
+      "sourceBytes": 1638622,
+      "warmup": 5,
+      "runs": 15,
+      "medianMs": 531.813792,
+      "rawSamplesMs": [
+        520.991666,
+        527.143958,
+        528.932625,
+        529.037666,
+        529.829875,
+        530.362917,
+        531.801334,
+        531.813792,
+        531.851375,
+        534.121917,
+        534.747708,
+        535.034334,
+        535.78825,
+        536.5395,
+        587.551583
+      ],
+      "outputBytes": 2155822,
+      "note": "Palamedes has a single native macro transform path, so the same measured baseline is intentionally reported against both Lingui transform lanes."
+    },
+    {
+      "tool": "lingui",
+      "version": "6.5.1",
+      "engineVersion": "1.15.46",
+      "track": "macro-transform-swc",
+      "profile": "large",
+      "fileCount": 1200,
+      "messageCount": 12000,
+      "sourceBytes": 1638622,
+      "warmup": 5,
+      "runs": 15,
+      "medianMs": 504.64175,
+      "rawSamplesMs": [
+        497.590583,
+        499.450292,
+        499.708834,
+        500.777583,
+        501.483166,
+        503.707834,
+        503.835417,
+        504.64175,
+        506.604209,
+        509.236209,
+        514.769375,
+        516.441666,
+        526.63425,
+        527.719125,
+        548.880709
+      ],
+      "outputBytes": 2155222
+    },
+    {
+      "tool": "palamedes",
+      "version": "1.7.0",
+      "engineVersion": "1.7.0",
+      "track": "extract",
+      "profile": "large",
+      "fileCount": 1200,
+      "messageCount": 12000,
+      "sourceBytes": 1638622,
+      "warmup": 5,
+      "runs": 15,
+      "medianMs": 271.19875,
+      "rawSamplesMs": [
+        268.917,
+        269.016667,
+        269.116583,
+        269.354208,
+        269.672083,
+        269.720208,
+        270.777417,
+        271.19875,
+        271.319125,
+        272.12075,
+        272.131208,
+        272.777459,
+        273.05575,
+        273.115333,
+        275.913167
+      ]
+    },
+    {
+      "tool": "lingui",
+      "version": "6.5.0",
+      "engineVersion": "8.0.1",
+      "track": "extract",
+      "profile": "large",
+      "fileCount": 1200,
+      "messageCount": 12000,
+      "sourceBytes": 1638622,
+      "warmup": 5,
+      "runs": 15,
+      "medianMs": 1271.117333,
+      "rawSamplesMs": [
+        1238.338791,
+        1253.886083,
+        1259.64675,
+        1260.910291,
+        1263.490334,
+        1268.088167,
+        1271.027708,
+        1271.117333,
+        1273.886,
+        1281.968959,
+        1283.082167,
+        1284.048042,
+        1285.460708,
+        1288.0655,
+        1290.851833
+      ]
+    },
+    {
+      "tool": "palamedes",
+      "version": "1.7.0",
+      "engineVersion": "1.7.0",
+      "track": "compile-from-catalog",
+      "profile": "large",
+      "fileCount": 1200,
+      "messageCount": 12000,
+      "sourceBytes": 1638622,
+      "catalogBytes": 2175807,
+      "warmup": 5,
+      "runs": 15,
+      "medianMs": 404.353667,
+      "rawSamplesMs": [
+        400.236125,
+        401.190333,
+        401.758625,
+        402.953666,
+        403.187625,
+        404.044,
+        404.137709,
+        404.353667,
+        404.377417,
+        404.777833,
+        404.89675,
+        404.998458,
+        405.31125,
+        405.376,
+        495.331792
+      ],
+      "outputBytes": 896723,
+      "locale": "de"
+    },
+    {
+      "tool": "lingui",
+      "version": "6.5.0",
+      "engineVersion": "6.5.0",
+      "track": "compile-from-catalog",
+      "profile": "large",
+      "fileCount": 1200,
+      "messageCount": 12000,
+      "sourceBytes": 1638622,
+      "catalogBytes": 2175807,
+      "warmup": 5,
+      "runs": 15,
+      "medianMs": 68.661334,
+      "rawSamplesMs": [
+        65.011208,
+        66.503917,
+        67.217666,
+        67.586292,
+        67.807958,
+        68.330541,
+        68.605334,
+        68.661334,
+        69.554709,
+        69.749666,
+        69.825167,
+        70.13475,
+        70.896708,
+        70.969,
+        93.238584
+      ],
+      "outputBytes": 974136,
       "locale": "de"
     }
   ],
@@ -416,33 +1646,97 @@
       "profile": "small",
       "track": "macro-transform-babel",
       "fasterTool": "palamedes",
-      "speedupFactor": 2.8304593279267505,
-      "palamedesMedianMs": 36.645083,
-      "linguiMedianMs": 103.722417
+      "speedupFactor": 1.9874218199919873,
+      "palamedesMedianMs": 42.073416,
+      "linguiMedianMs": 83.617625
     },
     {
       "profile": "small",
       "track": "macro-transform-swc",
-      "fasterTool": "palamedes",
-      "speedupFactor": 1.3888777929633833,
-      "palamedesMedianMs": 36.645083,
-      "linguiMedianMs": 50.895542
+      "fasterTool": "lingui",
+      "speedupFactor": 1.0442169497670422,
+      "palamedesMedianMs": 42.073416,
+      "linguiMedianMs": 40.291834
     },
     {
       "profile": "small",
       "track": "extract",
       "fasterTool": "palamedes",
-      "speedupFactor": 4.9505628437292515,
-      "palamedesMedianMs": 22.854834,
-      "linguiMedianMs": 113.144292
+      "speedupFactor": 4.7368250862102474,
+      "palamedesMedianMs": 22.510375,
+      "linguiMedianMs": 106.627709
     },
     {
       "profile": "small",
       "track": "compile-from-catalog",
       "fasterTool": "lingui",
-      "speedupFactor": 6.19453479414534,
-      "palamedesMedianMs": 36.185375,
-      "linguiMedianMs": 5.8415
+      "speedupFactor": 6.8121376159619595,
+      "palamedesMedianMs": 36.531791,
+      "linguiMedianMs": 5.36275
+    },
+    {
+      "profile": "medium",
+      "track": "macro-transform-babel",
+      "fasterTool": "palamedes",
+      "speedupFactor": 1.8519048702945768,
+      "palamedesMedianMs": 176.009333,
+      "linguiMedianMs": 325.952541
+    },
+    {
+      "profile": "medium",
+      "track": "macro-transform-swc",
+      "fasterTool": "lingui",
+      "speedupFactor": 1.0876290559476256,
+      "palamedesMedianMs": 176.009333,
+      "linguiMedianMs": 161.828458
+    },
+    {
+      "profile": "medium",
+      "track": "extract",
+      "fasterTool": "palamedes",
+      "speedupFactor": 4.548169358170282,
+      "palamedesMedianMs": 90.190417,
+      "linguiMedianMs": 410.201291
+    },
+    {
+      "profile": "medium",
+      "track": "compile-from-catalog",
+      "fasterTool": "lingui",
+      "speedupFactor": 6.262503203916668,
+      "palamedesMedianMs": 133.086541,
+      "linguiMedianMs": 21.251333
+    },
+    {
+      "profile": "large",
+      "track": "macro-transform-babel",
+      "fasterTool": "palamedes",
+      "speedupFactor": 1.7629401288637507,
+      "palamedesMedianMs": 531.813792,
+      "linguiMedianMs": 937.555875
+    },
+    {
+      "profile": "large",
+      "track": "macro-transform-swc",
+      "fasterTool": "lingui",
+      "speedupFactor": 1.053844221172743,
+      "palamedesMedianMs": 531.813792,
+      "linguiMedianMs": 504.64175
+    },
+    {
+      "profile": "large",
+      "track": "extract",
+      "fasterTool": "palamedes",
+      "speedupFactor": 4.6870324181066465,
+      "palamedesMedianMs": 271.19875,
+      "linguiMedianMs": 1271.117333
+    },
+    {
+      "profile": "large",
+      "track": "compile-from-catalog",
+      "fasterTool": "lingui",
+      "speedupFactor": 5.889102984803645,
+      "palamedesMedianMs": 404.353667,
+      "linguiMedianMs": 68.661334
     }
   ]
 }

--- a/benchmarks/lingui-v6/results/latest.md
+++ b/benchmarks/lingui-v6/results/latest.md
@@ -1,23 +1,23 @@
 # Palamedes vs. Lingui v6 Benchmark
 
-Generated: 2026-07-05T20:27:53.982Z
+Generated: 2026-07-27T09:45:09.215Z
 Node: v24.18.0
 Platform: darwin/arm64
 Seed: 20260318
-Warmup: 1
-Runs: 3
+Warmup: 5
+Runs: 15
 Machine-local: yes
 
 ## Versions
 
-- Palamedes core: 1.1.2
-- Ferrocat: 2.1.1
+- Palamedes core: 1.7.0
+- Ferrocat: 2.2.0
 - Babel core: 8.0.1
-- SWC core: 1.15.43
-- Lingui CLI: 6.4.0
-- Lingui Babel macro plugin: 6.4.0
-- Lingui SWC plugin: 6.4.0
-- Lingui format-po: 6.4.0
+- SWC core: 1.15.46
+- Lingui CLI: 6.5.0
+- Lingui Babel macro plugin: 6.5.0
+- Lingui SWC plugin: 6.5.1
+- Lingui format-po: 6.5.0
 
 ## Track Definitions
 
@@ -38,15 +38,39 @@ Machine-local: yes
 
 ## Small
 
-- Corpus: 100 files, 1000 messages, 140216 source bytes
+- Corpus: 100 files, 1000 messages, 136466 source bytes
 - Validation: transform palamedes=100, lingui-babel=100, lingui-swc=100; extract=1000; compile=1000
 
 | Track | Palamedes median | Lingui median | Faster | Speedup |
 | --- | ---: | ---: | --- | ---: |
-| Macro Transform (Babel) | 36.65 ms | 103.72 ms | palamedes | 2.83x |
-| Macro Transform (SWC) | 36.65 ms | 50.90 ms | palamedes | 1.39x |
-| Extract | 22.85 ms | 113.14 ms | palamedes | 4.95x |
-| Compile from Catalog | 36.19 ms | 5.84 ms | lingui | 6.19x |
+| Macro Transform (Babel) | 42.07 ms | 83.62 ms | palamedes | 1.99x |
+| Macro Transform (SWC) | 42.07 ms | 40.29 ms | lingui | 1.04x |
+| Extract | 22.51 ms | 106.63 ms | palamedes | 4.74x |
+| Compile from Catalog | 36.53 ms | 5.36 ms | lingui | 6.81x |
+
+## Medium
+
+- Corpus: 400 files, 4000 messages, 546349 source bytes
+- Validation: transform palamedes=400, lingui-babel=400, lingui-swc=400; extract=4000; compile=4000
+
+| Track | Palamedes median | Lingui median | Faster | Speedup |
+| --- | ---: | ---: | --- | ---: |
+| Macro Transform (Babel) | 176.01 ms | 325.95 ms | palamedes | 1.85x |
+| Macro Transform (SWC) | 176.01 ms | 161.83 ms | lingui | 1.09x |
+| Extract | 90.19 ms | 410.20 ms | palamedes | 4.55x |
+| Compile from Catalog | 133.09 ms | 21.25 ms | lingui | 6.26x |
+
+## Large
+
+- Corpus: 1200 files, 12000 messages, 1638622 source bytes
+- Validation: transform palamedes=1200, lingui-babel=1200, lingui-swc=1200; extract=12000; compile=12000
+
+| Track | Palamedes median | Lingui median | Faster | Speedup |
+| --- | ---: | ---: | --- | ---: |
+| Macro Transform (Babel) | 531.81 ms | 937.56 ms | palamedes | 1.76x |
+| Macro Transform (SWC) | 531.81 ms | 504.64 ms | lingui | 1.05x |
+| Extract | 271.20 ms | 1271.12 ms | palamedes | 4.69x |
+| Compile from Catalog | 404.35 ms | 68.66 ms | lingui | 5.89x |
 
 ## Notes
 

--- a/benchmarks/lingui-v6/src/corpus.mjs
+++ b/benchmarks/lingui-v6/src/corpus.mjs
@@ -113,7 +113,7 @@ function createTsxFixture(fileIndex, relativePath, seed) {
   const text = createFixtureText(fileIndex, seed)
   const positionLabel = fileIndex % 2 === 0 ? "SelectOrdinal" : "Select"
   const imports = [
-    'import { defineMessage, msg, plural, select, selectOrdinal, t } from "@lingui/core/macro"',
+    'import { plural, select, selectOrdinal, t } from "@lingui/core/macro"',
     `import { Plural, ${positionLabel}, Trans } from "@lingui/react/macro"`,
   ]
   const entries = [
@@ -125,12 +125,12 @@ function createTsxFixture(fileIndex, relativePath, seed) {
     makeEntry(
       `Batch {taskCount} hit ${text.action} ${tokenFor(fileIndex, 2)}`,
       undefined,
-      `const message02 = msg\`Batch \${taskCount} hit ${text.action} ${tokenFor(fileIndex, 2)}\``
+      `const message02 = t\`Batch \${taskCount} hit ${text.action} ${tokenFor(fileIndex, 2)}\``
     ),
     makeEntry(
       `Open ${text.surface} ${tokenFor(fileIndex, 3)}`,
       undefined,
-      `const message03 = defineMessage({ message: "Open ${text.surface} ${tokenFor(fileIndex, 3)}" })`
+      `const message03 = t({ message: "Open ${text.surface} ${tokenFor(fileIndex, 3)}" })`
     ),
     makeEntry(
       `Save ${text.area} ${tokenFor(fileIndex, 4)}`,
@@ -228,12 +228,12 @@ function createTsFixture(fileIndex, relativePath, seed) {
     makeEntry(
       `Sync {taskCount} ${text.areaPlural} in ${text.surface} ${tokenFor(fileIndex, 2)}`,
       undefined,
-      `const message02 = msg\`Sync \${taskCount} ${text.areaPlural} in ${text.surface} ${tokenFor(fileIndex, 2)}\``
+      `const message02 = t\`Sync \${taskCount} ${text.areaPlural} in ${text.surface} ${tokenFor(fileIndex, 2)}\``
     ),
     makeEntry(
       `Archive ${text.area} ${tokenFor(fileIndex, 3)}`,
       undefined,
-      `const message03 = defineMessage({ message: "Archive ${text.area} ${tokenFor(fileIndex, 3)}" })`
+      `const message03 = t({ message: "Archive ${text.area} ${tokenFor(fileIndex, 3)}" })`
     ),
     makeEntry(
       `Confirm ${text.surface} ${tokenFor(fileIndex, 4)}`,
@@ -263,17 +263,17 @@ function createTsFixture(fileIndex, relativePath, seed) {
     makeEntry(
       `Open ${text.area} ${tokenFor(fileIndex, 9)}`,
       "sidebar",
-      `const message09 = defineMessage({ message: "Open ${text.area} ${tokenFor(fileIndex, 9)}", context: "sidebar" })`
+      `const message09 = t({ message: "Open ${text.area} ${tokenFor(fileIndex, 9)}", context: "sidebar" })`
     ),
     makeEntry(
       `Stage {taskCount} ${text.areaPlural} for ${text.action} ${tokenFor(fileIndex, 10)}`,
       undefined,
-      `const message10 = msg\`Stage \${taskCount} ${text.areaPlural} for ${text.action} ${tokenFor(fileIndex, 10)}\``
+      `const message10 = t\`Stage \${taskCount} ${text.areaPlural} for ${text.action} ${tokenFor(fileIndex, 10)}\``
     ),
   ]
 
   const source = [
-    'import { defineMessage, msg, plural, select, selectOrdinal, t } from "@lingui/core/macro"',
+    'import { plural, select, selectOrdinal, t } from "@lingui/core/macro"',
     "",
     `export function buildFixture${padNumber(fileIndex, 4)}() {`,
     `  const accountName = "account-${padNumber(fileIndex, 4)}"`,

--- a/crates/palamedes/src/catalog_update.rs
+++ b/crates/palamedes/src/catalog_update.rs
@@ -340,6 +340,27 @@ fn read_existing_catalog(
     }
 
     let mut po = ferrocat_parse_po(&original)?;
+
+    /*
+     * Most catalogs carry no translator comments or gettext flags at all. For
+     * those the strip/restore dance below preserves nothing, so skip it: hand
+     * ferrocat the original text and let it render normally. That saves one
+     * serialize here plus a full parse/serialize pair in restore_po_metadata —
+     * two PO round trips per catalog file, which is ~11 ms per `pmds extract`
+     * on a 6k-message en/de pair.
+     */
+    if po
+        .items
+        .iter()
+        .all(|item| item.comments.is_empty() && item.flags.is_empty())
+    {
+        return Ok(Some(ExistingCatalog {
+            update_input: original.clone(),
+            original,
+            po_metadata: None,
+        }));
+    }
+
     let metadata = po
         .items
         .iter_mut()
@@ -702,6 +723,123 @@ mod tests {
             std::fs::read_to_string(&path).expect("read repeated output"),
             output
         );
+    }
+
+    /*
+     * read_existing_catalog skips the strip/restore round trip when no item
+     * carries translator comments or flags. The predicate is all-or-nothing per
+     * file, so the case that would break is a catalog where only one item among
+     * many has metadata: a per-item early-out would drop it.
+     */
+    #[test]
+    fn preserves_metadata_when_only_one_item_of_many_carries_it() {
+        let path = temp_file("po-metadata-sparse");
+        std::fs::write(
+            &path,
+            concat!(
+                "msgid \"First\"\n",
+                "msgstr \"Erste\"\n",
+                "\n",
+                "# translator note\n",
+                "#, fuzzy\n",
+                "msgid \"Second\"\n",
+                "msgstr \"Zweite\"\n",
+                "\n",
+                "msgid \"Third\"\n",
+                "msgstr \"Dritte\"\n",
+            ),
+        )
+        .expect("write existing");
+
+        let message = |text: &str| CatalogUpdateMessage {
+            message: text.to_owned(),
+            context: None,
+            placeholders: BTreeMap::new(),
+            extracted_comments: Vec::new(),
+            origins: vec![CatalogUpdateOrigin {
+                file: "src/App.tsx".to_owned(),
+                line: 1,
+                scope: None,
+            }],
+        };
+
+        update_catalog_file(CatalogUpdateRequest {
+            target_path: path.clone(),
+            locale: "de".to_owned(),
+            source_locale: "en".to_owned(),
+            clean: false,
+            force_clean: false,
+            format: crate::PalamedesCatalogFormat::Po,
+            messages: vec![message("First"), message("Second"), message("Third")],
+        })
+        .expect("update");
+
+        let output = std::fs::read_to_string(&path).expect("read output");
+        let po = parse_po(&output).expect("parse output");
+        let second = po
+            .items
+            .iter()
+            .find(|item| item.msgid == "Second")
+            .expect("second item");
+        assert_eq!(second.comments.as_slice(), ["translator note"]);
+        assert_eq!(second.flags, BTreeMap::from([("fuzzy".to_owned(), true)]));
+
+        for msgid in ["First", "Third"] {
+            let item = po
+                .items
+                .iter()
+                .find(|item| item.msgid == msgid)
+                .expect("item");
+            assert!(item.comments.as_slice().is_empty());
+            assert!(item.flags.is_empty());
+        }
+    }
+
+    /*
+     * Guards the fast path itself: a catalog without any translator comments or
+     * flags skips the round trip, and must still get fresh source references
+     * and keep existing translations.
+     */
+    #[test]
+    fn refreshes_source_metadata_for_catalogs_without_preserved_metadata() {
+        let path = temp_file("po-no-metadata");
+        std::fs::write(
+            &path,
+            concat!(
+                "#: src/Old.tsx\n",
+                "msgid \"Hello\"\n",
+                "msgstr \"Hallo\"\n",
+            ),
+        )
+        .expect("write existing");
+
+        update_catalog_file(CatalogUpdateRequest {
+            target_path: path.clone(),
+            locale: "de".to_owned(),
+            source_locale: "en".to_owned(),
+            clean: false,
+            force_clean: false,
+            format: crate::PalamedesCatalogFormat::Po,
+            messages: vec![CatalogUpdateMessage {
+                message: "Hello".to_owned(),
+                context: None,
+                placeholders: BTreeMap::new(),
+                extracted_comments: Vec::new(),
+                origins: vec![CatalogUpdateOrigin {
+                    file: "src/New.tsx".to_owned(),
+                    line: 4,
+                    scope: None,
+                }],
+            }],
+        })
+        .expect("update");
+
+        let output = std::fs::read_to_string(&path).expect("read output");
+        let po = parse_po(&output).expect("parse output");
+        let item = &po.items[0];
+        assert_eq!(item.msgstr.first().map(String::as_str), Some("Hallo"));
+        assert_eq!(item.references.as_slice(), ["src/New.tsx"]);
+        assert!(item.comments.as_slice().is_empty());
     }
 
     #[test]

--- a/docs/benchmark-e2e-workflow.md
+++ b/docs/benchmark-e2e-workflow.md
@@ -108,13 +108,13 @@ message semantics.
 
 Latest checked full run:
 
-- timestamp: `2026-07-22T14:44:41.328Z`
+- timestamp: `2026-07-27T09:48:40.633Z`
 - Node: `v24.18.0`
 - platform: `darwin/arm64`
 - warmup: `3`
 - measured runs: `7`
-- Palamedes CLI: `1.3.0`
-- Lingui CLI: `6.4.0`
+- Palamedes CLI: `1.7.0`
+- Lingui CLI: `6.5.0`
 - FormatJS CLI: `6.16.14`
 - i18next-parser CLI: `9.4.0`
 - i18next-cli: `1.66.2`
@@ -130,16 +130,16 @@ Corpus:
 
 Median results:
 
-| Tool           |       Median |
-| -------------- | -----------: |
-| Palamedes      |   `43.88 ms` |
-| Lingui         | `1143.37 ms` |
-| FormatJS       |  `291.08 ms` |
-| i18next-parser |  `512.98 ms` |
-| i18next-cli    |  `378.21 ms` |
+| Tool           |      Median |
+| -------------- | ----------: |
+| Palamedes      |  `35.98 ms` |
+| Lingui         | `658.17 ms` |
+| FormatJS       | `275.79 ms` |
+| i18next-parser | `506.04 ms` |
+| i18next-cli    | `382.87 ms` |
 
-On this run, Palamedes measured `26.06x` faster than Lingui, `6.63x` faster
-than FormatJS, `11.69x` faster than i18next-parser, and `8.62x` faster than
+On this run, Palamedes measured `18.29x` faster than Lingui, `7.66x` faster
+than FormatJS, `14.06x` faster than i18next-parser, and `10.64x` faster than
 i18next-cli.
 
 ### Medium
@@ -155,14 +155,14 @@ Median results:
 
 | Tool           |      Median |
 | -------------- | ----------: |
-| Palamedes      |  `46.93 ms` |
-| Lingui         | `760.77 ms` |
-| FormatJS       | `299.82 ms` |
-| i18next-parser | `569.17 ms` |
-| i18next-cli    | `584.74 ms` |
+| Palamedes      |  `47.68 ms` |
+| Lingui         | `732.81 ms` |
+| FormatJS       | `293.86 ms` |
+| i18next-parser | `565.67 ms` |
+| i18next-cli    | `568.56 ms` |
 
-On this run, Palamedes measured `16.21x` faster than Lingui, `6.39x` faster
-than FormatJS, `12.13x` faster than i18next-parser, and `12.46x` faster than
+On this run, Palamedes measured `15.37x` faster than Lingui, `6.16x` faster
+than FormatJS, `11.86x` faster than i18next-parser, and `11.93x` faster than
 i18next-cli.
 
 ### Realistic
@@ -181,14 +181,14 @@ Median results:
 
 | Tool           |       Median |
 | -------------- | -----------: |
-| Palamedes      |  `179.87 ms` |
-| Lingui         | `2238.75 ms` |
-| FormatJS       |  `474.62 ms` |
-| i18next-parser | `1641.15 ms` |
-| i18next-cli    | `6612.71 ms` |
+| Palamedes      |  `192.94 ms` |
+| Lingui         | `2342.49 ms` |
+| FormatJS       |  `472.18 ms` |
+| i18next-parser | `1540.72 ms` |
+| i18next-cli    | `5804.35 ms` |
 
-On this run, Palamedes measured `12.45x` faster than Lingui, `2.64x` faster
-than FormatJS, `9.12x` faster than i18next-parser, and `36.76x` faster than
+On this run, Palamedes measured `12.14x` faster than Lingui, `2.45x` faster
+than FormatJS, `7.99x` faster than i18next-parser, and `30.08x` faster than
 i18next-cli.
 
 ## Reading The Numbers

--- a/docs/benchmark-lingui-v6-preview.md
+++ b/docs/benchmark-lingui-v6-preview.md
@@ -13,10 +13,10 @@ It is intentionally separate from the smaller Palamedes-only benchmark:
 
 The benchmark workspace currently pins:
 
-- `@lingui/cli@6.4.0`
-- `@lingui/babel-plugin-lingui-macro@6.4.0`
-- `@lingui/swc-plugin@6.4.0`
-- `@lingui/format-po@6.4.0`
+- `@lingui/cli@6.5.0`
+- `@lingui/babel-plugin-lingui-macro@6.5.0`
+- `@lingui/swc-plugin@6.5.1`
+- `@lingui/format-po@6.5.0`
 
 Those pins live in [`benchmarks/lingui-v6/package.json`](https://github.com/sebastian-software/palamedes/blob/main/benchmarks/lingui-v6/package.json).
 

--- a/docs/proof-and-benchmarks.md
+++ b/docs/proof-and-benchmarks.md
@@ -206,31 +206,35 @@ routine local checks.
 
 ## Local Baseline
 
-Checked local sample, captured on March 18, 2026 with:
+Checked local sample, captured on July 27, 2026 with:
 
 ```bash
-node ./scripts/benchmark-proof.mjs --warmup 1 --runs 3
+node ./scripts/benchmark-proof.mjs --warmup 3 --runs 7
 ```
 
 Environment:
 
-- Node `v24.14.0`
+- Node `v24.18.0`
 - macOS `darwin/arm64`
-- Palamedes core `0.1.0`
-- Ferrocat `0.8.0`
-- fixture corpus: 5 files / 7002 source bytes / 9 catalog messages
+- Palamedes core `1.7.0`
+- Ferrocat `2.2.0`
+- fixture corpus: 5 files / 1628 source bytes / 7 catalog messages
 
 Median results from that run:
 
-- transform: `0.97 ms`
-- extract: `0.89 ms`
-- catalog update: `0.64 ms`
-- catalog artifact compile: `4.04 ms`
+- transform: `0.51 ms`
+- extract: `0.33 ms`
+- catalog update: `0.45 ms`
+- catalog artifact compile: `5.17 ms`
 
-This sample is a historical reference point. Current Palamedes builds use
-Ferrocat `2.2.0`; rerun the command above when you need fresh numbers for the
-current release line. The benchmark script also prints the raw sample series and
-sampled peak RSS so the checked median and memory shape are easy to verify.
+Sampled peak RSS stayed between `53 MiB` and `56 MiB` across the four steps.
+
+These numbers are not comparable with the previously checked March 2026 sample:
+that one ran against a different fixture corpus (5 files / 7002 source bytes /
+9 catalog messages) on Palamedes core `0.1.0`. Treat each sample as a snapshot
+of its own corpus and release line, not as a trend line. The benchmark script
+prints the raw sample series and sampled peak RSS so the checked median and
+memory shape are easy to verify.
 
 ## End-To-End Workflow Baseline
 

--- a/site/app/data/bench.ts
+++ b/site/app/data/bench.ts
@@ -28,7 +28,7 @@ export interface BenchCorpus {
 }
 
 export const BENCH_META = {
-  generated: "2026-07-22",
+  generated: "2026-07-27",
   node: "v24.18.0",
   platform: "darwin/arm64",
   runs: 7,
@@ -47,17 +47,17 @@ export const BENCH_SMALL: BenchCorpus = {
   title: "Small corpus — 80 files, 640 messages (median of 7 runs)",
   corpus: "80 files, 640 messages",
   rows: [
-    { tool: "Palamedes", medianMs: 43.88, accent: true },
-    { tool: "Lingui", medianMs: 1143.37 },
-    { tool: "FormatJS", medianMs: 291.08 },
-    { tool: "i18next-parser", medianMs: 512.98 },
-    { tool: "i18next-cli", medianMs: 378.21 },
+    { tool: "Palamedes", medianMs: 35.98, accent: true },
+    { tool: "Lingui", medianMs: 658.17 },
+    { tool: "FormatJS", medianMs: 275.79 },
+    { tool: "i18next-parser", medianMs: 506.04 },
+    { tool: "i18next-cli", medianMs: 382.87 },
   ],
   ratios: {
-    lingui: "26.06×",
-    formatjs: "6.63×",
-    i18nextParser: "11.69×",
-    i18nextCli: "8.62×",
+    lingui: "18.29×",
+    formatjs: "7.66×",
+    i18nextParser: "14.06×",
+    i18nextCli: "10.64×",
   },
 }
 
@@ -66,17 +66,17 @@ export const BENCH_MEDIUM: BenchCorpus = {
   title: "Medium corpus — 240 files, 1920 messages (median of 7 runs)",
   corpus: "240 files, 1920 messages",
   rows: [
-    { tool: "Palamedes", medianMs: 46.93, accent: true },
-    { tool: "Lingui", medianMs: 760.77 },
-    { tool: "FormatJS", medianMs: 299.82 },
-    { tool: "i18next-parser", medianMs: 569.17 },
-    { tool: "i18next-cli", medianMs: 584.74 },
+    { tool: "Palamedes", medianMs: 47.68, accent: true },
+    { tool: "Lingui", medianMs: 732.81 },
+    { tool: "FormatJS", medianMs: 293.86 },
+    { tool: "i18next-parser", medianMs: 565.67 },
+    { tool: "i18next-cli", medianMs: 568.56 },
   ],
   ratios: {
-    lingui: "16.21×",
-    formatjs: "6.39×",
-    i18nextParser: "12.13×",
-    i18nextCli: "12.46×",
+    lingui: "15.37×",
+    formatjs: "6.16×",
+    i18nextParser: "11.86×",
+    i18nextCli: "11.93×",
   },
 }
 
@@ -85,16 +85,16 @@ export const BENCH_REALISTIC: BenchCorpus = {
   title: "Realistic corpus — 1,500 files across ~400k lines, 6,000 messages (median of 7 runs)",
   corpus: "1,500 files (750 with i18n), ~400k lines, 6,000 messages",
   rows: [
-    { tool: "Palamedes", medianMs: 179.87, accent: true },
-    { tool: "Lingui", medianMs: 2238.75 },
-    { tool: "FormatJS", medianMs: 474.62 },
-    { tool: "i18next-parser", medianMs: 1641.15 },
-    { tool: "i18next-cli", medianMs: 6612.71 },
+    { tool: "Palamedes", medianMs: 192.94, accent: true },
+    { tool: "Lingui", medianMs: 2342.49 },
+    { tool: "FormatJS", medianMs: 472.18 },
+    { tool: "i18next-parser", medianMs: 1540.72 },
+    { tool: "i18next-cli", medianMs: 5804.35 },
   ],
   ratios: {
-    lingui: "12.45×",
-    formatjs: "2.64×",
-    i18nextParser: "9.12×",
-    i18nextCli: "36.76×",
+    lingui: "12.14×",
+    formatjs: "2.45×",
+    i18nextParser: "7.99×",
+    i18nextCli: "30.08×",
   },
 }

--- a/site/app/data/rivals.ts
+++ b/site/app/data/rivals.ts
@@ -95,7 +95,7 @@ const NO_BENCHMARK =
  */
 export const NATIVE_SHIFT = {
   title: "The toolchain already moved. i18n tooling mostly hasn't.",
-  body: "Bundling went native with esbuild and Rolldown. Transforms went native with SWC and OXC. Linting and formatting went native with Biome and Oxlint. Extraction, catalog merging and ICU validation are the same category of work — parse the source, understand it, write structured output — and almost all of it is still running on JavaScript plugin stacks assembled over a decade. Palamedes was built after that shift rather than before it: one Rust core (ferrocat) owns parsing, merging, auditing and compilation, which is why the checked benchmark comes back between 2.64× and 36.76× faster depending on which tool you put next to it.",
+  body: "Bundling went native with esbuild and Rolldown. Transforms went native with SWC and OXC. Linting and formatting went native with Biome and Oxlint. Extraction, catalog merging and ICU validation are the same category of work — parse the source, understand it, write structured output — and almost all of it is still running on JavaScript plugin stacks assembled over a decade. Palamedes was built after that shift rather than before it: one Rust core (ferrocat) owns parsing, merging, auditing and compilation, which is why the checked benchmark comes back between 2.45× and 30.08× faster depending on which tool you put next to it.",
 }
 
 export const RIVALS: Rival[] = [
@@ -224,7 +224,7 @@ function checkoutLabel(seats) {
     researched: "July 2026",
     metaTitle: "Palamedes vs i18next — stop maintaining a naming layer",
     metaDescription:
-      "i18next is the most widely deployed i18n stack in JavaScript, and it asks every developer to invent and maintain keys. Palamedes uses the sentence you already wrote — and extracts it up to 36.76× faster on the checked benchmark.",
+      "i18next is the most widely deployed i18n stack in JavaScript, and it asks every developer to invent and maintain keys. Palamedes uses the sentence you already wrote — and extracts it up to 30.08× faster on the checked benchmark.",
     eyebrow: "Compare · i18next",
     headline: "You already know what the string says.",
     lede: "i18next identifies messages by keys you invent, namespace, remember and keep in sync with a JSON tree. Palamedes identifies them by the source text you already typed. That single decision deletes a whole category of weekly work, changes what a missing translation looks like in production, and changes what lands in your translators' inbox.",

--- a/site/app/hooks/useCountUp.ts
+++ b/site/app/hooks/useCountUp.ts
@@ -3,7 +3,7 @@ import { useEffect, useState } from "react"
 import { usePrefersReducedMotion } from "./usePrefersReducedMotion"
 
 /*
- * Animates the leading number of a stat string ("12.45×" → 0.00×…12.45×,
+ * Animates the leading number of a stat string ("12.14×" → 0.00×…12.14×,
  * "6 × 4" animates only the first number). Returns the final string during
  * prerender, under reduced motion, and while inactive — the baked HTML always
  * shows the true value.


### PR DESCRIPTION
Follow-up to #451, which corrected the e2e-workflow corpus but deliberately left the checked report stale with a provenance note saying it needed a fresh run on the reference machine. This is that run — plus the two things it turned up.

## 1. The lingui-v6 harness was broken the same way

`pnpm benchmark:lingui-v6` failed outright on the first generated file:

```
Error: Unsupported `defineMessage` macro usage at .../fixture-0000.ts:1:1:
this deferred message macro has been removed; translate at the point of use with `t`
```

#451 fixed the e2e-workflow lane; this harness still rendered `msg` and `defineMessage`, both removed from the Palamedes macro surface in 1.5.0. `docs/benchmark-lingui-v6-preview.md` already listed both under "excluded on purpose" with the 1.5.0 removal as the reason — the generator just never implemented that boundary.

Both lanes share one corpus here (unlike the e2e harness, which renders per tool), so the replacements stay valid Lingui too: `msg`/`defineMessage` become eager `t`, which extracts to the same msgid. Manifest entries are untouched, so extract/compile validation compares the same logical inventory.

## 2. Fresh reports

darwin/arm64 (M1 Ultra), Node v24.18.0, warmup 3, runs 7, all three profiles. Recorded on Palamedes CLI 1.7.0 (was 1.3.0) and Lingui 6.5.0 (was 6.4.0). The lingui-v6 report is the first full three-profile run — the previous one was a quick sample (warmup 1, runs 3, small only).

Published ratios all move down (realistic: Lingui 12.45x → 12.14x, FormatJS 2.64x → 2.45x, i18next-parser 9.12x → 7.99x, i18next-cli 36.76x → 30.08x). Most of that is the competition getting faster, not Palamedes getting slower: Lingui 6.5.0 nearly halves its small-profile time (1143 → 658 ms), i18next-cli drops 6612 → 5804 ms on realistic.

`site/app/data/bench.ts` and the prose quoting it in `rivals.ts` are updated in lockstep; `scripts/verify-site-bench-data.mjs` passes and the site builds.

## 3. A real write-path regression, found and fixed

The realistic profile came back +7% (179.87 → 192.94 ms). The `PALAMEDES_TIMING_JSON` breakdown localized it to the catalog write phase (38 → 52 ms) while extract actually improved slightly. Reproduced across two full harness runs.

Bisected to 5b69165 `fix(core): preserve PO translator metadata`. A/B with `--pmds-bin` over an identical corpus, that commit vs its parent:

| profile | median | write |
| --- | ---: | ---: |
| small (640 msgs) | 31.80 → 32.71 ms | 20 → 21 ms |
| realistic (6000 msgs) | 180.80 → 195.27 ms | 36 → 47 ms |

Cost scales with message count, which ruled out the two added `sync_all()` calls (a fixed per-file cost would have hit small equally) and pointed at the PO round trips: the commit turned one `ferrocat_update_catalog_file` call into three parse/serialize cycles.

Most catalogs carry no translator comments or flags at all, and for those the whole strip/restore dance is a no-op that still costs two full round trips. `read_existing_catalog` now checks first and, when there is nothing to preserve, hands ferrocat the original text and skips restore.

| variant | median | write |
| --- | ---: | ---: |
| pre-5b69165 (1.5.1) | 180.80 ms | 36 ms |
| 1.7.0 | 195.27 ms | 47 ms |
| this PR | 182.13 ms | 41 ms |

End-to-end back to parity — the 1.3 ms gap is inside the run-to-run spread measured for a single binary. The write counter still shows +5 ms because the metadata check itself needs a parse; removing that would mean scanning raw text for comment markers, which is easy to get wrong around obsolete `#~` blocks, so it is deliberately not attempted.

## Verification

- Output equivalence checked directly, not inferred: both binaries over the realistic corpus produce byte-identical `en.po` and `de.po` (~1 MB each).
- Two new tests. The predicate is all-or-nothing per file, so the case that would break is a catalog where only one item among many carries metadata — a per-item early-out would silently drop it. The second guards the fast path itself.
- `cargo test --workspace`, clippy `-D warnings`, `cargo fmt --check`, all package tests, lint, format, site build.

## Note on the checked report

It is deliberately **not** regenerated with the perf fix. It records released CLI v1.7.0 on reference hardware, and the fix is unreleased — re-recording now would file post-1.7.0 numbers under a 1.7.0 provenance line, which is the exact failure #451 called out. It should be re-run once this ships; realistic should then land around 182 ms instead of 192.94 ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)