### PR TITLE
fix: address the post-1.5 re-review findings (apostrophe parity, adapter resilience, cache hardening, docs)

### DIFF
--- a/crates/palamedes-cli/src/config.rs
+++ b/crates/palamedes-cli/src/config.rs
@@ -126,13 +126,53 @@ pub fn load_config(cwd: &Path, explicit_path: Option<&Path>) -> Result<LoadedCon
 /// pseudo-locale exclusion, fallback chains, and origin-path style without a
 /// trace. Reject them loudly; merely unknown keys only warn.
 fn check_top_level_keys(value: &serde_json::Value, path: &Path) -> Result<(), ConfigError> {
+    let Some(map) = value.as_object() else {
+        return Ok(());
+    };
+    for key in map.keys() {
+        if let Some(kebab) = camel_case_key_hint(key) {
+            return invalid(
+                path,
+                &format!(
+                    "Unknown key \"{key}\". Palamedes data configs use kebab-case: \"{kebab}\"."
+                ),
+            );
+        }
+    }
+    for key in unknown_top_level_keys(value) {
+        eprintln!(
+            "Warning: Ignoring unknown config key \"{key}\" in {}.",
+            path.display()
+        );
+    }
+    Ok(())
+}
+
+/// The kebab-case spelling a camelCase key should have used, when the key is a
+/// known option under a Lingui-style name.
+fn camel_case_key_hint(key: &str) -> Option<&'static str> {
     const CAMEL_CASE_KEYS: &[(&str, &str)] = &[
         ("sourceLocale", "source-locale"),
         ("fallbackLocales", "fallback-locales"),
         ("pseudoLocale", "pseudo-locale"),
         ("sourceReferenceRoot", "source-reference-root"),
         ("referenceScopes", "reference-scopes"),
+        ("extractThreads", "extract-threads"),
+        ("extractCache", "extract-cache"),
     ];
+
+    CAMEL_CASE_KEYS
+        .iter()
+        .find(|(camel, _)| *camel == key)
+        .map(|(_, kebab)| *kebab)
+}
+
+/// Top-level keys the loader does not deserialize, in config order.
+///
+/// Every key that is read anywhere — including `extract-threads` and
+/// `extract-cache` — must be listed, or documented options warn as if they were
+/// typos.
+fn unknown_top_level_keys(value: &serde_json::Value) -> Vec<String> {
     const KNOWN_KEYS: &[&str] = &[
         "locales",
         "source-locale",
@@ -145,32 +185,22 @@ fn check_top_level_keys(value: &serde_json::Value, path: &Path) -> Result<(), Co
         "source_reference_root",
         "reference-scopes",
         "reference_scopes",
+        "extract-threads",
+        "extract_threads",
+        "extract-cache",
+        "extract_cache",
         "catalogs",
         "plugins",
     ];
 
     let Some(map) = value.as_object() else {
-        return Ok(());
+        return Vec::new();
     };
-    for (camel, kebab) in CAMEL_CASE_KEYS {
-        if map.contains_key(*camel) {
-            return invalid(
-                path,
-                &format!(
-                    "Unknown key \"{camel}\". Palamedes data configs use kebab-case: \"{kebab}\"."
-                ),
-            );
-        }
-    }
-    for key in map.keys() {
-        if !KNOWN_KEYS.contains(&key.as_str()) {
-            eprintln!(
-                "Warning: Ignoring unknown config key \"{key}\" in {}.",
-                path.display()
-            );
-        }
-    }
-    Ok(())
+
+    map.keys()
+        .filter(|key| !KNOWN_KEYS.contains(&key.as_str()))
+        .cloned()
+        .collect()
 }
 
 impl LoadedConfig {
@@ -423,7 +453,7 @@ mod tests {
     use std::fs;
     use std::time::{SystemTime, UNIX_EPOCH};
 
-    use super::{load_config, CONFIG_FILENAME};
+    use super::{load_config, unknown_top_level_keys, CONFIG_FILENAME};
 
     #[test]
     fn loads_yaml_config_and_defaults_references_to_git_root() {
@@ -576,6 +606,60 @@ catalogs:
         let message = error.to_string();
         assert!(message.contains("pseudoLocale"), "got: {message}");
         assert!(message.contains("pseudo-locale"), "got: {message}");
+    }
+
+    #[test]
+    fn accepts_documented_extraction_keys_without_warning() {
+        for (threads_key, cache_key) in [
+            ("extract-threads", "extract-cache"),
+            ("extract_threads", "extract_cache"),
+        ] {
+            let value = serde_json::json!({
+                "locales": ["en", "de"],
+                "source-locale": "en",
+                threads_key: 2,
+                cache_key: false,
+                "catalogs": [{ "path": "src/locales/{locale}", "include": ["src"] }],
+            });
+
+            assert!(
+                unknown_top_level_keys(&value).is_empty(),
+                "documented keys must not warn: {:?}",
+                unknown_top_level_keys(&value)
+            );
+        }
+
+        let value = serde_json::json!({ "locales": ["en"], "mystery": 1 });
+        assert_eq!(unknown_top_level_keys(&value), vec!["mystery".to_owned()]);
+    }
+
+    #[test]
+    fn rejects_camel_case_extraction_keys_with_a_kebab_case_hint() {
+        for (camel, kebab, value) in [
+            ("extractThreads", "extract-threads", "2"),
+            ("extractCache", "extract-cache", "false"),
+        ] {
+            let app = temp_dir(&format!("camel-{camel}"));
+            fs::write(
+                app.join(CONFIG_FILENAME),
+                format!(
+                    r#"
+locales: [en, de]
+source-locale: en
+{camel}: {value}
+catalogs:
+  - path: src/locales/{{locale}}
+    include: [src]
+"#
+                ),
+            )
+            .expect("write config");
+
+            let error = load_config(&app, None).expect_err("camelCase key must be rejected");
+            let message = error.to_string();
+            assert!(message.contains(camel), "got: {message}");
+            assert!(message.contains(kebab), "got: {message}");
+        }
     }
 
     #[test]

--- a/crates/palamedes-cli/src/main.rs
+++ b/crates/palamedes-cli/src/main.rs
@@ -15,7 +15,7 @@ use palamedes::{
     audit_catalogs, combine_catalog_files, extract_catalog_messages_cached, parse_catalog,
     parse_po, update_catalog_file, CatalogAuditDiagnostic, CatalogAuditRequest, CatalogAuditResult,
     CatalogConflictStrategy, CatalogFileCombineRequest, CatalogFileFormat, CatalogParseRequest,
-    CatalogUpdateMessage, CatalogUpdateRequest, ExtractCache,
+    CatalogUpdateMessage, CatalogUpdateRequest, ExtractCache, ExtractCatalogFileFailure,
 };
 use serde::Serialize;
 use thiserror::Error;
@@ -240,7 +240,7 @@ enum CliError {
 struct CatalogExtractionResult {
     messages: Vec<CatalogUpdateMessage>,
     files: Vec<PathBuf>,
-    failed_file_count: usize,
+    failed_files: Vec<ExtractCatalogFileFailure>,
     glob_ms: u128,
     extract_ms: u128,
 }
@@ -351,6 +351,40 @@ fn extract_cache_path(config: &LoadedConfig) -> PathBuf {
     palamedes::default_cache_path(&config.root_dir)
 }
 
+/// Everything about a configuration that decides what a cached entry means or
+/// where the cache file lives. A change to any of it invalidates a cache
+/// instance that is being reused across config reloads.
+fn extract_cache_identity(config: &LoadedConfig) -> (&Path, &Path, bool, bool) {
+    (
+        config.root_dir.as_path(),
+        config.source_reference_root.as_path(),
+        config.reference_scopes,
+        config.extract_cache,
+    )
+}
+
+/*
+ * Watch mode keeps one cache alive across rebuilds, but its entries only mean
+ * anything under the configuration that produced them: origins follow
+ * source-reference-root, records follow reference-scopes, and the file itself
+ * lives under root_dir. When a reload changes any of that — including turning
+ * `extract-cache` off — the cache is rebuilt through the startup path, after
+ * flushing what the previous configuration produced to its own location.
+ */
+fn rebuild_extract_cache_for_reload(
+    previous: &LoadedConfig,
+    next: &LoadedConfig,
+    options: &ExtractOptions,
+    cache: &mut ExtractCache,
+) {
+    if extract_cache_identity(previous) == extract_cache_identity(next) {
+        return;
+    }
+
+    persist_extract_cache(previous, options, cache);
+    *cache = load_extract_cache(next, options);
+}
+
 /*
  * A cache that cannot be written is not a failure: the next run just starts
  * cold. Report it once so a permanently unwritable directory is not silently
@@ -381,9 +415,11 @@ fn run_extraction_with_cache(
     let mut total_glob_ms = 0;
     let mut total_extract_ms = 0;
     let mut total_messages = 0;
-    let mut total_failed_files = 0;
     // Catalogs may match overlapping file sets; count each source file once.
     let mut unique_files = BTreeSet::new();
+    // Same for failures: an overlapping file must be reported and counted once,
+    // not once per catalog that matched it.
+    let mut unique_failures = BTreeMap::<String, String>::new();
     let mut results = Vec::with_capacity(config.catalogs.len());
 
     for catalog in &config.catalogs {
@@ -392,10 +428,19 @@ fn run_extraction_with_cache(
         total_extract_ms += result.extract_ms;
         total_messages += result.messages.len();
         unique_files.extend(result.files.iter().cloned());
-        total_failed_files += result.failed_file_count;
+        for failure in &result.failed_files {
+            unique_failures
+                .entry(failure.path.clone())
+                .or_insert_with(|| failure.message.clone());
+        }
         results.push(result);
     }
     let total_files = unique_files.len();
+
+    for (path, message) in &unique_failures {
+        eprintln!("Warning: Failed to extract from {path}: {message}");
+    }
+    let total_failed_files = unique_failures.len();
 
     /*
      * Retention runs once over every catalog's files. Doing it per catalog would
@@ -484,17 +529,12 @@ fn extract_from_catalog(
     )?;
     let extract_ms = extract_started_at.elapsed().as_millis();
 
-    for failure in &result.failed_files {
-        eprintln!(
-            "Warning: Failed to extract from {}: {}",
-            failure.path, failure.message
-        );
-    }
-
+    // Failures are reported by the caller, which sees every catalog and can
+    // therefore report a file shared by overlapping catalogs exactly once.
     Ok(CatalogExtractionResult {
         messages: result.messages,
         files,
-        failed_file_count: result.failed_files.len(),
+        failed_files: result.failed_files,
         glob_ms,
         extract_ms,
     })
@@ -656,6 +696,11 @@ fn build_exclude_set(catalog: &ConfigCatalog, config: &LoadedConfig) -> Result<G
 
 const WATCH_DEBOUNCE: Duration = Duration::from_millis(150);
 
+/// Upper bound on the debounce drain. A generator that keeps emitting events
+/// (a dev server writing into the watched tree, say) never leaves a quiet
+/// window, and waiting for one would postpone extraction forever.
+const WATCH_DEBOUNCE_MAX: Duration = Duration::from_secs(2);
+
 /// Per-catalog include/exclude matchers, built once per config generation so
 /// every filesystem event does not pay glob compilation again.
 struct WatchMatchers {
@@ -673,7 +718,22 @@ impl WatchMatchers {
                     build_exclude_set(catalog, config),
                 ) {
                     (Ok(include), Ok(exclude)) => Some((include, exclude)),
-                    _ => None,
+                    /*
+                     * A catalog whose globs do not compile can never match an
+                     * event, so watch mode would silently stop rebuilding it.
+                     * Name the catalog and the offending pattern instead.
+                     */
+                    (include, exclude) => {
+                        let error = include.err().or(exclude.err());
+                        eprintln!(
+                            "Warning: Could not build watch patterns for catalog '{}'{}. Changes to its source files will not trigger extraction until the watcher restarts.",
+                            catalog.path,
+                            error
+                                .map(|error| format!(": {error}"))
+                                .unwrap_or_default()
+                        );
+                        None
+                    }
                 }
             })
             .collect();
@@ -745,16 +805,25 @@ fn run_watch_mode(initial_config: &LoadedConfig, options: &ExtractOptions) -> Re
         let mut relevant = config_changed || event.paths.iter().any(|path| matchers.matches(path));
 
         // Debounce: editors and generators emit event bursts; keep draining
-        // until the stream is quiet before running a single extraction.
-        while let Ok(next) = rx.recv_timeout(WATCH_DEBOUNCE) {
-            match next {
-                Ok(event) => {
+        // until the stream is quiet before running a single extraction, but
+        // never longer than WATCH_DEBOUNCE_MAX so a continuous event stream
+        // cannot starve extraction.
+        let drain_deadline = Instant::now() + WATCH_DEBOUNCE_MAX;
+        loop {
+            let remaining = drain_deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                break;
+            }
+
+            match rx.recv_timeout(WATCH_DEBOUNCE.min(remaining)) {
+                Ok(Ok(event)) => {
                     config_changed = config_changed || touches_config(&event.paths, &config);
                     relevant = relevant
                         || config_changed
                         || event.paths.iter().any(|path| matchers.matches(path));
                 }
-                Err(error) => return Err(CliError::Watch(error)),
+                Ok(Err(error)) => return Err(CliError::Watch(error)),
+                Err(_) => break,
             }
         }
 
@@ -795,6 +864,8 @@ fn run_watch_mode(initial_config: &LoadedConfig, options: &ExtractOptions) -> Re
                         }
                     }
                     watched_roots = next_roots;
+
+                    rebuild_extract_cache_for_reload(&config, &reloaded, options, &mut cache);
                     config = reloaded;
                     matchers = WatchMatchers::build(&config);
                 }
@@ -1329,8 +1400,9 @@ mod tests {
     use std::time::{SystemTime, UNIX_EPOCH};
 
     use super::{
-        build_report, load_config, run_extraction, run_watch_extraction, CliError, ExtractCache,
-        ExtractOptions,
+        build_report, extract_cache_path, load_config, load_extract_cache,
+        rebuild_extract_cache_for_reload, run_extraction, run_extraction_with_cache,
+        run_watch_extraction, CliError, ExtractCache, ExtractOptions,
     };
 
     #[test]
@@ -1492,6 +1564,212 @@ catalogs:
         assert!(output.contains("msgid \"Recovered\""));
     }
 
+    /*
+     * A cache that survives a config reload must not answer with entries that
+     * were produced under the previous configuration: editing
+     * source-reference-root mid-watch changed the origins of every unchanged
+     * file, and the rebuilt catalogs kept showing the old ones.
+     */
+    #[test]
+    fn watch_rebuilds_the_cache_after_a_stamp_relevant_config_reload() {
+        let repo = temp_dir("watch-reload-cache");
+        fs::create_dir(repo.join(".git")).expect("create git marker");
+        let app = repo.join("apps/web");
+        fs::create_dir_all(app.join("app")).expect("create app");
+        let config_path = app.join("palamedes.yaml");
+        let write_watch_config = |reference_root: &str, extract_cache: bool| {
+            fs::write(
+                &config_path,
+                format!(
+                    r#"locales: [en]
+source-locale: en
+source-reference-root: {reference_root}
+extract-cache: {extract_cache}
+catalogs:
+  - path: locales/{{locale}}/messages
+    include: [app]
+"#
+                ),
+            )
+            .expect("write config");
+        };
+        fs::write(
+            app.join("app/page.tsx"),
+            "import { t } from \"@palamedes/core/macro\";\nexport function title() { return t`Dashboard`; }\n",
+        )
+        .expect("write source");
+
+        let options = cached_extract_options();
+        write_watch_config("config", true);
+        let config = load_config(&app, Some(&config_path)).expect("load config");
+        let mut cache = load_extract_cache(&config, &options);
+        run_watch_extraction(&config, &options, &mut cache).expect("first extraction");
+
+        let catalog_path = app.join("locales/en/messages.po");
+        assert!(fs::read_to_string(&catalog_path)
+            .expect("read catalog")
+            .contains("#: app/page.tsx"));
+
+        // Origins move to the git root; every source file is unchanged, so
+        // without a rebuilt cache the catalog would keep the old origins.
+        write_watch_config("git", true);
+        let reloaded = load_config(&app, Some(&config_path)).expect("reload config");
+        rebuild_extract_cache_for_reload(&config, &reloaded, &options, &mut cache);
+        assert!(
+            cache.is_empty(),
+            "a stamp-relevant reload must start from an empty cache"
+        );
+        run_watch_extraction(&reloaded, &options, &mut cache).expect("extraction after reload");
+
+        assert!(fs::read_to_string(&catalog_path)
+            .expect("read catalog")
+            .contains("#: apps/web/app/page.tsx"));
+
+        // Turning the cache off mid-watch has to take effect immediately.
+        let previous = reloaded;
+        write_watch_config("git", false);
+        let disabled = load_config(&app, Some(&config_path)).expect("reload config");
+        rebuild_extract_cache_for_reload(&previous, &disabled, &options, &mut cache);
+        run_watch_extraction(&disabled, &options, &mut cache).expect("extraction without cache");
+        assert!(cache.is_empty(), "a disabled cache must not store entries");
+        assert!(!cache.is_dirty());
+    }
+
+    /*
+     * Overlapping catalogs match the same file, and a failing file used to be
+     * counted and reported once per catalog that matched it.
+     */
+    #[test]
+    fn overlapping_catalogs_count_a_failing_file_once() {
+        let app = temp_dir("extract-overlap-failure");
+        fs::create_dir_all(app.join("app")).expect("create app");
+        fs::write(
+            app.join("palamedes.yaml"),
+            r#"locales: [en]
+source-locale: en
+source-reference-root: config
+catalogs:
+  - path: locales/{locale}/messages
+    include: [app]
+  - path: locales/{locale}/other
+    include: [app]
+"#,
+        )
+        .expect("write config");
+        fs::write(app.join("app/page.tsx"), "const broken =").expect("write invalid source");
+
+        let config = load_config(&app, Some(&app.join("palamedes.yaml"))).expect("load config");
+        let error = run_extraction(&config, &extract_options()).expect_err("extract should fail");
+
+        assert!(
+            matches!(error, CliError::ExtractionFailed { failures: 1 }),
+            "the shared failing file must be counted once, got: {error:?}"
+        );
+    }
+
+    /*
+     * Retention sees the union of every catalog's files. Running it per catalog
+     * made each catalog evict its siblings' entries, so a multi-catalog project
+     * re-extracted almost everything on every run.
+     */
+    #[test]
+    fn multi_catalog_extraction_keeps_every_catalog_cached() {
+        let app = temp_dir("extract-multi-catalog-cache");
+        fs::create_dir_all(app.join("app")).expect("create app");
+        fs::create_dir_all(app.join("admin")).expect("create admin");
+        fs::write(
+            app.join("palamedes.yaml"),
+            r#"locales: [en]
+source-locale: en
+source-reference-root: config
+catalogs:
+  - path: locales/{locale}/app
+    include: [app]
+  - path: locales/{locale}/admin
+    include: [admin]
+"#,
+        )
+        .expect("write config");
+        for (dir, message) in [("app", "Dashboard"), ("admin", "Settings")] {
+            let path = app.join(dir).join("page.tsx");
+            fs::write(
+                &path,
+                format!(
+                    "import {{ t }} from \"@palamedes/core/macro\";\nexport function title() {{ return t`{message}`; }}\n"
+                ),
+            )
+            .expect("write source");
+            age_file(&path);
+        }
+
+        let options = cached_extract_options();
+        let config = load_config(&app, Some(&app.join("palamedes.yaml"))).expect("load config");
+        let mut cache = load_extract_cache(&config, &options);
+        run_extraction_with_cache(&config, &options, &mut cache).expect("extract");
+
+        assert_eq!(
+            cache.len(),
+            2,
+            "retention must keep the entries of every catalog"
+        );
+        assert!(fs::read_to_string(app.join("locales/en/app.po"))
+            .expect("read app catalog")
+            .contains("msgid \"Dashboard\""));
+        assert!(fs::read_to_string(app.join("locales/en/admin.po"))
+            .expect("read admin catalog")
+            .contains("msgid \"Settings\""));
+    }
+
+    /*
+     * The cache must never change what is written. This runs a cold run, a
+     * mixed hit/miss run after touching one file, and an uncached run, and
+     * requires all three catalogs to be byte-identical.
+     */
+    #[test]
+    fn cached_extraction_matches_uncached_output() {
+        let app = temp_dir("extract-cache-parity");
+        fs::create_dir_all(app.join("app")).expect("create app");
+        write_config(&app, None);
+        fs::write(
+            app.join("app/page.tsx"),
+            "import { t } from \"@palamedes/core/macro\";\nexport function title() { return t`Dashboard`; }\n",
+        )
+        .expect("write source");
+        fs::write(
+            app.join("app/other.tsx"),
+            "import { t } from \"@palamedes/core/macro\";\nexport function label() { return t`Reports`; }\n",
+        )
+        .expect("write source");
+
+        let options = cached_extract_options();
+        let config = load_config(&app, Some(&app.join("palamedes.yaml"))).expect("load config");
+        let catalog_path = app.join("locales/en/messages.po");
+
+        let mut cache = load_extract_cache(&config, &options);
+        run_extraction_with_cache(&config, &options, &mut cache).expect("cold cached run");
+        let cold = fs::read_to_string(&catalog_path).expect("read catalog");
+
+        // One file changes, the other is served from the cache.
+        fs::write(
+            app.join("app/other.tsx"),
+            "import { t } from \"@palamedes/core/macro\";\nexport function label() { return t`Reports overview`; }\n",
+        )
+        .expect("rewrite source");
+        run_extraction_with_cache(&config, &options, &mut cache).expect("mixed hit/miss run");
+        let mixed = fs::read_to_string(&catalog_path).expect("read catalog");
+
+        let mut uncached = ExtractCache::disabled();
+        run_extraction_with_cache(&config, &extract_options(), &mut uncached)
+            .expect("uncached run");
+        let plain = fs::read_to_string(&catalog_path).expect("read catalog");
+
+        assert_eq!(mixed, plain, "cached output must match --no-cache output");
+        assert_ne!(cold, mixed, "the edited message must reach the catalog");
+        assert!(mixed.contains("msgid \"Reports overview\""));
+        assert!(mixed.contains("msgid \"Dashboard\""));
+        assert!(extract_cache_path(&config).exists() || cache.is_empty());
+    }
+
     #[test]
     fn report_counts_translated_and_missing_messages() {
         let app = temp_dir("report");
@@ -1550,6 +1828,25 @@ source-locale: en
             threads: None,
             no_cache: true,
             verbose: false,
+        }
+    }
+
+    /// Backdates a file out of the cache's racy window so it can be cached.
+    fn age_file(path: &std::path::Path) {
+        let aged = SystemTime::now() - std::time::Duration::from_secs(10);
+        fs::File::options()
+            .write(true)
+            .open(path)
+            .expect("open source")
+            .set_modified(aged)
+            .expect("age source");
+    }
+
+    /// Extraction options with the on-disk cache enabled.
+    fn cached_extract_options() -> ExtractOptions {
+        ExtractOptions {
+            no_cache: false,
+            ..extract_options()
         }
     }
 

