### PR TITLE
feat(cli): add configurable reference scopes

### DIFF
--- a/adr/016-native-cli-and-yaml-first-configuration.md
+++ b/adr/016-native-cli-and-yaml-first-configuration.md
@@ -57,6 +57,7 @@ The documented schema uses kebab-case field names:
 - `fallback-locales`
 - `pseudo-locale`
 - `source-reference-root`
+- `reference-scopes`
 - `catalogs`
 
 Snake-case field names remain accepted aliases at the loader boundary for

--- a/crates/palamedes-cli/src/config.rs
+++ b/crates/palamedes-cli/src/config.rs
@@ -47,6 +47,7 @@ pub struct LoadedConfig {
     pub config_path: PathBuf,
     pub root_dir: PathBuf,
     pub source_reference_root: PathBuf,
+    pub reference_scopes: bool,
     pub locales: Vec<String>,
     pub source_locale: String,
     pub fallback_locales: Option<ConfigFallbackLocales>,
@@ -89,6 +90,8 @@ struct RawConfig {
     source_reference_root: Option<String>,
     #[serde(default, alias = "extract_threads")]
     extract_threads: Option<usize>,
+    #[serde(default = "default_reference_scopes", alias = "reference_scopes")]
+    reference_scopes: bool,
     catalogs: Vec<ConfigCatalog>,
 }
 
@@ -120,6 +123,7 @@ fn check_top_level_keys(value: &serde_json::Value, path: &Path) -> Result<(), Co
         ("fallbackLocales", "fallback-locales"),
         ("pseudoLocale", "pseudo-locale"),
         ("sourceReferenceRoot", "source-reference-root"),
+        ("referenceScopes", "reference-scopes"),
     ];
     const KNOWN_KEYS: &[&str] = &[
         "locales",
@@ -131,6 +135,8 @@ fn check_top_level_keys(value: &serde_json::Value, path: &Path) -> Result<(), Co
         "pseudo_locale",
         "source-reference-root",
         "source_reference_root",
+        "reference-scopes",
+        "reference_scopes",
         "catalogs",
         "plugins",
     ];
@@ -258,6 +264,7 @@ fn normalize_config(raw: RawConfig, config_path: PathBuf) -> Result<LoadedConfig
         config_path,
         root_dir,
         source_reference_root,
+        reference_scopes: raw.reference_scopes,
         locales: raw.locales,
         source_locale: raw.source_locale,
         fallback_locales: raw.fallback_locales,
@@ -265,6 +272,10 @@ fn normalize_config(raw: RawConfig, config_path: PathBuf) -> Result<LoadedConfig
         catalogs: raw.catalogs,
         extract_threads: raw.extract_threads,
     })
+}
+
+const fn default_reference_scopes() -> bool {
+    true
 }
 
 fn validate_config(raw: &RawConfig, path: &Path) -> Result<(), ConfigError> {
@@ -427,7 +438,29 @@ catalogs:
 
         assert_eq!(config.root_dir, app);
         assert_eq!(config.source_reference_root, repo);
+        assert!(config.reference_scopes);
         assert_eq!(config.catalogs[0].path, "src/locales/{locale}");
+    }
+
+    #[test]
+    fn disables_reference_scopes_from_yaml_config() {
+        let app = temp_dir("reference-scopes");
+        fs::write(
+            app.join(CONFIG_FILENAME),
+            r#"
+locales: [en, de]
+source-locale: en
+reference-scopes: false
+catalogs:
+  - path: src/locales/{locale}
+    include: [src]
+"#,
+        )
+        .expect("write config");
+
+        let config = load_config(&app, None).expect("load config");
+
+        assert!(!config.reference_scopes);
     }
 
     #[test]
@@ -460,6 +493,7 @@ catalogs:
 locales = ["en", "de"]
 source-locale = "en"
 source-reference-root = "config"
+reference_scopes = false
 
 [[catalogs]]
 path = "src/locales/{locale}"
@@ -473,6 +507,7 @@ include = ["src"]
         assert_eq!(config.config_path, app.join("palamedes.toml"));
         assert_eq!(config.source_locale, "en");
         assert_eq!(config.source_reference_root, app);
+        assert!(!config.reference_scopes);
     }
 
     #[test]

