### PR TITLE
Add framework-specific i18n landing pages

### DIFF
--- a/scripts/verify-site-routes.mjs
+++ b/scripts/verify-site-routes.mjs
@@ -45,6 +45,34 @@ const MIME = {
 const ROUTE_EXPECTATIONS = [
   { path: "/", h1: "One translation model." },
   { path: "/frameworks", h1: "Six frameworks." },
+  {
+    path: "/frameworks/nextjs",
+    h1: "Next.js i18n for the App Router, from server to client.",
+  },
+  {
+    path: "/frameworks/tanstack-start",
+    h1: "TanStack Start i18n for routes, server functions, and the client.",
+  },
+  {
+    path: "/frameworks/solidstart",
+    h1: "SolidStart i18n that stays native to Solid.",
+  },
+  {
+    path: "/frameworks/waku",
+    h1: "Waku i18n across React Server and Client Components.",
+  },
+  {
+    path: "/frameworks/react-router",
+    h1: "React Router i18n for Framework Mode.",
+  },
+  {
+    path: "/frameworks/remix-v3",
+    h1: "Remix v3 i18n for its new server-first stack.",
+  },
+  {
+    path: "/frameworks/vite",
+    h1: "Vite i18n for React and Solid, in one plugin.",
+  },
   { path: "/proof", h1: "Claims you can re-run." },
   { path: "/get-started", h1: "First working translation" },
   { path: "/compare", h1: "Compare it properly." },

--- a/site/app/components/frameworks/FrameworkLandingPage.tsx
+++ b/site/app/components/frameworks/FrameworkLandingPage.tsx
@@ -1,0 +1,207 @@
+import { Link } from "react-router"
+
+import { ButtonLink } from "~/components/chrome/Button"
+import { Page } from "~/components/chrome/Page"
+import { Section } from "~/components/chrome/Section"
+import { CtaBand } from "~/components/home/CtaBand"
+import type { FrameworkLanding, FrameworkLandingFact } from "~/data/framework-landing"
+import { STRATEGY_CARDS } from "~/data/features"
+import { docsHref } from "~/data/links"
+import { cellFor, STRATEGIES } from "~/data/matrix"
+
+function Facts({ facts }: { facts: FrameworkLandingFact[] }) {
+  return (
+    <dl className="hairline-grid grid-cols-4 max-grid:grid-cols-2 max-tight:grid-cols-1">
+      {facts.map((fact) => (
+        <div key={fact.label} className="bg-paper px-5 py-5">
+          <dt className="micro text-[10px] tracking-label text-gray-spec">{fact.label}</dt>
+          <dd className="mono-nums mt-2 text-[17px] text-accent">{fact.value}</dd>
+          <p className="mt-2 text-[12.5px] leading-relaxed text-ink/85">{fact.note}</p>
+        </div>
+      ))}
+    </dl>
+  )
+}
+
+function StrategyGrid({ page }: { page: FrameworkLanding }) {
+  const matrixSlug = page.strategies.matrixSlug
+  const cells = matrixSlug
+    ? STRATEGIES.map((strategy) => cellFor(matrixSlug, strategy.slug))
+    : undefined
+
+  return (
+    <div className="hairline-grid grid-cols-4 max-grid:grid-cols-2 max-tight:grid-cols-1">
+      {STRATEGY_CARDS.map((strategy, index) => {
+        const cell = cells?.[index]
+        return (
+          <div key={strategy.title} className="bg-paper px-5 py-5">
+            <h3 className="text-[15px] font-bold">{strategy.title}</h3>
+            <p className="mt-2 text-[12.5px] leading-relaxed text-ink/85">{strategy.body}</p>
+            {cell ? (
+              <p className="mono-nums mt-4 flex flex-wrap gap-3 text-[11px]">
+                {cell.demoLinks?.[0] ? (
+                  <a href={cell.demoLinks[0].href} className="text-accent hover:text-ink">
+                    <span aria-hidden>● </span>open demo
+                  </a>
+                ) : (
+                  <span className="text-gray-spec">◌ local / CI</span>
+                )}
+                <a href={cell.sourceHref} className="text-gray-spec hover:text-accent">
+                  source →
+                </a>
+              </p>
+            ) : null}
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+export function FrameworkLandingPage({ page }: { page: FrameworkLanding }) {
+  return (
+    <Page>
+      <section className="px-8 pt-16 pb-14 max-tight:px-5">
+        <p className="eyebrow">{page.eyebrow}</p>
+        <h1 className="mt-6 max-w-[15em] text-display leading-[0.98] font-bold tracking-[-0.03em] text-balance">
+          {page.headline}
+        </h1>
+        <p className="mt-6 max-w-[44em]">{page.lede}</p>
+        <div className="mt-8 flex flex-wrap gap-3">
+          <ButtonLink href={page.primary.href}>{page.primary.label}</ButtonLink>
+          <ButtonLink variant="outline" href={page.secondary.href}>
+            {page.secondary.label}
+          </ButtonLink>
+        </div>
+        <div className="mt-12">
+          <Facts facts={page.facts} />
+        </div>
+      </section>
+
+      <Section num="01 — The framework problem" title={page.problem.title} lede={page.problem.lede}>
+        <div className="border-l-4 border-gray-spec pl-5">
+          <p className="micro text-[10px] tracking-label text-gray-spec">
+            What the integration has to get right
+          </p>
+          <ul className="mt-3 space-y-2">
+            {page.problem.points.map((point) => (
+              <li
+                key={point}
+                className="flex max-w-[56em] gap-2.5 text-[13.5px] leading-relaxed text-ink/85"
+              >
+                <span aria-hidden className="mono-nums text-gray-spec">
+                  ·
+                </span>
+                <span>{point}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </Section>
+
+      <Section num="02 — The Palamedes model" title={page.approach.title} lede={page.approach.lede}>
+        <div className="hairline-grid grid-cols-3 max-grid:grid-cols-2 max-tight:grid-cols-1">
+          {page.approach.points.map((point) => (
+            <div key={point.title} className="bg-paper px-6 py-6">
+              <h3 className="text-[15px] font-bold">{point.title}</h3>
+              <p className="mt-2 text-[13.5px] leading-relaxed text-ink/85">{point.body}</p>
+            </div>
+          ))}
+        </div>
+      </Section>
+
+      <Section num="03 — In TypeScript" title={page.code.caption}>
+        <div className="border border-hair bg-paper">
+          <p className="micro border-b border-hair px-5 py-3 text-[10.5px] tracking-label text-gray-spec">
+            {page.code.label}
+          </p>
+          <pre className="overflow-x-auto bg-ink px-5 py-4 font-mono text-[12.5px] leading-[1.7] text-paper/85">
+            <code>{page.code.source}</code>
+          </pre>
+        </div>
+        <p className="mt-4 max-w-[54em] text-[13.5px] leading-relaxed text-ink/85">
+          {page.code.note}
+        </p>
+      </Section>
+
+      <Section
+        num="04 — Locale strategy"
+        title={`Choose the URL model that fits your ${page.name} product.`}
+        lede={page.strategies.lede}
+      >
+        <StrategyGrid page={page} />
+        <Link
+          to="/locale-routing"
+          viewTransition
+          className="mono-nums mt-6 inline-block text-[13px] text-accent"
+        >
+          Compare the four locale strategies →
+        </Link>
+      </Section>
+
+      <Section num="05 — Proof and boundaries" title={page.proof.title} lede={page.proof.lede}>
+        <Facts facts={page.proof.facts} />
+        <div className="mt-8 border-l-4 border-accent pl-5">
+          <h3 className="text-[15px] font-bold">{page.boundary.title}</h3>
+          <p className="mt-2 max-w-[56em] text-[13.5px] leading-relaxed text-ink/85">
+            {page.boundary.body}
+          </p>
+          {page.boundary.link ? (
+            <ButtonLink variant="small" className="mt-4" href={page.boundary.link.href}>
+              {page.boundary.link.label}
+            </ButtonLink>
+          ) : null}
+        </div>
+      </Section>
+
+      <Section
+        num="06 — Questions"
+        id="faq"
+        title={`${page.name} i18n questions, answered`}
+        lede="The short version of the decisions that usually block an implementation."
+      >
+        <dl className="border border-hair">
+          {page.faq.map((entry, index) => (
+            <div
+              key={entry.q}
+              className={`px-6 py-5 max-tight:px-4 ${index > 0 ? "border-t border-hair" : ""}`}
+            >
+              <dt className="text-[15px] font-bold">{entry.q}</dt>
+              <dd className="mt-2 max-w-[58em] text-[13.5px] leading-relaxed text-ink/85">
+                {entry.a}
+              </dd>
+            </div>
+          ))}
+        </dl>
+      </Section>
+
+      <Section num="07 — Keep exploring" title="See how the same model meets a different host.">
+        <div className="hairline-grid grid-cols-3 max-tight:grid-cols-1">
+          {page.related.map((related) => (
+            <Link
+              key={related.href}
+              to={related.href}
+              viewTransition
+              className="group bg-paper px-6 py-5 transition-colors hover:bg-hover-fill"
+            >
+              <p className="text-[14px] font-bold group-hover:text-accent">{related.label}</p>
+              <span className="micro mt-2 inline-block text-[12px] text-accent">Open page →</span>
+            </Link>
+          ))}
+        </div>
+        <a
+          href={docsHref("framework-example-notes")}
+          className="mono-nums mt-6 inline-block text-[13px] text-accent"
+        >
+          Read the framework verification notes →
+        </a>
+      </Section>
+
+      <CtaBand
+        headline={page.finalCta.headline}
+        primary={page.finalCta.primary}
+        secondary={page.finalCta.secondary}
+      />
+    </Page>
+  )
+}

--- a/site/app/components/frameworks/FrameworkLandingPage.tsx
+++ b/site/app/components/frameworks/FrameworkLandingPage.tsx
@@ -7,7 +7,7 @@ import { CtaBand } from "~/components/home/CtaBand"
 import type { FrameworkLanding, FrameworkLandingFact } from "~/data/framework-landing"
 import { STRATEGY_CARDS } from "~/data/features"
 import { docsHref } from "~/data/links"
-import { cellFor, STRATEGIES } from "~/data/matrix"
+import { cellFor } from "~/data/matrix"
 
 function Facts({ facts }: { facts: FrameworkLandingFact[] }) {
   return (
@@ -25,14 +25,11 @@ function Facts({ facts }: { facts: FrameworkLandingFact[] }) {
 
 function StrategyGrid({ page }: { page: FrameworkLanding }) {
   const matrixSlug = page.strategies.matrixSlug
-  const cells = matrixSlug
-    ? STRATEGIES.map((strategy) => cellFor(matrixSlug, strategy.slug))
-    : undefined
 
   return (
     <div className="hairline-grid grid-cols-4 max-grid:grid-cols-2 max-tight:grid-cols-1">
-      {STRATEGY_CARDS.map((strategy, index) => {
-        const cell = cells?.[index]
+      {STRATEGY_CARDS.map((strategy) => {
+        const cell = matrixSlug ? cellFor(matrixSlug, strategy.slug) : undefined
         return (
           <div key={strategy.title} className="bg-paper px-5 py-5">
             <h3 className="text-[15px] font-bold">{strategy.title}</h3>

--- a/site/app/components/frameworks/FrameworkMatrix.tsx
+++ b/site/app/components/frameworks/FrameworkMatrix.tsx
@@ -1,4 +1,7 @@
+import { Link } from "react-router"
+
 import contentStats from "~/data/generated/content-stats.json"
+import { frameworkLandingHref } from "~/data/framework-landing"
 import { cellFor, FRAMEWORKS, STRATEGIES, type MatrixCell } from "~/data/matrix"
 
 function CellContent({ cell }: { cell: MatrixCell }) {
@@ -73,7 +76,13 @@ export function FrameworkMatrix({ scan = false }: { scan?: boolean }) {
                   scope="row"
                   className="border border-hair px-4 py-4 text-left align-top text-[14px] font-bold"
                 >
-                  {framework.name}
+                  <Link
+                    to={frameworkLandingHref(framework.slug)}
+                    viewTransition
+                    className="hover:text-accent"
+                  >
+                    {framework.name}
+                  </Link>
                   <span className="mono-nums mt-1 block text-[10px] font-normal text-gray-spec">
                     {framework.slug}
                   </span>

--- a/site/app/components/frameworks/FrameworkMatrix.tsx
+++ b/site/app/components/frameworks/FrameworkMatrix.tsx
@@ -98,8 +98,8 @@ export function FrameworkMatrix({ scan = false }: { scan?: boolean }) {
         </table>
       </div>
       <p className="mono-nums mt-3 text-[11px] text-gray-spec">
-        <span className="text-accent">●</span> live demo · ◌ provisioning (#306) · ✓ CI
-        browser-verified — all {contentStats.exampleCount} apps run the same verification flow
+        <span className="text-accent">●</span> live demo · ◌ local / provisioning · ✓ verified in CI
+        — browser flows for the five UI adapters, server smoke proofs for Remix v3
       </p>
     </div>
   )

--- a/site/app/components/frameworks/FwPanels.tsx
+++ b/site/app/components/frameworks/FwPanels.tsx
@@ -1,3 +1,6 @@
+import { Link } from "react-router"
+
+import { frameworkLandingHref } from "~/data/framework-landing"
 import { cellFor } from "~/data/matrix"
 import { repoHref } from "~/data/links"
 
@@ -7,38 +10,58 @@ interface FwPanel {
   name: string
   slug: string
   body: string
+  matrixSlug?: string
+  sourcePath: string
 }
 
 const PANELS: FwPanel[] = [
   {
     name: "Next.js",
     slug: "nextjs",
+    matrixSlug: "nextjs",
+    sourcePath: "examples/nextjs-route",
     body: "App Router with server components and server actions. The @palamedes/next-plugin handles the host-specific build wiring; authoring, catalogs, and runtime access stay on the shared model.",
   },
   {
     name: "TanStack Start",
     slug: "tanstack",
+    matrixSlug: "tanstack",
+    sourcePath: "examples/tanstack-route",
     body: "Server functions and file-based routing, integrated through @palamedes/vite-plugin. Locale resolution runs in a server function; the client stays island-light.",
   },
   {
     name: "SolidStart",
     slug: "solidstart",
+    matrixSlug: "solidstart",
+    sourcePath: "examples/solidstart-route",
     body: "Fine-grained reactivity with @palamedes/solid — the same macro authoring and catalogs as React, no fork of your i18n strategy for a different renderer.",
   },
   {
     name: "Waku",
     slug: "waku",
+    matrixSlug: "waku",
+    sourcePath: "examples/waku-route",
     body: "Minimal RSC framework. Waku exercises the request-local runtime model through a different server integration, which is why it belongs in the matrix.",
   },
   {
     name: "React Router",
     slug: "react-router",
+    matrixSlug: "react-router",
+    sourcePath: "examples/react-router-route",
     body: "Framework-mode React Router with loaders and actions. The classic SPA-plus-SSR shape, same catalogs, same runtime.",
   },
   {
     name: "Remix v3",
     slug: "remix",
-    body: "Server-first Remix v3 integration, currently verified as a local and CI smoke-proof surface. It uses the same catalogs and runtime contract while the adapter and hosting story mature.",
+    matrixSlug: "remix",
+    sourcePath: "examples/remix-route",
+    body: "The new server-first Remix stack — not React Router Framework Mode and not React. It is currently a local and CI smoke-proof surface with explicit server-only boundaries.",
+  },
+  {
+    name: "Vite",
+    slug: "vite",
+    sourcePath: "packages/vite-plugin",
+    body: "The shared build integration behind the TanStack Start, SolidStart, Waku, and React Router families. Use it directly with React or Solid for macro transforms, PO imports, and build diagnostics.",
   },
 ]
 
@@ -46,10 +69,10 @@ export function FwPanels() {
   return (
     <div className="border border-hair">
       {PANELS.map((panel, index) => {
-        const cookie = cellFor(panel.slug, "cookie")
-        const route = cellFor(panel.slug, "route")
-        const subdomain = cellFor(panel.slug, "subdomain")
-        const tld = cellFor(panel.slug, "tld")
+        const cookie = panel.matrixSlug ? cellFor(panel.matrixSlug, "cookie") : undefined
+        const route = panel.matrixSlug ? cellFor(panel.matrixSlug, "route") : undefined
+        const subdomain = panel.matrixSlug ? cellFor(panel.matrixSlug, "subdomain") : undefined
+        const tld = panel.matrixSlug ? cellFor(panel.matrixSlug, "tld") : undefined
         return (
           <div
             key={panel.slug}
@@ -58,41 +81,58 @@ export function FwPanels() {
             }`}
           >
             <div>
-              <h3 className="text-[15px] font-bold">{panel.name}</h3>
-              <p className="mono-nums mt-1 text-[10px] text-gray-spec">examples/{panel.slug}-*</p>
+              <h3 className="text-[15px] font-bold">
+                <Link
+                  to={frameworkLandingHref(panel.slug)}
+                  viewTransition
+                  className="hover:text-accent"
+                >
+                  {panel.name}
+                </Link>
+              </h3>
+              <p className="mono-nums mt-1 text-[10px] text-gray-spec">
+                {panel.matrixSlug ? `examples/${panel.matrixSlug}-*` : panel.sourcePath}
+              </p>
             </div>
             <div>
               <p className="max-w-[52em] text-[13.5px] leading-relaxed text-ink/85">{panel.body}</p>
-              <p className="mono-nums mt-3 space-x-3 text-[12px]">
-                {cookie.demoLinks?.map((link) => (
+              <p className="mono-nums mt-3 flex flex-wrap gap-x-3 gap-y-1 text-[12px]">
+                {cookie?.demoLinks?.map((link) => (
                   <a key={link.href} href={link.href} className="text-accent hover:text-ink">
                     <span aria-hidden>● </span>cookie
                   </a>
                 ))}
-                {route.demoLinks?.[0] ? (
+                {route?.demoLinks?.[0] ? (
                   <a href={route.demoLinks[0].href} className="text-accent hover:text-ink">
                     <span aria-hidden>● </span>route
                   </a>
                 ) : null}
-                {subdomain.demoLinks?.[0] ? (
+                {subdomain?.demoLinks?.[0] ? (
                   <a href={subdomain.demoLinks[0].href} className="text-accent hover:text-ink">
                     <span aria-hidden>● </span>subdomain
                   </a>
-                ) : (
+                ) : panel.matrixSlug ? (
                   <span className="text-gray-spec">◌ subdomain</span>
-                )}
-                {tld.demoLinks?.[0] ? (
+                ) : null}
+                {tld?.demoLinks?.[0] ? (
                   <a href={tld.demoLinks[0].href} className="text-accent hover:text-ink">
                     <span aria-hidden>● </span>tld
                   </a>
-                ) : (
+                ) : panel.matrixSlug ? (
                   <span className="text-gray-spec">◌ tld</span>
-                )}
+                ) : null}
+                <Link
+                  to={frameworkLandingHref(panel.slug)}
+                  viewTransition
+                  className="text-accent hover:text-ink"
+                >
+                  i18n guide →
+                </Link>
                 <a
-                  href={repoHref(`examples/${panel.slug}-route`, "tree")}
+                  href={repoHref(panel.sourcePath, "tree")}
                   className="text-gray-spec hover:text-accent"
                 >
-                  all source →
+                  source →
                 </a>
               </p>
             </div>

--- a/site/app/components/frameworks/FwPanels.tsx
+++ b/site/app/components/frameworks/FwPanels.tsx
@@ -73,6 +73,7 @@ export function FwPanels() {
         const route = panel.matrixSlug ? cellFor(panel.matrixSlug, "route") : undefined
         const subdomain = panel.matrixSlug ? cellFor(panel.matrixSlug, "subdomain") : undefined
         const tld = panel.matrixSlug ? cellFor(panel.matrixSlug, "tld") : undefined
+        const hasLiveDemos = Boolean(cookie?.demoLinks?.length)
         return (
           <div
             key={panel.slug}
@@ -102,6 +103,9 @@ export function FwPanels() {
                     <span aria-hidden>● </span>cookie
                   </a>
                 ))}
+                {panel.matrixSlug && !hasLiveDemos ? (
+                  <span className="text-gray-spec">◌ local / CI</span>
+                ) : null}
                 {route?.demoLinks?.[0] ? (
                   <a href={route.demoLinks[0].href} className="text-accent hover:text-ink">
                     <span aria-hidden>● </span>route
@@ -111,14 +115,14 @@ export function FwPanels() {
                   <a href={subdomain.demoLinks[0].href} className="text-accent hover:text-ink">
                     <span aria-hidden>● </span>subdomain
                   </a>
-                ) : panel.matrixSlug ? (
+                ) : hasLiveDemos ? (
                   <span className="text-gray-spec">◌ subdomain</span>
                 ) : null}
                 {tld?.demoLinks?.[0] ? (
                   <a href={tld.demoLinks[0].href} className="text-accent hover:text-ink">
                     <span aria-hidden>● </span>tld
                   </a>
-                ) : panel.matrixSlug ? (
+                ) : hasLiveDemos ? (
                   <span className="text-gray-spec">◌ tld</span>
                 ) : null}
                 <Link

--- a/site/app/data/features.ts
+++ b/site/app/data/features.ts
@@ -1,4 +1,5 @@
 import { decisionHref, docsHref } from "./links"
+import type { StrategySlug } from "./matrix"
 
 /* Feature-cell copy, verbatim from the page specs. */
 
@@ -27,6 +28,10 @@ export interface FeatureCard {
   href?: string
 }
 
+export interface StrategyCard extends FeatureCard {
+  slug: StrategySlug
+}
+
 export const HOME_MODEL_CARDS: FeatureCard[] = [
   {
     icon: "pen",
@@ -48,23 +53,27 @@ export const HOME_MODEL_CARDS: FeatureCard[] = [
   },
 ]
 
-export const STRATEGY_CARDS: FeatureCard[] = [
+export const STRATEGY_CARDS: StrategyCard[] = [
   {
+    slug: "cookie",
     icon: "cookie",
     title: "Cookie",
     body: "One URL for all locales. Best for apps behind login where SEO is irrelevant and switching should be instant.",
   },
   {
+    slug: "route",
     icon: "route",
     title: "Route segment",
     body: "/de/checkout-style paths. The SEO-friendly default for public content with indexable localized pages.",
   },
   {
+    slug: "subdomain",
     icon: "globe",
     title: "Subdomain",
     body: "de.example.com. Clean separation per market, works well with regional CDNs and analytics splits.",
   },
   {
+    slug: "tld",
     icon: "flag",
     title: "Top-level domain",
     body: "example.de vs example.com. Maximum market trust; Palamedes maps each domain to its locale.",

--- a/site/app/data/framework-landing.ts
+++ b/site/app/data/framework-landing.ts
@@ -1,0 +1,70 @@
+export interface FrameworkLandingLink {
+  label: string
+  href: string
+}
+
+export interface FrameworkLandingPoint {
+  title: string
+  body: string
+}
+
+export interface FrameworkLandingFact {
+  label: string
+  value: string
+  note: string
+}
+
+export interface FrameworkLandingFaq {
+  q: string
+  a: string
+}
+
+export interface FrameworkLanding {
+  name: string
+  path: string
+  eyebrow: string
+  metaTitle: string
+  metaDescription: string
+  headline: string
+  lede: string
+  primary: FrameworkLandingLink
+  secondary: FrameworkLandingLink
+  facts: FrameworkLandingFact[]
+  problem: {
+    title: string
+    lede: string
+    points: string[]
+  }
+  approach: {
+    title: string
+    lede: string
+    points: FrameworkLandingPoint[]
+  }
+  code: {
+    label: string
+    caption: string
+    source: string
+    note: string
+  }
+  strategies: {
+    lede: string
+    matrixSlug?: string
+  }
+  proof: {
+    title: string
+    lede: string
+    facts: FrameworkLandingFact[]
+  }
+  boundary: {
+    title: string
+    body: string
+    link?: FrameworkLandingLink
+  }
+  faq: FrameworkLandingFaq[]
+  related: FrameworkLandingLink[]
+  finalCta: {
+    headline: string
+    primary: FrameworkLandingLink
+    secondary: FrameworkLandingLink
+  }
+}

--- a/site/app/data/framework-landing.ts
+++ b/site/app/data/framework-landing.ts
@@ -68,3 +68,21 @@ export interface FrameworkLanding {
     secondary: FrameworkLandingLink
   }
 }
+
+const FRAMEWORK_LANDING_PATHS: Record<string, string> = {
+  nextjs: "/frameworks/nextjs",
+  tanstack: "/frameworks/tanstack-start",
+  solidstart: "/frameworks/solidstart",
+  waku: "/frameworks/waku",
+  "react-router": "/frameworks/react-router",
+  remix: "/frameworks/remix-v3",
+  vite: "/frameworks/vite",
+}
+
+export function frameworkLandingHref(slug: string): string {
+  const href = FRAMEWORK_LANDING_PATHS[slug]
+  if (!href) {
+    throw new Error(`No framework landing page for ${slug}`)
+  }
+  return href
+}

--- a/site/app/data/matrix.ts
+++ b/site/app/data/matrix.ts
@@ -20,17 +20,19 @@ export interface DemoLink {
 
 export interface MatrixCell {
   framework: string
-  strategy: string
+  strategy: StrategySlug
   verified: true
   status: MatrixStatus
   demoLinks?: DemoLink[]
   sourceHref: string
 }
 
-export interface MatrixAxis {
+export interface MatrixAxis<TSlug extends string = string> {
   name: string
-  slug: string
+  slug: TSlug
 }
+
+export type StrategySlug = "cookie" | "route" | "subdomain" | "tld"
 
 export const FRAMEWORKS: MatrixAxis[] = [
   { name: "Next.js", slug: "nextjs" },
@@ -41,7 +43,7 @@ export const FRAMEWORKS: MatrixAxis[] = [
   { name: "Remix v3", slug: "remix" },
 ]
 
-export const STRATEGIES: MatrixAxis[] = [
+export const STRATEGIES: MatrixAxis<StrategySlug>[] = [
   { name: "Cookie", slug: "cookie" },
   { name: "Route", slug: "route" },
   { name: "Subdomain", slug: "subdomain" },
@@ -96,7 +98,7 @@ export const MATRIX_CELLS: MatrixCell[] = FRAMEWORKS.flatMap(({ slug: framework 
   },
 ])
 
-export function cellFor(framework: string, strategy: string): MatrixCell {
+export function cellFor(framework: string, strategy: StrategySlug): MatrixCell {
   const cell = MATRIX_CELLS.find((c) => c.framework === framework && c.strategy === strategy)
   if (!cell) {
     throw new Error(`No matrix cell for ${framework}/${strategy}`)

--- a/site/app/lib/meta.ts
+++ b/site/app/lib/meta.ts
@@ -91,3 +91,80 @@ export function topicMeta({
     },
   ]
 }
+
+/*
+ * Framework landing pages use the same visible FAQ / structured-data
+ * contract as topic pages, plus a breadcrumb back to the framework hub.
+ * The shared OG image is deliberate: framework pages do not pretend that a
+ * logo or screenshot exists until one is generated from a checked-in proof.
+ */
+export function frameworkMeta({
+  title,
+  description,
+  path,
+  framework,
+  faq,
+}: {
+  title: string
+  description: string
+  path: string
+  framework: string
+  faq: { q: string; a: string }[]
+}) {
+  const url = `${SITE_ORIGIN}${path}`
+  return [
+    ...pageMeta({ title, description, path }),
+    {
+      "script:ld+json": {
+        "@context": "https://schema.org",
+        "@type": "TechArticle",
+        headline: title,
+        description,
+        url,
+        inLanguage: "en",
+        isAccessibleForFree: true,
+        about: {
+          "@type": "SoftwareApplication",
+          name: framework,
+          applicationCategory: "DeveloperApplication",
+        },
+        publisher: {
+          "@type": "Organization",
+          name: "Sebastian Software GmbH",
+          url: SITE_ORIGIN,
+        },
+      },
+    },
+    {
+      "script:ld+json": {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        mainEntity: faq.map((entry) => ({
+          "@type": "Question",
+          name: entry.q,
+          acceptedAnswer: { "@type": "Answer", text: entry.a },
+        })),
+      },
+    },
+    {
+      "script:ld+json": {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        itemListElement: [
+          {
+            "@type": "ListItem",
+            position: 1,
+            name: "Frameworks",
+            item: `${SITE_ORIGIN}/frameworks`,
+          },
+          {
+            "@type": "ListItem",
+            position: 2,
+            name: framework,
+            item: url,
+          },
+        ],
+      },
+    },
+  ]
+}

--- a/site/app/routes.ts
+++ b/site/app/routes.ts
@@ -141,6 +141,7 @@ export default [
   route("frameworks/nextjs", "routes/frameworks/nextjs.tsx"),
   route("frameworks/solidstart", "routes/frameworks/solidstart.tsx"),
   route("frameworks/tanstack-start", "routes/frameworks/tanstack-start.tsx"),
+  route("frameworks/waku", "routes/frameworks/waku.tsx"),
   route("get-started", "routes/get-started.tsx"),
   route("guides", "routes/guides.tsx"),
   route("i18n-performance", "routes/i18n-performance.tsx"),

--- a/site/app/routes.ts
+++ b/site/app/routes.ts
@@ -140,6 +140,7 @@ export default [
   route("frameworks", "routes/frameworks.tsx"),
   route("frameworks/nextjs", "routes/frameworks/nextjs.tsx"),
   route("frameworks/react-router", "routes/frameworks/react-router.tsx"),
+  route("frameworks/remix-v3", "routes/frameworks/remix-v3.tsx"),
   route("frameworks/solidstart", "routes/frameworks/solidstart.tsx"),
   route("frameworks/tanstack-start", "routes/frameworks/tanstack-start.tsx"),
   route("frameworks/waku", "routes/frameworks/waku.tsx"),

--- a/site/app/routes.ts
+++ b/site/app/routes.ts
@@ -139,6 +139,7 @@ export default [
   route("docs/troubleshooting", "routes/docs/troubleshooting.md"),
   route("frameworks", "routes/frameworks.tsx"),
   route("frameworks/nextjs", "routes/frameworks/nextjs.tsx"),
+  route("frameworks/tanstack-start", "routes/frameworks/tanstack-start.tsx"),
   route("get-started", "routes/get-started.tsx"),
   route("guides", "routes/guides.tsx"),
   route("i18n-performance", "routes/i18n-performance.tsx"),

--- a/site/app/routes.ts
+++ b/site/app/routes.ts
@@ -139,6 +139,7 @@ export default [
   route("docs/troubleshooting", "routes/docs/troubleshooting.md"),
   route("frameworks", "routes/frameworks.tsx"),
   route("frameworks/nextjs", "routes/frameworks/nextjs.tsx"),
+  route("frameworks/solidstart", "routes/frameworks/solidstart.tsx"),
   route("frameworks/tanstack-start", "routes/frameworks/tanstack-start.tsx"),
   route("get-started", "routes/get-started.tsx"),
   route("guides", "routes/guides.tsx"),

--- a/site/app/routes.ts
+++ b/site/app/routes.ts
@@ -138,6 +138,7 @@ export default [
   route("docs/translation-workflow-surface", "routes/docs/translation-workflow-surface.md"),
   route("docs/troubleshooting", "routes/docs/troubleshooting.md"),
   route("frameworks", "routes/frameworks.tsx"),
+  route("frameworks/nextjs", "routes/frameworks/nextjs.tsx"),
   route("get-started", "routes/get-started.tsx"),
   route("guides", "routes/guides.tsx"),
   route("i18n-performance", "routes/i18n-performance.tsx"),

--- a/site/app/routes.ts
+++ b/site/app/routes.ts
@@ -143,6 +143,7 @@ export default [
   route("frameworks/remix-v3", "routes/frameworks/remix-v3.tsx"),
   route("frameworks/solidstart", "routes/frameworks/solidstart.tsx"),
   route("frameworks/tanstack-start", "routes/frameworks/tanstack-start.tsx"),
+  route("frameworks/vite", "routes/frameworks/vite.tsx"),
   route("frameworks/waku", "routes/frameworks/waku.tsx"),
   route("get-started", "routes/get-started.tsx"),
   route("guides", "routes/guides.tsx"),

--- a/site/app/routes.ts
+++ b/site/app/routes.ts
@@ -139,6 +139,7 @@ export default [
   route("docs/troubleshooting", "routes/docs/troubleshooting.md"),
   route("frameworks", "routes/frameworks.tsx"),
   route("frameworks/nextjs", "routes/frameworks/nextjs.tsx"),
+  route("frameworks/react-router", "routes/frameworks/react-router.tsx"),
   route("frameworks/solidstart", "routes/frameworks/solidstart.tsx"),
   route("frameworks/tanstack-start", "routes/frameworks/tanstack-start.tsx"),
   route("frameworks/waku", "routes/frameworks/waku.tsx"),

--- a/site/app/routes/frameworks.tsx
+++ b/site/app/routes/frameworks.tsx
@@ -32,11 +32,11 @@ export default function Frameworks() {
           Six frameworks. Four locale strategies. One mental model.
         </h1>
         <p className="mt-6 max-w-[38em]">
-          Every cell below is a real application — the same booking UI, the same catalogs, the same
-          runtime calls — browser-verified in CI. Where public hosting is ready, open the demo,
-          switch the language, and watch copy, plurals, currency, and dates change together. Then
-          open the framework guide for its exact server boundary, TypeScript setup, and current
-          limitations.
+          Every cell below is a real application verified in CI. The five established UI adapters
+          run browser flows against the same booking UI, catalogs, and runtime calls; Remix v3 runs
+          server smoke proofs against its new non-React stack. Where public hosting is ready, open
+          the demo and switch the language. Then open the framework guide for its exact server
+          boundary, TypeScript setup, and current limitations.
         </p>
         <div className="mt-8 flex flex-wrap gap-3">
           <ButtonLink href={DEMO_NEXTJS_COOKIE}>Open a live demo</ButtonLink>
@@ -52,13 +52,14 @@ export default function Frameworks() {
       >
         <FrameworkMatrix scan />
         <p className="mt-4 max-w-[52em] text-[12.5px] text-gray-spec">
-          All {contentStats.exampleCount} apps are verified in CI: SSR output, locale switching,
-          localized server actions or server handlers. Screenshots cover the established UI-adapter
-          matrix and are versioned in the repo. Cookie, route, and subdomain demos are publicly
-          hosted for the five browser-verified frameworks; the TLD domains are still being
-          provisioned, and Remix v3 is a local/CI proof surface without public hosting yet — those
-          cells link the verified source instead. Hosting status is documented in the repo&apos;s
-          demo-deployments guide.
+          All {contentStats.exampleCount} apps are verified in CI. The{" "}
+          {contentStats.exampleCount - contentStats.strategyCount} established UI-adapter apps cover
+          SSR output, locale switching, and localized server actions or functions in the browser;
+          the {contentStats.strategyCount} Remix v3 apps cover server responses and locale handling
+          through smoke checks. Screenshots cover the UI-adapter matrix and are versioned in the
+          repo. Cookie, route, and subdomain demos are publicly hosted for the five browser-verified
+          frameworks; the TLD domains are still being provisioned, and Remix v3 has no public
+          hosting yet. Hosting status is documented in the repo&apos;s demo-deployments guide.
         </p>
       </Section>
 

--- a/site/app/routes/frameworks.tsx
+++ b/site/app/routes/frameworks.tsx
@@ -16,9 +16,9 @@ export const handle = { layout: "bare" }
 
 export function meta() {
   return pageMeta({
-    title: "Palamedes — one i18n model across six framework families",
+    title: "Framework i18n guides for TypeScript | Palamedes",
     description:
-      "Six frameworks, four locale strategies, one mental model: the browser-verified Palamedes example matrix across Next.js, TanStack Start, SolidStart, Waku, React Router, and Remix v3.",
+      "Framework-specific i18n guides and verified examples for Next.js, TanStack Start, SolidStart, Waku, React Router, Remix v3, and Vite.",
     path: "/frameworks",
   })
 }
@@ -34,7 +34,9 @@ export default function Frameworks() {
         <p className="mt-6 max-w-[38em]">
           Every cell below is a real application — the same booking UI, the same catalogs, the same
           runtime calls — browser-verified in CI. Where public hosting is ready, open the demo,
-          switch the language, and watch copy, plurals, currency, and dates change together.
+          switch the language, and watch copy, plurals, currency, and dates change together. Then
+          open the framework guide for its exact server boundary, TypeScript setup, and current
+          limitations.
         </p>
         <div className="mt-8 flex flex-wrap gap-3">
           <ButtonLink href={DEMO_NEXTJS_COOKIE}>Open a live demo</ButtonLink>

--- a/site/app/routes/frameworks/nextjs.tsx
+++ b/site/app/routes/frameworks/nextjs.tsx
@@ -1,0 +1,181 @@
+import { FrameworkLandingPage } from "~/components/frameworks/FrameworkLandingPage"
+import type { FrameworkLanding } from "~/data/framework-landing"
+import { docsHref, NPM, repoHref } from "~/data/links"
+import { frameworkMeta } from "~/lib/meta"
+
+const page: FrameworkLanding = {
+  name: "Next.js",
+  path: "/frameworks/nextjs",
+  eyebrow: "Next.js i18n · TypeScript",
+  metaTitle: "Next.js i18n with TypeScript | Palamedes",
+  metaDescription:
+    "Internationalize the Next.js App Router with TypeScript macros, request-scoped Server Component rendering, PO catalogs, and verified locale strategies.",
+  headline: "Next.js i18n for the App Router, from server to client.",
+  lede: "Palamedes gives Next.js 16 one translation model across Server Components, Client Components, and server actions. The Next plugin handles macro transforms and catalog loading; your application keeps control of routing and locale policy.",
+  primary: {
+    label: "Open the Next.js demo",
+    href: "https://nextjs-route.examples.palamedes.dev/en",
+  },
+  secondary: {
+    label: "Browse the TypeScript source",
+    href: repoHref("examples/nextjs-route", "tree"),
+  },
+  facts: [
+    {
+      label: "Integration",
+      value: "@palamedes/next-plugin",
+      note: "One host adapter for macro transforms and PO imports.",
+    },
+    {
+      label: "Verified against",
+      value: "Next.js 16.2",
+      note: "App Router with the current Turbopack path.",
+    },
+    {
+      label: "Rendering",
+      value: "RSC + client",
+      note: "Server Components, Client Components, and server actions.",
+    },
+    {
+      label: "Locale models",
+      value: "4 examples",
+      note: "Cookie, route, subdomain, and top-level domain.",
+    },
+  ],
+  problem: {
+    title: "Next.js makes locale routing visible. The harder boundary is request-local rendering.",
+    lede: "A locale segment or cookie is only the first decision. Translations must resolve to the same locale while React crosses server and client boundaries, streams HTML, hydrates the browser, and runs a server action later.",
+    points: [
+      "Server Components need a request-scoped i18n instance without leaking locale state between requests.",
+      "Client hydration must start with the same catalog and locale that produced the server HTML.",
+      "Message macros and PO imports must work through the Next.js 16 build pipeline before either side executes them.",
+    ],
+  },
+  approach: {
+    title: "Keep the framework-specific wiring at the edge of one i18n model.",
+    lede: "Palamedes treats Next.js as a host, not as a separate translation architecture. The adapter owns the build integration while the core keeps message identity, catalogs, diagnostics, and runtime access consistent.",
+    points: [
+      {
+        title: "A native Next.js build path",
+        body: "withPalamedes() transforms TypeScript macros and compiles imported PO catalogs for Turbopack, with webpack available as a fallback.",
+      },
+      {
+        title: "Request-scoped server i18n",
+        body: "A server-only scope binds getI18n() to the active request so downstream Server Components and actions use the right locale.",
+      },
+      {
+        title: "The same authoring model",
+        body: "Write t and Trans next to the component. Server and client code share source-string-first catalogs instead of maintaining parallel APIs.",
+      },
+    ],
+  },
+  code: {
+    label: "next.config.ts + app/page.tsx",
+    caption: "The adapter is visible in config. The translation stays beside the UI.",
+    source: `// next.config.ts
+import { withPalamedes } from "@palamedes/next-plugin"
+
+export default withPalamedes(
+  {},
+  { runtimeModule: "@palamedes/react/runtime" },
+)
+
+// app/page.tsx — a Server Component
+import { t } from "@palamedes/core/macro"
+import { createActiveServerI18n } from "@/lib/i18n.server"
+
+export default async function Page() {
+  await createActiveServerI18n()
+  return <h1>{t\`Welcome to Palamedes\`}</h1>
+}`,
+    note: "The server helper resolves the locale, loads its catalog, and activates a request-local scope once. The checked example also initializes the client boundary and verifies a localized server action.",
+  },
+  strategies: {
+    matrixSlug: "nextjs",
+    lede: "Next.js owns URL structure and request handling. Palamedes supplies typed locale controls and the same catalog runtime for all four patterns, so choosing an SEO-friendly route segment does not require choosing a different translation library.",
+  },
+  proof: {
+    title: "A real App Router application, exercised like a user would use it.",
+    lede: "The Next.js family is part of the repository's browser-verification matrix. The checks start the application, inspect server-rendered output, switch locale, and invoke translated server behavior.",
+    facts: [
+      {
+        label: "Initial response",
+        value: "SSR checked",
+        note: "The expected locale is present before hydration.",
+      },
+      {
+        label: "Interaction",
+        value: "Switch checked",
+        note: "Copy, plurals, dates, and currency move together.",
+      },
+      {
+        label: "Server behavior",
+        value: "Action checked",
+        note: "A server action returns localized output after interaction.",
+      },
+      {
+        label: "Evidence",
+        value: "Source + CI",
+        note: "Examples, verifier, and screenshots are checked in.",
+      },
+    ],
+  },
+  boundary: {
+    title: "Current boundary: the request scope targets the Node runtime.",
+    body: "The @palamedes/runtime/server entry uses Node async hooks and must stay out of Edge and Client Components. Direct catalog imports currently use PO files even when FCL is configured for other catalog workflows.",
+    link: {
+      label: "Read the Next.js integration notes",
+      href: docsHref("api/next-plugin"),
+    },
+  },
+  faq: [
+    {
+      q: "Does Palamedes replace Next.js internationalized routing?",
+      a: "No. Next.js still owns routes, redirects, middleware, and URL design. Palamedes handles translated messages, catalogs, diagnostics, and the runtime that follows the locale your application resolved.",
+    },
+    {
+      q: "Does Next.js i18n work in Server Components?",
+      a: "Yes on the verified Node runtime path. Initialize one request-local server scope before downstream Server Components call Palamedes macros; keep that server-only module outside Edge and client bundles.",
+    },
+    {
+      q: "Can the same messages run in Client Components and server actions?",
+      a: "Yes. The React runtime initializes the browser-side instance while the server scope serves Server Components and actions. Both consume the same source-string-first catalogs.",
+    },
+    {
+      q: "How is this different from next-intl?",
+      a: "next-intl is deeply centered on Next.js. Palamedes provides a broader source-to-runtime toolchain with a native core, repository-owned PO or FCL catalogs, semantic merging, audits, and first-party adapters across several hosts. The right choice depends on whether that shared workflow matters to your team.",
+    },
+  ],
+  related: [
+    { label: "Waku i18n for React Server Components", href: "/frameworks/waku" },
+    { label: "TanStack Start i18n", href: "/frameworks/tanstack-start" },
+    { label: "Vite i18n for React and Solid", href: "/frameworks/vite" },
+  ],
+  finalCta: {
+    headline: "See Next.js switch locale without switching i18n models.",
+    primary: {
+      label: "Open the live route demo",
+      href: "https://nextjs-route.examples.palamedes.dev/en",
+    },
+    secondary: {
+      label: "View @palamedes/next-plugin",
+      href: NPM("@palamedes/next-plugin"),
+    },
+  },
+}
+
+export const handle = { layout: "bare" }
+
+export function meta() {
+  return frameworkMeta({
+    title: page.metaTitle,
+    description: page.metaDescription,
+    path: page.path,
+    framework: page.name,
+    faq: page.faq,
+  })
+}
+
+export default function NextjsI18n() {
+  return <FrameworkLandingPage page={page} />
+}

--- a/site/app/routes/frameworks/react-router.tsx
+++ b/site/app/routes/frameworks/react-router.tsx
@@ -1,0 +1,182 @@
+import { FrameworkLandingPage } from "~/components/frameworks/FrameworkLandingPage"
+import type { FrameworkLanding } from "~/data/framework-landing"
+import { docsHref, NPM, repoHref } from "~/data/links"
+import { frameworkMeta } from "~/lib/meta"
+
+const page: FrameworkLanding = {
+  name: "React Router",
+  path: "/frameworks/react-router",
+  eyebrow: "React Router i18n · Framework Mode",
+  metaTitle: "React Router i18n in Framework Mode | Palamedes",
+  metaDescription:
+    "Internationalize React Router Framework Mode with TypeScript macros, localized loaders and actions, PO catalogs, SSR, and verified locale switching.",
+  headline: "React Router i18n for Framework Mode.",
+  lede: "Palamedes connects React Router 8 loaders, actions, SSR, and hydrated React components to one translation runtime. The Vite plugin compiles messages; route modules resolve the locale and activate the matching catalog.",
+  primary: {
+    label: "Open the React Router demo",
+    href: "https://react-router-route.examples.palamedes.dev/en",
+  },
+  secondary: {
+    label: "Browse the TypeScript source",
+    href: repoHref("examples/react-router-route", "tree"),
+  },
+  facts: [
+    {
+      label: "Mode",
+      value: "Framework",
+      note: "Type-safe route modules, loaders, actions, and SSR.",
+    },
+    {
+      label: "Verified against",
+      value: "React Router 8.3",
+      note: "React 19 and the React Router Vite plugin.",
+    },
+    {
+      label: "Integration",
+      value: "@palamedes/vite-plugin",
+      note: "Macro transforms and PO loading in the route build.",
+    },
+    {
+      label: "Locale models",
+      value: "4 examples",
+      note: "Cookie, route, subdomain, and top-level domain.",
+    },
+  ],
+  problem: {
+    title: "The locale has to be route data, server state, and client state at the right times.",
+    lede: "Framework Mode spans the initial server render and later browser navigations. A translated route must activate its locale before loader or action macros run, then hydrate React with the same catalog.",
+    points: [
+      "Loaders and actions can execute on the server independently, so each boundary must resolve the correct request locale.",
+      "The document locale and client runtime must match loader data before HydratedRouter starts.",
+      "Route-based, cookie-based, and host-based locale policies should not require different message APIs.",
+    ],
+  },
+  approach: {
+    title: "Use route modules for policy and Palamedes for the translation lifecycle.",
+    lede: "React Router continues to own matching, redirects, data loading, and mutations. Palamedes supplies transformed authoring, catalogs, request activation, and client synchronization around those APIs.",
+    points: [
+      {
+        title: "Compose two Vite plugins",
+        body: "The Palamedes transform runs beside the React Router plugin, so macros and PO imports become normal modules in the Framework Mode build.",
+      },
+      {
+        title: "Activate inside route boundaries",
+        body: "A loader or action normalizes its locale and activates the server runtime before translated messages execute.",
+      },
+      {
+        title: "Hydrate from root locale data",
+        body: "The root route exposes the resolved locale and the client entry loads the same catalog before React hydrates the document.",
+      },
+    ],
+  },
+  code: {
+    label: "vite.config.ts + routes/locale-home.tsx",
+    caption: "Framework Mode keeps the locale close to the loader and action.",
+    source: `// vite.config.ts
+import { reactRouter } from "@react-router/dev/vite"
+import { palamedes } from "@palamedes/vite-plugin"
+
+export default {
+  plugins: [
+    palamedes({ runtimeModule: "@palamedes/react/runtime" }),
+    reactRouter(),
+  ],
+}
+
+// routes/locale-home.tsx
+export async function loader({ params }: Route.LoaderArgs) {
+  const locale = normalizeLocale(params.locale)
+  activateServerI18n(locale)
+  return { locale, title: t\`Welcome to Palamedes\` }
+}`,
+    note: "The checked route module also localizes an action response. Its client entry activates the locale from root loader data before HydratedRouter hydrates the React tree.",
+  },
+  strategies: {
+    matrixSlug: "react-router",
+    lede: "React Router route modules own params, requests, redirects, and links. Palamedes keeps the catalog and component model identical while the four examples change how those route modules derive a locale.",
+  },
+  proof: {
+    title: "Framework Mode is tested as a full server-and-browser application.",
+    lede: "The verifier checks the initial document, route or host behavior, client switching, and a localized action after hydration.",
+    facts: [
+      {
+        label: "Route modules",
+        value: "Typed",
+        note: "The examples use generated loader and action types.",
+      },
+      {
+        label: "Initial response",
+        value: "SSR checked",
+        note: "Server-rendered messages match the resolved locale.",
+      },
+      {
+        label: "Mutation",
+        value: "Action checked",
+        note: "A post-hydration action returns localized output.",
+      },
+      {
+        label: "Evidence",
+        value: "Live + CI",
+        note: "Hosted demos and checked source cover the matrix.",
+      },
+    ],
+  },
+  boundary: {
+    title: "This page is about React Router Framework Mode, not every router mode.",
+    body: "The browser matrix verifies the Vite-powered Framework Mode with SSR, loaders, and actions. Palamedes can be assembled in other Vite React applications, but Declarative and Data Mode do not inherit this page's framework-specific proof automatically.",
+    link: {
+      label: "Read the framework example notes",
+      href: docsHref("framework-example-notes"),
+    },
+  },
+  faq: [
+    {
+      q: "Where should React Router resolve the locale?",
+      a: "At the route or request boundary that owns the policy: a root loader, a locale route loader, middleware, or a shared request helper. Activate the Palamedes server runtime before translated loader or action code executes.",
+    },
+    {
+      q: "Can actions return translated messages?",
+      a: "Yes. The checked examples activate the route locale inside the action and return a message produced by a transformed Palamedes macro.",
+    },
+    {
+      q: "Does client navigation keep the active catalog synchronized?",
+      a: "Yes in the verified examples. Root locale data initializes the browser runtime before hydration, and the React client helper follows locale changes during navigation and switching.",
+    },
+    {
+      q: "Is React Router Framework Mode the same as Remix v3?",
+      a: "No. React Router Framework Mode is a React framework built around route modules and a Vite plugin. The new Remix v3 is a separate server-first full-stack project with its own router, loaders, UI direction, and integration constraints.",
+    },
+  ],
+  related: [
+    { label: "Remix v3 server-first i18n", href: "/frameworks/remix-v3" },
+    { label: "TanStack Start i18n", href: "/frameworks/tanstack-start" },
+    { label: "Vite i18n for React and Solid", href: "/frameworks/vite" },
+  ],
+  finalCta: {
+    headline: "Let route modules own the request and one runtime own the messages.",
+    primary: {
+      label: "Open the live route demo",
+      href: "https://react-router-route.examples.palamedes.dev/en",
+    },
+    secondary: {
+      label: "View @palamedes/react",
+      href: NPM("@palamedes/react"),
+    },
+  },
+}
+
+export const handle = { layout: "bare" }
+
+export function meta() {
+  return frameworkMeta({
+    title: page.metaTitle,
+    description: page.metaDescription,
+    path: page.path,
+    framework: page.name,
+    faq: page.faq,
+  })
+}
+
+export default function ReactRouterI18n() {
+  return <FrameworkLandingPage page={page} />
+}

--- a/site/app/routes/frameworks/remix-v3.tsx
+++ b/site/app/routes/frameworks/remix-v3.tsx
@@ -1,0 +1,185 @@
+import { FrameworkLandingPage } from "~/components/frameworks/FrameworkLandingPage"
+import type { FrameworkLanding } from "~/data/framework-landing"
+import { docsHref, NPM, repoHref } from "~/data/links"
+import { frameworkMeta } from "~/lib/meta"
+
+const page: FrameworkLanding = {
+  name: "Remix v3",
+  path: "/frameworks/remix-v3",
+  eyebrow: "Remix v3 i18n · Server-first",
+  metaTitle: "Remix v3 i18n for server-first apps | Palamedes",
+  metaDescription:
+    "Add server-first i18n to the new Remix v3 with TypeScript macros, request-local catalogs, a Node loader integration, and four smoke-verified locale strategies.",
+  headline: "Remix v3 i18n for its new server-first stack.",
+  lede: "The new Remix v3 is not React Router Framework Mode and it is not a React framework. Palamedes integrates with its Node TypeScript loader and Fetch API request model to translate server-loaded modules with request-local PO catalogs.",
+  primary: {
+    label: "Browse the Remix v3 example",
+    href: repoHref("examples/remix-route", "tree"),
+  },
+  secondary: {
+    label: "Read the current limitations",
+    href: docsHref("api/remix"),
+  },
+  facts: [
+    {
+      label: "Integration",
+      value: "@palamedes/remix",
+      note: "A Node loader hook plus request-local server helpers.",
+    },
+    {
+      label: "Verified against",
+      value: "Remix 3 beta.5",
+      note: "The new full-stack Remix package, not React Router.",
+    },
+    {
+      label: "Current scope",
+      value: "Server modules",
+      note: "TypeScript macros and PO imports on the server path.",
+    },
+    {
+      label: "Locale models",
+      value: "4 smoke proofs",
+      note: "Cookie, route, subdomain, and top-level domain.",
+    },
+  ],
+  problem: {
+    title: "Remix v3 moved the integration point from a bundler to the running server.",
+    lede: "Remix v3 intentionally executes TypeScript through its Node loader instead of relying on a traditional application build. Translation macros therefore have to compose with that loader and establish request scope before controllers render a response.",
+    points: [
+      "A transform hook must run after remix/node-tsx without allowing uncompiled macro stubs to reach runtime.",
+      "Fetch API requests need isolated locale state while several requests share one Node process.",
+      "Server-loaded modules and browser assets currently expose different extension points and cannot be presented as one finished adapter.",
+    ],
+  },
+  approach: {
+    title: "Join the loader Remix already uses, then stay request-local.",
+    lede: "Palamedes does not add a separate Remix build. Its register hook receives the output from Remix's TypeScript loader, transforms message macros, and lets controllers resolve catalogs through a server helper.",
+    points: [
+      {
+        title: "A composable Node loader",
+        body: "Register remix/node-tsx first and @palamedes/remix/register second. Macro-containing server modules are transformed once when Node loads them.",
+      },
+      {
+        title: "Fetch-native locale resolution",
+        body: "createRemixI18nServer() reads a Request, applies the chosen strategy, loads the catalog, and scopes the active runtime to the handler.",
+      },
+      {
+        title: "No per-request transform work",
+        body: "After process startup, handlers execute ordinary runtime calls against compiled catalogs; the transform does not repeat for every response.",
+      },
+    ],
+  },
+  code: {
+    label: "package.json + app/i18n.ts",
+    caption: "Loader order is explicit; locale policy stays in a typed server helper.",
+    source: `// package.json
+{
+  "scripts": {
+    "start": "node --import remix/node-tsx --import @palamedes/remix/register server.ts"
+  }
+}
+
+// app/i18n.ts
+import { createRemixI18nServer } from "@palamedes/remix/server"
+
+export const remixI18n = createRemixI18nServer({
+  locales,
+  strategy: "route",
+  loadMessages,
+  routeParam: "locale",
+})
+
+export function resolveLocale(request: Request) {
+  return remixI18n.resolveLocale(request)
+}`,
+    note: "The registration order is load-bearing: Remix lowers TypeScript first, then Palamedes transforms the resulting server module. The checked controller runs translated t and plural calls inside the resolved request scope.",
+  },
+  strategies: {
+    matrixSlug: "remix",
+    lede: "The Remix server helper supports the same four locale decisions as the established UI adapters. These examples are local and CI smoke proofs today; the cells link source rather than implying a public interactive deployment.",
+  },
+  proof: {
+    title: "Four server proofs, with the maturity level stated plainly.",
+    lede: "Remix v3 support is checked separately from React Router and separately from the browser-verified React/Solid matrix. The tests start each server and assert locale-specific responses and switching behavior.",
+    facts: [
+      {
+        label: "Module loading",
+        value: "Hook checked",
+        note: "TypeScript macros are transformed after remix/node-tsx.",
+      },
+      {
+        label: "Catalog loading",
+        value: "PO checked",
+        note: "Server-loaded PO imports compile through the register hook.",
+      },
+      {
+        label: "Request state",
+        value: "Scoped",
+        note: "Locale and catalog resolve per Fetch API request.",
+      },
+      {
+        label: "Hosting",
+        value: "Local / CI",
+        note: "No public Remix v3 demo is claimed yet.",
+      },
+    ],
+  },
+  boundary: {
+    title: "Server modules work today; client modules and rich JSX do not.",
+    body: "The current Remix asset pipeline does not expose the script transform hook Palamedes needs for browser-delivered modules. Remix also lowers JSX before the register hook sees it, so rich JSX messages are not supported on this path. The integration requires Node.js 24.3 or newer.",
+    link: {
+      label: "Read the Remix v3 package scope",
+      href: docsHref("api/remix"),
+    },
+  },
+  faq: [
+    {
+      q: "Is Remix v3 the same thing as React Router Framework Mode?",
+      a: "No. React Router Framework Mode remains a React framework with a Vite plugin, route modules, loaders, and actions. Remix v3 is a separate server-first full-stack project with its own packages, router, loaders, UI direction, and runtime model.",
+    },
+    {
+      q: "Does Palamedes support Remix v3 without React?",
+      a: "Yes for the current server-loaded module path. The integration transforms core t, plural, select, and selectOrdinal macros and loads PO catalogs without depending on @palamedes/react.",
+    },
+    {
+      q: "Can Remix v3 browser modules use Palamedes macros?",
+      a: "Not yet. Remix's current asset pipeline does not expose a script transform hook for the Palamedes adapter, so this page deliberately limits the support claim to server-loaded modules.",
+    },
+    {
+      q: "Is Remix v3 support production-ready?",
+      a: "Treat it as an early integration for an upstream beta. Four locale strategies are smoke-verified, but there is no public hosted demo, client-module transform, or rich JSX path yet.",
+    },
+  ],
+  related: [
+    { label: "React Router i18n in Framework Mode", href: "/frameworks/react-router" },
+    { label: "Vite i18n for React and Solid", href: "/frameworks/vite" },
+    { label: "Next.js App Router i18n", href: "/frameworks/nextjs" },
+  ],
+  finalCta: {
+    headline: "Explore the new Remix on its own terms, including the sharp edges.",
+    primary: {
+      label: "Browse the route example",
+      href: repoHref("examples/remix-route", "tree"),
+    },
+    secondary: {
+      label: "View @palamedes/remix",
+      href: NPM("@palamedes/remix"),
+    },
+  },
+}
+
+export const handle = { layout: "bare" }
+
+export function meta() {
+  return frameworkMeta({
+    title: page.metaTitle,
+    description: page.metaDescription,
+    path: page.path,
+    framework: page.name,
+    faq: page.faq,
+  })
+}
+
+export default function RemixV3I18n() {
+  return <FrameworkLandingPage page={page} />
+}

--- a/site/app/routes/frameworks/solidstart.tsx
+++ b/site/app/routes/frameworks/solidstart.tsx
@@ -1,0 +1,184 @@
+import { FrameworkLandingPage } from "~/components/frameworks/FrameworkLandingPage"
+import type { FrameworkLanding } from "~/data/framework-landing"
+import { docsHref, NPM, repoHref } from "~/data/links"
+import { frameworkMeta } from "~/lib/meta"
+
+const page: FrameworkLanding = {
+  name: "SolidStart",
+  path: "/frameworks/solidstart",
+  eyebrow: "SolidStart i18n · TypeScript",
+  metaTitle: "SolidStart i18n with TypeScript | Palamedes",
+  metaDescription:
+    "Add i18n to SolidStart with TypeScript macros, fine-grained locale reactivity, server-side translation, PO catalogs, and verified locale strategies.",
+  headline: "SolidStart i18n that stays native to Solid.",
+  lede: "Palamedes pairs a Vite build integration with dedicated Solid authoring and runtime packages. Components keep Solid's fine-grained reactivity while server routes, client effects, and catalogs follow one source-to-runtime model.",
+  primary: {
+    label: "Open the SolidStart demo",
+    href: "https://solidstart-route.examples.palamedes.dev/en",
+  },
+  secondary: {
+    label: "Browse the TypeScript source",
+    href: repoHref("examples/solidstart-route", "tree"),
+  },
+  facts: [
+    {
+      label: "UI integration",
+      value: "@palamedes/solid",
+      note: "Solid macros, formatters, and locale primitives.",
+    },
+    {
+      label: "Verified against",
+      value: "SolidStart 1.3",
+      note: "Vinxi and Vite 8 on the checked matrix path.",
+    },
+    {
+      label: "Rendering",
+      value: "SSR + client",
+      note: "Isomorphic routes with fine-grained client updates.",
+    },
+    {
+      label: "Locale models",
+      value: "4 examples",
+      note: "Cookie, route, subdomain, and top-level domain.",
+    },
+  ],
+  problem: {
+    title:
+      "SolidStart i18n has to cross the server boundary without importing a React mental model.",
+    lede: "A Solid application should not need provider patterns designed for another renderer. Locale state must still agree across the server response, hydration, route navigation, and fine-grained updates in the browser.",
+    points: [
+      "Server-side macros need the request's active catalog before an isomorphic route renders.",
+      "The client locale must update Solid signals and translated computations without remounting the application.",
+      "Rich messages and locale controls need Solid-specific primitives rather than a thin React compatibility layer.",
+    ],
+  },
+  approach: {
+    title: "Share catalog semantics, not renderer internals.",
+    lede: "The native core and Vite adapter stay common across hosts. @palamedes/solid owns the renderer-facing surface so the application uses Solid components, effects, and signals directly.",
+    points: [
+      {
+        title: "Solid-native authoring",
+        body: "Use t, plural, and the Solid Trans macro beside JSX. Rich messages compile for Solid instead of passing through a React adapter.",
+      },
+      {
+        title: "Fine-grained locale sync",
+        body: "Client helpers connect the active i18n instance to Solid reactivity, so dependent text updates when the locale changes.",
+      },
+      {
+        title: "One catalog pipeline",
+        body: "The same extraction, ICU diagnostics, PO or FCL storage, audits, and semantic merging apply before the renderer sees a message.",
+      },
+    ],
+  },
+  code: {
+    label: "app.config.ts + routes/[locale].tsx",
+    caption: "Configure the transform once, then author messages as Solid code.",
+    source: `// app.config.ts
+import { defineConfig } from "@solidjs/start/config"
+import { palamedes } from "@palamedes/vite-plugin"
+
+export default defineConfig({
+  vite: {
+    plugins: [
+      palamedes({ runtimeModule: "@palamedes/solid/runtime" }),
+    ],
+  },
+})
+
+// routes/[locale].tsx
+import { Trans } from "@palamedes/solid/macro"
+
+export default function LocalePage() {
+  return <h1><Trans>Welcome to Palamedes</Trans></h1>
+}`,
+    note: "The route example activates a server i18n instance for SSR and uses the public Solid client helpers to keep the browser locale synchronized after hydration.",
+  },
+  strategies: {
+    matrixSlug: "solidstart",
+    lede: "SolidStart's file routes and request APIs decide where the locale lives. Each checked Palamedes example keeps the Solid authoring and runtime surface unchanged while swapping the detection and switching policy.",
+  },
+  proof: {
+    title: "Solid behavior is verified, not inferred from the React adapter.",
+    lede: "The SolidStart matrix uses @palamedes/solid directly. Browser checks exercise the rendered page, the locale switch, and localized server work for every URL strategy.",
+    facts: [
+      {
+        label: "Renderer",
+        value: "Solid-native",
+        note: "No React provider or React translation component.",
+      },
+      {
+        label: "Initial response",
+        value: "SSR checked",
+        note: "The selected catalog renders before hydration.",
+      },
+      {
+        label: "Interaction",
+        value: "Signals checked",
+        note: "Client-visible content follows the active locale.",
+      },
+      {
+        label: "Server behavior",
+        value: "Handler checked",
+        note: "Translated server output is exercised in CI.",
+      },
+    ],
+  },
+  boundary: {
+    title: "Current proof targets SolidStart 1.x.",
+    body: "The checked examples use SolidStart 1.3 with app.config.ts and Vinxi. SolidStart 2 moves configuration into vite.config.ts; the Palamedes Vite model is compatible in shape, but the repository does not claim SolidStart 2 verification until that matrix is updated.",
+    link: {
+      label: "Read the Solid API guide",
+      href: docsHref("api/solid"),
+    },
+  },
+  faq: [
+    {
+      q: "Is Palamedes for SolidStart a React wrapper?",
+      a: "No. @palamedes/solid provides Solid-specific macros, components, formatters, runtime wiring, and client locale helpers. Only the lower catalog and transformation model is shared.",
+    },
+    {
+      q: "Does SolidStart i18n work during server-side rendering?",
+      a: "Yes on the verified SolidStart 1.x path. The example activates a server i18n instance before route rendering and initializes the matching client locale for hydration.",
+    },
+    {
+      q: "Can I use route-based locales such as /de/products?",
+      a: "Yes. The route example derives the locale from a dynamic SolidStart segment. Cookie, subdomain, and top-level-domain examples use the same messages and Solid runtime with different resolution policies.",
+    },
+    {
+      q: "Is SolidStart 2 already verified?",
+      a: "Not yet. The current browser matrix pins SolidStart 1.3.2. The integration uses a standard Vite plugin, but Palamedes will not label the v2 path verified until a checked v2 example replaces or extends the matrix.",
+    },
+  ],
+  related: [
+    { label: "Vite i18n for React and Solid", href: "/frameworks/vite" },
+    { label: "TanStack Start i18n", href: "/frameworks/tanstack-start" },
+    { label: "React Router i18n in Framework Mode", href: "/frameworks/react-router" },
+  ],
+  finalCta: {
+    headline: "Use Solid for the renderer and one coherent model for the translations.",
+    primary: {
+      label: "Open the live route demo",
+      href: "https://solidstart-route.examples.palamedes.dev/en",
+    },
+    secondary: {
+      label: "View @palamedes/solid",
+      href: NPM("@palamedes/solid"),
+    },
+  },
+}
+
+export const handle = { layout: "bare" }
+
+export function meta() {
+  return frameworkMeta({
+    title: page.metaTitle,
+    description: page.metaDescription,
+    path: page.path,
+    framework: page.name,
+    faq: page.faq,
+  })
+}
+
+export default function SolidStartI18n() {
+  return <FrameworkLandingPage page={page} />
+}

--- a/site/app/routes/frameworks/tanstack-start.tsx
+++ b/site/app/routes/frameworks/tanstack-start.tsx
@@ -1,0 +1,185 @@
+import { FrameworkLandingPage } from "~/components/frameworks/FrameworkLandingPage"
+import type { FrameworkLanding } from "~/data/framework-landing"
+import { docsHref, NPM, repoHref } from "~/data/links"
+import { frameworkMeta } from "~/lib/meta"
+
+const page: FrameworkLanding = {
+  name: "TanStack Start",
+  path: "/frameworks/tanstack-start",
+  eyebrow: "TanStack Start i18n · TypeScript",
+  metaTitle: "TanStack Start i18n with TypeScript | Palamedes",
+  metaDescription:
+    "Add i18n to TanStack Start routes and server functions with TypeScript macros, PO catalogs, a Vite integration, and verified locale switching.",
+  headline: "TanStack Start i18n for routes, server functions, and the client.",
+  lede: "Palamedes connects TanStack Start's type-safe router and server functions to one source-string-first translation workflow. Locale routing stays in TanStack; macro transforms, catalogs, diagnostics, and runtime access stay coherent across the request.",
+  primary: {
+    label: "Open the TanStack Start demo",
+    href: "https://tanstack-route.examples.palamedes.dev/en",
+  },
+  secondary: {
+    label: "Browse the TypeScript source",
+    href: repoHref("examples/tanstack-route", "tree"),
+  },
+  facts: [
+    {
+      label: "Integration",
+      value: "@palamedes/vite-plugin",
+      note: "Transforms macros before the React and Start pipeline.",
+    },
+    {
+      label: "Verified against",
+      value: "Start 1.168",
+      note: "With TanStack Router 1.170 and Vite 8.",
+    },
+    {
+      label: "Server model",
+      value: "Server Functions",
+      note: "Request data activates the matching server runtime.",
+    },
+    {
+      label: "Locale models",
+      value: "4 examples",
+      note: "Cookie, route, subdomain, and top-level domain.",
+    },
+  ],
+  problem: {
+    title: "A typed locale route is useful only when the server function speaks the same locale.",
+    lede: "TanStack Router can model localized URLs precisely. An i18n integration still has to carry that decision into SSR, server functions, browser hydration, and later client interactions without turning the router into a translation store.",
+    points: [
+      "Route params and locale redirects need to stay type-safe without coupling message catalogs to route generation.",
+      "Each server function must activate the locale for its own request before a translated macro executes.",
+      "The client runtime must follow navigation and switching while keeping the server-rendered language stable during hydration.",
+    ],
+  },
+  approach: {
+    title: "Let TanStack own navigation and Palamedes own translation semantics.",
+    lede: "The integration composes at the Vite and request boundaries. It does not replace TanStack Router's route tree, rewrites, params, or metadata APIs.",
+    points: [
+      {
+        title: "A normal Vite plugin",
+        body: "The Palamedes plugin runs in the existing TanStack Start toolchain and compiles TypeScript macros plus imported PO catalogs.",
+      },
+      {
+        title: "Explicit server activation",
+        body: "A server function validates its locale input, activates a request-local i18n instance, and then uses the same t macro as application code.",
+      },
+      {
+        title: "Router-native locale URLs",
+        body: "Use required, optional, or rewritten locale params in TanStack Router. Palamedes follows the resolved locale instead of prescribing the URL.",
+      },
+    ],
+  },
+  code: {
+    label: "vite.config.ts + server-functions.ts",
+    caption: "The Vite adapter and server function meet at one runtime contract.",
+    source: `// vite.config.ts
+import { tanstackStart } from "@tanstack/react-start/plugin/vite"
+import react from "@vitejs/plugin-react"
+import { palamedes } from "@palamedes/vite-plugin"
+
+export default {
+  plugins: [
+    tanstackStart(),
+    palamedes({ runtimeModule: "@palamedes/react/runtime" }),
+    react(),
+  ],
+}
+
+// server-functions.ts
+export const getStatus = createServerFn({ method: "GET" })
+  .validator((data: { locale: Locale }) => data)
+  .handler(async ({ data }) => {
+    activateServerI18n(data.locale)
+    return t\`Server function confirmed locale \${data.locale}.\`
+  })`,
+    note: "The checked route example derives the locale from a typed route param, passes it into server functions, and initializes the browser runtime for subsequent navigation.",
+  },
+  strategies: {
+    matrixSlug: "tanstack",
+    lede: "TanStack Router supports several localized URL patterns, including optional path params and rewrites. The Palamedes matrix keeps message handling identical while each example changes only the locale-resolution strategy.",
+  },
+  proof: {
+    title: "Verified across the initial request and a later server-function call.",
+    lede: "The browser flow checks more than rendered text. It proves that route resolution, client switching, and server work agree on one active locale.",
+    facts: [
+      {
+        label: "Routing",
+        value: "Redirect checked",
+        note: "Accept-Language reaches the configured locale URL.",
+      },
+      {
+        label: "Initial response",
+        value: "SSR checked",
+        note: "Localized content is present before client interaction.",
+      },
+      {
+        label: "Server behavior",
+        value: "Function checked",
+        note: "A later server function returns translated output.",
+      },
+      {
+        label: "Evidence",
+        value: "4 app shapes",
+        note: "Every locale strategy has source and CI coverage.",
+      },
+    ],
+  },
+  boundary: {
+    title: "Palamedes translates content; TanStack Router still localizes URLs.",
+    body: "Route rewrites, translated pathnames, alternate links, and metadata remain application or router concerns. Palamedes supplies locale helpers and translated messages without taking ownership of the route tree.",
+    link: {
+      label: "Read the locale strategy guide",
+      href: docsHref("locale-strategies"),
+    },
+  },
+  faq: [
+    {
+      q: "Does Palamedes replace TanStack Router's i18n routing patterns?",
+      a: "No. Keep locale params, rewrites, redirects, and links in TanStack Router. Palamedes turns the locale resolved by those routes into the active catalog for server and client code.",
+    },
+    {
+      q: "Can Palamedes translate TanStack Start server functions?",
+      a: "Yes. Validate or normalize the locale at the server-function boundary, activate a request-local i18n instance, and use the same transformed macros as the rest of the application.",
+    },
+    {
+      q: "Does it work with server-side rendering?",
+      a: "Yes. The example matrix verifies localized SSR output and then checks client switching plus a localized server-function response.",
+    },
+    {
+      q: "How does this compare with Paraglide in the TanStack guide?",
+      a: "Paraglide offers a generated, typesafe message API and dedicated URL-localization helpers. Palamedes uses source-string-first PO or FCL catalogs, macro-style authoring, a native catalog toolchain, and one runtime model shared with its other supported hosts.",
+    },
+  ],
+  related: [
+    { label: "React Router i18n in Framework Mode", href: "/frameworks/react-router" },
+    { label: "Vite i18n for React and Solid", href: "/frameworks/vite" },
+    { label: "Next.js App Router i18n", href: "/frameworks/nextjs" },
+  ],
+  finalCta: {
+    headline: "Keep TanStack's route types and add a coherent translation toolchain.",
+    primary: {
+      label: "Open the live route demo",
+      href: "https://tanstack-route.examples.palamedes.dev/en",
+    },
+    secondary: {
+      label: "View @palamedes/vite-plugin",
+      href: NPM("@palamedes/vite-plugin"),
+    },
+  },
+}
+
+export const handle = { layout: "bare" }
+
+export function meta() {
+  return frameworkMeta({
+    title: page.metaTitle,
+    description: page.metaDescription,
+    path: page.path,
+    framework: page.name,
+    faq: page.faq,
+  })
+}
+
+export default function TanstackStartI18n() {
+  return <FrameworkLandingPage page={page} />
+}

--- a/site/app/routes/frameworks/vite.tsx
+++ b/site/app/routes/frameworks/vite.tsx
@@ -1,0 +1,185 @@
+import { FrameworkLandingPage } from "~/components/frameworks/FrameworkLandingPage"
+import type { FrameworkLanding } from "~/data/framework-landing"
+import { docsHref, NPM, repoHref } from "~/data/links"
+import { frameworkMeta } from "~/lib/meta"
+
+const page: FrameworkLanding = {
+  name: "Vite",
+  path: "/frameworks/vite",
+  eyebrow: "Vite i18n · React and Solid",
+  metaTitle: "Vite i18n for React and Solid | Palamedes",
+  metaDescription:
+    "Add i18n to Vite with TypeScript macros, React or Solid runtime packages, PO catalogs, native transforms, extraction, and build-time diagnostics.",
+  headline: "Vite i18n for React and Solid, in one plugin.",
+  lede: "Add Palamedes beside your renderer plugin and keep translation authoring inside TypeScript. The Vite adapter transforms macros, compiles imported PO catalogs, and reports catalog problems during development and production builds.",
+  primary: {
+    label: "Use the 5-minute setup",
+    href: docsHref("first-working-translation"),
+  },
+  secondary: {
+    label: "Browse the plugin source",
+    href: repoHref("packages/vite-plugin", "tree"),
+  },
+  facts: [
+    {
+      label: "Integration",
+      value: "@palamedes/vite-plugin",
+      note: "One transform and catalog loader for Vite projects.",
+    },
+    {
+      label: "Renderer packages",
+      value: "React + Solid",
+      note: "Choose the runtime module that matches the UI.",
+    },
+    {
+      label: "Version range",
+      value: "Vite 3–8",
+      note: "The current matrix itself runs on Vite 8.",
+    },
+    {
+      label: "Catalog workflow",
+      value: "PO + FCL",
+      note: "PO imports today; PO or FCL for CLI catalog storage.",
+    },
+  ],
+  problem: {
+    title: "Vite supplies a fast module pipeline, not an internationalization architecture.",
+    lede: "A useful Vite i18n setup still needs an authoring model, extraction, catalogs, ICU validation, renderer integration, and an active runtime. Adding unrelated plugins for each step creates boundaries that fail at different times.",
+    points: [
+      "Message syntax has to transform before React or Solid consumes the TypeScript module.",
+      "Catalog imports need to become executable modules while missing or invalid translations remain visible during builds.",
+      "The browser runtime, extraction CLI, and catalog updater must agree on message identity instead of defining separate formats.",
+    ],
+  },
+  approach: {
+    title: "Use Vite as the host for a complete local i18n workflow.",
+    lede: "The plugin is only the build boundary. Palamedes connects it to the same native transform, catalog engine, runtime contract, and CLI used by the framework adapters.",
+    points: [
+      {
+        title: "Transform before the renderer",
+        body: "Place palamedes() before the React plugin, or add it to SolidStart's Vite configuration with the Solid runtime module.",
+      },
+      {
+        title: "Choose a renderer, not a new model",
+        body: "@palamedes/react and @palamedes/solid expose renderer-specific macros and client helpers over the same catalog semantics.",
+      },
+      {
+        title: "Keep extraction out of the browser build",
+        body: "The native pmds CLI extracts and updates catalogs explicitly, while Vite focuses on turning application modules into runnable code.",
+      },
+    ],
+  },
+  code: {
+    label: "vite.config.ts",
+    caption: "The only difference between React and Solid is the renderer boundary.",
+    source: `// React
+import react from "@vitejs/plugin-react"
+import { palamedes } from "@palamedes/vite-plugin"
+import { defineConfig } from "vite"
+
+export default defineConfig({
+  plugins: [
+    palamedes({ runtimeModule: "@palamedes/react/runtime" }),
+    react(),
+  ],
+})
+
+// Solid
+import solid from "vite-plugin-solid"
+
+export default defineConfig({
+  plugins: [
+    palamedes({ runtimeModule: "@palamedes/solid/runtime" }),
+    solid(),
+  ],
+})`,
+    note: "Both paths use TypeScript macros, the same palamedes.yaml format, and the same extraction CLI. The renderer package supplies rich-message and client-locale primitives where the UI models differ.",
+  },
+  strategies: {
+    lede: "Vite does not prescribe routing or server request APIs. Cookie, route, subdomain, and top-level-domain locale policies remain application concerns; Palamedes keeps the translation pipeline stable underneath whichever policy your React or Solid host implements.",
+  },
+  proof: {
+    title: "The plugin is exercised through several full-stack hosts, not just a fixture.",
+    lede: "TanStack Start, SolidStart, Waku, and React Router use @palamedes/vite-plugin throughout the browser-verified framework matrix. Package tests cover the transform and loader boundary directly.",
+    facts: [
+      {
+        label: "React hosts",
+        value: "3 families",
+        note: "TanStack Start, Waku, and React Router.",
+      },
+      {
+        label: "Solid hosts",
+        value: "1 family",
+        note: "SolidStart uses the Solid runtime integration.",
+      },
+      {
+        label: "Build behavior",
+        value: "Dev + build",
+        note: "The same plugin handles transforms and PO imports.",
+      },
+      {
+        label: "Diagnostics",
+        value: "Native",
+        note: "Macro, placeholder, and ICU problems surface early.",
+      },
+    ],
+  },
+  boundary: {
+    title: "Vite support does not mean every Vite renderer is supported.",
+    body: "Palamedes currently ships public UI packages for React and Solid. Vue, Svelte, Preact, Lit, and other Vite templates do not receive a renderer adapter merely because the build plugin can transform TypeScript. Direct application catalog imports currently use PO files.",
+    link: {
+      label: "Read the Vite plugin guide",
+      href: docsHref("api/vite-plugin"),
+    },
+  },
+  faq: [
+    {
+      q: "Does Vite have built-in internationalization?",
+      a: "No. Vite supplies a development server, module transforms, and production builds. Palamedes adds message authoring, catalog loading, extraction, validation, runtime access, and renderer integrations on top of that pipeline.",
+    },
+    {
+      q: "Should the Palamedes plugin run before the React or Solid plugin?",
+      a: "Yes. Put palamedes() before the renderer plugin so message macros are transformed while their original TypeScript and JSX structure is still available.",
+    },
+    {
+      q: "Does Palamedes type-check my Vite application?",
+      a: "No. Like Vite itself, the plugin transforms source modules rather than running whole-program type checking. Keep tsc --noEmit or your existing type-check command in development and CI.",
+    },
+    {
+      q: "Can I use Palamedes with Vue or Svelte?",
+      a: "Not as a supported end-to-end UI integration today. The build plugin is Vite-based, but public authoring and client runtime packages currently target React and Solid.",
+    },
+  ],
+  related: [
+    { label: "TanStack Start i18n", href: "/frameworks/tanstack-start" },
+    { label: "SolidStart i18n", href: "/frameworks/solidstart" },
+    { label: "React Router i18n in Framework Mode", href: "/frameworks/react-router" },
+  ],
+  finalCta: {
+    headline: "Add one Vite plugin, then keep the whole translation workflow coherent.",
+    primary: {
+      label: "Try the TypeScript quickstart",
+      href: docsHref("first-working-translation"),
+    },
+    secondary: {
+      label: "View @palamedes/vite-plugin",
+      href: NPM("@palamedes/vite-plugin"),
+    },
+  },
+}
+
+export const handle = { layout: "bare" }
+
+export function meta() {
+  return frameworkMeta({
+    title: page.metaTitle,
+    description: page.metaDescription,
+    path: page.path,
+    framework: page.name,
+    faq: page.faq,
+  })
+}
+
+export default function ViteI18n() {
+  return <FrameworkLandingPage page={page} />
+}

--- a/site/app/routes/frameworks/waku.tsx
+++ b/site/app/routes/frameworks/waku.tsx
@@ -1,0 +1,185 @@
+import { FrameworkLandingPage } from "~/components/frameworks/FrameworkLandingPage"
+import type { FrameworkLanding } from "~/data/framework-landing"
+import { docsHref, NPM, repoHref } from "~/data/links"
+import { frameworkMeta } from "~/lib/meta"
+
+const page: FrameworkLanding = {
+  name: "Waku",
+  path: "/frameworks/waku",
+  eyebrow: "Waku i18n · React Server Components",
+  metaTitle: "Waku i18n for React Server Components | Palamedes",
+  metaDescription:
+    "Internationalize Waku Server and Client Components with TypeScript macros, request-local catalogs, Vite transforms, and verified locale strategies.",
+  headline: "Waku i18n across React Server and Client Components.",
+  lede: "Palamedes keeps translation state aligned across Waku's React Server Component tree and its hydrated client islands. A Vite adapter transforms messages; the shared runtime resolves the active catalog on the correct side of the boundary.",
+  primary: {
+    label: "Open the Waku demo",
+    href: "https://waku-route.examples.palamedes.dev/en",
+  },
+  secondary: {
+    label: "Browse the TypeScript source",
+    href: repoHref("examples/waku-route", "tree"),
+  },
+  facts: [
+    {
+      label: "Build integration",
+      value: "@palamedes/vite-plugin",
+      note: "Configured inside Waku's Vite plugin surface.",
+    },
+    {
+      label: "Verified against",
+      value: "Waku 1 beta",
+      note: "React 19 Server Components on beta.6.",
+    },
+    {
+      label: "Rendering",
+      value: "RSC + islands",
+      note: "Server-first pages with hydrated client boundaries.",
+    },
+    {
+      label: "Locale models",
+      value: "4 examples",
+      note: "Cookie, route, subdomain, and top-level domain.",
+    },
+  ],
+  problem: {
+    title: "RSC moves the translation boundary before the traditional client application starts.",
+    lede: "Waku begins with a Server Component tree, then introduces client boundaries only where interactivity is needed. Locale state must be available in both environments without shipping server machinery to the browser or rendering two languages during hydration.",
+    points: [
+      "Server Components need an active request-local catalog before translated JSX and macro calls execute.",
+      "Client Components need a browser runtime that starts with the server-selected locale and updates independently afterward.",
+      "The build pipeline must transform messages for both Waku environments without changing the component architecture.",
+    ],
+  },
+  approach: {
+    title: "Treat the server and client as two hosts of one compiled message model.",
+    lede: "Palamedes keeps the environment-specific activation explicit while sharing authoring, catalogs, ICU semantics, and diagnostics across the RSC boundary.",
+    points: [
+      {
+        title: "Waku-native Vite composition",
+        body: "Add the Palamedes transform through Waku's vite.plugins configuration beside the React plugin already used by the application.",
+      },
+      {
+        title: "Server-first activation",
+        body: "Resolve the request locale and activate a fresh i18n instance before the Server Component page calls t or Trans.",
+      },
+      {
+        title: "Small client boundaries",
+        body: "Only interactive islands load the React client helpers. Server-rendered translated content does not require turning the whole page into a Client Component.",
+      },
+    ],
+  },
+  code: {
+    label: "waku.config.ts + pages/[locale].tsx",
+    caption: "Palamedes joins Waku's Vite pipeline without changing the RSC page model.",
+    source: `// waku.config.ts
+import react from "@vitejs/plugin-react"
+import { defineConfig } from "waku/config"
+import { palamedes } from "@palamedes/vite-plugin"
+
+export default defineConfig({
+  vite: {
+    plugins: [
+      palamedes({ runtimeModule: "@palamedes/react/runtime" }),
+      react(),
+    ],
+  },
+})
+
+// pages/[locale].tsx — a Server Component
+import { t } from "@palamedes/core/macro"
+
+export default async function LocalePage() {
+  return <h1>{t\`Welcome to Palamedes\`}</h1>
+}`,
+    note: "The checked example resolves and activates the request locale before rendering this page, then initializes only the interactive client components with the same catalog.",
+  },
+  strategies: {
+    matrixSlug: "waku",
+    lede: "Waku decides how pages map to URLs and requests. Palamedes keeps the RSC and client translation model fixed while the matrix changes where the locale is detected and how a switch is represented.",
+  },
+  proof: {
+    title: "The matrix exercises both halves of the React Server Component architecture.",
+    lede: "Waku has its own browser-verified example family. It is not counted as proof merely because the Next.js adapter also supports Server Components.",
+    facts: [
+      {
+        label: "Server tree",
+        value: "RSC checked",
+        note: "Translated output is rendered in the server-first page.",
+      },
+      {
+        label: "Client boundary",
+        value: "Island checked",
+        note: "Interactive translated components hydrate and switch.",
+      },
+      {
+        label: "Locale behavior",
+        value: "4 strategies",
+        note: "Host and path decisions are verified separately.",
+      },
+      {
+        label: "Evidence",
+        value: "Live + source",
+        note: "Three hosted strategies plus the checked TLD source.",
+      },
+    ],
+  },
+  boundary: {
+    title: "Current proof follows Waku's beta API.",
+    body: "The matrix pins Waku 1.0.0-beta.6. The integration is intentionally thin and Vite-based, but Waku may still change configuration or rendering APIs before a stable release. Version-specific claims on this page follow the checked example.",
+    link: {
+      label: "Read the RSC i18n guide",
+      href: "/react-server-components-i18n",
+    },
+  },
+  faq: [
+    {
+      q: "Can Palamedes translate Waku Server Components?",
+      a: "Yes. Activate the request's i18n instance before the Server Component tree executes translated macros. The checked Waku examples render localized server output for all four locale strategies.",
+    },
+    {
+      q: "Do translated Waku pages become Client Components?",
+      a: "No. Server Components can render translated messages on the server. Only interactive islands that react to a client-side locale change need the React client runtime.",
+    },
+    {
+      q: "How does the locale cross the RSC boundary?",
+      a: "The server resolves and activates its request-local catalog. The client boundary is initialized with the same locale and messages before interactive translated components run.",
+    },
+    {
+      q: "Is Waku support production-stable?",
+      a: "Palamedes browser-verifies its Waku integration, but the framework version in the matrix is still a Waku 1 beta. Evaluate that upstream maturity separately from the translation integration.",
+    },
+  ],
+  related: [
+    { label: "Next.js App Router i18n", href: "/frameworks/nextjs" },
+    { label: "Vite i18n for React and Solid", href: "/frameworks/vite" },
+    { label: "React Router i18n in Framework Mode", href: "/frameworks/react-router" },
+  ],
+  finalCta: {
+    headline: "Keep Waku server-first and make every boundary speak the same locale.",
+    primary: {
+      label: "Open the live route demo",
+      href: "https://waku-route.examples.palamedes.dev/en",
+    },
+    secondary: {
+      label: "View @palamedes/react",
+      href: NPM("@palamedes/react"),
+    },
+  },
+}
+
+export const handle = { layout: "bare" }
+
+export function meta() {
+  return frameworkMeta({
+    title: page.metaTitle,
+    description: page.metaDescription,
+    path: page.path,
+    framework: page.name,
+    faq: page.faq,
+  })
+}
+
+export default function WakuI18n() {
+  return <FrameworkLandingPage page={page} />
+}

--- a/site/vite.config.ts
+++ b/site/vite.config.ts
@@ -52,8 +52,7 @@ export default defineConfig({
     markdownRouteMeta(),
     ardo({
       title: "Palamedes",
-      description:
-        "Rust-powered i18n tooling for JavaScript and TypeScript with source-string-first catalogs.",
+      description: "Rust-powered i18n tooling for TypeScript with source-string-first catalogs.",
       siteUrl: "https://palamedes.dev",
       githubPages: false,
       icons: false,


### PR DESCRIPTION
## Summary

- add a reusable, SEO-aware framework landing-page structure with canonical metadata, TechArticle, FAQ, and breadcrumb structured data
- add focused TypeScript i18n guides for Next.js, TanStack Start, SolidStart, Waku, React Router, Remix v3, and Vite
- keep Remix v3 explicitly separate from React Router and describe its current non-React, server-side proof boundary
- connect the guides to the framework hub and matrix, while distinguishing browser-verified UI examples from Remix server smoke proofs

## Positioning

The pages lead with Palamedes' breadth and straight path: framework-aware adapters, four locale strategies, server/client boundaries, CI proofs, and a focused API surface. They avoid the earlier lightweight/small framing and artificial JavaScript/TypeScript pairings.

## Verification

- `pnpm --filter @palamedes/site typecheck`
- `pnpm format:check`
- `pnpm lint`
- `pnpm build:site`
- desktop and mobile visual QA for the shared layout
- final browser QA for Next.js, Remix v3, Vite, and the framework hub

The branch keeps the shared foundation and each framework page in separate commits.