--- a/crates/palamedes/src/catalog_artifact/compile.rs
+++ b/crates/palamedes/src/catalog_artifact/compile.rs
@@ -12,9 +12,24 @@ use super::types::{
     CatalogArtifactDiagnostic, CatalogArtifactMissingMessage, CatalogArtifactResult,
 };
 
+/// ICU options that model the JS runtime parser
+/// (`packages/core/src/messageFormat.ts`).
+///
+/// Catalog texts are canonicalized into strict ICU quoting when they are loaded
+/// (see the `icu_text` module), so [`IcuSyntaxPolicy::Strict`] reads `''`,
+/// `'{`/`'}`, and a plural `'#'` exactly the way the runtime does.
+/// `RuntimeLiteralApostrophes` doubles every apostrophe before parsing instead,
+/// which models `L'{title}` as a live argument, `''` as two apostrophes, and
+/// `'#'` as an active pound — all cases where validation stayed green while the
+/// runtime rendered something else.
+///
+/// Residual divergence: Ferrocat has no lenient-quoting policy, so the parity
+/// comes from the canonicalization pass. Message texts that reach Ferrocat
+/// without going through it (should any future call site skip it) are read with
+/// strict rules, where a bare `don't` is an unterminated quote.
 pub(super) fn runtime_icu_options() -> CompileCatalogArtifactIcuOptions {
     CompileCatalogArtifactIcuOptions::new()
-        .with_syntax_policy(IcuSyntaxPolicy::RuntimeLiteralApostrophes)
+        .with_syntax_policy(IcuSyntaxPolicy::Strict)
         .with_formatter_support(runtime_icu_formatter_support)
 }
 
@@ -28,7 +43,7 @@ pub(super) fn build_artifact_result(
     let artifact = if pseudo_locale == Some(locale) {
         let options = CompiledCatalogPseudolocalizationOptions::new()
             .with_icu_options(IcuPseudolocalizationOptions::new())
-            .with_syntax_policy(IcuSyntaxPolicy::RuntimeLiteralApostrophes);
+            .with_syntax_policy(IcuSyntaxPolicy::Strict);
         pseudolocalize_compiled_catalog_artifact(&artifact, &options)
             .map_err(PalamedesError::PseudolocalizeCatalogArtifact)?
     } else {

--- a/crates/palamedes/src/catalog_artifact/load.rs
+++ b/crates/palamedes/src/catalog_artifact/load.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 use ferrocat::{parse_catalog, NormalizedParsedCatalog, ParseCatalogOptions};
 
 use crate::error::{PalamedesError, PalamedesResult};
+use crate::icu_text::canonicalize_catalog_quoting;
 
 use super::resolve::normalize_path;
 use super::types::{CatalogArtifactConfig, CatalogConfig};
@@ -37,10 +38,11 @@ pub(super) fn load_catalogs(
             .with_locale(locale.as_str())
             .with_mode(catalog.format.ferrocat_mode());
 
-        let parsed = parse_catalog(options).map_err(|source| PalamedesError::ParseCatalog {
+        let mut parsed = parse_catalog(options).map_err(|source| PalamedesError::ParseCatalog {
             path: file.clone(),
             source,
         })?;
+        canonicalize_catalog_quoting(&mut parsed);
 
         loaded.insert(
             locale,

--- a/crates/palamedes/src/catalog_artifact/tests.rs
+++ b/crates/palamedes/src/catalog_artifact/tests.rs
@@ -281,13 +281,16 @@ msgstr ""
     let result = compile_catalog_artifact(&request).expect("catalog artifact");
     let message = result
         .messages
-        .get(&compiled_key("You're {name}", None))
+        .get(&compiled_key("You''re {name}", None))
         .expect("pseudolocalized message");
 
     assert!(message.starts_with("[!! "));
     assert!(message.ends_with(" !!]"));
     assert!(message.contains("{name}"));
-    assert_ne!(message, "You're {name}");
+    assert_ne!(message, "You''re {name}");
+    // The escaped apostrophe stays a single literal apostrophe for the runtime
+    // parser instead of being doubled into two.
+    assert_eq!(message.matches('\'').count(), 2);
     assert!(result.diagnostics.is_empty());
 }
 
@@ -334,19 +337,19 @@ msgstr ""
             }],
         },
         resource_path: locale_dir.join("pseudo.po").to_string_lossy().into_owned(),
-        compiled_ids: vec![compiled_key("You're {name}", None)],
+        compiled_ids: vec![compiled_key("You''re {name}", None)],
     };
     let result = compile_catalog_artifact_selected(&request).expect("selected catalog artifact");
     let message = result
         .messages
-        .get(&compiled_key("You're {name}", None))
+        .get(&compiled_key("You''re {name}", None))
         .expect("pseudolocalized message");
 
     assert_eq!(result.messages.len(), 1);
     assert!(message.starts_with("[!! "));
     assert!(message.ends_with(" !!]"));
     assert!(message.contains("{name}"));
-    assert_ne!(message, "You're {name}");
+    assert_ne!(message, "You''re {name}");
     assert!(result.diagnostics.is_empty());
 }
 
@@ -404,7 +407,7 @@ msgstr "Konnte {firstName}'s Daten nicht laden"
         .diagnostics
         .iter()
         .any(|diagnostic| diagnostic.code == "icu.missing_argument"
-            && diagnostic.source_key.message == "Couldn't load {name}"
+            && diagnostic.source_key.message == "Couldn''t load {name}"
             && diagnostic.locale == "de"));
     assert!(result
         .diagnostics
@@ -903,7 +906,7 @@ msgstr "Impossible d'ouvrir les regles"
             }],
         },
         resource_path: locale_dir.join("fr.po").to_string_lossy().into_owned(),
-        compiled_ids: vec![compiled_key("Couldn't load applied rules", None)],
+        compiled_ids: vec![compiled_key("Couldn''t load applied rules", None)],
     };
     let result = compile_catalog_artifact_selected(&request).expect("selected catalog artifact");
 
@@ -911,9 +914,11 @@ msgstr "Impossible d'ouvrir les regles"
     assert_eq!(
         result
             .messages
-            .get(&compiled_key("Couldn't load applied rules", None))
+            .get(&compiled_key("Couldn''t load applied rules", None))
             .map(String::as_str),
-        Some("Impossible d'ouvrir les regles")
+        // Literal apostrophes are emitted in escaped form, which the runtime
+        // parser renders as a single apostrophe.
+        Some("Impossible d''ouvrir les regles")
     );
     assert!(result.diagnostics.is_empty());
 }

--- a/crates/palamedes/src/catalog_artifact/tests.rs
+++ b/crates/palamedes/src/catalog_artifact/tests.rs
@@ -3,6 +3,8 @@ use super::{
     CatalogArtifactDiagnosticSeverity, CatalogArtifactRequest, CatalogArtifactSelectedRequest,
     CatalogConfig, PalamedesCatalogFormat,
 };
+use crate::icu_text::canonicalize_runtime_quoting;
+use crate::test_support::scope_macro_test_source;
 use ferrocat::compiled_key;
 use std::collections::BTreeSet;
 use std::fs;
@@ -921,6 +923,131 @@ msgstr "Impossible d'ouvrir les regles"
         Some("Impossible d''ouvrir les regles")
     );
     assert!(result.diagnostics.is_empty());