--- a/crates/palamedes-cli/src/main.rs
+++ b/crates/palamedes-cli/src/main.rs
@@ -12,10 +12,10 @@ use globset::{Glob, GlobSet, GlobSetBuilder};
 use ignore::WalkBuilder;
 use notify::{RecursiveMode, Watcher};
 use palamedes::{
-    audit_catalogs, combine_catalog_files, extract_catalog_messages_from_files, parse_catalog,
-    parse_po, update_catalog_file, CatalogAuditDiagnostic, CatalogAuditRequest, CatalogAuditResult,
-    CatalogConflictStrategy, CatalogFileCombineRequest, CatalogFileFormat, CatalogParseRequest,
-    CatalogUpdateMessage, CatalogUpdateRequest,
+    audit_catalogs, combine_catalog_files, parse_catalog, parse_po, update_catalog_file,
+    CatalogAuditDiagnostic, CatalogAuditRequest, CatalogAuditResult, CatalogConflictStrategy,
+    CatalogFileCombineRequest, CatalogFileFormat, CatalogParseRequest, CatalogUpdateMessage,
+    CatalogUpdateRequest,
 };
 use serde::Serialize;
 use thiserror::Error;
@@ -401,15 +401,20 @@ fn extract_from_catalog(
     }
 
     let extract_started_at = Instant::now();
-    let result = extract_catalog_messages_from_files(palamedes::ExtractCatalogMessagesRequest {
-        root_dir: config.source_reference_root.to_string_lossy().into_owned(),
-        files: files
-            .iter()
-            .map(|path| path.to_string_lossy().into_owned())
-            .collect(),
-        // --threads wins over the config file; both fall back to the core default.
-        max_threads: options.threads.or(config.extract_threads),
-    })?;
+    let result = palamedes::extract_catalog_messages_from_files_with_options(
+        palamedes::ExtractCatalogMessagesRequest {
+            root_dir: config.source_reference_root.to_string_lossy().into_owned(),
+            files: files
+                .iter()
+                .map(|path| path.to_string_lossy().into_owned())
+                .collect(),
+            // --threads wins over the config file; both fall back to the core default.
+            max_threads: options.threads.or(config.extract_threads),
+        },
+        palamedes::ExtractCatalogMessagesOptions {
+            reference_scopes: config.reference_scopes,
+        },
+    )?;
     let extract_ms = extract_started_at.elapsed().as_millis();
 
     for failure in &result.failed_files {
@@ -1266,7 +1271,7 @@ mod tests {
 
         let output = fs::read_to_string(app.join("locales/en/messages.po")).expect("read po");
         assert!(output.contains("msgid \"Dashboard\""));
-        assert!(output.contains("#: apps/web/app/page.tsx"));
+        assert!(output.contains("#: apps/web/app/page.tsx#title"));
     }
 
     #[test]
@@ -1285,6 +1290,47 @@ mod tests {
 
         let output = fs::read_to_string(app.join("locales/en/messages.po")).expect("read po");
         assert!(output.contains("#: app/page.tsx"));
+    }
+
+    #[test]
+    fn extract_can_disable_reference_scopes() {
+        let app = temp_dir("extract-without-reference-scopes");
+        fs::create_dir_all(app.join("app")).expect("create app");
+        fs::write(
+            app.join("palamedes.yaml"),
+            r#"locales: [en, de]
+source-locale: en
+source-reference-root: config
+reference-scopes: false
+catalogs:
+  - path: locales/{locale}/messages
+    include: [app]
+"#,
+        )
+        .expect("write config");
+        fs::write(
+            app.join("app/page.tsx"),
+            concat!(
+                "import { t } from \"@palamedes/core/macro\";\n",
+                "export function title() { return t`Dashboard`; }\n",
+                "export function repeatedTitle() { return t`Dashboard`; }\n",
+            ),
+        )
+        .expect("write source");
+
+        let config = load_config(&app, Some(&app.join("palamedes.yaml"))).expect("load config");
+        run_extraction(&config, &extract_options()).expect("extract");
+
+        let output = fs::read_to_string(app.join("locales/en/messages.po")).expect("read po");
+        assert!(output.contains("#: app/page.tsx\n"));
+        assert!(!output.contains("#title"));
+        assert_eq!(output.matches("#: app/page.tsx\n").count(), 1);
+
+        run_extraction(&config, &extract_options()).expect("repeat extraction");
+        assert_eq!(
+            fs::read_to_string(app.join("locales/en/messages.po")).expect("read repeated po"),
+            output
+        );
     }
 
     #[test]

--- a/crates/palamedes-node/src/extract.rs
+++ b/crates/palamedes-node/src/extract.rs
@@ -30,6 +30,7 @@ pub struct ExtractCatalogMessagesRequest {
     /// Worker threads for the parallel extraction pass. Omit to use the
     /// measured default; 1 forces serial extraction.
     pub max_threads: Option<u32>,
+    pub reference_scopes: Option<bool>,
 }
 
 #[napi(object)]
@@ -63,16 +64,6 @@ impl TryFrom<palamedes::ExtractedMessageRecord> for NativeExtractedMessage {
                 scope: value.scope,
             },
         })
