### PR TITLE
fix: resolve vite plugin declarations for TypeScript 6/7

### DIFF
--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -42,9 +42,14 @@
   ],
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs"
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     }
   },
   "dependencies": {

--- a/scripts/check-published-types.mjs
+++ b/scripts/check-published-types.mjs
@@ -41,12 +41,14 @@ try {
   mkdirSync(scopeDirectory, { recursive: true })
   linkPackage("core")
   linkPackage("next-plugin")
+  linkPackage("vite-plugin")
 
   const esmFixture = path.join(fixtureRoot, "consumer.mts")
   writeFileSync(
     esmFixture,
     `import { plural, select, selectOrdinal, t } from "@palamedes/core/macro"
 import withPalamedes from "@palamedes/next-plugin"
+import vitePalamedes, { palamedes } from "@palamedes/vite-plugin"
 
 export const lengths = [
   t\`Hello\`.length,
@@ -56,6 +58,7 @@ export const lengths = [
 ]
 
 export default withPalamedes({})
+export const vitePlugins = [vitePalamedes(), palamedes()]
 `
   )
   checkProgram(esmFixture, {
@@ -67,8 +70,10 @@ export default withPalamedes({})
   writeFileSync(
     commonJsFixture,
     `import nextPlugin = require("@palamedes/next-plugin")
+import vitePlugin = require("@palamedes/vite-plugin")
 
 export const config = nextPlugin.withPalamedes({})
+export const vitePlugins = vitePlugin.palamedes()
 `
   )
   checkProgram(commonJsFixture, {
@@ -80,8 +85,10 @@ export const config = nextPlugin.withPalamedes({})
   writeFileSync(
     legacyCommonJsFixture,
     `import nextPlugin = require("@palamedes/next-plugin")
+import vitePlugin = require("@palamedes/vite-plugin")
 
 export const config = nextPlugin.withPalamedes({})
+export const vitePlugins = vitePlugin.palamedes()
 `
   )
   checkProgram(legacyCommonJsFixture, {


### PR DESCRIPTION
## Summary

- route ESM consumers of `@palamedes/vite-plugin` to the generated `.d.mts` declaration
- route CommonJS consumers to the generated `.d.cts` declaration
- cover default, named, CommonJS, and legacy CommonJS imports in the published-types regression check

## Root cause

The package export map pointed every consumer at `index.d.ts`. Unbuild's compatibility declaration combines `export =` with named exports, which TypeScript 6/7 cannot resolve correctly under bundler module resolution. The build already emits format-specific declarations; the export map now selects the matching one.

## Validation

- `pnpm check:published-types`
- `pnpm --filter @palamedes/vite-plugin test`
- package TypeScript check after building direct dependencies
- targeted ESLint and formatting checks
- TypeScript 7.0.2 reproduction with `moduleResolution: bundler`, `esModuleInterop`, and `verbatimModuleSyntax`

Fixes #457