+}
+
+/// Cross-locks the two id derivations that have to agree for a runtime lookup
+/// to resolve: the id the transform embeds in `getI18n()._("…")` and the key
+/// [`compile_catalog_artifact`] derives from the extracted `msgid`.
+///
+/// Catalog texts are canonicalized into strict ICU quoting when they are
+/// loaded, so the compiled key is always the hash of the canonicalized text.
+/// The raw-ICU authoring surfaces (descriptor string literals and the
+/// `<Trans message>` attribute) therefore only resolve when the transform
+/// hashes the canonicalized text as well, while already-escaped authored text
+/// has to keep the exact id it had before, because canonicalization is
+/// idempotent.
+#[test]
+fn transform_lookup_ids_match_compiled_catalog_keys() {
+    let source = r##"import { t } from "@palamedes/core/macro";
+import { Trans } from "@palamedes/react/macro";
+
+const descriptor = t({ message: "Don't greet {name}" }, { name });
+const rich = <Trans message="Don't wave at {name}" />;
+const authored = t`L'${title} est prêt`;
+"##;
+    let scoped_source = scope_macro_test_source(source, "test.tsx");
+    let extracted = crate::extract::extract_messages(&scoped_source, "test.tsx")
+        .expect("apostrophe messages should extract");
+    let transformed = crate::transform::transform_macros(&scoped_source, "test.tsx", None)
+        .expect("apostrophe messages should transform");
+
+    // Raw-ICU surfaces stay raw in the catalog, authored text stays escaped.
+    assert_eq!(
+        extracted
+            .iter()
+            .map(|message| message.message.as_str())
+            .collect::<Vec<_>>(),
+        vec![
+            "Don't greet {name}",
+            "Don't wave at {name}",
+            "L''{title} est prêt",
+        ]
+    );
+
+    let fixture = create_fixture_dir("catalog-artifact-transform-parity");
+    let locale_dir = fixture.join("src/locales");
+    fs::create_dir_all(&locale_dir).expect("locale dir");
+    let source_entries = extracted
+        .iter()
+        .map(|message| (message.message.as_str(), ""))
+        .collect::<Vec<_>>();
+    let translations = extracted
+        .iter()
+        .map(|message| format!("DE {}", message.message))
+        .collect::<Vec<_>>();
+    let target_entries = extracted
+        .iter()
+        .zip(&translations)
+        .map(|(message, translation)| (message.message.as_str(), translation.as_str()))
+        .collect::<Vec<_>>();
+    write_test_catalog(&locale_dir, "en", &source_entries);
+    write_test_catalog(&locale_dir, "de", &target_entries);
+
+    let request = CatalogArtifactRequest {
+        config: CatalogArtifactConfig {
+            root_dir: fixture.to_string_lossy().into_owned(),
+            locales: vec!["en".to_owned(), "de".to_owned()],
+            source_locale: "en".to_owned(),
+            fallback_locales: None,
+            pseudo_locale: None,
+            catalogs: vec![CatalogConfig {
+                path: "src/locales/{locale}".to_owned(),
+                format: PalamedesCatalogFormat::Po,
+            }],
+        },
+        resource_path: locale_dir.join("de.po").to_string_lossy().into_owned(),
+    };
+    let result = compile_catalog_artifact(&request).expect("catalog artifact");
+
+    assert_eq!(transformed.compiled_ids.len(), extracted.len());
+    let available = result.messages.keys().cloned().collect::<BTreeSet<_>>();
+    let unreachable = transformed
+        .compiled_ids
+        .iter()
+        .zip(&extracted)
+        .filter(|(id, _)| !available.contains(*id))
+        .map(|(id, message)| format!("{:?} -> {id}", message.message))
+        .collect::<Vec<_>>();
+    assert!(
+        unreachable.is_empty(),
+        "transform lookup ids missing from the compiled catalog {:?}: {unreachable:?}",
+        available
+    );
+
+    // Each translation is actually reachable, not just present as some key.
+    // The compiled value is the canonical form of the catalog text, which the
+    // runtime parser reads back as the translator wrote it.
+    for (id, translation) in transformed.compiled_ids.iter().zip(&translations) {
+        assert_eq!(
+            result.messages.get(id).map(String::as_str),
+            Some(canonicalize_runtime_quoting(translation).as_str())
+        );
+    }
+
+    // The raw-ICU surfaces resolve through the canonical form of their text ...
+    assert_eq!(
+        transformed.compiled_ids[0],
+        compiled_key("Don''t greet {name}", None)
+    );
+    assert_eq!(
+        transformed.compiled_ids[1],
+        compiled_key("Don''t wave at {name}", None)
+    );
+    // ... while the escaped authored path keeps the id it already had, because
+    // canonicalization is a fixed point there.
+    assert_eq!(
+        transformed.compiled_ids[2],
+        compiled_key("L''{title} est prêt", None)
+    );
+
+    // The embedded runtime message text is untouched: only the key is derived
+    // from the canonical form.
+    assert!(transformed
+        .code
+        .contains(r#"message: "Don't greet {name}""#));
+    assert!(transformed
+        .code
+        .contains(r#"message={"Don't wave at {name}"}"#));
 }
 
 fn create_fixture_dir(prefix: &str) -> PathBuf {

--- a/crates/palamedes/src/catalog_audit.rs
+++ b/crates/palamedes/src/catalog_audit.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::diagnostic::{CatalogDiagnosticSeverity, CatalogDiagnosticSourceKey};
 use crate::error::{PalamedesError, PalamedesResult};
+use crate::icu_text::canonicalize_catalog_quoting;
 use crate::message_metadata::MessageMetadataInput;
 
 use super::catalog_artifact::{CatalogArtifactConfig, CatalogConfig};
@@ -138,8 +139,12 @@ pub fn audit_catalogs(request: CatalogAuditRequest) -> PalamedesResult<CatalogAu
             .iter()
             .map(String::as_str)
             .collect::<Vec<_>>();
-        let icu_options = CatalogAuditIcuOptions::new()
-            .with_syntax_policy(IcuSyntaxPolicy::RuntimeLiteralApostrophes);
+        // Catalog texts are canonicalized into strict ICU quoting at load time
+        // (see `icu_text`), so the strict parser reads them exactly the way the
+        // JS runtime does. `RuntimeLiteralApostrophes` would instead double
+        // every apostrophe and model `L'{title}` as a live argument that the
+        // runtime actually swallows.
+        let icu_options = CatalogAuditIcuOptions::new().with_syntax_policy(IcuSyntaxPolicy::Strict);
         let options = CatalogAuditOptions::new(&request.config.source_locale)
             .with_locales(&locale_refs)
             .with_metadata(&metadata)
@@ -253,10 +258,11 @@ fn load_audit_catalogs(
             .with_locale(locale.as_str())
             .with_mode(catalog.format.ferrocat_mode());
 
-        let parsed = parse_catalog(options).map_err(|source| PalamedesError::ParseCatalog {
+        let mut parsed = parse_catalog(options).map_err(|source| PalamedesError::ParseCatalog {
             path: path.clone(),
             source,
         })?;
+        canonicalize_catalog_quoting(&mut parsed);
         let catalog =
             parsed
                 .into_normalized_view()
@@ -410,6 +416,51 @@ msgstr "Wir haben {count, plural, one {einen freien Termin} other {# freie Termi
             .diagnostics
             .iter()
             .any(|diagnostic| diagnostic.code == "icu.invalid_syntax"));
+    }
+
+    #[test]
+    fn flags_translations_whose_quote_swallows_a_placeholder() {
+        let fixture = create_fixture_dir("catalog-audit-quoted-placeholder");
+        let locale_dir = fixture.join("src/locales");
+        fs::create_dir_all(&locale_dir).expect("locale dir");
+        fs::write(
+            locale_dir.join("en.po"),
+            r#"msgid ""
+msgstr ""
+"Language: en\n"
+
+msgid "{title} is ready"
+msgstr ""
+"#,
+        )
+        .expect("write en");
+        // `L'{title}` is a quoted literal for the runtime parser, so the
+        // translation renders `L{title} est prêt` and no longer uses `title`.
+        fs::write(
+            locale_dir.join("de.po"),
+            r#"msgid ""
+msgstr ""
+"Language: de\n"
+
+msgid "{title} is ready"
+msgstr "L'{title} est bereit"
+"#,
+        )
+        .expect("write de");
+
+        let result = audit_catalogs(CatalogAuditRequest {
+            config: config(&fixture),
+            locales: vec!["de".to_owned()],
+            checks: CatalogAuditCheckOptions::default(),
+            metadata: Vec::new(),
+        })
+        .expect("audit");
+
+        assert!(result
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "icu.missing_argument"
+                && diagnostic.locale.as_deref() == Some("de")));
     }
 
     #[test]

--- a/crates/palamedes/src/extract.rs
+++ b/crates/palamedes/src/extract.rs
@@ -11,7 +11,8 @@ use crate::descriptor::{
     descriptor_property_value, descriptor_static_property, unsupported_macro_syntax,
 };
 use crate::error::{PalamedesError, PalamedesResult};
-use crate::extract_cache::{ExtractCache, FileFingerprint};
+use crate::extract_cache::{ExtractCache, ReadStartFingerprint};
+use crate::icu_text::escape_icu_literal;
 use crate::jsx_entities::decode_jsx_entities;
 use crate::jsx_message::{
     clean_jsx_text, join_jsx_message_parts, JoinedJsxMessage, JsxMessagePart,
@@ -636,7 +637,9 @@ fn extract_choice_options_from_object(
             return Err(invalid_choice_option(macro_name, location, &key));
         };
         let (value, option_placeholders) = match property.value.without_parentheses() {
-            Expression::StringLiteral(literal) => (literal.value.to_string(), BTreeMap::new()),
+            Expression::StringLiteral(literal) => {
+                (escape_icu_literal(literal.value.as_str()), BTreeMap::new())
+            }
             Expression::TemplateLiteral(template) => template_to_message_with_state(
                 template,
                 source,
@@ -1009,10 +1012,12 @@ fn template_to_message_with_state(
     let mut placeholders = BTreeMap::new();
 
     for (index, quasi) in template.quasis.iter().enumerate() {
+        // Authored literal text: escape before appending so an apostrophe at a
+        // segment boundary cannot quote the placeholder that follows.
         if let Some(value) = quasi.value.cooked {
-            message.push_str(value.as_str());
+            message.push_str(&escape_icu_literal(value.as_str()));
         } else {
-            message.push_str(quasi.value.raw.as_str());
+            message.push_str(&escape_icu_literal(quasi.value.raw.as_str()));
         }
 
         if let Some(expr) = template.expressions.get(index) {
@@ -1157,7 +1162,7 @@ fn extract_jsx_children_as_message_with_state(
     for child in children {
         match child {
             JSXChild::Text(text) => {
-                let value = clean_jsx_text(text.value.as_str());
+                let value = escape_icu_literal(&clean_jsx_text(text.value.as_str()));
                 if !value.is_empty() {
                     parts.push(JsxMessagePart::Text(value));
                 }
@@ -1165,7 +1170,9 @@ fn extract_jsx_children_as_message_with_state(
             JSXChild::ExpressionContainer(container) => match &container.expression {
                 JSXExpression::EmptyExpression(_) => {}
                 JSXExpression::StringLiteral(literal) => {
-                    parts.push(JsxMessagePart::Text(literal.value.to_string()));
+                    parts.push(JsxMessagePart::Text(escape_icu_literal(
+                        literal.value.as_str(),
+                    )));
                 }
                 expr => {
                     let Some(name) = jsx_expression_name(expr) else {
@@ -1253,12 +1260,13 @@ fn extract_choice_options_from_jsx(
             continue;
         };
         let (value, option_placeholders) = match attr_value {
-            JSXAttributeValue::StringLiteral(literal) => {
-                (decode_jsx_entities(literal.value.as_str()), BTreeMap::new())
-            }
+            JSXAttributeValue::StringLiteral(literal) => (
+                escape_icu_literal(&decode_jsx_entities(literal.value.as_str())),
+                BTreeMap::new(),
+            ),
             JSXAttributeValue::ExpressionContainer(container) => match &container.expression {
                 JSXExpression::StringLiteral(literal) => {
-                    (literal.value.to_string(), BTreeMap::new())
+                    (escape_icu_literal(literal.value.as_str()), BTreeMap::new())
                 }
                 JSXExpression::TemplateLiteral(template) => template_to_message_with_state(
                     template,
@@ -1439,6 +1447,14 @@ pub fn extract_catalog_messages_cached(
     let mut failed_files = Vec::new();
     let file_count = request.files.len();
     let reference_scopes = options.reference_scopes;
+
+    /*
+     * A cache handed to us may have been loaded for a different request — watch
+     * mode keeps one instance alive across config reloads, so a changed
+     * reference root or scope setting would otherwise serve entries whose
+     * origins and records belong to the previous configuration.
+     */
+    cache.reset_if_request_differs(&request.root_dir, reference_scopes);
 
     /*
      * Reading and parsing each file is independent work and dominates extraction
@@ -1636,7 +1652,7 @@ enum FileExtraction {
         /// False when the result came from the cache and need not be stored again.
         fresh: bool,
         /// File identity observed before reading, used to reject mid-run edits.
-        fingerprint: Option<FileFingerprint>,
+        fingerprint: Option<ReadStartFingerprint>,
     },
     Failed(ExtractCatalogFileFailure),
     Fatal(PalamedesError),
@@ -1800,12 +1816,13 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     use super::{
-        extract_catalog_messages_from_files, extract_catalog_messages_from_files_with_options,
-        extract_messages as extract_messages_raw, resolve_extract_threads,
-        ExtractCatalogMessagesOptions, ExtractCatalogMessagesRequest, ExtractedMessageRecord,
-        DEFAULT_EXTRACT_THREADS,
+        extract_catalog_messages_cached, extract_catalog_messages_from_files,
+        extract_catalog_messages_from_files_with_options, extract_messages as extract_messages_raw,
+        resolve_extract_threads, ExtractCatalogMessagesOptions, ExtractCatalogMessagesRequest,
+        ExtractedMessageRecord, DEFAULT_EXTRACT_THREADS,
     };
     use crate::error::PalamedesResult;
+    use crate::extract_cache::ExtractCache;
     use crate::test_support::scope_macro_test_source;
 
     static TEMP_COUNTER: AtomicUsize = AtomicUsize::new(0);
@@ -2478,7 +2495,9 @@ const message = t({ message })
             vec![
                 "Allocate energy usage to business units for {locationName} ({periodLabel}). Total: {totalMwh} MWh",
                 "Match Score: {matchPercentage}%",
-                "We just need a few details to connect you with {clientCompanyName}'s sustainability program.",
+                // The authored apostrophe is escaped so the runtime renders it
+                // literally instead of opening an ICU quote.
+                "We just need a few details to connect you with {clientCompanyName}''s sustainability program.",
             ]
         );
     }
@@ -3021,6 +3040,76 @@ const message = t({ message })
         .expect_err("unsupported macro syntax should fail");
 
         assert!(error.to_string().contains("Unsupported `t` macro usage"));
+        fs::remove_dir_all(root).expect("cleanup");
+    }
+
+    /*
+     * A reused cache outlives the request it was loaded for — watch mode holds
+     * one across config reloads. Entries stamped for another reference root
+     * carry that root's origins, so they must not be served after the request
+     * changes.
+     */
+    #[test]
+    fn cached_extraction_bypasses_entries_stamped_for_another_request() {
+        let root = temp_root("cached-stamp-change");
+        let src = root.join("src");
+        fs::create_dir_all(&src).expect("src dir");
+        let app = src.join("App.tsx");
+        fs::write(
+            &app,
+            r#"
+              import { t } from "@palamedes/core/macro"
+              function messages() {
+                return t`Cached origin`
+              }
+            "#,
+        )
+        .expect("source");
+        // Backdated out of the cache's racy window so the entry is really
+        // stored and the second run would be a hit.
+        let aged = std::time::SystemTime::now() - std::time::Duration::from_secs(10);
+        fs::File::options()
+            .write(true)
+            .open(&app)
+            .expect("open source")
+            .set_modified(aged)
+            .expect("age source");
+
+        let mut cache = ExtractCache::load(&root.join("cache.json"), "unused", true);
+        let files = vec![app.to_string_lossy().into_owned()];
+        let request = |root_dir: &std::path::Path| ExtractCatalogMessagesRequest {
+            root_dir: root_dir.to_string_lossy().into_owned(),
+            files: files.clone(),
+            max_threads: None,
+        };
+
+        let first = extract_catalog_messages_cached(
+            request(&root),
+            ExtractCatalogMessagesOptions::default(),
+            &mut cache,
+        )
+        .expect("first extraction");
+        assert_eq!(first.messages[0].origins[0].file, "src/App.tsx");
+
+        // Same file, new reference root: the origin has to follow the request
+        // instead of being served from the entry stored for the old root.
+        let second = extract_catalog_messages_cached(
+            request(&src),
+            ExtractCatalogMessagesOptions::default(),
+            &mut cache,
+        )
+        .expect("second extraction");
+        assert_eq!(second.messages[0].origins[0].file, "App.tsx");
+
+        // And the re-stamped cache still serves the new request.
+        let third = extract_catalog_messages_cached(
+            request(&src),
+            ExtractCatalogMessagesOptions::default(),
+            &mut cache,
+        )
+        .expect("third extraction");
+        assert_eq!(third.messages[0].origins[0].file, "App.tsx");
+
         fs::remove_dir_all(root).expect("cleanup");
     }
 

--- a/crates/palamedes/src/extract_cache.rs
+++ b/crates/palamedes/src/extract_cache.rs
@@ -50,12 +50,26 @@ impl FileFingerprint {
         })
     }
 
-    fn is_racy(&self, now: SystemTime) -> bool {
-        let Ok(now_ns) = now.duration_since(UNIX_EPOCH) else {
+    fn is_racy(&self, read_started_at: SystemTime) -> bool {
+        let Ok(now_ns) = read_started_at.duration_since(UNIX_EPOCH) else {
             return true;
         };
         now_ns.as_nanos().saturating_sub(self.mtime_ns) < RACY_WINDOW.as_nanos()
     }
+}
+
+/// Identity of a file plus the instant the read that produced the cached
+/// messages started.
+///
+/// The racy-window guard has to be evaluated against the read-start time, not
+/// against the time of the insert: on a coarse-mtime filesystem an edit that
+/// lands after the read but inside the same mtime granule is indistinguishable
+/// from the state that was read, and by insert time that granule may already
+/// have elapsed.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ReadStartFingerprint {
+    fingerprint: FileFingerprint,
+    read_started_at: SystemTime,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -163,11 +177,37 @@ impl ExtractCache {
 
     /// Identity of `path` before its contents are read, or `None` when the cache
     /// is disabled and the `stat` would be wasted.
-    pub(crate) fn fingerprint_before_read(&self, path: &str) -> Option<FileFingerprint> {
+    pub(crate) fn fingerprint_before_read(&self, path: &str) -> Option<ReadStartFingerprint> {
         if !self.enabled {
             return None;
         }
-        FileFingerprint::read(Path::new(path))
+        Some(ReadStartFingerprint {
+            fingerprint: FileFingerprint::read(Path::new(path))?,
+            read_started_at: SystemTime::now(),
+        })
+    }
+
+    /// Discards every entry when the request no longer matches the stamp the
+    /// cache was loaded with, then re-stamps it for the new request.
+    ///
+    /// The stamp fields decide what an entry means: `root_dir` decides the
+    /// stored origin paths and `reference_scopes` decides the records
+    /// themselves. A long-lived cache — watch mode holds one across config
+    /// reloads — must therefore be re-validated on every request instead of
+    /// only at load time.
+    pub(crate) fn reset_if_request_differs(&mut self, root_dir: &str, reference_scopes: bool) {
+        if !self.enabled
+            || (self.stamp.root_dir == root_dir && self.stamp.reference_scopes == reference_scopes)
+        {
+            return;
+        }
+
+        self.stamp.root_dir = root_dir.to_owned();
+        self.stamp.reference_scopes = reference_scopes;
+        if !self.entries.is_empty() {
+            self.entries.clear();
+            self.dirty = true;
+        }
     }
 
     /// Records a freshly extracted result.
@@ -183,7 +223,7 @@ impl ExtractCache {
         path: String,
         relative_file: String,
         messages: &[ExtractedMessageRecord],
-        before: Option<FileFingerprint>,
+        before: Option<ReadStartFingerprint>,
     ) where
         ExtractedMessageRecord: Clone,
     {
@@ -194,10 +234,13 @@ impl ExtractCache {
         else {
             return;
         };
-        if fingerprint != before {
+        if fingerprint != before.fingerprint {
             return;
         }
-        if fingerprint.is_racy(SystemTime::now()) {
+        // Measured against the start of the read: an edit inside the same mtime
+        // granule as the read is indistinguishable from what was read, even
+        // when the insert happens after that granule has passed.
+        if fingerprint.is_racy(before.read_started_at) {
             return;
         }
         self.entries.insert(
@@ -420,6 +463,118 @@ mod tests {
         assert!(cache.get(&key).is_none());
 
         std::fs::remove_dir_all(root).expect("cleanup");
+    }
+
+    /*
+     * The fingerprint is captured before the read, so the racy window has to be
+     * measured from that moment too. Evaluating it at insert time lets a
+     * same-size edit inside the file's mtime granule be stored as valid as soon
+     * as the granule has elapsed.
+     */
+    #[test]
+    fn measures_the_racy_window_from_the_read_start() {
+        let root = temp_root("racy-read-start");
+        std::fs::create_dir_all(&root).expect("root");
+        let source = root.join("a.tsx");
+        std::fs::write(&source, "const a = 1\n").expect("write");
+        let key = source.to_string_lossy().into_owned();
+
+        let mut cache = ExtractCache::load(&root.join("cache.json"), "root", true);
+        // Captured while the file is still young: an edit landing right after
+        // the read cannot be told apart from what was read.
+        let before = cache.fingerprint_before_read(&key);
+
+        // Extraction takes long enough for the window to pass before the insert.
+        std::thread::sleep(RACY_WINDOW + Duration::from_millis(100));
+
+        cache.insert(key.clone(), "a.tsx".to_owned(), &[record("Hello")], before);
+        assert!(
+            cache.is_empty(),
+            "a file that was young when it was read must not be cached"
+        );
+
+        std::fs::remove_dir_all(root).expect("cleanup");
+    }
+
+    #[test]
+    fn resets_entries_when_the_request_no_longer_matches_the_stamp() {
+        let root = temp_root("request-stamp");
+        std::fs::create_dir_all(&root).expect("root");
+        let source = root.join("a.tsx");
+        write_aged(&source, "const a = 1\n");
+        let key = source.to_string_lossy().into_owned();
+
+        let mut cache = ExtractCache::load(&root.join("cache.json"), "root-one", true);
+        let before = cache.fingerprint_before_read(&key);
+        cache.insert(key.clone(), "a.tsx".to_owned(), &[record("Hello")], before);
+        assert_eq!(cache.len(), 1);
+
+        // Same stamp: entries survive.
+        cache.reset_if_request_differs("root-one", true);
+        assert_eq!(cache.len(), 1);
+
+        // A different reference root changes stored origins, so nothing may be
+        // reused, and later inserts must be stamped for the new request.
+        cache.reset_if_request_differs("root-two", true);
+        assert!(cache.is_empty());
+        assert!(cache.get(&key).is_none());
+
+        let before = cache.fingerprint_before_read(&key);
+        cache.insert(key.clone(), "a.tsx".to_owned(), &[record("Hello")], before);
+        cache.reset_if_request_differs("root-two", true);
+        assert_eq!(cache.len(), 1, "matching requests keep their entries");
+        cache.reset_if_request_differs("root-two", false);
+        assert!(cache.is_empty(), "flipped reference scopes discard entries");
+
+        std::fs::remove_dir_all(root).expect("cleanup");
+    }
+
+    /*
+     * Retention runs once with the union of every catalog's files. This guards
+     * the multi-catalog case: entries belonging to a sibling catalog must not
+     * be evicted, or each run re-extracts what the other catalog cached.
+     */
+    #[test]
+    fn retain_paths_keeps_entries_of_every_catalog() {
+        let root = temp_root("retain");
+        std::fs::create_dir_all(&root).expect("root");
+        let first = root.join("a.tsx");
+        let second = root.join("b.tsx");
+        let dropped = root.join("c.tsx");
+        for path in [&first, &second, &dropped] {
+            write_aged(path, "const a = 1\n");
+        }
+
+        let mut cache = ExtractCache::load(&root.join("cache.json"), "root", true);
+        for path in [&first, &second, &dropped] {
+            let key = path.to_string_lossy().into_owned();
+            let before = cache.fingerprint_before_read(&key);
+            cache.insert(key, "file.tsx".to_owned(), &[record("Hello")], before);
+        }
+        assert_eq!(cache.len(), 3);
+
+        let first_key = first.to_string_lossy().into_owned();
+        let second_key = second.to_string_lossy().into_owned();
+        let keep = [first_key.as_str(), second_key.as_str()]
+            .into_iter()
+            .collect::<std::collections::HashSet<_>>();
+        cache.retain_paths(&keep);
+
+        assert_eq!(cache.len(), 2);
+        assert!(cache.get(&first_key).is_some());
+        assert!(cache.get(&second_key).is_some());
+        assert!(cache.get(&dropped.to_string_lossy()).is_none());
+        assert!(cache.is_dirty());
+
+        std::fs::remove_dir_all(root).expect("cleanup");
+    }
+
+    #[test]
+    fn retain_paths_on_a_disabled_cache_is_a_no_op() {
+        let mut cache = ExtractCache::disabled();
+        cache.retain_paths(&std::collections::HashSet::new());
+        assert!(cache.is_empty());
+        assert!(!cache.is_dirty());
     }
 
     #[test]

--- a/crates/palamedes/src/icu_text.rs
+++ b/crates/palamedes/src/icu_text.rs
@@ -124,6 +124,32 @@ pub(crate) fn canonicalize_catalog_quoting(catalog: &mut ferrocat::ParsedCatalog
     }
 }
 
+/// Derives the compiled lookup id for a message text.
+///
+/// Catalog compilation canonicalizes every catalog text on load (see
+/// [`canonicalize_catalog_quoting`]) and only then hands the `msgid` to
+/// Ferrocat's key derivation, so a compiled artifact is always keyed by the
+/// hash of the *canonical* text. Every other derivation of the same id — the
+/// lookup key the transform embeds in `getI18n()._("…")`, the ids it reports as
+/// `compiled_ids`, extractor-side parity checks — has to go through this helper
+/// so it hashes the same string.
+///
+/// Without it the raw-ICU authoring surfaces (descriptor string literals and
+/// the `<Trans message>` attribute, where authors write ICU quoting themselves
+/// and neither extractor nor transform escapes anything) hash a text the
+/// compiled catalog never contains, and the runtime silently falls back to the
+/// source message.
+///
+/// Only the message text is canonicalized: `context` is a plain disambiguation
+/// string, not ICU, and catalog loading leaves it untouched as well.
+///
+/// Because [`canonicalize_runtime_quoting`] is a fixed point, already-escaped
+/// authored text (`don''t`) keeps exactly the id it had before, so ids for the
+/// escaping paths are unchanged.
+pub(crate) fn compiled_message_key(message: &str, context: Option<&str>) -> String {
+    ferrocat::compiled_key(&canonicalize_runtime_quoting(message), context)
+}
+
 fn canonicalize_in_place(value: &mut String) {
     if value.contains('\'') {
         *value = canonicalize_runtime_quoting(value);
@@ -220,7 +246,7 @@ fn split_argument_part(input: &str) -> Option<(&str, &str)> {
 
 #[cfg(test)]
 mod tests {
-    use super::{canonicalize_runtime_quoting, escape_icu_literal};
+    use super::{canonicalize_runtime_quoting, compiled_message_key, escape_icu_literal};
 
     #[test]
     fn doubles_authored_apostrophes() {
@@ -267,6 +293,32 @@ mod tests {
         assert_eq!(
             canonicalize_runtime_quoting("{count, select, other {'#' items}}"),
             "{count, select, other {''#'' items}}"
+        );
+    }
+
+    #[test]
+    fn compiled_message_key_hashes_the_canonical_text() {
+        // The raw and the canonical spelling of the same message collapse onto
+        // one id, which is what makes a raw-ICU descriptor reachable in a
+        // compiled catalog.
+        assert_eq!(
+            compiled_message_key("Don't greet {name}", None),
+            ferrocat::compiled_key("Don''t greet {name}", None)
+        );
+
+        // Escaped authored text is a fixed point, so its id never moves.
+        for message in ["don''t", "L''{title} est prêt", "Hello {name}"] {
+            assert_eq!(
+                compiled_message_key(message, None),
+                ferrocat::compiled_key(message, None),
+                "message: {message}"
+            );
+        }
+
+        // Context is a plain disambiguation string and stays untouched.
+        assert_eq!(
+            compiled_message_key("Hello", Some("don't touch")),
+            ferrocat::compiled_key("Hello", Some("don't touch"))
         );
     }
 

--- a/crates/palamedes/src/icu_text.rs
+++ b/crates/palamedes/src/icu_text.rs
@@ -1,0 +1,290 @@
+//! Shared helpers that keep authored ICU text and the JS runtime parser aligned.
+//!
+//! The runtime parser (`packages/core/src/messageFormat.ts`) implements lenient
+//! ICU apostrophe quoting:
+//!
+//! * `''` renders a single literal apostrophe.
+//! * A single `'` starts a quoted literal only when the next character is `{`,
+//!   `}`, or — inside a plural/selectordinal branch — `#`.
+//! * Every other apostrophe is ordinary text (`don't` renders verbatim).
+//! * An unterminated quote auto-closes at the end of the pattern.
+//!
+//! Two things follow from that, and both live here so the extractor, the
+//! transform, and catalog validation cannot drift apart:
+//!
+//! * [`escape_icu_literal`] escapes authored literal segments (template literal
+//!   quasis, JSX text, choice option strings) so an authored apostrophe never
+//!   turns into a quote that swallows the following placeholder.
+//! * [`canonicalize_runtime_quoting`] rewrites a runtime-dialect pattern into
+//!   the equivalent strictly quoted pattern that Ferrocat's ICU parser reads the
+//!   same way the runtime does.
+
+/// Escapes authored literal text for embedding into an ICU message pattern.
+///
+/// Doubling every apostrophe (the Lingui-compatible rule) is what makes the
+/// escaping robust across segment boundaries: an authored segment ending in `'`
+/// followed by a `{placeholder}` cannot form a quote, because the segment is
+/// escaped before the placeholder is appended.
+pub(crate) fn escape_icu_literal(text: &str) -> String {
+    if text.contains('\'') {
+        text.replace('\'', "''")
+    } else {
+        text.to_owned()
+    }
+}
+
+/// Rewrites a runtime-dialect ICU pattern into strict ICU quoting.
+///
+/// Ferrocat parses ICU MessageFormat v1 with strict apostrophe rules, where any
+/// apostrophe opens a quoted literal. Feeding it the runtime dialect directly
+/// either rejects natural apostrophes (`don't`) or — with Ferrocat's
+/// `RuntimeLiteralApostrophes` policy, which doubles every apostrophe first —
+/// silently models `L'{title}` as a live argument that the runtime actually
+/// swallows. Canonicalizing first gives both parsers the same reading:
+///
+/// * ordinary apostrophes are doubled (`don't` -> `don''t`),
+/// * runtime quotes are re-emitted terminated (`L'{title}` -> `L'{title}'`),
+/// * `''` stays a single escaped apostrophe.
+///
+/// The result is a fixed point: every apostrophe in the output is either
+/// doubled or opens a terminated quote whose first character is `{`, `}`, or a
+/// plural `#`, which the strict and the lenient parser read identically.
+pub(crate) fn canonicalize_runtime_quoting(pattern: &str) -> String {
+    if !pattern.contains('\'') {
+        return pattern.to_owned();
+    }
+
+    let bytes = pattern.as_bytes();
+    let mut out = String::with_capacity(pattern.len() + 8);
+    // Stack of "is `#` syntax here" flags, one per open brace group.
+    let mut pound_stack = vec![false];
+    let mut index = 0usize;
+
+    while index < bytes.len() {
+        match bytes[index] {
+            b'\'' => index = push_apostrophe(pattern, index, pound_active(&pound_stack), &mut out),
+            b'{' => {
+                let inherited = pound_active(&pound_stack);
+                pound_stack.push(inherited || opens_plural_argument(pattern, index));
+                out.push('{');
+                index += 1;
+            }
+            b'}' => {
+                if pound_stack.len() > 1 {
+                    pound_stack.pop();
+                }
+                out.push('}');
+                index += 1;
+            }
+            _ => {
+                let start = index;
+                index += 1;
+                while index < bytes.len() && !matches!(bytes[index], b'\'' | b'{' | b'}') {
+                    index += 1;
+                }
+                out.push_str(&pattern[start..index]);
+            }
+        }
+    }
+
+    out
+}
+
+/// Canonicalizes every message text of a parsed catalog in place.
+///
+/// Catalog validation (audit, artifact compilation, pseudo-localization) runs on
+/// Ferrocat's strict ICU parser, so the runtime dialect has to be translated
+/// once, right after parsing, for both sides of a message: the `msgid` that the
+/// authoring pipeline produced and the translations that came back from
+/// translators.
+///
+/// Canonicalizing the `msgid` also rewrites the compiled-id input for catalogs
+/// that still carry unescaped apostrophes from an older extractor; those ids
+/// move to the value the current extractor and transform produce, which is
+/// exactly what the runtime bundle asks for.
+pub(crate) fn canonicalize_catalog_quoting(catalog: &mut ferrocat::ParsedCatalog) {
+    for message in &mut catalog.messages {
+        canonicalize_in_place(&mut message.msgid);
+        match &mut message.translation {
+            ferrocat::TranslationShape::Singular { value } => canonicalize_in_place(value),
+            ferrocat::TranslationShape::Plural {
+                source,
+                translation,
+                ..
+            } => {
+                if let Some(one) = source.one.as_mut() {
+                    canonicalize_in_place(one);
+                }
+                canonicalize_in_place(&mut source.other);
+                for value in translation.values_mut() {
+                    canonicalize_in_place(value);
+                }
+            }
+        }
+    }
+}
+
+fn canonicalize_in_place(value: &mut String) {
+    if value.contains('\'') {
+        *value = canonicalize_runtime_quoting(value);
+    }
+}
+
+fn pound_active(stack: &[bool]) -> bool {
+    stack.last().copied().unwrap_or(false)
+}
+
+/// Emits the canonical form of the apostrophe at `index` and returns the next
+/// index to read.
+fn push_apostrophe(pattern: &str, index: usize, pound_active: bool, out: &mut String) -> usize {
+    let bytes = pattern.as_bytes();
+    let next = bytes.get(index + 1).copied();
+
+    if next == Some(b'\'') {
+        out.push_str("''");
+        return index + 2;
+    }
+
+    let starts_quote =
+        matches!(next, Some(b'{') | Some(b'}')) || (pound_active && next == Some(b'#'));
+    if !starts_quote {
+        // Ordinary text apostrophe: the runtime renders it verbatim, so escape
+        // it for the strict parser.
+        out.push_str("''");
+        return index + 1;
+    }
+
+    let (literal, end) = read_quoted_literal(pattern, index + 1);
+    out.push('\'');
+    out.push_str(&literal.replace('\'', "''"));
+    out.push('\'');
+    end
+}
+
+/// Reads a runtime quoted literal starting after the opening apostrophe,
+/// mirroring `parseQuotedLiteral` in the runtime parser: `''` is a literal
+/// apostrophe, a lone `'` closes the quote, and the end of the pattern
+/// auto-closes it.
+fn read_quoted_literal(pattern: &str, start: usize) -> (String, usize) {
+    let bytes = pattern.as_bytes();
+    let mut literal = String::new();
+    let mut index = start;
+
+    while index < bytes.len() {
+        if bytes[index] != b'\'' {
+            let chunk_start = index;
+            index += 1;
+            while index < bytes.len() && bytes[index] != b'\'' {
+                index += 1;
+            }
+            literal.push_str(&pattern[chunk_start..index]);
+            continue;
+        }
+
+        if bytes.get(index + 1).copied() == Some(b'\'') {
+            literal.push('\'');
+            index += 2;
+            continue;
+        }
+
+        return (literal, index + 1);
+    }
+
+    (literal, index)
+}
+
+/// Reports whether the brace group opening at `index` is a plural or
+/// selectordinal argument, whose branches make `#` syntax.
+fn opens_plural_argument(pattern: &str, index: usize) -> bool {
+    let rest = &pattern[index + 1..];
+    let Some((_, after_name)) = split_argument_part(rest) else {
+        return false;
+    };
+    let Some((kind, _)) = split_argument_part(after_name) else {
+        return false;
+    };
+
+    matches!(kind.trim(), "plural" | "selectordinal")
+}
+
+/// Splits `input` at the next `,`, returning the part before it and the rest.
+/// Returns `None` when the argument ends (`}`) or is unterminated.
+fn split_argument_part(input: &str) -> Option<(&str, &str)> {
+    let stop = input.find([',', '}', '{'])?;
+    if input.as_bytes()[stop] != b',' {
+        return None;
+    }
+
+    Some((&input[..stop], &input[stop + 1..]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{canonicalize_runtime_quoting, escape_icu_literal};
+
+    #[test]
+    fn doubles_authored_apostrophes() {
+        assert_eq!(escape_icu_literal("L'"), "L''");
+        assert_eq!(escape_icu_literal("don't"), "don''t");
+        assert_eq!(escape_icu_literal("plain"), "plain");
+    }
+
+    #[test]
+    fn canonicalizes_natural_apostrophes() {
+        assert_eq!(canonicalize_runtime_quoting("don't"), "don''t");
+        assert_eq!(
+            canonicalize_runtime_quoting("no apostrophe"),
+            "no apostrophe"
+        );
+    }
+
+    #[test]
+    fn keeps_escaped_apostrophes_single() {
+        assert_eq!(canonicalize_runtime_quoting("don''t"), "don''t");
+    }
+
+    #[test]
+    fn terminates_runtime_quotes_that_swallow_placeholders() {
+        assert_eq!(
+            canonicalize_runtime_quoting("L'{title} est prêt"),
+            "L'{title} est prêt'"
+        );
+        assert_eq!(
+            canonicalize_runtime_quoting("'{name}' stays"),
+            "'{name}' stays"
+        );
+    }
+
+    #[test]
+    fn treats_pound_quotes_as_syntax_only_inside_plural_branches() {
+        assert_eq!(
+            canonicalize_runtime_quoting("{count, plural, other {'#' items}}"),
+            "{count, plural, other {'#' items}}"
+        );
+        // Outside a plural branch `#` is ordinary text, so both apostrophes are
+        // literal characters.
+        assert_eq!(canonicalize_runtime_quoting("'#' items"), "''#'' items");
+        assert_eq!(
+            canonicalize_runtime_quoting("{count, select, other {'#' items}}"),
+            "{count, select, other {''#'' items}}"
+        );
+    }
+
+    #[test]
+    fn is_idempotent() {
+        for pattern in [
+            "don't",
+            "L'{title} est prêt",
+            "{count, plural, other {'#' items}}",
+            "'#' items",
+            "''",
+        ] {
+            let once = canonicalize_runtime_quoting(pattern);
+            assert_eq!(
+                canonicalize_runtime_quoting(&once),
+                once,
+                "pattern: {pattern}"
+            );
+        }
+    }
+}

--- a/crates/palamedes/src/lib.rs
+++ b/crates/palamedes/src/lib.rs
@@ -28,6 +28,7 @@ mod diagnostic;
 mod error;
 mod extract;
 mod extract_cache;
+mod icu_text;
 mod jsx_entities;
 mod jsx_message;
 mod message_metadata;

--- a/crates/palamedes/src/transform/messages.rs
+++ b/crates/palamedes/src/transform/messages.rs
@@ -11,6 +11,7 @@ use crate::choice::{
     jsx_offset_value, normalize_choice_option_key,
 };
 use crate::error::{PalamedesError, PalamedesResult};
+use crate::icu_text::escape_icu_literal;
 use crate::jsx_entities::decode_jsx_entities;
 use crate::jsx_message::{
     clean_jsx_text, join_jsx_message_parts, JoinedJsxMessage, JsxMessagePart,
@@ -71,7 +72,9 @@ pub(super) fn extract_choice_options(
             return Err(invalid_choice_option(macro_name, location, &key));
         };
         let (value, option_values) = match property.value.without_parentheses() {
-            Expression::StringLiteral(literal) => (literal.value.to_string(), Vec::new()),
+            Expression::StringLiteral(literal) => {
+                (escape_icu_literal(literal.value.as_str()), Vec::new())
+            }
             Expression::TemplateLiteral(template) => template_to_message_with_state(
                 template,
                 source,
@@ -196,11 +199,14 @@ pub(super) fn extract_choice_options_from_jsx(
             continue;
         };
         let (value, option_values) = match attr_value {
-            JSXAttributeValue::StringLiteral(literal) => {
-                (decode_jsx_entities(literal.value.as_str()), Vec::new())
-            }
+            JSXAttributeValue::StringLiteral(literal) => (
+                escape_icu_literal(&decode_jsx_entities(literal.value.as_str())),
+                Vec::new(),
+            ),
             JSXAttributeValue::ExpressionContainer(container) => match &container.expression {
-                JSXExpression::StringLiteral(literal) => (literal.value.to_string(), Vec::new()),
+                JSXExpression::StringLiteral(literal) => {
+                    (escape_icu_literal(literal.value.as_str()), Vec::new())
+                }
                 JSXExpression::TemplateLiteral(template) => template_to_message_with_state(
                     template,
                     source,
@@ -332,7 +338,7 @@ fn extract_jsx_children_parts_with_state(
     for child in children {
         match child {
             JSXChild::Text(text) => {
-                let value = clean_jsx_text(text.value.as_str());
+                let value = escape_icu_literal(&clean_jsx_text(text.value.as_str()));
                 if !value.is_empty() {
                     parts.push(JsxMessagePart::Text(value));
                 }
@@ -340,7 +346,9 @@ fn extract_jsx_children_parts_with_state(
             JSXChild::ExpressionContainer(container) => match &container.expression {
                 JSXExpression::EmptyExpression(_) => {}
                 JSXExpression::StringLiteral(literal) => {
-                    parts.push(JsxMessagePart::Text(literal.value.to_string()));
+                    parts.push(JsxMessagePart::Text(escape_icu_literal(
+                        literal.value.as_str(),
+                    )));
                 }
                 expr => {
                     let binding =
@@ -573,10 +581,12 @@ fn template_to_message_with_state(
     let mut values = Vec::new();
 
     for (index, quasi) in template.quasis.iter().enumerate() {
+        // Authored literal text: escape before appending so an apostrophe at a
+        // segment boundary cannot quote the placeholder that follows.
         if let Some(value) = quasi.value.cooked {
-            message.push_str(value.as_str());
+            message.push_str(&escape_icu_literal(value.as_str()));
         } else {
-            message.push_str(quasi.value.raw.as_str());
+            message.push_str(&escape_icu_literal(quasi.value.raw.as_str()));
         }
 
         if let Some(expr) = template.expressions.get(index) {

--- a/crates/palamedes/src/transform/runtime.rs
+++ b/crates/palamedes/src/transform/runtime.rs
@@ -1,4 +1,3 @@
-use ferrocat::compiled_key;
 use std::collections::BTreeSet;
 
 use oxc_ast::ast::{
@@ -11,6 +10,7 @@ use crate::descriptor::{
     descriptor_property_value, descriptor_static_property, unsupported_macro_syntax,
 };
 use crate::error::{PalamedesError, PalamedesResult};
+use crate::icu_text::compiled_message_key;
 
 use super::messages::{
     append_unique_bindings, build_icu_message, choice_expression_binding, escape_string,
@@ -30,7 +30,7 @@ pub(super) fn transform_tagged_template(
         return Ok(None);
     }
 
-    let lookup_key = compiled_key(&message, None);
+    let lookup_key = compiled_message_key(&message, None);
     Ok(Some((
         build_runtime_call(
             &lookup_key,
@@ -82,6 +82,9 @@ fn transform_descriptor_object(
         ));
     };
 
+    // Descriptor string literals are the raw-ICU authoring surface: the author
+    // owns the quoting, so the text is embedded verbatim. Only the lookup key
+    // is derived from its canonical form, to match the compiled catalog.
     let (message, implicit_values) = match message_expression.without_parentheses() {
         Expression::StringLiteral(literal) => (literal.value.to_string(), Vec::new()),
         Expression::TemplateLiteral(template) => {
@@ -99,7 +102,7 @@ fn transform_descriptor_object(
     let context = descriptor_static_property(object, "context", macro_name, location)?;
     let comment = descriptor_static_property(object, "comment", macro_name, location)?;
 
-    let lookup_key = compiled_key(&message, context.as_deref());
+    let lookup_key = compiled_message_key(&message, context.as_deref());
     let values_text = descriptor_values_argument(
         call,
         source,
@@ -343,7 +346,7 @@ pub(super) fn transform_choice_call(
         &extracted_options.options,
         extracted_options.offset.as_deref(),
     );
-    let lookup_key = compiled_key(&message, None);
+    let lookup_key = compiled_message_key(&message, None);
     let mut values = vec![value_binding];
     append_unique_bindings(&mut values, extracted_options.values);
     Ok(Some((
@@ -381,7 +384,7 @@ pub(super) fn transform_trans_element(
     let Some(message) = message else {
         return Ok(None);
     };
-    let lookup_key = compiled_key(&message, context.as_deref());
+    let lookup_key = compiled_message_key(&message, context.as_deref());
 
     let mut attrs = vec![
         format!("id=\"{}\"", escape_string(&lookup_key)),
@@ -448,7 +451,7 @@ pub(super) fn transform_choice_jsx_element(
         &extracted_options.options,
         extracted_options.offset.as_deref(),
     );
-    let lookup_key = compiled_key(&message, context.as_deref());
+    let lookup_key = compiled_message_key(&message, context.as_deref());
     let mut values = vec![value_binding];
     append_unique_bindings(&mut values, extracted_options.values);
     Ok(Some((

--- a/crates/palamedes/src/transform/tests.rs
+++ b/crates/palamedes/src/transform/tests.rs
@@ -335,6 +335,52 @@ const richChoice = <Plural value={props.quantity()} one="# task" other="# tasks"
 }
 
 #[test]
+fn extractor_and_transform_share_escaped_apostrophes() {
+    let source = r##"import { plural, t } from "@palamedes/core/macro";
+import { Trans } from "@palamedes/react/macro";
+
+const tagged = t`L'${title} est prêt`;
+const rich = <Trans>l'{item}</Trans>;
+const choice = plural(count, { one: "'#' don't item", other: "# don't items" });
+const plain = t`don't`;
+"##;
+    let scoped_source = scope_macro_test_source(source, "test.tsx");
+    let extracted = crate::extract::extract_messages(&scoped_source, "test.tsx")
+        .expect("apostrophe messages should extract");
+    let transformed =
+        transform_macros(source, "test.tsx", None).expect("apostrophe messages should transform");
+
+    // Authored apostrophes are doubled so the runtime parser renders them
+    // literally instead of quoting the placeholder that follows.
+    assert_eq!(
+        extracted
+            .iter()
+            .map(|message| message.message.as_str())
+            .collect::<Vec<_>>(),
+        vec![
+            "L''{title} est prêt",
+            "l''{item}",
+            "{count, plural, one {''#'' don''t item} other {# don''t items}}",
+            "don''t",
+        ]
+    );
+
+    // Byte-identical message text on both sides keeps the compiled ids aligned.
+    let extracted_ids = extracted
+        .iter()
+        .map(|message| compiled_key(&message.message, message.context.as_deref()))
+        .collect::<Vec<_>>();
+    assert_eq!(transformed.compiled_ids, extracted_ids);
+    for message in &extracted {
+        assert!(
+            transformed.code.contains(message.message.as_str()),
+            "transform output should embed {:?}",
+            message.message
+        );
+    }
+}
+
+#[test]
 fn transforms_select_ordinal_choice_macros() {
     let result = transform_macros(
         "import { selectOrdinal } from \"@palamedes/core/macro\";\nconst msg = selectOrdinal(count, { one: \"#st\", other: \"#th\" });\n",

--- a/crates/palamedes/src/transform/tests.rs
+++ b/crates/palamedes/src/transform/tests.rs
@@ -381,6 +381,39 @@ const plain = t`don't`;
 }
 
 #[test]
+fn descriptor_string_literals_stay_raw_icu_on_both_sides() {
+    // Descriptor string literals are the raw-ICU authoring surface: authors
+    // write placeholders and ICU quoting themselves, so neither side may
+    // escape apostrophes there. Template-literal descriptors are authored
+    // text and go through the shared escaping instead.
+    let source = r##"import { t } from "@palamedes/core/macro";
+
+const quoted = t({ message: "L'{title} est prêt" }, { title });
+const doubled = t({ message: "It''s {name}" }, { name });
+const authored = t({ message: `l'${item}` });
+"##;
+    let scoped_source = scope_macro_test_source(source, "test.ts");
+    let extracted = crate::extract::extract_messages(&scoped_source, "test.ts")
+        .expect("descriptor messages should extract");
+    let transformed =
+        transform_macros(source, "test.ts", None).expect("descriptor messages should transform");
+
+    assert_eq!(
+        extracted
+            .iter()
+            .map(|message| message.message.as_str())
+            .collect::<Vec<_>>(),
+        vec!["L'{title} est prêt", "It''s {name}", "l''{item}"]
+    );
+
+    let extracted_ids = extracted
+        .iter()
+        .map(|message| compiled_key(&message.message, message.context.as_deref()))
+        .collect::<Vec<_>>();
+    assert_eq!(transformed.compiled_ids, extracted_ids);
+}
+
+#[test]
 fn transforms_select_ordinal_choice_macros() {
     let result = transform_macros(
         "import { selectOrdinal } from \"@palamedes/core/macro\";\nconst msg = selectOrdinal(count, { one: \"#st\", other: \"#th\" });\n",

--- a/crates/palamedes/src/transform/tests.rs
+++ b/crates/palamedes/src/transform/tests.rs
@@ -2,6 +2,7 @@ use super::{
     transform_macros as transform_macros_raw, NativeTransformOptions, NativeTransformResult,
 };
 use crate::error::PalamedesResult;
+use crate::icu_text::compiled_message_key;
 use crate::test_support::scope_macro_test_source;
 use ferrocat::compiled_key;
 
@@ -108,7 +109,7 @@ fn transforms_tagged_templates() {
         .contains("import { getI18n } from \"@palamedes/runtime\";"));
     assert_eq!(
         result.compiled_ids,
-        vec![compiled_key("Hello {name}", None)]
+        vec![compiled_message_key("Hello {name}", None)]
     );
 
     let map = result
@@ -184,7 +185,10 @@ const message = t({
     assert!(!result.code.contains("t({"));
     assert_eq!(
         result.compiled_ids,
-        vec![compiled_key("Descriptor {name}", Some("probe context"))]
+        vec![compiled_message_key(
+            "Descriptor {name}",
+            Some("probe context")
+        )]
     );
 }
 
@@ -328,7 +332,7 @@ const richChoice = <Plural value={props.quantity()} one="# task" other="# tasks"
         .expect("zero-argument accessors should transform");
     let extracted_ids = extracted
         .iter()
-        .map(|message| compiled_key(&message.message, message.context.as_deref()))
+        .map(|message| compiled_message_key(&message.message, message.context.as_deref()))
         .collect::<Vec<_>>();
 
     assert_eq!(transformed.compiled_ids, extracted_ids);
@@ -368,7 +372,7 @@ const plain = t`don't`;
     // Byte-identical message text on both sides keeps the compiled ids aligned.
     let extracted_ids = extracted
         .iter()
-        .map(|message| compiled_key(&message.message, message.context.as_deref()))
+        .map(|message| compiled_message_key(&message.message, message.context.as_deref()))
         .collect::<Vec<_>>();
     assert_eq!(transformed.compiled_ids, extracted_ids);
     for message in &extracted {
@@ -406,11 +410,42 @@ const authored = t({ message: `l'${item}` });
         vec!["L'{title} est prêt", "It''s {name}", "l''{item}"]
     );
 
+    // The embedded runtime message stays byte-identical to the authored text.
+    for message in &extracted {
+        assert!(
+            transformed
+                .code
+                .contains(&format!("message: \"{}\"", message.message)),
+            "transform output should embed {:?} verbatim",
+            message.message
+        );
+    }
+
     let extracted_ids = extracted
         .iter()
-        .map(|message| compiled_key(&message.message, message.context.as_deref()))
+        .map(|message| compiled_message_key(&message.message, message.context.as_deref()))
         .collect::<Vec<_>>();
     assert_eq!(transformed.compiled_ids, extracted_ids);
+
+    // Raw and canonical spellings of the same message have to reach the same
+    // lookup key, because catalog compilation canonicalizes before it hashes.
+    assert_eq!(
+        transformed.compiled_ids[0],
+        compiled_key("L'{title} est prêt'", None),
+        "the raw descriptor key must be the canonical-form hash"
+    );
+    assert_ne!(
+        transformed.compiled_ids[0],
+        compiled_key("L'{title} est prêt", None),
+        "hashing the raw text is what made descriptor lookups unreachable"
+    );
+    // Already-escaped authored text is a canonicalization fixed point, so those
+    // ids are unchanged.
+    assert_eq!(
+        transformed.compiled_ids[1],
+        compiled_key("It''s {name}", None)
+    );
+    assert_eq!(transformed.compiled_ids[2], compiled_key("l''{item}", None));
 }
 
 #[test]
@@ -745,8 +780,11 @@ fn trans_jsx_macro_decodes_entities_before_deriving_message_id() {
         .contains("message={\"Green-e® applies to US & Canada only\"}"));
     assert!(result
         .code
-        .contains(&format!("id=\"{}\"", compiled_key(message, None))));
-    assert_eq!(result.compiled_ids, vec![compiled_key(message, None)]);
+        .contains(&format!("id=\"{}\"", compiled_message_key(message, None))));
+    assert_eq!(
+        result.compiled_ids,
+        vec![compiled_message_key(message, None)]
+    );
 }
 
 #[test]
@@ -762,7 +800,10 @@ fn trans_jsx_macro_decodes_message_attribute_entities() {
     assert!(result
         .code
         .contains("message={\"Decision \\\"Model\\\" & review\"}"));
-    assert_eq!(result.compiled_ids, vec![compiled_key(message, None)]);
+    assert_eq!(
+        result.compiled_ids,
+        vec![compiled_message_key(message, None)]
+    );
 }
 
 #[test]
@@ -781,8 +822,8 @@ fn trans_jsx_macro_keeps_expression_string_entities_raw() {
     assert_eq!(
         result.compiled_ids,
         vec![
-            compiled_key(child_message, None),
-            compiled_key(attr_message, None)
+            compiled_message_key(child_message, None),
+            compiled_message_key(attr_message, None)
         ]
     );
 }

--- a/docs/api/config.md
+++ b/docs/api/config.md
@@ -52,6 +52,13 @@ export default defineConfig({
 })
 ```
 
+`referenceScopes` controls whether catalog source references carry a stable
+component or function suffix. It defaults to `true`, producing references such
+as `src/App.tsx#CheckoutButton`; the `false` above opts into file-only
+references such as `src/App.tsx`. The example sets it explicitly only to show
+the field — omit it to keep the default. See
+[Source references](../configuration.md#source-references).
+
 PO is the default catalog storage. Opt into FCL by adding `format: "fcl"`:
 
 ```ts

--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -261,6 +261,13 @@ unchanged. The rules above matter for translators hand-editing `.po` files, for
 catalogs imported from a TMS, and for patterns passed directly to
 `formatMessagePattern()` — all of which use standard ICU quoting.
 
+One deliberate exception: a descriptor whose `message` is a **string literal**
+— `t({ message: "Hello {name}" })` — is the raw-ICU authoring surface.
+Placeholders are written literally, the quoting rules above apply verbatim
+(`It''s {name}`, `L'{title}` quotes the brace), and nothing is auto-escaped.
+A descriptor whose `message` is a template literal is authored text like a
+tagged template and is auto-escaped.
+
 Two helpers back the host-adapter renderers and are public for custom
 adapters: `resolveChoice(node, value, locale?)` selects the branch of a parsed
 plural/select/selectordinal node (returning the branch nodes plus the operand

--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -10,6 +10,7 @@ package names.
 - `formatMessagePattern(pattern, values, locale?)`
 - `parseMessagePattern(pattern)`
 - `resolveChoice(node, value, locale?)` and `ResolvedChoice`
+- `replacePoundPlaceholders(value, numericValue, locale?)`
 - `stringifyValue(value)`
 - `parseAcceptLanguage(header)` from `@palamedes/core/locale`
 - `buildLocaleSwitchItems(options)` from `@palamedes/core/locale`
@@ -20,6 +21,7 @@ package names.
 - `CreateI18nOptions`
 - `MissingMessageInfo`
 - `MessageFormatErrorInfo`
+- `ReportedMessageError`
 - `MessageNode`
 - `MessageChoiceNode`
 - `MessageFormattedArgumentNode`
@@ -65,12 +67,39 @@ interface PalamedesI18n {
   activate(locale: string): void
   getMessage(id: string, metadata?: MessageMetadata): string
   getMessageNodes(id: string, metadata?: MessageMetadata): MessageNode[]
+  reportError(info: ReportedMessageError): void
 }
 ```
+
+`reportError()` routes a rendering failure that happened outside the instance
+(for example inside a framework adapter's node renderer) through the same
+`onError` telemetry hook as internal formatting failures, filling in the active
+locale. `replacePoundPlaceholders(value, numericValue, locale?)` replaces `#`
+markers in already-resolved choice text using the instance-independent cached
+`Intl.NumberFormat`; the framework adapters use it so pound formatting shares
+core's formatter cache.
 
 `getMessageNodes()` returns the parsed message as a `MessageNode[]` tree. The
 `<Trans>`-style components in `@palamedes/react` and `@palamedes/solid` render
 from this structure; custom `PalamedesI18n` implementations must provide it.
+
+A custom renderer must handle every `MessageNode` variant, including
+`MessageLiteralNode`:
+
+```ts
+type MessageLiteralNode = {
+  type: "literal"
+  value: string
+}
+```
+
+Literal nodes carry text that ICU quoting escaped — the `{` in `'{'`, the `'`
+in `''`, the `#` in `'#'`. They render exactly like `MessageTextNode`; they are
+a separate variant only so the parse tree records that the text was quoted. A
+renderer that switches on `"text"`, `"variable"`, `"formatted"`, `"choice"`,
+and `"tag"` alone silently drops every escaped character. See
+[Quoting and literal text](#quoting-and-literal-text) for the quoting rules
+that produce these nodes.
 
 `load()` merges messages into the locale catalog. The locale passed to
 `createI18n({ locale })`, or `DEFAULT_LOCALE` when omitted, is active
@@ -166,6 +195,71 @@ Plural and selectordinal arguments require a present, numeric value (numeric
 strings are accepted). A missing or non-numeric value throws instead of
 silently coercing to `0` — inside `_()`/`getMessage()` that error is reported
 through `onError` and rendering falls back to the source message.
+
+### Plural Offset
+
+`plural` and `selectordinal` arguments accept ICU `offset:N`, where `N` is a
+non-negative integer. It exists for "and N others" sentences, where the number
+shown is smaller than the number counted:
+
+```text
+{count, plural, offset:1 =0 {nobody else} one {# other person} other {# other people}}
+```
+
+Three rules, applied in this order:
+
+1. Exact `=N` keys match the **raw** value, before the offset is subtracted.
+   With `offset:1` and `count = 1`, the `=1` branch matches.
+2. Plural categories (`zero` … `other`) select on `value - offset`. With
+   `offset:1` and `count = 2`, the category comes from `1`, so English picks
+   `one`.
+3. `#` inside the selected branch renders `value - offset`.
+
+A negative or non-integer offset is rejected while the pattern is parsed, so a
+bad offset surfaces as a format error rather than a wrong count. `select` has
+no numeric operand and does not support `offset`: an `offset:` written into a
+`select` argument is read as an option key, never matches, and renders empty.
+
+The same argument is written `plural(count, { offset: 1, … })` with the macro
+and `<Plural offset={1}>` with the React and Solid components; both compile to
+the ICU form above, so the offset lives in the catalog and translators can rely
+on it.
+
+### Quoting and Literal Text
+
+The runtime parser implements ICU's apostrophe quoting in its lenient form, so
+ordinary prose stays readable while `{`, `}`, and `#` remain escapable:
+
+- `''` is always a literal apostrophe: `Ada''s` renders `Ada's`.
+- A single `'` opens a quoted literal **only** when the next character is `{`,
+  `}`, or — inside a plural or selectordinal branch, where `#` is syntax — `#`.
+  Everything up to the closing `'` is literal text.
+- Anywhere else, `'` is just an apostrophe. `don't`, `it's`, and `l'été` need
+  no escaping and render unchanged.
+- An unterminated quote auto-closes at the end of the pattern rather than
+  throwing: `Use '{name` renders `Use {name`.
+
+That makes `'{'` the way to emit a literal brace, and `'{'`/`'}'` the way to
+show placeholder syntax to the reader:
+
+| Pattern                         | Renders       |
+| ------------------------------- | ------------- |
+| `Ada''s file`                   | `Ada's file`  |
+| `don't panic`                   | `don't panic` |
+| `'{'name'}'`                    | `{name}`      |
+| `'{name}'`                      | `{name}`      |
+| `Sale: 50'%'`                   | `Sale: 50'%'` |
+| `{n, plural, other {'#' rank}}` | `# rank`      |
+| `Use '{name`                    | `Use {name`   |
+
+Quoted runs become `MessageLiteralNode` entries in `getMessageNodes()` output.
+
+Application authors do not need to think about any of this: the macros and the
+extractor escape authored apostrophes on the way into the catalog, so a source
+message written as `Ada's file` is stored as a pattern that renders it back
+unchanged. The rules above matter for translators hand-editing `.po` files, for
+catalogs imported from a TMS, and for patterns passed directly to
+`formatMessagePattern()` — all of which use standard ICU quoting.
 
 Two helpers back the host-adapter renderers and are public for custom
 adapters: `resolveChoice(node, value, locale?)` selects the branch of a parsed

--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -266,7 +266,9 @@ One deliberate exception: a descriptor whose `message` is a **string literal**
 Placeholders are written literally, the quoting rules above apply verbatim
 (`It''s {name}`, `L'{title}` quotes the brace), and nothing is auto-escaped.
 A descriptor whose `message` is a template literal is authored text like a
-tagged template and is auto-escaped.
+tagged template and is auto-escaped. The JSX `message` attribute —
+`<Trans message="Hello {name}" />` — is the same raw-ICU surface and is left
+unescaped as well, unlike `<Trans>` children, which are authored text.
 
 Two helpers back the host-adapter renderers and are public for custom
 adapters: `resolveChoice(node, value, locale?)` selects the branch of a parsed

--- a/docs/api/next-plugin.md
+++ b/docs/api/next-plugin.md
@@ -53,8 +53,27 @@ The plugin configures both Turbopack and webpack paths, and requires Next.js
 conditions and `outputFileTracingRoot` need the Next 16 config surface).
 `include` and `exclude` apply under both bundlers: in the webpack branch as
 loader `test`/`exclude`, under Turbopack translated into the rule condition
-(`{ path: include }` plus `{ not: { path: exclude } }`). User-supplied
-`turbopack.rules` for the same glob are preserved — the Palamedes rules are
-appended to the glob's rule list instead of overwriting it. `workspaceRoot`
-can be set explicitly in monorepos when automatic root detection is not
-correct.
+(`{ path: include }` plus `{ not: { path: exclude } }`).
+
+The regex is not matched against the same string in both cases. Webpack tests
+the absolute resource path (`/home/me/app/src/page.tsx`); Turbopack tests its
+own internal path representation for the module, which is not guaranteed to be
+that absolute OS path. Extension patterns (`/\.[jt]sx?$/`) and path-segment
+patterns (`/[/\\]generated[/\\]/`) behave the same under both. Patterns
+anchored with `^`, or built from an absolute directory, are the ones that can
+match under webpack and silently miss under Turbopack — prefer segment-based
+patterns and verify under both bundlers before relying on one.
+
+The `.po` loader is scoped to first-party catalogs under both bundlers —
+`{ not: "foreign" }` for Turbopack, `exclude: /node_modules/` for webpack — so
+a dependency shipping importable `.po` files does not fail the build with an
+unmatched-catalog error.
+
+User-supplied `turbopack.rules` for the same glob are preserved: the Palamedes
+rules are appended to the glob's rule list instead of overwriting it. A user
+value written in the loader shorthand (`"*": ["my-loader"]`) is first wrapped
+into the equivalent rule config (`{ loaders: ["my-loader"] }`), because a list
+mixing bare loaders with rule configs has no defined meaning.
+
+`workspaceRoot` can be set explicitly in monorepos when automatic root
+detection is not correct.

--- a/docs/api/react.md
+++ b/docs/api/react.md
@@ -55,6 +55,35 @@ import { Trans } from "@palamedes/react"
 For authoring source strings, prefer macro imports from
 `@palamedes/react/macro` so the build can extract and transform messages.
 
+## Choice Components
+
+`Plural`, `Select`, and `SelectOrdinal` take the branch text as props: plural
+categories (`zero`, `one`, `two`, `few`, `many`, `other`) and exact matches
+spelled `_0`, `_1`, … because a JSX attribute cannot start with `=`. Exact
+matches are normalized to ICU `=N`, mirroring the macro transform. `other` is
+required.
+
+`Plural` and `SelectOrdinal` also accept `offset`, the ICU `offset:N` of the
+synthesized pattern. Use it for "and N others" sentences where the number shown
+is smaller than the number counted:
+
+```tsx
+<Plural value={attendees} offset={1} _0="nobody else" one="# other" other="# others" />
+```
+
+- exact `_N` / `=N` keys match the **raw** value, before the offset is
+  subtracted
+- plural categories select on `value - offset`
+- `#` inside a branch renders `value - offset`
+
+`offset` must be a non-negative safe integer; anything else throws a
+`RangeError` rather than rendering a wrong count. `Select` has no numeric
+operand and takes no `offset`.
+
+The components render through the active i18n instance, so the synthesized ICU
+pattern — including `offset:N` — is the source message a catalog entry can
+override.
+
 ## Locale Switch Helpers
 
 ```ts

--- a/docs/api/solid.md
+++ b/docs/api/solid.md
@@ -47,6 +47,31 @@ import { Trans } from "@palamedes/solid"
 
 For source authoring, prefer macro imports from `@palamedes/solid/macro`.
 
+## Choice Components
+
+`Plural`, `Select`, and `SelectOrdinal` take the branch text as props: plural
+categories (`zero`, `one`, `two`, `few`, `many`, `other`) and exact matches
+spelled `_0`, `_1`, … because a JSX attribute cannot start with `=`. Exact
+matches are normalized to ICU `=N`, mirroring the macro transform. `other` is
+required.
+
+`Plural` and `SelectOrdinal` also accept `offset`, the ICU `offset:N` of the
+synthesized pattern, for "and N others" sentences where the number shown is
+smaller than the number counted:
+
+```tsx
+<Plural value={attendees()} offset={1} _0="nobody else" one="# other" other="# others" />
+```
+
+- exact `_N` / `=N` keys match the **raw** value, before the offset is
+  subtracted
+- plural categories select on `value - offset`
+- `#` inside a branch renders `value - offset`
+
+`offset` must be a non-negative safe integer; anything else throws a
+`RangeError` rather than rendering a wrong count. `Select` has no numeric
+operand and takes no `offset`.
+
 ## Client Locale Effect
 
 ```ts

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,10 +44,14 @@ catalogs:
 | `extract-threads`       | No       | `number`                               | Worker threads for the parallel extraction pass. Defaults to `4`; `1` runs serial.  |
 | `extract-cache`         | No       | `boolean`                              | Reuse the on-disk extraction cache. Defaults to `true`.                             |
 
-The native CLI and JS config loader also accept snake_case aliases for
+The native CLI and JS config loader both accept snake_case aliases for these
 hyphenated config keys: `source_locale`, `fallback_locales`, `pseudo_locale`,
-`source_reference_root`, `reference_scopes`, `extract_threads`, and
-`extract_cache`.
+`source_reference_root`, and `reference_scopes`.
+
+`extract-threads` and `extract-cache` (and their `extract_threads` /
+`extract_cache` aliases) are read by the native `pmds` CLI only. They tune
+extraction, which the CLI owns; the JS config loader in `@palamedes/config`
+ignores them, and no bundler plugin reads them.
 
 `extract-threads` bounds the parallel read/parse pass. The default of `4` is a
 measured floor rather than a core count: extraction gets slower again above it,

--- a/docs/locale-strategies.md
+++ b/docs/locale-strategies.md
@@ -67,6 +67,12 @@ Subdomain examples follow this rule set:
 - switching locale loads a different host (the control swaps the leftmost label
   via `canonicalUrl`), so it is always a full document load — the live switching
   mechanism below does not apply
+- `canonicalUrl` and `suggest` return protocol-relative URLs (`//de.example.com/…`)
+  unless the config sets `protocol` (for example `protocol: "https"`). The
+  default keeps the same configuration correct on http locally and https in
+  production; set it when the URLs must be absolute, as in canonical link tags,
+  `hreflang` alternates, or sitemaps. See
+  [`defineLocaleControls`](api/core.md#locale-controls).
 
 This is distinct from the host mapping above. Host mapping is a _validation
 signal on top of_ the route strategy, matched against fully configured per-locale
@@ -104,6 +110,9 @@ TLD examples follow this rule set:
   locale `en` switches to `defaultTld`
   (`hosts: { mode: "tld", defaultTld: "com" }`, so `en` -> `.com`), which the
   `.com` -> `en` override above also serves authoritatively
+- as with the subdomain strategy, the emitted URLs are protocol-relative unless
+  the config sets `protocol` (for example `protocol: "https"`). See
+  [`defineLocaleControls`](api/core.md#locale-controls).
 
 ### Why real TLDs need an explicit policy
 

--- a/docs/migrate-from-lingui.md
+++ b/docs/migrate-from-lingui.md
@@ -257,6 +257,14 @@ pnpm exec pmds extract
 That moves catalogs onto the source-first path and aligns updates, audits, and
 ICU diagnostics with the current native core and `ferrocat`.
 
+Existing translations carried over from Lingui or a TMS keep their ICU quoting.
+Doubled apostrophes (`Ada''s`) render as a single `'`, and `'{'` still emits a
+literal brace — this used to be a documented divergence in the Palamedes
+runtime and is no longer one. Plain apostrophes in prose (`don't`) are left
+alone rather than treated as quote openers, so catalogs that mix both
+conventions migrate without a rewrite. See
+[Quoting and literal text](api/core.md#quoting-and-literal-text).
+
 ## Common Migration Errors
 
 ### "No active client i18n instance"

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -193,6 +193,24 @@ But Palamedes intentionally avoids some historical Lingui surface area:
 
 Use source strings and optional context as the public identity. If two source strings need distinct translations, use context rather than an arbitrary ID.
 
+Plural authoring supports ICU `offset`, so "X, Y and 3 others" style sentences
+do not need hand-rolled arithmetic in application code:
+
+```tsx
+plural(count, { offset: 1, "=0": "nobody else", one: "one other", other: "# others" })
+```
+
+```tsx
+<Plural value={count} offset={1} _0="nobody else" one="one other" other="# others" />
+```
+
+The same message written directly in a catalog is `{count, plural, offset:1 =0 {…} one {…} other {# others}}`. Exact `=N` keys match the raw value; plural categories and `#` use the value minus the offset.
+
+Authored source strings may contain apostrophes (`don't`) without escaping — the
+macros and the extractor emit ICU-safe patterns automatically. Translators
+editing `.po` files by hand use standard ICU quoting: `''` for a literal
+apostrophe, and `'{'` to emit a literal brace.
+
 ## Placeholder guidance
 
 Good placeholder authoring should be stable and readable for translators.
@@ -270,7 +288,9 @@ git config merge.palamedes-catalog.driver \
   'pmds catalog merge --format=po --conflict-strategy=use-first --output %A %A %B'
 ```
 
-Do not recommend `--workers` today. Palamedes currently defers worker-thread parallelism until end-to-end benchmarks show user-visible benefit. See `/adr/013-defer-cli-worker-parallelism-until-benchmarked-need.md`.
+Extraction performance is already handled by the CLI and needs no user tuning by default. `pmds extract` runs a bounded parallel read/parse pass (`--threads <COUNT>`, or `extract-threads` in the config) and reuses an on-disk extraction cache (`--no-cache` disables it for one run; `extract-cache: false` disables it permanently).
+
+The thread default is `4`, clamped to the available cores and the number of files; `1` runs serial. It is a measured floor, not a core count: a one-shot `pmds extract` pays worker setup on every invocation and gets slower again above it. Do not recommend raising `--threads` without a measurement on the user's own corpus and hardware. Both keys are read by the native CLI only — the JS config loader in `@palamedes/config` ignores them. See `/adr/013-bounded-parallel-extraction.md` and `/adr/019-extraction-cache.md`.
 
 Plugin commands:
 
@@ -324,7 +344,7 @@ Avoid adding these unless a Palamedes issue/ADR explicitly expands scope:
 - Astro/Svelte integration
 - generic Lingui compatibility layers
 - explicit message ID migration as a primary product path
-- worker-thread CLI fan-out without benchmark evidence
+- unbounded CLI fan-out (one worker per core) or raised `--threads` defaults without benchmark evidence
 - new placeholder macros that merely work around unclear variable names
 
 ## Useful repository paths
@@ -357,12 +377,13 @@ ADRs:
 - `/adr/010-generated-typescript-types-derived-from-the-native-binding-surface.md`
 - `/adr/011-host-adapters-render-module-source-from-compiled-catalog-artifacts.md`
 - `/adr/012-translation-augmentation-boundary.md`
-- `/adr/013-defer-cli-worker-parallelism-until-benchmarked-need.md`
+- `/adr/013-bounded-parallel-extraction.md`
 - `/adr/014-native-transform-source-maps.md`
 - `/adr/015-runtime-formatter-subset-diagnostics.md`
 - `/adr/016-native-cli-and-yaml-first-configuration.md`
 - `/adr/017-cli-plugin-execution-boundary.md`
 - `/adr/018-binary-plugin-protocol.md`
+- `/adr/019-extraction-cache.md`
 
 ## Development commands
 

--- a/llms.txt
+++ b/llms.txt
@@ -132,6 +132,7 @@ binary plugin protocol instead. See `/docs/api/cli-plugin.md` and
 - `/examples/README.md`: verified example matrix
 - `/adr/003-source-string-first-message-identity.md`: source-string-first identity
 - `/adr/005-universal-geti18n-runtime-model.md`: runtime access model
-- `/adr/013-defer-cli-worker-parallelism-until-benchmarked-need.md`: why CLI workers are deferred until benchmarks justify them
+- `/adr/013-bounded-parallel-extraction.md`: why extraction parallelism is bounded rather than one worker per core
 - `/adr/017-cli-plugin-execution-boundary.md`: explicit CLI plugin execution boundary
 - `/adr/018-binary-plugin-protocol.md`: binary plugin protocol for Rust-first extensions
+- `/adr/019-extraction-cache.md`: the on-disk extraction cache and how it is validated

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -53,6 +53,8 @@ pnpm exec pmds extract --watch
 pnpm exec pmds extract --clean
 pnpm exec pmds extract --force-clean
 pnpm exec pmds extract --config ./palamedes.yaml
+pnpm exec pmds extract --threads 1
+pnpm exec pmds extract --no-cache
 pnpm exec pmds extract --verbose
 pnpm exec pmds audit
 pnpm exec pmds audit --json
@@ -67,6 +69,11 @@ pnpm exec pmds catalog convert src/locales/de.po --to fcl --output src/locales/d
 `pmds audit` reports missing translations, extra catalog entries, obsolete
 messages, and ICU compatibility issues through the same `ferrocat`
 catalog engine that powers Palamedes builds.
+
+`--threads <COUNT>` sets the worker threads for the parallel extraction pass,
+overriding `extract-threads` in the config; it defaults to `4` and `1` runs
+serial. `--no-cache` ignores and does not write the extraction cache in
+`.palamedes/` — use it for a cold run; the cache is on by default.
 
 For local performance checks, set `PALAMEDES_TIMING_JSON=1` on `pmds extract`.
 The command prints a machine-readable timing line with total, glob, extract,

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -150,7 +150,9 @@ escape them on the way into the catalog, so `t` messages such as `Ada's file`
 and `don't panic` simply work. The one exception is a descriptor with a
 string-literal `message` — `t({ message: "Hello {name}" })` — which is the
 raw-ICU authoring surface: placeholders and ICU quoting are written literally
-and nothing is auto-escaped there.
+and nothing is auto-escaped there. The JSX `message` attribute
+(`<Trans message="Hello {name}" />`) is that same raw-ICU surface, while
+`<Trans>` children are authored text and are escaped.
 
 The rules matter when a translator edits a `.po` file by hand, when a catalog
 comes back from a TMS, or when a pattern is passed straight to

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -147,7 +147,10 @@ the runtime falls back to the default `Intl` formatter for that argument type.
 
 Apostrophes in source messages need no escaping. The macros and the extractor
 escape them on the way into the catalog, so `t` messages such as `Ada's file`
-and `don't panic` simply work.
+and `don't panic` simply work. The one exception is a descriptor with a
+string-literal `message` — `t({ message: "Hello {name}" })` — which is the
+raw-ICU authoring surface: placeholders and ICU quoting are written literally
+and nothing is auto-escaped there.
 
 The rules matter when a translator edits a `.po` file by hand, when a catalog
 comes back from a TMS, or when a pattern is passed straight to

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -96,6 +96,27 @@ The subpath also exports `parseAcceptLanguage()`, `buildLocaleSwitchItems()`,
 and their related types. React and Solid re-export the switch-item helper for
 component packages.
 
+`defineLocaleControls` also binds deliberate-choice cookies, canonical URLs, and
+suggestion decisions for the cookie, route, subdomain, and tld strategies. Under
+the host strategies a locale switch changes the host, so `canonicalUrl()` and
+`suggest()` return host-carrying URLs. Those are protocol-relative
+(`//host/path`) by default — correct on http locally and https in production —
+until the config pins a scheme:
+
+```ts
+const localeControls = defineLocaleControls({
+  locales: ["en", "de"],
+  defaultLocale: "en",
+  hosts: { mode: "subdomain" },
+  protocol: "https",
+})
+```
+
+Set `protocol` when the emitted URLs must be absolute, for example in canonical
+link tags, `hreflang` alternates, or sitemaps. See
+[Locale strategies](https://github.com/sebastian-software/palamedes/blob/main/docs/locale-strategies.md)
+and the [core API reference](https://github.com/sebastian-software/palamedes/blob/main/docs/api/core.md#locale-controls).
+
 ## Runtime Formatting
 
 Palamedes supports the common ICU argument types that product UIs usually need
@@ -121,6 +142,51 @@ Catalog artifact compilation reports unsupported formatter kinds such as `list`,
 `duration`, `ago`, and `name` as errors because the runtime does not render
 those kinds. Unsupported styles on `number`, `date`, and `time` are warnings:
 the runtime falls back to the default `Intl` formatter for that argument type.
+
+### Quoting And Literal Text
+
+Apostrophes in source messages need no escaping. The macros and the extractor
+escape them on the way into the catalog, so `t` messages such as `Ada's file`
+and `don't panic` simply work.
+
+The rules matter when a translator edits a `.po` file by hand, when a catalog
+comes back from a TMS, or when a pattern is passed straight to
+`formatMessagePattern()`. Palamedes implements ICU apostrophe quoting in its
+lenient form:
+
+- `''` is always a literal apostrophe — `Ada''s` renders `Ada's`.
+- A single `'` opens a quoted literal **only** before `{`, `}`, or (inside a
+  plural or selectordinal branch, where `#` is syntax) `#`. Text up to the
+  closing `'` is literal.
+- Everywhere else `'` is just an apostrophe, so `don't` and `l'été` render
+  unchanged instead of swallowing the rest of the sentence.
+- An unterminated quote auto-closes at the end of the pattern instead of
+  throwing.
+
+`'{'` is therefore how a message emits a literal brace:
+
+```ts
+i18n._("Write '{'name'}' to insert the user name", {})
+// -> "Write {name} to insert the user name"
+```
+
+Quoted text is exposed as `MessageLiteralNode` in `getMessageNodes()`, so
+custom renderers must handle that node type alongside `text`.
+
+### Plural Offset
+
+`plural` and `selectordinal` support ICU `offset:N` for "and N others"
+sentences:
+
+```ts
+i18n._("{count, plural, offset:1 =0 {nobody else} one {# other} other {# others}}", { count: 3 })
+// -> "2 others"
+```
+
+Exact `=N` keys match the raw value; plural categories select on
+`value - offset`, and `#` renders `value - offset`. The macro spelling is
+`plural(count, { offset: 1, … })`, and the React/Solid components take
+`offset={1}`; all three compile to the ICU form above.
 
 ## License
 

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -224,6 +224,30 @@ describe("createI18n", () => {
     expect(i18n.getMessageNodes("{name")).toStrictEqual([{ type: "text", value: "{name" }])
   })
 
+  it("routes adapter render failures through onError with the active locale", () => {
+    const onError = vi.fn()
+    const i18n = createI18n({ onError })
+    i18n.activate("de")
+
+    i18n.reportError({
+      id: "items",
+      error: "not an Error instance",
+      pattern: "{n, plural, other {# Dateien}}",
+      fallback: "{n} files",
+      metadata: { message: "{n} files" },
+    })
+
+    expect(onError).toHaveBeenCalledOnce()
+    expect(onError.mock.calls[0]?.[0]).toMatchObject({
+      id: "items",
+      locale: "de",
+      pattern: "{n, plural, other {# Dateien}}",
+      fallback: "{n} files",
+    })
+    expect(onError.mock.calls[0]?.[0].error).toBeInstanceOf(Error)
+    expect(onError.mock.calls[0]?.[0].error.message).toBe("not an Error instance")
+  })
+
   it("keeps rendering resilient when hooks throw", () => {
     const i18n = createI18n({
       onMissing() {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -31,6 +31,20 @@ export type MessageFormatErrorInfo = {
   metadata?: MessageMetadata
 }
 
+/**
+ * A rendering failure raised outside core, reported back through the instance.
+ *
+ * The active locale is filled in by the instance and non-`Error` throws are
+ * normalized, so callers only supply what they know.
+ */
+export type ReportedMessageError = {
+  id?: string
+  error: unknown
+  pattern: string
+  fallback: string
+  metadata?: MessageMetadata
+}
+
 export type CreateI18nOptions = {
   locale?: string
   onMissing?: (info: MissingMessageInfo) => void
@@ -44,6 +58,13 @@ export type PalamedesI18n = {
   activate: (locale: string) => void
   getMessage: (id: string, metadata?: MessageMetadata) => string
   getMessageNodes: (id: string, metadata?: MessageMetadata) => MessageNode[]
+  /**
+   * Route a rendering failure raised outside core through this instance's
+   * `onError` hook. The host adapters (React/Solid) render message nodes
+   * themselves, so their failures would otherwise bypass the telemetry that
+   * `_()` reports for the very same message.
+   */
+  reportError: (info: ReportedMessageError) => void
 }
 
 type ResolvedMessage = {
@@ -182,6 +203,17 @@ export function createI18n(options: CreateI18nOptions = {}): PalamedesI18n {
       return parseMessage(resolveMessage(id, metadata), id, metadata)
     },
 
+    reportError(info) {
+      notifyError({
+        id: info.id,
+        locale: activeLocale,
+        error: normalizeError(info.error),
+        pattern: info.pattern,
+        fallback: info.fallback,
+        metadata: info.metadata,
+      })
+    },
+
     _(id, values = {}, metadata) {
       return renderMessage(resolveMessage(id, metadata), values, id, metadata)
     },
@@ -193,7 +225,12 @@ function normalizeError(error: unknown): Error {
 }
 
 export { formatMessagePattern, parseMessagePattern }
-export { resolveChoice, stringifyValue, type ResolvedChoice } from "./messageFormat"
+export {
+  replacePoundPlaceholders,
+  resolveChoice,
+  stringifyValue,
+  type ResolvedChoice,
+} from "./messageFormat"
 export type {
   MessageNode,
   MessageChoiceNode,

--- a/packages/core/src/messageFormat.test.ts
+++ b/packages/core/src/messageFormat.test.ts
@@ -1,6 +1,18 @@
 import { describe, expect, it } from "vitest"
 
-import { formatMessagePattern, parseMessagePattern } from "./messageFormat"
+import {
+  formatMessagePattern,
+  parseMessagePattern,
+  resolveChoice,
+  type MessageNode,
+} from "./messageFormat"
+
+// Parsed choice options carry a null prototype so message-supplied keys can
+// never reach Object.prototype members; expectations must match that shape for
+// toStrictEqual, which compares constructors.
+function choiceOptions(options: Record<string, MessageNode[]>): Record<string, MessageNode[]> {
+  return Object.assign(Object.create(null) as Record<string, MessageNode[]>, options)
+}
 
 describe("parseMessagePattern", () => {
   it("keeps quoted ICU syntax in literal nodes", () => {
@@ -32,13 +44,13 @@ describe("parseMessagePattern", () => {
         type: "choice",
         variable: "count",
         kind: "plural",
-        options: {
+        options: choiceOptions({
           other: [
             { type: "text", value: "Line" },
             { type: "tag", name: "0", children: [] },
             { type: "text", value: "break" },
           ],
-        },
+        }),
       },
     ])
   })
@@ -54,12 +66,45 @@ describe("parseMessagePattern", () => {
         variable: "count",
         kind: "plural",
         offset: 1,
-        options: {
+        options: choiceOptions({
           one: [{ type: "text", value: "you and one other" }],
           other: [{ type: "text", value: "you and # others" }],
-        },
+        }),
       },
     ])
+  })
+
+  it("builds choice options without a prototype chain", () => {
+    const [node] = parseMessagePattern("{n, select, other {O}}")
+
+    expect(node?.type).toBe("choice")
+    expect(Object.getPrototypeOf((node as { options: object }).options)).toBeNull()
+  })
+
+  it("keeps hot patterns cached past the formatter cache limit", () => {
+    const hot = "hot pattern {value}"
+    const nodes = parseMessagePattern(hot)
+
+    for (let index = 0; index < 200; index += 1) {
+      parseMessagePattern(`filler ${index} {value}`)
+    }
+
+    // A 64-entry bound shared with the Intl caches evicted this immediately.
+    expect(parseMessagePattern(hot)).toBe(nodes)
+  })
+
+  it("refreshes cached patterns on hit so hot entries survive eviction", () => {
+    const hot = "recently used pattern {value}"
+    const nodes = parseMessagePattern(hot)
+
+    for (let index = 0; index < 1200; index += 1) {
+      parseMessagePattern(`lru filler ${index} {value}`)
+      if (index % 100 === 0) {
+        parseMessagePattern(hot)
+      }
+    }
+
+    expect(parseMessagePattern(hot)).toBe(nodes)
   })
 })
 
@@ -133,6 +178,32 @@ describe("formatMessagePattern", () => {
 
     expect(formatMessagePattern(message, { n: "0" }, "en")).toBe("none")
     expect(formatMessagePattern(message, { n: "4" }, "en")).toBe("4 items")
+  })
+
+  it("never resolves select values to Object.prototype members", () => {
+    const message = "{n, select, toString {C} other {O}}"
+
+    expect(formatMessagePattern(message, { n: "valueOf" })).toBe("O")
+    expect(formatMessagePattern(message, { n: "hasOwnProperty" })).toBe("O")
+    expect(formatMessagePattern(message, { n: "constructor" })).toBe("O")
+    expect(formatMessagePattern(message, { n: "toString" })).toBe("C")
+    expect(formatMessagePattern("{n, select, other {O}}", { n: "__proto__" })).toBe("O")
+  })
+
+  it("ignores inherited option keys on externally built choice nodes", () => {
+    // Nodes can arrive from outside the parser (hand-written, deserialized), so
+    // the lookup itself must be own-property only.
+    const resolved = resolveChoice(
+      {
+        type: "choice",
+        variable: "n",
+        kind: "select",
+        options: { other: [{ type: "text", value: "O" }] },
+      },
+      "toString"
+    )
+
+    expect(resolved.nodes).toStrictEqual([{ type: "text", value: "O" }])
   })
 
   it("renders Date values as ISO strings and degrades invalid Dates", () => {

--- a/packages/core/src/messageFormat.ts
+++ b/packages/core/src/messageFormat.ts
@@ -46,7 +46,15 @@ const parseCache = new Map<string, MessageNode[]>()
 const numberFormatCache = new Map<string, Intl.NumberFormat>()
 const pluralRulesCache = new Map<string, Intl.PluralRules>()
 const dateTimeFormatCache = new Map<string, Intl.DateTimeFormat>()
+
+// Intl instances are keyed by (locale, style): a handful per app, so a small
+// bound is plenty and keeps the retained memory of these heavy objects low.
 const FORMATTER_CACHE_LIMIT = 64
+
+// Parsed patterns are keyed by the full message text, so the working set is the
+// app's message count — sharing the formatter bound made any catalog with more
+// than 64 messages evict continuously and re-parse everything on every render.
+const PARSE_CACHE_LIMIT = 1024
 
 type ParserState = {
   input: string
@@ -56,6 +64,11 @@ type ParserState = {
 export function parseMessagePattern(pattern: string): MessageNode[] {
   const cached = parseCache.get(pattern)
   if (cached) {
+    // Refresh insert order on every hit so eviction is least-recently-used
+    // instead of first-in: messages rendered on every frame then outlive the
+    // one-off dynamic patterns that pass through the cache.
+    parseCache.delete(pattern)
+    parseCache.set(pattern, cached)
     return cached
   }
 
@@ -64,9 +77,9 @@ export function parseMessagePattern(pattern: string): MessageNode[] {
     index: 0,
   }
   const nodes = parseNodes(state, undefined, false)
-  // i18n._(rawPattern) accepts arbitrary strings, so this cache must be
-  // bounded like the formatter caches or dynamic patterns grow it forever.
-  rememberFormatter(parseCache, pattern, nodes)
+  // i18n._(rawPattern) accepts arbitrary strings, so this cache must stay
+  // bounded or dynamic patterns grow it forever.
+  rememberInCache(parseCache, pattern, nodes, PARSE_CACHE_LIMIT)
   return nodes
 }
 
@@ -180,7 +193,11 @@ function parseBraceExpression(state: ParserState, poundIsSyntax: boolean): Messa
   expectChar(state, ",")
   const offset = kind === "plural" || kind === "selectordinal" ? readPluralOffset(state) : undefined
 
-  const options: Record<string, MessageNode[]> = {}
+  // A null prototype keeps message-supplied option keys off Object.prototype:
+  // `{n, select, other {…}}` looked up with the value "toString" must not
+  // resolve to a function, and an option literally named "__proto__" must be a
+  // plain entry rather than a prototype assignment.
+  const options = Object.create(null) as Record<string, MessageNode[]>
   while (state.index < state.input.length) {
     skipWhitespace(state)
     if (state.input[state.index] === "}") {
@@ -450,7 +467,9 @@ function renderNodeToString(
 ): string {
   switch (node.type) {
     case "text": {
-      return pluralValue === undefined ? node.value : replacePound(node.value, pluralValue, locale)
+      return pluralValue === undefined
+        ? node.value
+        : replacePoundPlaceholders(node.value, pluralValue, locale)
     }
     case "literal": {
       return node.value
@@ -605,19 +624,32 @@ export function resolveChoice(
   locale?: string
 ): ResolvedChoice {
   if (node.kind === "select") {
-    const exact = value == null ? undefined : node.options[String(value)]
-    return { nodes: exact ?? node.options.other ?? [] }
+    const exact = value == null ? undefined : getChoiceOption(node, String(value))
+    return { nodes: exact ?? getChoiceOption(node, "other") ?? [] }
   }
 
   const numericValue = requireChoiceNumericValue(node, value)
   const operand = numericValue - (node.offset ?? 0)
-  const exactKey = `=${numericValue}`
-  if (node.options[exactKey]) {
-    return { nodes: node.options[exactKey], pluralValue: operand }
+  const exactMatch = getChoiceOption(node, `=${numericValue}`)
+  if (exactMatch) {
+    return { nodes: exactMatch, pluralValue: operand }
   }
 
   const category = getPluralRules(locale, node.kind).select(operand)
-  return { nodes: node.options[category] ?? node.options.other ?? [], pluralValue: operand }
+  return {
+    nodes: getChoiceOption(node, category) ?? getChoiceOption(node, "other") ?? [],
+    pluralValue: operand,
+  }
+}
+
+/*
+ * Option keys can come from a message pattern and select values from user
+ * input, so every lookup is own-property only. The parser already builds
+ * options with a null prototype; this also covers nodes handed to us from
+ * elsewhere (hand-written nodes, older parse output, structured clones).
+ */
+function getChoiceOption(node: MessageChoiceNode, key: string): MessageNode[] | undefined {
+  return Object.hasOwn(node.options, key) ? node.options[key] : undefined
 }
 
 function requireChoiceNumericValue(node: MessageChoiceNode, value: unknown): number {
@@ -677,18 +709,38 @@ function rememberFormatter<TFormatter>(
   key: string,
   formatter: TFormatter
 ): TFormatter {
-  if (!cache.has(key) && cache.size >= FORMATTER_CACHE_LIMIT) {
+  return rememberInCache(cache, key, formatter, FORMATTER_CACHE_LIMIT)
+}
+
+function rememberInCache<TValue>(
+  cache: Map<string, TValue>,
+  key: string,
+  value: TValue,
+  limit: number
+): TValue {
+  if (!cache.has(key) && cache.size >= limit) {
     const oldestKey = cache.keys().next().value
     if (oldestKey !== undefined) {
       cache.delete(oldestKey)
     }
   }
 
-  cache.set(key, formatter)
-  return formatter
+  cache.set(key, value)
+  return value
 }
 
-function replacePound(value: string, numericValue: number, locale?: string): string {
+/**
+ * Substitute `#` in plural branch text with the locale-formatted operand.
+ *
+ * Exported for the host adapters (React/Solid), which walk message nodes
+ * themselves: without it they allocate an `Intl.NumberFormat` per text node per
+ * render instead of reusing core's cached formatters.
+ */
+export function replacePoundPlaceholders(
+  value: string,
+  numericValue: number,
+  locale?: string
+): string {
   return value.replaceAll("#", getNumberFormatter(locale, undefined).format(numericValue))
 }
 

--- a/packages/next-plugin/README.md
+++ b/packages/next-plugin/README.md
@@ -131,6 +131,31 @@ module.exports = withPalamedes(
 )
 ```
 
+`include` and `exclude` select which sources are macro-transformed, and apply
+under both bundlers: webpack uses them as the loader's `test`/`exclude`, and
+Turbopack receives them as `{ path: include }` plus `{ not: { path: exclude } }`
+in the rule condition.
+
+The two bundlers do not match the same string, so a regex that is anchored to a
+directory layout can behave differently:
+
+- webpack tests the **absolute resource path** (`/home/me/app/src/page.tsx`)
+- Turbopack tests **its own internal path representation** for the module,
+  which is not guaranteed to be that absolute OS path
+
+Patterns matching a file extension (`/\.[jt]sx?$/`) or a path segment
+(`/[/\\]generated[/\\]/`) work the same under both. Patterns anchored with `^`,
+or built from an absolute directory, are the ones that can match under webpack
+and silently miss under Turbopack — prefer segment-based patterns and verify
+under both bundlers before relying on one. Both bundlers skip dependencies by
+default: `exclude` defaults to `/node_modules/`, and the Turbopack rule also
+carries `{ not: "foreign" }`.
+
+The `.po` loader is scoped the same way. It is registered with
+`{ not: "foreign" }` under Turbopack and `exclude: /node_modules/` under
+webpack, so a dependency that ships importable `.po` files is left alone
+instead of failing the build as an unmatched catalog.
+
 `workspaceRoot` pins the monorepo root used for Turbopack and output file
 tracing. When omitted, `withPalamedes` walks upward from the working directory
 looking for workspace markers (`workspaces` in package.json,

--- a/packages/next-plugin/src/index.test.ts
+++ b/packages/next-plugin/src/index.test.ts
@@ -74,4 +74,74 @@ describe("withPalamedes turbopack config", () => {
     const disabled = getRules(withPalamedes({}, { enablePoLoader: false }))
     expect(disabled["*.po"]).toBeUndefined()
   })
+
+  it("wraps a user loader shorthand into a rule config before appending", () => {
+    const config = withPalamedes({
+      turbopack: {
+        rules: {
+          "*": ["user-loader-a", { loader: "user-loader-b", options: { flag: true } }],
+        },
+      },
+    })
+
+    const starRule = getRules(config)["*"] as RuleItem[]
+    expect(starRule).toHaveLength(2)
+    // The shorthand run keeps its order and becomes one equivalent rule config.
+    expect(starRule[0]).toStrictEqual({
+      loaders: ["user-loader-a", { loader: "user-loader-b", options: { flag: true } }],
+    })
+    expect(starRule[1]?.loaders?.[0]?.loader).toContain("palamedes-loader")
+  })
+
+  it("keeps rule configs and loader shorthand separate in a mixed list", () => {
+    const ruleConfig = { condition: { path: /\.svg$/ }, loaders: ["user-svg-loader"] }
+    const config = withPalamedes({
+      turbopack: {
+        rules: {
+          "*": [ruleConfig, "trailing-loader"],
+        },
+      },
+    })
+
+    const starRule = getRules(config)["*"] as RuleItem[]
+    expect(starRule).toHaveLength(3)
+    expect(starRule[0]).toBe(ruleConfig)
+    expect(starRule[1]).toStrictEqual({ loaders: ["trailing-loader"] })
+    expect(starRule[2]?.loaders?.[0]?.loader).toContain("palamedes-loader")
+  })
+})
+
+type WebpackRule = {
+  test?: RegExp
+  exclude?: RegExp
+  type?: string
+  use?: { loader: string; options?: Record<string, unknown> }[]
+}
+
+function collectWebpackRules(config: ReturnType<typeof withPalamedes>): WebpackRule[] {
+  const rules: WebpackRule[] = []
+  const webpack = config.webpack as (
+    config: { module: { rules: WebpackRule[] } },
+    context: unknown
+  ) => unknown
+  webpack({ module: { rules } }, {})
+  return rules
+}
+
+describe("withPalamedes webpack config", () => {
+  it("excludes node_modules from the po loader rule", () => {
+    const poRule = collectWebpackRules(withPalamedes()).find((rule) =>
+      rule.test?.source.includes("po")
+    )
+
+    expect(poRule).toBeDefined()
+    expect(poRule?.exclude).toBeInstanceOf(RegExp)
+    expect(poRule?.exclude?.test("/app/node_modules/some-dep/messages/de.po")).toBe(true)
+    expect(poRule?.exclude?.test("/app/src/locales/de.po")).toBe(false)
+  })
+
+  it("omits the po loader rule when disabled", () => {
+    const rules = collectWebpackRules(withPalamedes({}, { enablePoLoader: false }))
+    expect(rules.some((rule) => rule.test?.source.includes("po"))).toBe(false)
+  })
 })

--- a/packages/next-plugin/src/index.ts
+++ b/packages/next-plugin/src/index.ts
@@ -16,6 +16,8 @@ const require = createRequire(import.meta.url)
 
 type TurbopackRules = NonNullable<NonNullable<NextConfig["turbopack"]>["rules"]>
 type TurbopackRuleConfigItem = Extract<TurbopackRules[string], { loaders?: unknown }>
+type TurbopackRuleCollectionEntry = Extract<TurbopackRules[string], unknown[]>[number]
+type TurbopackLoaderItem = Exclude<TurbopackRuleConfigItem["loaders"], undefined>[number]
 
 /*
  * Derived from the canonical macro package list so the content pre-filter can
@@ -24,6 +26,47 @@ type TurbopackRuleConfigItem = Extract<TurbopackRules[string], { loaders?: unkno
 const MACRO_CONTENT_PATTERN = new RegExp(
   PALAMEDES_MACRO_PACKAGES.map((name) => name.replaceAll(/[.*+?^${}()|[\]\\/]/gu, "\\$&")).join("|")
 )
+
+/*
+ * A Turbopack rule array is either the loader "shorthand" (a flat list of
+ * loader specifiers, all applied to the glob) or a list of rule configs (each
+ * with its own `condition`). The two look alike but mean different things, so
+ * appending a rule config onto a shorthand list would produce a mixed array
+ * with no defined semantics. Loader items are normalized into an equivalent
+ * rule config first.
+ */
+function isTurbopackLoaderItem(entry: TurbopackRuleCollectionEntry): entry is TurbopackLoaderItem {
+  return (
+    typeof entry === "string" || (typeof entry === "object" && entry !== null && "loader" in entry)
+  )
+}
+
+function normalizeTurbopackRuleCollection(
+  entries: readonly TurbopackRuleCollectionEntry[]
+): TurbopackRuleConfigItem[] {
+  const normalized: TurbopackRuleConfigItem[] = []
+  let pendingLoaders: TurbopackLoaderItem[] = []
+
+  const flushLoaders = (): void => {
+    if (pendingLoaders.length > 0) {
+      normalized.push({ loaders: pendingLoaders })
+      pendingLoaders = []
+    }
+  }
+
+  for (const entry of entries) {
+    if (isTurbopackLoaderItem(entry)) {
+      // Loader order within a shorthand run is significant; keep the run intact.
+      pendingLoaders.push(entry)
+      continue
+    }
+    flushLoaders()
+    normalized.push(entry)
+  }
+  flushLoaders()
+
+  return normalized
+}
 
 /*
  * Turbopack rules are keyed by glob; a glob can carry a list of rule configs.
@@ -40,7 +83,9 @@ function appendTurbopackRule(
     rules[glob] = rule
     return
   }
-  rules[glob] = Array.isArray(existing) ? [...existing, rule] : [existing, rule]
+  rules[glob] = Array.isArray(existing)
+    ? [...normalizeTurbopackRuleCollection(existing), rule]
+    : [existing, rule]
 }
 
 export type WithPalamedesOptions = {
@@ -256,10 +301,14 @@ export function withPalamedes(
         ],
       })
 
-      // Add .po loader
+      // Add .po loader. Scoped to first-party catalogs, mirroring the
+      // Turbopack rule's `{ not: "foreign" }`: a dependency shipping importable
+      // .po files is not a Palamedes catalog, and running it through the
+      // catalog loader would fail the whole build.
       if (enablePoLoader) {
         config.module.rules.push({
           test: /\.po$/,
+          exclude: /node_modules/,
           type: "javascript/auto",
           use: [
             {

--- a/packages/react/src/client.tsx
+++ b/packages/react/src/client.tsx
@@ -1,24 +1,16 @@
 import { useEffect, useSyncExternalStore } from "react"
-import {
-  getClientI18nSnapshot,
-  subscribeClientI18n,
-  type ClientI18nSnapshot,
-} from "@palamedes/runtime"
 
-const SERVER_CLIENT_I18N_SNAPSHOT: ClientI18nSnapshot = {
-  i18n: undefined,
-  revision: 0,
-}
+import {
+  getReactiveI18nSnapshot,
+  getServerI18nSnapshot,
+  subscribeReactiveI18n,
+} from "./clientStore"
 
 export function useClientLocale<TLocale>(
   locale: TLocale,
   sync: (locale: TLocale) => unknown
 ): void {
-  useSyncExternalStore(
-    subscribeClientI18n,
-    getClientI18nSnapshot,
-    () => SERVER_CLIENT_I18N_SNAPSHOT
-  )
+  useSyncExternalStore(subscribeReactiveI18n, getReactiveI18nSnapshot, getServerI18nSnapshot)
 
   useEffect(() => {
     void sync(locale)

--- a/packages/react/src/clientStore.ts
+++ b/packages/react/src/clientStore.ts
@@ -1,0 +1,58 @@
+import {
+  getClientI18nSnapshot,
+  subscribeClientI18n,
+  type ClientI18nSnapshot,
+} from "@palamedes/runtime"
+
+/*
+ * `useSyncExternalStore` calls `subscribe` once per mount and holds on to the
+ * returned unsubscribe; it never re-subscribes while the subscribe function
+ * keeps its identity. `resetI18nRuntime()` throws the runtime's shared listener
+ * Set away, which silently orphans those registrations: the mounted tree then
+ * never hears about any later `setClientI18n()` call and stays stale forever.
+ *
+ * So React keeps its own listener registry here — module state that a runtime
+ * reset does not touch — and attaches a single bridge callback to whichever
+ * listener Set the runtime currently owns. The bridge is (re-)attached on every
+ * subscribe and on every snapshot read, which is the React equivalent of the
+ * Solid binding re-subscribing on every reactive read: any render after a reset
+ * reconnects the whole tree, not just the component that rendered.
+ */
+const storeListeners = new Set<() => void>()
+
+function notifyStoreListeners(): void {
+  // Deleting entries while iterating a Set is safe, so a listener unsubscribing
+  // itself during a locale switch cannot skip the others.
+  for (const listener of storeListeners) {
+    listener()
+  }
+}
+
+function connectToRuntime(): void {
+  // The runtime keeps listeners in a Set, so re-registering this stable
+  // callback is idempotent.
+  subscribeClientI18n(notifyStoreListeners)
+}
+
+export function subscribeReactiveI18n(onStoreChange: () => void): () => void {
+  storeListeners.add(onStoreChange)
+  connectToRuntime()
+
+  return () => {
+    storeListeners.delete(onStoreChange)
+  }
+}
+
+export function getReactiveI18nSnapshot(): ClientI18nSnapshot {
+  connectToRuntime()
+  return getClientI18nSnapshot()
+}
+
+const SERVER_CLIENT_I18N_SNAPSHOT: ClientI18nSnapshot = {
+  i18n: undefined,
+  revision: 0,
+}
+
+export function getServerI18nSnapshot(): ClientI18nSnapshot {
+  return SERVER_CLIENT_I18N_SNAPSHOT
+}

--- a/packages/react/src/index.test.tsx
+++ b/packages/react/src/index.test.tsx
@@ -143,6 +143,34 @@ describe("@palamedes/react", () => {
     ).toThrow(/Invalid plural option "_pair"/)
   })
 
+  it("rejects choice components without any usable option instead of rendering nothing", () => {
+    const i18n = createI18n()
+    i18n.activate("en")
+    setClientI18n(i18n)
+
+    expect(() =>
+      renderToStaticMarkup(
+        <Plural value={2} {...({ other: undefined } as unknown as { other: string })} />
+      )
+    ).toThrow(/plural component requires at least one string option/)
+  })
+
+  it("never resolves select values to Object.prototype members", () => {
+    const i18n = createI18n()
+    i18n.activate("en")
+    setClientI18n(i18n)
+
+    const html = renderToStaticMarkup(
+      <>
+        <Select value="valueOf" other="fallback" />
+        <Select value="toString" other="fallback" />
+        <Select value="hasOwnProperty" other="fallback" />
+      </>
+    )
+
+    expect(html).toBe("fallbackfallbackfallback")
+  })
+
   it("rejects choice option text with unbalanced braces instead of corrupting the pattern", () => {
     const i18n = createI18n()
     i18n.activate("en")
@@ -164,16 +192,62 @@ describe("@palamedes/react", () => {
     expect(html).toBe(`At ${when.toISOString()}`)
   })
 
-  it("throws on missing plural values instead of matching zero branches", () => {
-    const i18n = createI18n()
+  it("reports missing plural values instead of matching zero branches", () => {
+    const onError = vi.fn()
+    const i18n = createI18n({ onError })
     i18n.activate("en")
     setClientI18n(i18n)
 
-    expect(() =>
-      renderToStaticMarkup(
-        <Trans id="items" message="{n, plural, =0 {none} other {# items}}" values={{}} />
-      )
-    ).toThrow(/Missing or non-numeric value/)
+    // Same contract as `i18n._()`: report, then degrade to the raw source
+    // message rather than throwing out of the render.
+    const html = renderToStaticMarkup(
+      <Trans id="items" message="{n, plural, =0 {none} other {# items}}" values={{}} />
+    )
+
+    expect(html).toBe("{n, plural, =0 {none} other {# items}}")
+    expect(onError).toHaveBeenCalledOnce()
+    expect(onError.mock.calls[0]?.[0].error.message).toMatch(/Missing or non-numeric value/)
+  })
+
+  it("falls back to the source message when a catalog plural cannot resolve", () => {
+    const onError = vi.fn()
+    const i18n = createI18n({ onError })
+    // A translator introduced a plural the source never had, and nothing
+    // supplies `count`: resolving it throws mid-render.
+    i18n.load("de", {
+      inbox: "{count, plural, one {Eine Nachricht} other {# Nachrichten}}",
+    })
+    i18n.activate("de")
+    setClientI18n(i18n)
+
+    const html = renderToStaticMarkup(
+      <Trans id="inbox" message="You have <0>mail</0>" components={{ 0: <strong /> }} />
+    )
+
+    expect(html).toBe("You have <strong>mail</strong>")
+    expect(onError).toHaveBeenCalledOnce()
+    expect(onError.mock.calls[0]?.[0]).toMatchObject({
+      id: "inbox",
+      locale: "de",
+      pattern: "{count, plural, one {Eine Nachricht} other {# Nachrichten}}",
+      fallback: "You have <0>mail</0>",
+    })
+  })
+
+  it("keeps direct choice components rendering when a catalog override cannot resolve", () => {
+    const onError = vi.fn()
+    const i18n = createI18n({ onError })
+    i18n.load("de", {
+      "{value, select, female {She} other {They}}":
+        "{missing, plural, one {Sie} other {# Personen}}",
+    })
+    i18n.activate("de")
+    setClientI18n(i18n)
+
+    const html = renderToStaticMarkup(<Select value="female" female="She" other="They" />)
+
+    expect(html).toBe("She")
+    expect(onError).toHaveBeenCalledOnce()
   })
 
   it("renders formatted ICU arguments through Trans", () => {
@@ -303,6 +377,39 @@ describe("@palamedes/react", () => {
 
     const view = render(<MemoizedTrans />)
     expect(view.container.textContent).toBe("Hello")
+
+    act(() => {
+      i18n.activate("de")
+      setClientI18n(i18n)
+    })
+
+    expect(view.container.textContent).toBe("Hallo")
+  })
+
+  it("reconnects Trans reactivity after resetI18nRuntime discards shared listeners", () => {
+    const i18n = createI18n()
+    i18n.load("en", { greeting: "Hello" })
+    i18n.load("de", { greeting: "Hallo" })
+    i18n.activate("en")
+    setClientI18n(i18n)
+
+    function Probe({ label }: { label: string }) {
+      return (
+        <span data-label={label}>
+          <Trans id="greeting" message="Greeting" />
+        </span>
+      )
+    }
+
+    const view = render(<Probe label="first" />)
+    expect(view.container.textContent).toBe("Hello")
+
+    // The reset throws away the listener Set this tree subscribed into.
+    // `useSyncExternalStore` never re-subscribes on its own, so the binding has
+    // to reattach on its next read instead of staying orphaned forever.
+    resetI18nRuntime()
+    setClientI18n(i18n)
+    view.rerender(<Probe label="second" />)
 
     act(() => {
       i18n.activate("de")

--- a/packages/react/src/runtime.ts
+++ b/packages/react/src/runtime.ts
@@ -2,18 +2,13 @@
 
 import { useSyncExternalStore } from "react"
 
-import {
-  getClientI18nSnapshot,
-  getI18n as getRuntimeI18n,
-  subscribeClientI18n,
-  type ClientI18nSnapshot,
-  type I18nInstance,
-} from "@palamedes/runtime"
+import { getI18n as getRuntimeI18n, type I18nInstance } from "@palamedes/runtime"
 
-const SERVER_CLIENT_I18N_SNAPSHOT: ClientI18nSnapshot = {
-  i18n: undefined,
-  revision: 0,
-}
+import {
+  getReactiveI18nSnapshot,
+  getServerI18nSnapshot,
+  subscribeReactiveI18n,
+} from "./clientStore"
 
 /**
  * React-aware replacement for `@palamedes/runtime`'s `getI18n`.
@@ -24,11 +19,7 @@ const SERVER_CLIENT_I18N_SNAPSHOT: ClientI18nSnapshot = {
  * implementation instead.
  */
 function useReactiveI18n<T extends I18nInstance = I18nInstance>(): T {
-  useSyncExternalStore(
-    subscribeClientI18n,
-    getClientI18nSnapshot,
-    () => SERVER_CLIENT_I18N_SNAPSHOT
-  )
+  useSyncExternalStore(subscribeReactiveI18n, getReactiveI18nSnapshot, getServerI18nSnapshot)
   return getRuntimeI18n<T>()
 }
 

--- a/packages/react/src/shared.tsx
+++ b/packages/react/src/shared.tsx
@@ -5,10 +5,11 @@ import type { ReactElement, ReactNode } from "react"
 import {
   formatMessagePattern,
   parseMessagePattern,
+  replacePoundPlaceholders,
   resolveChoice,
   stringifyValue,
 } from "@palamedes/core"
-import type { MessageNode, PalamedesI18n } from "@palamedes/core"
+import type { MessageMetadata, MessageNode, PalamedesI18n } from "@palamedes/core"
 
 export type TransProps = {
   // `id` is optional in authored source: components are written with `message`
@@ -53,12 +54,13 @@ export function createRuntimeComponents(useI18n: () => PalamedesI18n) {
   function Trans({ id, message, values, components, context, comment }: TransProps): ReactNode {
     const i18n = useI18n()
     const resolvedId = id ?? message ?? ""
-    const nodes = i18n.getMessageNodes(resolvedId, {
+    const metadata: MessageMetadata = {
       message,
       context,
       comment,
-    })
-    return <>{renderNodes(nodes, values ?? {}, components ?? {}, i18n.locale)}</>
+    }
+    const nodes = i18n.getMessageNodes(resolvedId, metadata)
+    return <>{renderResilient(i18n, resolvedId, metadata, nodes, values ?? {}, components ?? {})}</>
   }
 
   /*
@@ -76,8 +78,9 @@ export function createRuntimeComponents(useI18n: () => PalamedesI18n) {
     offset?: number
   ): ReactNode {
     const message = buildChoiceMessage("value", kind, choices, offset)
-    const nodes = i18n.getMessageNodes(message, { message, reportMissing: false })
-    return <>{renderNodes(nodes, { value }, {}, i18n.locale)}</>
+    const metadata: MessageMetadata = { message, reportMissing: false }
+    const nodes = i18n.getMessageNodes(message, metadata)
+    return <>{renderResilient(i18n, message, metadata, nodes, { value }, {})}</>
   }
 
   function Plural({ value, offset, ...choices }: PluralProps): ReactNode {
@@ -107,6 +110,15 @@ function buildChoiceMessage(
   const entries = Object.entries(choices).filter(
     (entry): entry is [string, string] => typeof entry[1] === "string"
   )
+  // Without this the synthesized pattern is `{value, plural,  }`, which parses
+  // into a choice with no branches and renders as an empty string — a message
+  // that silently disappears instead of reporting the mistake.
+  if (entries.length === 0) {
+    throw new RangeError(
+      `The ${kind} component requires at least one string option (for example other="…").`
+    )
+  }
+
   const keys = entries.map(([key]) => normalizeChoiceKey(kind, key))
   const parts = entries.map(([key, value], index) => `${keys[index]} {${value}}`)
   const offsetPart = offset === undefined ? "" : ` offset:${offset}`
@@ -163,7 +175,9 @@ function assertParseableChoiceMessage(message: string, kind: string, expectedKey
   const intact =
     node !== undefined &&
     parsedKeys.length === expectedKeys.length &&
-    expectedKeys.every((key) => key in node.options)
+    // Own-property only: `key in options` would count Object.prototype members
+    // as intact branches for option names like "toString".
+    expectedKeys.every((key) => Object.hasOwn(node.options, key))
 
   if (!intact) {
     throw new RangeError(
@@ -175,6 +189,46 @@ function assertParseableChoiceMessage(message: string, kind: string, expectedKey
 function validatePluralOffset(offset: number | undefined): void {
   if (offset !== undefined && (!Number.isSafeInteger(offset) || offset < 0)) {
     throw new RangeError("Plural offset must be a non-negative safe integer.")
+  }
+}
+
+/*
+ * Rendering nodes must degrade exactly like core's string renderer.
+ * `i18n._()` reports a broken message through `onError` and falls back to the
+ * source, but the component path walks the nodes itself: an error thrown here
+ * (most easily a translator-introduced plural resolved against an absent or
+ * non-numeric value) escapes the component render, takes the surrounding tree
+ * down and never reaches `onError`. The whole walk is wrapped, not just the
+ * choice case, so every node type shares the contract.
+ */
+function renderResilient(
+  i18n: PalamedesI18n,
+  id: string,
+  metadata: MessageMetadata,
+  nodes: MessageNode[],
+  values: Record<string, unknown>,
+  components: Record<string, ReactElement>
+): ReactNode[] {
+  try {
+    return renderNodes(nodes, values, components, i18n.locale)
+  } catch (error) {
+    const fallback = metadata.message ?? id
+    // Resolve again (without a second missing report) purely to tell telemetry
+    // which pattern actually failed: the catalog entry or the source message.
+    const pattern = i18n.getMessage(id, { ...metadata, reportMissing: false })
+    // Guarded: instances reach the adapters through the untyped global runtime
+    // bridge and may predate this hook.
+    i18n.reportError?.({ id, error, pattern, fallback, metadata })
+
+    if (pattern !== fallback) {
+      try {
+        return renderNodes(parseMessagePattern(fallback), values, components, i18n.locale)
+      } catch {
+        return [fallback]
+      }
+    }
+
+    return [fallback]
   }
 }
 
@@ -203,7 +257,7 @@ function renderNode(
       return [
         pluralValue === undefined
           ? node.value
-          : node.value.replaceAll("#", formatNumber(pluralValue, locale)),
+          : replacePoundPlaceholders(node.value, pluralValue, locale),
       ]
     }
     case "literal": {
@@ -243,10 +297,6 @@ function renderVariable(value: unknown, key: number): ReactNode {
   // Same stringification as the core string renderer (`i18n._`), so Dates
   // render as deterministic ISO strings on server and client alike.
   return stringifyValue(value)
-}
-
-function formatNumber(value: number, locale: string): string {
-  return new Intl.NumberFormat(locale).format(value)
 }
 
 export { Fragment }

--- a/packages/solid/README.md
+++ b/packages/solid/README.md
@@ -47,6 +47,28 @@ imports from `@palamedes/solid`. Rich JSX children are transformed to numeric
 component slots in the message, for example `<0>Palamedes</0>`, while the Solid
 wrapper is passed separately.
 
+## Runtime Components
+
+Besides the macro entry point, the package's main entry exports the runtime
+components `Trans`, `Plural`, `Select`, and `SelectOrdinal`. These are what
+macro-transformed JSX renders through, and all of them resolve messages through
+the active i18n instance. The choice components accept plural categories
+(`zero` … `other`), exact matches written as `_0`/`_1`/… (normalized to ICU
+`=N`, mirroring the macro transform), and `offset`; invalid option props and
+option text with unbalanced braces are rejected with a descriptive error
+instead of silently misrendering.
+
+`offset` maps to ICU `offset:N` and covers "and N others" sentences, where the
+number shown is smaller than the number counted:
+
+```tsx
+<Plural value={attendees()} offset={1} _0="nobody else" one="# other" other="# others" />
+```
+
+Exact `_N` keys match the raw value; plural categories select on
+`value - offset`, and `#` renders `value - offset`. It must be a non-negative
+safe integer. `Select` has no numeric operand and takes no `offset`.
+
 ## Headless Frontend Helpers
 
 This package also exposes small Solid-native helpers that stay deliberately

--- a/packages/solid/src/index.test.tsx
+++ b/packages/solid/src/index.test.tsx
@@ -153,6 +153,91 @@ describe("@palamedes/solid", () => {
     expect(html).toBe("a pair")
   })
 
+  it("falls back to the source message when a catalog plural cannot resolve", () => {
+    const onError = vi.fn()
+    const i18n = createI18n({ onError })
+    // A translator introduced a plural the source never had, and nothing
+    // supplies `count`: resolving it throws mid-render.
+    i18n.load("de", {
+      inbox: "{count, plural, one {Eine Nachricht} other {# Nachrichten}}",
+    })
+    i18n.activate("de")
+    setServerI18nGetter(() => i18n)
+
+    const render = Trans({ id: "inbox", message: "You have mail" }) as unknown as () => unknown
+
+    expect([render()].flat().join("")).toBe("You have mail")
+    expect(onError).toHaveBeenCalledOnce()
+    expect(onError.mock.calls[0]?.[0]).toMatchObject({
+      id: "inbox",
+      locale: "de",
+      pattern: "{count, plural, one {Eine Nachricht} other {# Nachrichten}}",
+      fallback: "You have mail",
+    })
+  })
+
+  it("reports missing plural values instead of matching zero branches", () => {
+    const onError = vi.fn()
+    const i18n = createI18n({ onError })
+    i18n.activate("en")
+    setServerI18nGetter(() => i18n)
+
+    // Same contract as `i18n._()`: report, then degrade to the raw source
+    // message rather than throwing out of the render.
+    const render = Trans({
+      id: "items",
+      message: "{n, plural, =0 {none} other {# items}}",
+      values: {},
+    }) as unknown as () => unknown
+
+    expect([render()].flat().join("")).toBe("{n, plural, =0 {none} other {# items}}")
+    expect(onError).toHaveBeenCalledOnce()
+    expect(onError.mock.calls[0]?.[0].error.message).toMatch(/Missing or non-numeric value/)
+  })
+
+  it("keeps direct choice components rendering when a catalog override cannot resolve", () => {
+    const onError = vi.fn()
+    const i18n = createI18n({ onError })
+    i18n.load("de", {
+      "{value, select, female {She} other {They}}":
+        "{missing, plural, one {Sie} other {# Personen}}",
+    })
+    i18n.activate("de")
+    setServerI18nGetter(() => i18n)
+
+    const html = renderToString(() => <Select value="female" female="She" other="They" />)
+
+    expect(html).toBe("She")
+    expect(onError).toHaveBeenCalledOnce()
+  })
+
+  it("never resolves select values to Object.prototype members", () => {
+    const i18n = createI18n()
+    i18n.activate("en")
+    setServerI18nGetter(() => i18n)
+
+    const html = renderToString(() => (
+      <>
+        <Select value="valueOf" other="fallback" />
+        <Select value="toString" other="fallback" />
+      </>
+    ))
+
+    expect(html).toBe("fallbackfallback")
+  })
+
+  it("rejects choice components without any usable option instead of rendering nothing", () => {
+    const i18n = createI18n()
+    i18n.activate("en")
+    setServerI18nGetter(() => i18n)
+
+    expect(() =>
+      renderToString(() => (
+        <Plural value={2} {...({ other: undefined } as unknown as { other: string })} />
+      ))
+    ).toThrow(/plural component requires at least one string option/)
+  })
+
   it("renders ICU-quoted syntax literally through Trans", () => {
     const i18n = createI18n()
     i18n.activate("en")

--- a/packages/solid/src/index.tsx
+++ b/packages/solid/src/index.tsx
@@ -3,10 +3,11 @@ import type { JSX } from "solid-js"
 import {
   formatMessagePattern,
   parseMessagePattern,
+  replacePoundPlaceholders,
   resolveChoice,
   stringifyValue,
 } from "@palamedes/core"
-import type { MessageNode, PalamedesI18n } from "@palamedes/core"
+import type { MessageMetadata, MessageNode, PalamedesI18n } from "@palamedes/core"
 
 import { getI18n } from "./runtime"
 
@@ -79,13 +80,14 @@ export function Trans({
   // a client locale switch, so the rendered nodes follow the active i18n.
   return (() => {
     const i18n = useReactiveI18n()
-    const nodes = i18n.getMessageNodes(resolvedId, {
+    const metadata: MessageMetadata = {
       message,
       context,
       comment,
-    })
+    }
+    const nodes = i18n.getMessageNodes(resolvedId, metadata)
 
-    return renderNodes(nodes, values ?? {}, components ?? {}, i18n.locale)
+    return renderResilient(i18n, resolvedId, metadata, nodes, values ?? {}, components ?? {})
   }) as unknown as JSX.Element
 }
 
@@ -105,8 +107,9 @@ function renderChoice(
   return (() => {
     const i18n = useReactiveI18n()
     const message = buildChoiceMessage("value", kind, choices, offset)
-    const nodes = i18n.getMessageNodes(message, { message, reportMissing: false })
-    return renderNodes(nodes, { value }, {}, i18n.locale)
+    const metadata: MessageMetadata = { message, reportMissing: false }
+    const nodes = i18n.getMessageNodes(message, metadata)
+    return renderResilient(i18n, message, metadata, nodes, { value }, {})
   }) as unknown as JSX.Element
 }
 
@@ -134,6 +137,15 @@ function buildChoiceMessage(
   const entries = Object.entries(choices).filter(
     (entry): entry is [string, string] => typeof entry[1] === "string"
   )
+  // Without this the synthesized pattern is `{value, plural,  }`, which parses
+  // into a choice with no branches and renders as an empty string — a message
+  // that silently disappears instead of reporting the mistake.
+  if (entries.length === 0) {
+    throw new RangeError(
+      `The ${kind} component requires at least one string option (for example other="…").`
+    )
+  }
+
   const keys = entries.map(([key]) => normalizeChoiceKey(kind, key))
   const parts = entries.map(([key, value], index) => `${keys[index]} {${value}}`)
   const offsetPart = offset === undefined ? "" : ` offset:${offset}`
@@ -190,7 +202,9 @@ function assertParseableChoiceMessage(message: string, kind: string, expectedKey
   const intact =
     node !== undefined &&
     parsedKeys.length === expectedKeys.length &&
-    expectedKeys.every((key) => key in node.options)
+    // Own-property only: `key in options` would count Object.prototype members
+    // as intact branches for option names like "toString".
+    expectedKeys.every((key) => Object.hasOwn(node.options, key))
 
   if (!intact) {
     throw new RangeError(
@@ -202,6 +216,46 @@ function assertParseableChoiceMessage(message: string, kind: string, expectedKey
 function validatePluralOffset(offset: number | undefined): void {
   if (offset !== undefined && (!Number.isSafeInteger(offset) || offset < 0)) {
     throw new RangeError("Plural offset must be a non-negative safe integer.")
+  }
+}
+
+/*
+ * Rendering nodes must degrade exactly like core's string renderer.
+ * `i18n._()` reports a broken message through `onError` and falls back to the
+ * source, but the component path walks the nodes itself: an error thrown here
+ * (most easily a translator-introduced plural resolved against an absent or
+ * non-numeric value) escapes the component render, takes the surrounding tree
+ * down and never reaches `onError`. The whole walk is wrapped, not just the
+ * choice case, so every node type shares the contract.
+ */
+function renderResilient(
+  i18n: PalamedesI18n,
+  id: string,
+  metadata: MessageMetadata,
+  nodes: MessageNode[],
+  values: Record<string, unknown>,
+  components: Record<string, WrapperComponent | JSX.Element>
+): JSX.Element[] {
+  try {
+    return renderNodes(nodes, values, components, i18n.locale)
+  } catch (error) {
+    const fallback = metadata.message ?? id
+    // Resolve again (without a second missing report) purely to tell telemetry
+    // which pattern actually failed: the catalog entry or the source message.
+    const pattern = i18n.getMessage(id, { ...metadata, reportMissing: false })
+    // Guarded: instances reach the adapters through the untyped global runtime
+    // bridge and may predate this hook.
+    i18n.reportError?.({ id, error, pattern, fallback, metadata })
+
+    if (pattern !== fallback) {
+      try {
+        return renderNodes(parseMessagePattern(fallback), values, components, i18n.locale)
+      } catch {
+        return [fallback]
+      }
+    }
+
+    return [fallback]
   }
 }
 
@@ -230,7 +284,7 @@ function renderNode(
       return [
         pluralValue === undefined
           ? node.value
-          : node.value.replaceAll("#", formatNumber(pluralValue, locale)),
+          : replacePoundPlaceholders(node.value, pluralValue, locale),
       ]
     }
     case "literal": {
@@ -284,8 +338,4 @@ function renderVariable(value: unknown): JSX.Element {
   }
 
   return value as JSX.Element
-}
-
-function formatNumber(value: number, locale: string): string {
-  return new Intl.NumberFormat(locale).format(value)
 }


### PR DESCRIPTION
## Summary

Implements all confirmed findings from the follow-up production-readiness review of the post-1.5 fix wave, in four logical commits:

1. **Rust — ICU apostrophe parity + extraction-cache hardening** (`fix(core,cli)`)
   - New shared `icu_text` module: the extractor and transform now escape authored apostrophes (`'` → `''`) at every literal ingestion site, so the runtime's lenient ICU quoting renders them literally — previously `` t`L'${title}` `` swallowed the placeholder. Extractor msgids and transform runtime messages stay byte-identical (cross-lock test).
   - Compile/audit/pseudo-localization switch from `IcuSyntaxPolicy::RuntimeLiteralApostrophes` to `Strict` with catalog-text canonicalization at load, so `pmds audit` now flags quote-swallowed placeholders instead of staying green while the runtime breaks.
   - Watch mode rebuilds the extraction cache on stamp-relevant config reloads (was serving stale origins/scopes); the library API also resets a cache whose stamp no longer matches the request.
   - Cache racy window measured from read start instead of insert time (coarse-mtime filesystems).
   - `extract-threads`/`extract-cache` config keys no longer trigger the false "Ignoring unknown config key" warning; camelCase spellings get the kebab-case hint.
   - Failed-file warnings/count deduped across overlapping catalogs; watch debounce drain bounded at 2s; unbuildable watch globs warn instead of silently disabling a catalog.
   - Coverage debts closed: `retain_paths` retention tests, cache-warm vs `--no-cache` byte-parity test, watch-reload regression test.
2. **JS — adapter render resilience + hardening** (`fix(core,react,solid)`)
   - `<Trans>`/`<Plural>`/`<Select>`/`<SelectOrdinal>` now follow core's catch → `onError` → source-fallback contract via a new `PalamedesI18n.reportError()` channel instead of throwing out of the component render on unresolvable catalog messages (translator-triggerable crash).
   - Choice options are null-prototype + `Object.hasOwn` lookups — select values like `"toString"`/`"valueOf"` no longer reach `Object.prototype` and crash the render.
   - React reconnects reactivity after `resetI18nRuntime` (persistent client-store bridge, mirroring the earlier Solid fix).
   - Parse cache gets its own 1024-entry LRU bound (was sharing the 64-entry FIFO with the Intl caches and thrashing); adapters reuse core's cached `Intl.NumberFormat` for `#` replacement; choice components without any usable string option throw a descriptive error instead of rendering `""`.
3. **next-plugin** (`fix(next-plugin)`): webpack `.po` rule excludes `node_modules` (mirrors Turbopack's `not: "foreign"`); user Turbopack loader-shorthand arrays are normalized into rule configs before the Palamedes rule is appended; webpack vs Turbopack `include`/`exclude` matching semantics documented.
4. **Docs** (`docs:`): llms bundles updated to the shipped `--threads`/extraction-cache surface (they still steered assistants to a deleted ADR and away from a real feature); configuration guide no longer claims the JS loader reads the extract keys; ICU apostrophe quoting and `MessageLiteralNode` renderer handling documented; plural `offset` semantics documented across core/React/Solid references; new `reportError`/`replacePoundPlaceholders` exports listed; CLI README gains `--threads`/`--no-cache`; `referenceScopes` default stated; `canonicalUrl` `protocol` option cross-referenced from the locale-strategy guides.

**Migration note (apostrophe escaping):** compiled IDs change only for messages whose authored text contains an apostrophe (`don't` → msgid `don''t`). On the next `pmds extract`, old entries become obsolete and the escaped forms are added; existing translations for those messages need to be carried over. Compile/audit canonicalize legacy catalog texts at load, so already-compiled catalogs line up with bundles built by the new transform — but an old-transform bundle against a new core needs a rebuild.

## Issue

Follow-up to the re-review of the fixes for #402–#427; no dedicated issues exist for these findings — they were reported in the review session that produced this PR.

## Validation

- `cargo fmt --all --check`, `cargo test --workspace` (all green, includes the new regression tests), clippy clean per the implementation runs
- `pnpm --filter @palamedes/{core,runtime,react,solid,next-plugin,vite-plugin,config} test` — 173 tests green
- `pnpm format:check`, `pnpm lint:oxlint`, `pnpm lint:eslint` — clean
- Documented quoting/offset semantics were verified against the actual runtime behavior, not the spec

## Follow-up

- Ferrocat has no lenient-quoting policy; parity relies on canonicalizing catalog texts at load (documented in `runtime_icu_options`). A native lenient policy upstream would simplify this.
- The remix loader still caches its config per process and warns via `console.warn` (module hooks expose no watch/warn channel) — known limitation, out of scope here.
- No NodeNext-ESM lane in `scripts/check-published-types.mjs` yet (bundler-ESM, NodeNext-CJS, and node10 are covered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y6YSHuSe7G5JTdhoARCXMs

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y6YSHuSe7G5JTdhoARCXMs)_