-    }
-}
-
-impl From<ExtractCatalogMessagesRequest> for palamedes::ExtractCatalogMessagesRequest {
-    fn from(value: ExtractCatalogMessagesRequest) -> Self {
-        Self {
-            root_dir: value.root_dir,
-            files: value.files,
-            max_threads: value.max_threads.map(|threads| threads as usize),
-        }
     }
 }
 
@@ -139,7 +130,15 @@ pub fn extract_messages(source: String, filename: String) -> Result<Vec<NativeEx
 pub fn extract_catalog_messages_from_files(
     request: ExtractCatalogMessagesRequest,
 ) -> Result<ExtractCatalogMessagesResult> {
-    palamedes::extract_catalog_messages_from_files(request.into())
+    let options = palamedes::ExtractCatalogMessagesOptions {
+        reference_scopes: request.reference_scopes.unwrap_or(true),
+    };
+    let request = palamedes::ExtractCatalogMessagesRequest {
+        root_dir: request.root_dir,
+        files: request.files,
+        max_threads: request.max_threads.map(|threads| threads as usize),
+    };
+    palamedes::extract_catalog_messages_from_files_with_options(request, options)
         .map_err(to_napi_error)
         .and_then(ExtractCatalogMessagesResult::try_from)
 }

--- a/crates/palamedes/src/extract.rs
+++ b/crates/palamedes/src/extract.rs
@@ -85,6 +85,21 @@ pub struct ExtractCatalogMessagesRequest {
     pub max_threads: Option<usize>,
 }
 
+/// Optional behavior for aggregated catalog extraction.
+#[derive(Clone, Copy, Debug)]
+pub struct ExtractCatalogMessagesOptions {
+    /// Whether stable source scopes should be extracted for catalog references.
+    pub reference_scopes: bool,
+}
+
+impl Default for ExtractCatalogMessagesOptions {
+    fn default() -> Self {
+        Self {
+            reference_scopes: true,
+        }
+    }
+}
+
 /// Non-fatal source file extraction failure.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -199,6 +214,7 @@ struct ExtractionVisitor<'a> {
     messages: Vec<ExtractedMessageRecord>,
     error: Option<PalamedesError>,
     scope_stack: Vec<String>,
+    reference_scopes: bool,
 }
 
 impl<'a> ExtractionVisitor<'a> {
@@ -207,6 +223,7 @@ impl<'a> ExtractionVisitor<'a> {
         source: &'a str,
         line_locator: &'a LineLocator,
         imported_macros: &'a HashMap<String, ImportedMacro>,
+        reference_scopes: bool,
     ) -> Self {
         Self {
             filename: filename.to_string(),
@@ -216,6 +233,7 @@ impl<'a> ExtractionVisitor<'a> {
             messages: Vec::new(),
             error: None,
             scope_stack: Vec::new(),
+            reference_scopes,
         }
     }
 
@@ -274,11 +292,15 @@ impl<'a> ExtractionVisitor<'a> {
 
 impl<'a> Visit<'a> for ExtractionVisitor<'a> {
     fn visit_declaration(&mut self, it: &Declaration<'a>) {
-        let scope = match it {
-            Declaration::FunctionDeclaration(function) => {
-                function.id.as_ref().map(|id| id.name.as_str().to_string())
+        let scope = if self.reference_scopes {
+            match it {
+                Declaration::FunctionDeclaration(function) => {
+                    function.id.as_ref().map(|id| id.name.as_str().to_string())
+                }
+                _ => None,
             }
-            _ => None,
+        } else {
+            None
         };
 
         if let Some(scope) = scope {
@@ -291,7 +313,11 @@ impl<'a> Visit<'a> for ExtractionVisitor<'a> {
     }
 
     fn visit_variable_declarator(&mut self, it: &VariableDeclarator<'a>) {
-        let scope = function_like_initializer_name(it);
+        let scope = if self.reference_scopes {
+            function_like_initializer_name(it)
+        } else {
+            None
+        };
 
         if let Some(scope) = scope {
             self.push_scope(&scope);
@@ -1287,8 +1313,16 @@ pub fn extract_messages(
     source: &str,
     filename: &str,
 ) -> PalamedesResult<Vec<ExtractedMessageRecord>> {
+    extract_messages_with_scopes(source, filename, true)
+}
+
+fn extract_messages_with_scopes(
+    source: &str,
+    filename: &str,
+    reference_scopes: bool,
+) -> PalamedesResult<Vec<ExtractedMessageRecord>> {
     let allocator = Allocator::default();
-    extract_messages_in(&allocator, source, filename)
+    extract_messages_in(&allocator, source, filename, reference_scopes)
 }
 
 /*
@@ -1302,6 +1336,7 @@ fn extract_messages_in(
     allocator: &Allocator,
     source: &str,
     filename: &str,
+    reference_scopes: bool,
 ) -> PalamedesResult<Vec<ExtractedMessageRecord>> {
     let source_type = SourceType::from_path(filename).unwrap_or_else(|_| SourceType::tsx());
     let parsed = Parser::new(allocator, source, source_type).parse();
@@ -1336,8 +1371,13 @@ fn extract_messages_in(
             .map(|macro_info| macro_info.imported_name.clone())
     })?;
 
-    let mut extractor =
-        ExtractionVisitor::new(filename, source, &line_locator, &collector.imported_macros);
+    let mut extractor = ExtractionVisitor::new(
+        filename,
+        source,
+        &line_locator,
+        &collector.imported_macros,
+        reference_scopes,
+    );
     extractor.visit_program(&parsed.program);
 
     if let Some(error) = extractor.error {
@@ -1358,10 +1398,28 @@ fn extract_messages_in(
 pub fn extract_catalog_messages_from_files(
     request: ExtractCatalogMessagesRequest,
 ) -> PalamedesResult<ExtractCatalogMessagesResult> {
+    extract_catalog_messages_from_files_with_options(
+        request,
+        ExtractCatalogMessagesOptions::default(),
+    )
+}
+
+/// Extracts and aggregates source-first catalog update messages with explicit
+/// reference behavior.
+///
+/// # Errors
+///
+/// Returns the same fatal authoring errors and non-fatal file failures as
+/// [`extract_catalog_messages_from_files`].
+pub fn extract_catalog_messages_from_files_with_options(
+    request: ExtractCatalogMessagesRequest,
+    options: ExtractCatalogMessagesOptions,
+) -> PalamedesResult<ExtractCatalogMessagesResult> {
     let root_dir = PathBuf::from(&request.root_dir);
     let mut catalog = BTreeMap::<String, AggregatedCatalogEntry>::new();
     let mut failed_files = Vec::new();
     let file_count = request.files.len();
+    let reference_scopes = options.reference_scopes;
 
     /*
      * Reading and parsing each file is independent work and dominates extraction
@@ -1381,7 +1439,7 @@ pub fn extract_catalog_messages_from_files(
         request
             .files
             .iter()
-            .map(|file| extract_one_file(file, &root_dir))
+            .map(|file| extract_one_file(file, &root_dir, reference_scopes))
             .collect()
     } else {
         rayon::ThreadPoolBuilder::new()
@@ -1394,7 +1452,7 @@ pub fn extract_catalog_messages_from_files(
                 request
                     .files
                     .par_iter()
-                    .map(|file| extract_one_file(file, &root_dir))
+                    .map(|file| extract_one_file(file, &root_dir, reference_scopes))
                     .collect()
             })
     };
@@ -1444,7 +1502,7 @@ thread_local! {
 }
 
 /// Reads and extracts one file, classifying the outcome for ordered merging.
-fn extract_one_file(file: &String, root_dir: &Path) -> FileExtraction {
+fn extract_one_file(file: &String, root_dir: &Path, reference_scopes: bool) -> FileExtraction {
     let source = match std::fs::read_to_string(file) {
         Ok(source) => source,
         Err(source) => {
@@ -1461,7 +1519,7 @@ fn extract_one_file(file: &String, root_dir: &Path) -> FileExtraction {
 
     let extracted = EXTRACT_ARENA.with(|arena| {
         let mut arena = arena.borrow_mut();
-        let extracted = extract_messages_in(&arena, &source, file);
+        let extracted = extract_messages_in(&arena, &source, file, reference_scopes);
         /*
          * Safe to reset here: ExtractedMessageRecord owns its strings, so
          * nothing returned above borrows from the arena.
@@ -1674,8 +1732,9 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     use super::{
-        extract_catalog_messages_from_files, extract_messages as extract_messages_raw,
-        resolve_extract_threads, ExtractCatalogMessagesRequest, ExtractedMessageRecord,
+        extract_catalog_messages_from_files, extract_catalog_messages_from_files_with_options,
+        extract_messages as extract_messages_raw, resolve_extract_threads,
+        ExtractCatalogMessagesOptions, ExtractCatalogMessagesRequest, ExtractedMessageRecord,
         DEFAULT_EXTRACT_THREADS,
     };
     use crate::error::PalamedesResult;
@@ -2693,6 +2752,23 @@ const message = t({ message })
         assert_eq!(deferred.origins.len(), 1);
         assert_eq!(deferred.origins[0].file, "src/App.tsx");
         assert_eq!(deferred.origins[0].scope.as_deref(), Some("deferredLabel"));
+
+        let without_scopes = extract_catalog_messages_from_files_with_options(
+            ExtractCatalogMessagesRequest {
+                root_dir: root.to_string_lossy().into_owned(),
+                files: vec![app.to_string_lossy().into_owned()],
+                max_threads: None,
+            },
+            ExtractCatalogMessagesOptions {
+                reference_scopes: false,
+            },
+        )
+        .expect("batch extraction without scopes");
+        assert!(without_scopes
+            .messages
+            .iter()
+            .flat_map(|message| &message.origins)
+            .all(|origin| origin.scope.is_none()));
 
         fs::remove_dir_all(root).expect("cleanup");
     }

--- a/crates/palamedes/src/lib.rs
+++ b/crates/palamedes/src/lib.rs
@@ -62,7 +62,8 @@ pub use catalog_update::{
 pub use diagnostic::{CatalogDiagnostic, CatalogDiagnosticSeverity, CatalogDiagnosticSourceKey};
 pub use error::{PalamedesError, PalamedesResult};
 pub use extract::{
-    extract_catalog_messages_from_files, extract_messages, ExtractCatalogFileFailure,
+    extract_catalog_messages_from_files, extract_catalog_messages_from_files_with_options,
+    extract_messages, ExtractCatalogFileFailure, ExtractCatalogMessagesOptions,
     ExtractCatalogMessagesRequest, ExtractCatalogMessagesResult, ExtractedMessageRecord,
 };
 pub use message_metadata::{

--- a/docs/api/config.md
+++ b/docs/api/config.md
@@ -46,6 +46,7 @@ import { defineConfig } from "@palamedes/config"
 export default defineConfig({
   locales: ["en", "de"],
   sourceLocale: "en",
+  referenceScopes: false,
   catalogs: [{ path: "src/locales/{locale}", include: ["src"] }],
   plugins: [["@acme/palamedes-workflows", { policy: "strict" }]],
 })
@@ -64,8 +65,8 @@ export default defineConfig({
 ## `loadPalamedesConfig(options?)`
 
 Searches from `cwd` for a supported config file unless `configPath` is passed.
-The returned object includes `configPath`, `rootDir`, and
-`sourceReferenceRoot`.
+The returned object includes `configPath`, `rootDir`, `sourceReferenceRoot`,
+and the resolved `referenceScopes` boolean.
 
 ```ts
 const config = await loadPalamedesConfig({ cwd: process.cwd() })

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -169,8 +169,8 @@ The native CLI reads only data configs (`palamedes.yaml`, `.yml`, `.json`,
 `.toml`). When the upward search finds only a `palamedes.config.ts`/`.js`, the
 CLI reports that specifically instead of a generic not-found error — create a
 data config next to it for CLI use. Known keys written in camelCase
-(`sourceLocale`, `pseudoLocale`, `fallbackLocales`, `sourceReferenceRoot`) are
-rejected with a kebab-case hint instead of being silently ignored; other
-unknown top-level keys produce a warning. Fallback-locale entries must
-reference configured locales, and a `pseudo-locale` outside `locales` warns
-that it will be ignored.
+(`sourceLocale`, `pseudoLocale`, `fallbackLocales`, `sourceReferenceRoot`,
+`referenceScopes`) are rejected with a kebab-case hint instead of being
+silently ignored; other unknown top-level keys produce a warning.
+Fallback-locale entries must reference configured locales, and a
+`pseudo-locale` outside `locales` warns that it will be ignored.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,12 +39,13 @@ catalogs:
 | `fallback-locales`      | No       | `string[] \| Record<string, string[]>` | Shared or per-locale fallback chain.                                                |
 | `pseudo-locale`         | No       | `string`                               | Locale code used for pseudo-localized UI testing.                                   |
 | `source-reference-root` | No       | `git \| config \| lingui \| path`      | Root used for catalog source references. Defaults to nearest Git root, then config. |
+| `reference-scopes`      | No       | `boolean`                              | Adds stable source scopes to catalog references. Defaults to `true`.                |
 | `plugins`               | No       | `(string \| [string, options])[]`      | Explicit CLI plugin packages. Never auto-discovered.                                |
 | `extract-threads`       | No       | `number`                               | Worker threads for the parallel extraction pass. Defaults to `4`; `1` runs serial.  |
 
 The native CLI and JS config loader also accept snake_case aliases for
 hyphenated config keys: `source_locale`, `fallback_locales`, `pseudo_locale`,
-`source_reference_root`, and `extract_threads`.
+`source_reference_root`, `reference_scopes`, and `extract_threads`.
 
 `extract-threads` bounds the parallel read/parse pass. The default of `4` is a
 measured floor rather than a core count: extraction gets slower again above it,
@@ -82,11 +83,13 @@ When `exclude` is empty, the native CLI implicitly excludes
 
 ## Source References
 
-`source-reference-root` controls the root used for PO `#:` references written by
-`pmds extract`.
+`source-reference-root` controls the root used for catalog references written by
+`pmds extract`. `reference-scopes` controls whether those references include a
+stable component or function suffix.
 
 ```yaml
 source-reference-root: git
+reference-scopes: true
 ```
 
 Values:
@@ -94,6 +97,12 @@ Values:
 - `git`: nearest Git repository root, falling back to the config directory.
 - `config` or `lingui`: config-directory relative references.
 - Any other string: path resolved relative to the config directory.
+
+`reference-scopes` defaults to `true`, producing references such as
+`src/App.tsx#CheckoutButton`. Set it to `false` for file-only references such as
+`src/App.tsx`. When disabled, Palamedes skips source-scope extraction while
+retaining file references. The setting applies to both PO `#:` references and
+FCL `r=` tags.
 
 ## Fallback Locales
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -176,15 +176,18 @@ the configured Palamedes config when available, then `en`.
 locales: [en, de]
 source-locale: en
 source-reference-root: git
+reference-scopes: false
 catalogs:
   - path: src/locales/{locale}
     include: [src]
 ```
 
-`source-reference-root` controls PO `#:` references written by `pmds extract`.
+`source-reference-root` controls catalog references written by `pmds extract`.
 The default is `"git"`, so monorepo references are emitted relative to the
 nearest Git repository root. Use `"lingui"` or `"config"` to keep references
 relative to the config directory, matching Lingui's default behavior.
+`reference-scopes` defaults to `true`; set it to `false` to skip scope
+extraction and emit file-only PO `#:` and FCL `r=` references.
 
 ## Related Packages
 

--- a/packages/cli/scripts/binary-plugin.test.mjs
+++ b/packages/cli/scripts/binary-plugin.test.mjs
@@ -155,6 +155,7 @@ function loadedConfig(plugins) {
     configPath: fixtureConfigPath,
     rootDir: fixtureRoot,
     sourceReferenceRoot: fixtureRoot,
+    referenceScopes: true,
     locales: ["en", "de"],
     sourceLocale: "en",
     catalogs: [{ path: "locales/{locale}/messages", include: ["src"] }],

--- a/packages/cli/scripts/plugin-host.test.mjs
+++ b/packages/cli/scripts/plugin-host.test.mjs
@@ -369,6 +369,7 @@ function loadedConfig(plugins) {
     configPath: fixtureConfigPath,
     rootDir: fixtureRoot,
     sourceReferenceRoot: fixtureRoot,
+    referenceScopes: true,
     locales: ["en", "de"],
     sourceLocale: "en",
     catalogs: [{ path: "locales/{locale}/messages", include: ["src"] }],

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -43,19 +43,21 @@ catalogs:
 - `pseudo-locale` marks a generated pseudo-locale used for layout and hardcoded
   string checks. Plugin integrations skip `failOnMissing` failures for that
   locale while keeping strict checks for real locales.
-- `source-reference-root` controls the root used for PO `#:` source references.
+- `source-reference-root` controls the root used for catalog source references.
   The default is `"git"`, which emits paths relative to the nearest Git
   repository root and falls back to the config directory when no Git root is
   available. Use `"lingui"` or `"config"` for Lingui-compatible references
   relative to the config directory, or pass a custom path.
+- `reference-scopes` defaults to `true`. Set it to `false` to skip stable
+  component/function scope extraction and emit file-only PO and FCL references.
 - `catalogs[].format` defaults to `"po"`. Set it to `"fcl"` to use Ferrocat
   Catalog Lines for canonical, merge-friendly generated catalog storage.
 - `plugins` explicitly lists CLI plugin package specifiers or
   `[specifier, options]` pairs. Packages are never auto-discovered, and built-in
   CLI commands do not load them.
-- `loadPalamedesConfig()` returns `sourceReferenceRoot` in addition to
-  `configPath` and `rootDir`; pass `skipValidation` only when inspecting a
-  partially-authored config file.
+- `loadPalamedesConfig()` returns `sourceReferenceRoot` and the resolved
+  `referenceScopes` boolean in addition to `configPath` and `rootDir`; pass
+  `skipValidation` only when inspecting a partially-authored config file.
 
 See [Catalog formats](https://github.com/sebastian-software/palamedes/blob/main/docs/catalog-formats.md)
 for the PO/FCL storage boundary.

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -35,6 +35,7 @@ export type PalamedesConfig = {
   fallbackLocales?: PalamedesFallbackLocales
   pseudoLocale?: string
   sourceReferenceRoot?: PalamedesSourceReferenceRoot
+  referenceScopes?: boolean
   catalogs: PalamedesCatalogConfig[]
   plugins?: PalamedesPluginDeclaration[]
 }
@@ -49,6 +50,8 @@ type PalamedesDataConfig = {
   pseudo_locale?: unknown
   "source-reference-root"?: unknown
   source_reference_root?: unknown
+  "reference-scopes"?: unknown
+  reference_scopes?: unknown
   catalogs?: unknown
   plugins?: unknown
 }
@@ -57,7 +60,8 @@ export type LoadedPalamedesConfig = {
   configPath: string
   rootDir: string
   sourceReferenceRoot: string
-} & Omit<PalamedesConfig, "sourceReferenceRoot">
+  referenceScopes: boolean
+} & Omit<PalamedesConfig, "sourceReferenceRoot" | "referenceScopes">
 
 export type LoadPalamedesConfigOptions = {
   cwd?: string
@@ -158,6 +162,7 @@ const CAMEL_CASE_DATA_KEYS: [string, string][] = [
   ["fallbackLocales", "fallback-locales"],
   ["pseudoLocale", "pseudo-locale"],
   ["sourceReferenceRoot", "source-reference-root"],
+  ["referenceScopes", "reference-scopes"],
 ]
 
 /*
@@ -185,6 +190,7 @@ function normalizeDataConfig(config: PalamedesDataConfig, configPath: string): P
     "source-reference-root",
     "source_reference_root"
   )
+  const referenceScopes = getConfigValue(config, "reference-scopes", "reference_scopes")
 
   return {
     locales: config.locales as string[],
@@ -196,6 +202,7 @@ function normalizeDataConfig(config: PalamedesDataConfig, configPath: string): P
     ...(sourceReferenceRoot !== undefined
       ? { sourceReferenceRoot: sourceReferenceRoot as PalamedesSourceReferenceRoot }
       : {}),
+    ...(referenceScopes !== undefined ? { referenceScopes: referenceScopes as boolean } : {}),
     catalogs: config.catalogs as PalamedesCatalogConfig[],
     ...(config.plugins !== undefined
       ? { plugins: config.plugins as PalamedesPluginDeclaration[] }
@@ -336,6 +343,7 @@ async function normalizeConfig(
     ...(config.fallbackLocales !== undefined ? { fallbackLocales: config.fallbackLocales } : {}),
     ...(config.pseudoLocale !== undefined ? { pseudoLocale: config.pseudoLocale } : {}),
     sourceReferenceRoot: await resolveSourceReferenceRoot(config.sourceReferenceRoot, rootDir),
+    referenceScopes: config.referenceScopes ?? true,
     catalogs: config.catalogs.map((catalog) => ({
       path: catalog.path,
       ...(catalog.format !== undefined ? { format: catalog.format } : {}),
@@ -356,6 +364,7 @@ function normalizeConfigSync(config: PalamedesConfig, configPath: string): Loade
     ...(config.fallbackLocales !== undefined ? { fallbackLocales: config.fallbackLocales } : {}),
     ...(config.pseudoLocale !== undefined ? { pseudoLocale: config.pseudoLocale } : {}),
     sourceReferenceRoot: resolveSourceReferenceRootSync(config.sourceReferenceRoot, rootDir),
+    referenceScopes: config.referenceScopes ?? true,
     catalogs: config.catalogs.map((catalog) => ({
       path: catalog.path,
       ...(catalog.format !== undefined ? { format: catalog.format } : {}),
@@ -486,6 +495,12 @@ function validateConfig(config: unknown, configPath: string): asserts config is 
   ) {
     throw new TypeError(
       `Invalid Palamedes config in ${configPath}: "sourceReferenceRoot" must be a non-empty string when provided.`
+    )
+  }
+
+  if (record.referenceScopes !== undefined && typeof record.referenceScopes !== "boolean") {
+    throw new TypeError(
+      `Invalid Palamedes config in ${configPath}: "referenceScopes" must be a boolean when provided.`
     )
   }
 

--- a/packages/config/src/loadConfig.test.ts
+++ b/packages/config/src/loadConfig.test.ts
@@ -28,6 +28,7 @@ describe("loadPalamedesConfig", () => {
         export default {
           locales: ["en", "de"],
           sourceLocale: "en",
+          referenceScopes: false,
           catalogs: [
             {
               path: "src/locales/{locale}",
@@ -42,6 +43,7 @@ describe("loadPalamedesConfig", () => {
 
     expect(config.rootDir).toBe(fixtureDir)
     expect(config.sourceLocale).toBe("en")
+    expect(config.referenceScopes).toBe(false)
     expect(config.catalogs[0]?.path).toBe("src/locales/{locale}")
   })
 
@@ -54,6 +56,7 @@ describe("loadPalamedesConfig", () => {
         locales: [en, de]
         source-locale: en
         source-reference-root: config
+        reference-scopes: false
         catalogs:
           - path: src/locales/{locale}
             format: fcl
@@ -70,6 +73,7 @@ describe("loadPalamedesConfig", () => {
     expect(config.rootDir).toBe(fixtureDir)
     expect(config.sourceLocale).toBe("en")
     expect(config.sourceReferenceRoot).toBe(fixtureDir)
+    expect(config.referenceScopes).toBe(false)
     expect(config.catalogs[0]).toStrictEqual({
       path: "src/locales/{locale}",
       format: "fcl",
@@ -102,6 +106,7 @@ describe("loadPalamedesConfig", () => {
     expect(config.rootDir).toBe(fixtureDir)
     expect(config.sourceLocale).toBe("en")
     expect(config.sourceReferenceRoot).toBe(fixtureDir)
+    expect(config.referenceScopes).toBe(true)
     expect(config.catalogs[0]).toStrictEqual({
       path: "src/locales/{locale}",
       include: ["src"],
@@ -137,6 +142,7 @@ describe("loadPalamedesConfig", () => {
         locales = ["en", "de"]
         source-locale = "en"
         source-reference-root = "config"
+        reference_scopes = false
 
         [[catalogs]]
         path = "src/locales/{locale}"
@@ -149,6 +155,7 @@ describe("loadPalamedesConfig", () => {
     expect(config.configPath).toBe(path.join(fixtureDir, "palamedes.toml"))
     expect(config.sourceLocale).toBe("en")
     expect(config.sourceReferenceRoot).toBe(fixtureDir)
+    expect(config.referenceScopes).toBe(false)
   })
 
   it("loads palamedes.json as a secondary config format", async () => {
@@ -174,6 +181,7 @@ describe("loadPalamedesConfig", () => {
     expect(config.configPath).toBe(path.join(fixtureDir, "palamedes.json"))
     expect(config.sourceLocale).toBe("en")
     expect(config.sourceReferenceRoot).toBe(fixtureDir)
+    expect(config.referenceScopes).toBe(true)
   })
 
   it("loads an explicitly provided config path synchronously", async () => {
@@ -312,6 +320,25 @@ describe("loadPalamedesConfig", () => {
 
     await expect(loadPalamedesConfig({ cwd: fixtureDir })).rejects.toThrow(
       /"sourceLocale" must be included in "locales"/
+    )
+  })
+
+  it("rejects a non-boolean referenceScopes value", async () => {
+    const fixtureDir = await createTempDir()
+    await writeFile(
+      path.join(fixtureDir, "palamedes.config.js"),
+      `
+        module.exports = {
+          locales: ["en"],
+          sourceLocale: "en",
+          referenceScopes: "false",
+          catalogs: [],
+        }
+      `
+    )
+
+    await expect(loadPalamedesConfig({ cwd: fixtureDir })).rejects.toThrow(
+      /"referenceScopes" must be a boolean/
     )
   })
 

--- a/packages/core-node/src/generated/palamedes-node-types.ts
+++ b/packages/core-node/src/generated/palamedes-node-types.ts
@@ -300,6 +300,7 @@ export interface ExtractCatalogMessagesRequest {
  * measured default; 1 forces serial extraction.
  */
 maxThreads?: number;
+  referenceScopes?: boolean;
 }
 export interface ExtractCatalogFileFailure {
   path: string;


### PR DESCRIPTION
## Summary

- add the top-level `reference-scopes` configuration option, defaulting to `true`
- skip function/component scope discovery when disabled while retaining stable file references
- support the setting in native and JavaScript config loaders and the Node extraction API
- document file-only PO and FCL references

## Why

Projects migrating existing Lingui/PO catalogs may want to preserve file-only source references instead of adding a `#scope` suffix to every extracted origin. Keeping this global avoids per-catalog behavior that would be difficult to reason about.

With `reference-scopes: false`, Palamedes does not merely hide scopes during serialization: it skips scope discovery during extraction, so those values are neither allocated nor stored internally.

## Validation

- `cargo +1.95 test -p palamedes -p palamedes-cli -p palamedes-node`
- `cargo +1.95 clippy --workspace --all-targets --locked -- -D warnings`
- `rustup run 1.95 pnpm build`
- `rustup run 1.95 pnpm check-types`
- `rustup run 1.95 pnpm test`
- `pnpm lint`
- `pnpm format:check`
- `pnpm check:published-types`
- `pnpm check:release-set`

Closes #454