### PR TITLE
Select the framework once instead of naming runtime modules

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -51,6 +51,7 @@ Then read the CLI extension decisions:
 17. [ADR-017: Host Explicit CLI Plugins in the npm Wrapper](./adr/017-cli-plugin-execution-boundary.md)
 18. [ADR-018: Binary Plugin Protocol for Rust-First Extensions](./adr/018-binary-plugin-protocol.md)
 19. [ADR-019: Extraction Cache](./adr/019-extraction-cache.md)
+20. [ADR-020: Framework Selection Lives On The Plugins](./adr/020-framework-selection-lives-on-the-plugins.md)
 
 ## ADR Policy
 

--- a/adr/020-framework-selection-lives-on-the-plugins.md
+++ b/adr/020-framework-selection-lives-on-the-plugins.md
@@ -1,0 +1,75 @@
+# ADR-020: Framework Selection Lives On The Plugins
+
+**Status:** Accepted
+
+## Context
+
+Two runtime getters exist. `@palamedes/runtime` exports a plain `getI18n()`.
+The framework subpaths wrap it: `@palamedes/react/runtime` bridges through
+`useSyncExternalStore`, `@palamedes/solid/runtime` through a signal. Both make
+inline `t` / `plural` output follow a live locale switch. `<Trans>` and friends
+subscribe on their own and never needed either.
+
+The macro transform therefore had a `runtimeModule` option defaulting to the
+framework-agnostic `@palamedes/runtime`, and every app that wanted live
+switching wrote the subpath by hand — seven of our own examples did.
+
+MDX compilation then arrived with its own framework notion. Generated modules
+call `getI18n()` directly for frontmatter, image alt text, and translated
+attributes, so they must have the reactive runtime; `mdx.framework` in
+`palamedes.yaml` selected it and defaulted to React.
+
+That left two settings that look like one. Briefly the macro `runtimeModule`
+was made a fallback for MDX, which put the two defaults in conflict: an app
+pinning the macro target to `@palamedes/runtime` — the value our own README
+showed — silently downgraded its MDX modules, and a live locale switch stopped
+updating translated frontmatter with no error.
+
+## Decision
+
+Framework selection is a single `framework` option on the bundler plugins:
+
+```ts
+palamedes({ framework: "solid" })
+```
+
+It derives the macro transform's runtime module and seeds the MDX component
+contract. `runtimeModule` remains as a narrow override for the macro path only,
+and `mdx.framework` remains as a per-config override for MDX only.
+
+It does not move into `palamedes.yaml`. Extraction produces byte-identical
+messages for React and Solid — `MdxOptions::extraction_stamp()` deliberately
+omits `framework` for exactly this reason — so the catalog config has no reason
+to know. Sourcing it from the config would also force `@palamedes/next-plugin`
+and `@palamedes/remix` to load a config on their macro path, which they do not
+do today, reintroducing the configless-startup coupling we had just removed.
+
+Defaults differ per plugin, because the safe assumption differs:
+
+| Plugin                   | Default | Why                                                 |
+| ------------------------ | ------- | --------------------------------------------------- |
+| `@palamedes/vite-plugin` | `react` | React and Solid hosts; React is the common case     |
+| `@palamedes/next-plugin` | `react` | Next.js is React by construction                    |
+| `@palamedes/remix`       | `none`  | Remix 3 ships its own UI layer, no React dependency |
+
+`"none"` selects the framework-agnostic runtime for projects that are neither.
+
+## Consequences
+
+Apps stop naming runtime module paths: all seven examples that did now say
+`framework: "solid"` or nothing at all.
+
+React and Next apps become reactive by default. This is a behavior change for
+existing projects that relied on the neutral default, and is safe because the
+React subpath resolves to a hook-free implementation under the `react-server`
+condition.
+
+Solid apps **must** set `framework: "solid"`. Under the previous neutral
+default a Solid app that set nothing still worked; under a React default it
+would pull React's runtime into the build. `examples/solidstart-cookie` was
+exactly that case and is updated in this change.
+
+The cost is one asymmetry: three plugins, two defaults. It is documented at
+each option and pinned by tests, and it beats the alternative of either
+breaking Remix or making every React app configure what Palamedes already
+knows.

--- a/docs/api/next-plugin.md
+++ b/docs/api/next-plugin.md
@@ -26,6 +26,7 @@ interface WithPalamedesOptions {
   configPath?: string
   failOnMissing?: boolean
   failOnCompileError?: boolean
+  framework?: "react" | "solid" | "none"
   runtimeModule?: string
   workspaceRoot?: string
 }
@@ -38,7 +39,8 @@ Defaults:
 - `enablePoLoader`: `true`
 - `failOnMissing`: `false`
 - `failOnCompileError`: `false`
-- `runtimeModule`: `"@palamedes/runtime"`
+- `framework`: `"react"`
+- `runtimeModule`: derived from `framework`
 
 ## Usage
 

--- a/docs/api/react.md
+++ b/docs/api/react.md
@@ -108,12 +108,13 @@ not own loading UI or routing policy.
 
 ## Reactive Macro Runtime
 
-Macro `t` / `plural` calls use the transform's configured `runtimeModule`.
+Macro `t` / `plural` calls use the runtime module derived from the plugin's
+`framework` option, which defaults to React.
 Point it at the React runtime when a client-side locale switch must update
 memoized translated components:
 
 ```ts
-palamedes({ runtimeModule: "@palamedes/react/runtime" })
+palamedes()
 ```
 
 The bridge observes the activation revision rather than only object identity, so

--- a/docs/api/remix.md
+++ b/docs/api/remix.md
@@ -27,6 +27,7 @@ short-circuits TS/TSX loading before the Palamedes hook can transform macros.
 interface PalamedesRemixRegisterOptions {
   include?: RegExp
   exclude?: RegExp
+  framework?: "react" | "solid" | "none"
   runtimeModule?: string
   configPath?: string
   failOnMissing?: boolean
@@ -38,7 +39,8 @@ Defaults:
 
 - `include`: `/\.(tsx?|jsx?|mjs)$/`
 - `exclude`: `/[/\\]node_modules[/\\]/`
-- `runtimeModule`: `"@palamedes/runtime"`
+- `framework`: `"none"` — Remix 3 ships its own UI layer and does not depend on React
+- `runtimeModule`: derived from `framework`
 - `configPath`: unset — `.po` imports discover the Palamedes config from the
   imported catalog file's directory; relative paths resolve from there
 - `failOnMissing` / `failOnCompileError`: `false` — missing translations and

--- a/docs/api/solid.md
+++ b/docs/api/solid.md
@@ -94,7 +94,7 @@ transform at Solid's reactive runtime:
 
 ```ts
 // app.config.ts
-palamedes({ runtimeModule: "@palamedes/solid/runtime" })
+palamedes({ framework: "solid" })
 ```
 
 Reload-based apps do not need this. See `docs/locale-strategies.md` for the

--- a/docs/api/vite-plugin.md
+++ b/docs/api/vite-plugin.md
@@ -25,6 +25,7 @@ interface PalamedesPluginOptions {
   skipValidation?: boolean
   failOnMissing?: boolean
   failOnCompileError?: boolean
+  framework?: "react" | "solid" | "none"
   runtimeModule?: string
   mdx?: PalamedesMdxConfig | false
 }
@@ -37,12 +38,17 @@ Defaults:
 - `enablePoLoader`: `true`
 - `failOnMissing`: `false`
 - `failOnCompileError`: `false`
-- `runtimeModule`: `"@palamedes/runtime"`
+- `framework`: `"react"`
+- `runtimeModule`: derived from `framework`
 - `mdx`: values from Palamedes config with React defaults; `false` disables MDX
 
-`runtimeModule` configures the macro transform only. It is the opt-in described
-in [Locale strategies](../locale-strategies.md) that makes inline `t` / `plural`
-follow a live locale switch.
+`framework` states which UI framework the app compiles for. It selects the
+reactive runtime for the macro transform — so inline `t` / `plural` follow a
+live locale switch, see [Locale strategies](../locale-strategies.md) — and the
+component contract for generated MDX modules. Solid apps must set
+`framework: "solid"`; `"none"` restores the framework-agnostic runtime.
+
+`runtimeModule` overrides only the macro transform's module path.
 
 Generated MDX modules are independent: they already default to the framework's
 reactive runtime subpath, because their frontmatter, image alt text, and

--- a/docs/locale-strategies.md
+++ b/docs/locale-strategies.md
@@ -180,11 +180,12 @@ Live switching in React has two pieces:
 
 - `useClientLocale(locale, syncClientI18n)` pushes committed locale changes into
   the client runtime
-- point the macro transform at React's external-store bridge so memoized
-  `t` / `plural` output follows every activation:
+- nothing else: the Vite and Next plugins compile for React by default, so the
+  macro transform already points at React's external-store bridge and memoized
+  `t` / `plural` output follows every activation
 
   ```ts
-  palamedes({ runtimeModule: "@palamedes/react/runtime" })
+  palamedes()
   ```
 
 The runtime subpath selects a hook-free implementation under the `react-server`
@@ -192,10 +193,15 @@ condition, so the same transform target remains valid for React Server
 Components and server actions.
 
 `<Trans>` / `<Plural>` / `<Select>` / `<SelectOrdinal>` subscribe on their own
-and follow a live switch even with the default `runtimeModule`. Only inline
-`t` / `plural` calls need the reactive transform target. Those calls are
-hook-backed and therefore must execute unconditionally during a React
-function-component or custom-hook render.
+and follow a live switch under any setting. Only inline `t` / `plural` calls
+need the reactive transform target. Those calls are hook-backed and therefore
+must execute unconditionally during a React function-component or custom-hook
+render.
+
+A project that is neither React nor Solid opts out with
+`palamedes({ framework: "none" })`, which restores the framework-agnostic
+`@palamedes/runtime`. `@palamedes/remix` defaults to `"none"` already, because
+Remix 3 ships its own UI layer and does not depend on React.
 
 ### Enabling live switching (Solid)
 
@@ -204,18 +210,23 @@ two opt-in pieces:
 
 - `createClientLocaleEffect(localeAccessor, syncClientI18n)` pushes locale changes
   into the client runtime
-- point the macro transform at Solid's reactive runtime so `t` / `plural` output
-  follows the switch:
+- tell the plugin it compiles for Solid, which points the macro transform at
+  Solid's reactive runtime so `t` / `plural` output follows the switch:
 
   ```ts
   // app.config.ts
-  palamedes({ runtimeModule: "@palamedes/solid/runtime" })
+  palamedes({ framework: "solid" })
   ```
 
+Setting `framework` is required for Solid apps: the plugin compiles for React
+unless told otherwise, and that would pull React's runtime into a Solid build.
+The same option also selects Solid's component contract for compiled `.mdx`
+modules.
+
 `<Trans>` / `<Plural>` / `<Select>` / `<SelectOrdinal>` track the active instance
-on their own and follow a live switch even with the default `runtimeModule`. Only
-the macro `t` / `plural` calls depend on the reactive `runtimeModule` — so wire
-both, or use reload.
+on their own and follow a live switch under any setting. Only the macro
+`t` / `plural` calls depend on the reactive runtime — so wire both, or use
+reload.
 
 ## Why The Matrix Is Split Per Framework
 

--- a/docs/mdx.md
+++ b/docs/mdx.md
@@ -22,8 +22,8 @@ export default defineConfig({
 
 For React, Palamedes marks generated `.mdx` modules as JSX automatically.
 
-For Solid, opt `.mdx` into `vite-plugin-solid` explicitly and set the framework
-in `palamedes.yaml`:
+For Solid, set `framework: "solid"` on the plugin and opt `.mdx` into
+`vite-plugin-solid` explicitly:
 
 ```ts
 import solid from "vite-plugin-solid"
@@ -31,19 +31,15 @@ import { palamedes } from "@palamedes/vite-plugin"
 import { defineConfig } from "vite"
 
 export default defineConfig({
-  plugins: [palamedes(), solid({ extensions: [".mdx"] })],
+  plugins: [palamedes({ framework: "solid" }), solid({ extensions: [".mdx"] })],
 })
 ```
 
-```yaml
-locales: [en, de]
-source-locale: en
-mdx:
-  framework: solid
-catalogs:
-  - path: src/locales/{locale}
-    include: [src]
-```
+The plugin compiles for React unless told otherwise, so this option is required
+for Solid. It also selects the reactive runtime for macro `t` / `plural` calls,
+which is why it lives on the plugin rather than in `palamedes.yaml`: extraction
+produces identical messages for both frameworks, so the catalog config has no
+reason to know.
 
 Do not add React's JSX module type for Solid. Rolldown would otherwise lower
 the module with React's automatic runtime before Solid's Babel preset sees it.
@@ -125,8 +121,10 @@ TypeScript configs use the camelCase equivalents:
 `translatable-attributes` replaces the default list rather than extending it.
 Include `alt` explicitly when adding fields such as `title` or `aria-label`.
 `href` and `src` remain structural attributes and are never extracted.
-In Vite, the plugin's top-level `runtimeModule` option is the shared fallback
-for macros and MDX; `mdx.runtime-module` is the more specific MDX override.
+In Vite, the plugin's `framework` option selects the component contract for
+compiled MDX; `mdx.framework` overrides it per config. The plugin's
+`runtimeModule` option applies to macros only — use `mdx.runtime-module` to
+point MDX at a different runtime.
 
 Translated frontmatter remains explicit. The compiler exports the original
 scalar object as `frontmatter`; when configured fields are present it also

--- a/examples/nextjs-route/next.config.mjs
+++ b/examples/nextjs-route/next.config.mjs
@@ -1,3 +1,3 @@
 import { withPalamedes } from "@palamedes/next-plugin"
 
-export default withPalamedes({}, { runtimeModule: "@palamedes/react/runtime" })
+export default withPalamedes({})

--- a/examples/react-router-route/vite.config.ts
+++ b/examples/react-router-route/vite.config.ts
@@ -3,7 +3,7 @@ import { palamedes } from "@palamedes/vite-plugin"
 import { defineConfig } from "vite"
 
 export default defineConfig({
-  plugins: [palamedes({ runtimeModule: "@palamedes/react/runtime" }), reactRouter()],
+  plugins: [palamedes(), reactRouter()],
   resolve: {
     tsconfigPaths: true,
   },

--- a/examples/solidstart-cookie/app.config.ts
+++ b/examples/solidstart-cookie/app.config.ts
@@ -3,6 +3,6 @@ import { palamedes } from "@palamedes/vite-plugin"
 
 export default defineConfig({
   vite: {
-    plugins: [palamedes()],
+    plugins: [palamedes({ framework: "solid" })],
   },
 })

--- a/examples/solidstart-route/app.config.ts
+++ b/examples/solidstart-route/app.config.ts
@@ -5,6 +5,6 @@ export default defineConfig({
   vite: {
     // Point the macro transform at Solid's reactive `getI18n` so `t`/`plural`
     // output follows client-side locale switches, matching the `<Trans>` runtime.
-    plugins: [palamedes({ runtimeModule: "@palamedes/solid/runtime" })],
+    plugins: [palamedes({ framework: "solid" })],
   },
 })

--- a/examples/solidstart-subdomain/app.config.ts
+++ b/examples/solidstart-subdomain/app.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   vite: {
     // Point the macro transform at Solid's reactive `getI18n` so `t`/`plural`
     // output follows client-side locale switches, matching the `<Trans>` runtime.
-    plugins: [palamedes({ runtimeModule: "@palamedes/solid/runtime" })],
+    plugins: [palamedes({ framework: "solid" })],
     // The subdomain strategy serves each locale from its own host label
     // (`de.lvh.me`, `en.lvh.me`, …). Allow those hosts plus the deployed
     // preview domain for the dev/preview servers, and pin the demo port.

--- a/examples/solidstart-tld/app.config.ts
+++ b/examples/solidstart-tld/app.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   vite: {
     // Point the macro transform at Solid's reactive `getI18n` so `t`/`plural`
     // output follows client-side locale switches, matching the `<Trans>` runtime.
-    plugins: [palamedes({ runtimeModule: "@palamedes/solid/runtime" })],
+    plugins: [palamedes({ framework: "solid" })],
     // The TLD strategy serves each locale from its own top-level domain
     // (`example.de`, `example.fr`, …). Allow those hosts plus the deployed
     // preview domain for the dev/preview servers, and pin the demo port.

--- a/examples/tanstack-route/vite.config.ts
+++ b/examples/tanstack-route/vite.config.ts
@@ -4,7 +4,7 @@ import { tanstackStart } from "@tanstack/react-start/plugin/vite"
 import { palamedes } from "@palamedes/vite-plugin"
 
 export default defineConfig({
-  plugins: [tanstackStart(), palamedes({ runtimeModule: "@palamedes/react/runtime" }), react()],
+  plugins: [tanstackStart(), palamedes(), react()],
   preview: {
     allowedHosts: [".examples.palamedes.dev", "de.lvh.me", "en.lvh.me", "es.lvh.me"],
   },

--- a/examples/waku-route/waku.config.ts
+++ b/examples/waku-route/waku.config.ts
@@ -4,6 +4,6 @@ import { palamedes } from "@palamedes/vite-plugin"
 
 export default defineConfig({
   vite: {
-    plugins: [palamedes({ runtimeModule: "@palamedes/react/runtime" }), react()],
+    plugins: [palamedes(), react()],
   },
 })

--- a/packages/next-plugin/README.md
+++ b/packages/next-plugin/README.md
@@ -125,7 +125,7 @@ module.exports = withPalamedes(
     configPath: "./palamedes.yaml",
     failOnMissing: false,
     failOnCompileError: false,
-    runtimeModule: "@palamedes/runtime",
+    framework: "react",
     workspaceRoot: undefined,
   }
 )

--- a/packages/next-plugin/src/index.test.ts
+++ b/packages/next-plugin/src/index.test.ts
@@ -17,6 +17,26 @@ function conditionList(rule: RuleItem): unknown[] {
 }
 
 describe("withPalamedes turbopack config", () => {
+  it.each([
+    ["react", undefined, "@palamedes/react/runtime"],
+    ["solid", "solid", "@palamedes/solid/runtime"],
+    ["none", "none", "@palamedes/runtime"],
+  ] as const)("derives the macro runtime module for %s", (_label, framework, expected) => {
+    const config = withPalamedes({}, framework === undefined ? {} : { framework })
+
+    const rule = getRules(config)["*"] as RuleItem
+    expect(rule.loaders?.[0]?.options).toMatchObject({ runtimeModule: expected })
+  })
+
+  it("lets an explicit runtime module win over the framework default", () => {
+    const config = withPalamedes({}, { runtimeModule: "@acme/custom-runtime" })
+
+    const rule = getRules(config)["*"] as RuleItem
+    expect(rule.loaders?.[0]?.options).toMatchObject({
+      runtimeModule: "@acme/custom-runtime",
+    })
+  })
+
   it("translates include/exclude options into the turbopack rule condition", () => {
     const include = /\.custom\.tsx?$/
     const exclude = /[/\\]vendored[/\\]/

--- a/packages/next-plugin/src/index.ts
+++ b/packages/next-plugin/src/index.ts
@@ -10,7 +10,11 @@ import path from "node:path"
 import { createRequire } from "node:module"
 import type { NextConfig } from "next"
 
-import { PALAMEDES_MACRO_PACKAGES } from "@palamedes/transform"
+import {
+  PALAMEDES_MACRO_PACKAGES,
+  resolveMacroRuntimeModule,
+  type PalamedesFramework,
+} from "@palamedes/transform"
 
 const require = createRequire(import.meta.url)
 
@@ -126,8 +130,17 @@ export type WithPalamedesOptions = {
   failOnCompileError?: boolean
 
   /**
-   * Module to import the runtime getter from.
-   * @default "@palamedes/runtime"
+   * UI framework this app compiles for. Next.js is always React, so this only
+   * exists to opt out with `"none"` — inline `t` / `plural` then stop
+   * following a live locale switch.
+   * @default "react"
+   */
+  framework?: PalamedesFramework
+
+  /**
+   * Module to import the runtime getter from. Overrides the module derived
+   * from `framework`.
+   * @default derived from `framework`
    */
   runtimeModule?: string
 
@@ -218,10 +231,12 @@ export function withPalamedes(
     configPath,
     failOnMissing = false,
     failOnCompileError = false,
-    runtimeModule = "@palamedes/runtime",
+    framework = "react",
+    runtimeModule: explicitRuntimeModule,
     workspaceRoot: explicitWorkspaceRoot,
   } = options
 
+  const runtimeModule = resolveMacroRuntimeModule(framework, explicitRuntimeModule)
   const workspaceRoot = resolveWorkspaceRoot(explicitWorkspaceRoot)
   const configuredTurbopackRoot = baseConfig.turbopack?.root ?? workspaceRoot
   const outputFileTracingRoot =

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -37,7 +37,7 @@ For live client-side locale switches, point the macro transform at React's
 external-store bridge:
 
 ```ts
-palamedes({ runtimeModule: "@palamedes/react/runtime" })
+palamedes()
 ```
 
 The `@palamedes/react/runtime` subpath exports a React-aware `getI18n()` that

--- a/packages/remix/src/index.test.ts
+++ b/packages/remix/src/index.test.ts
@@ -67,6 +67,31 @@ describe("createPalamedesRemixLoadHook", () => {
     )
   })
 
+  it.each([
+    ["none by default", undefined, "@palamedes/runtime"],
+    ["react when asked", "react", "@palamedes/react/runtime"],
+    ["solid when asked", "solid", "@palamedes/solid/runtime"],
+  ] as const)("targets the %s runtime", (_label, framework, expected) => {
+    /*
+     * Unlike the Vite and Next plugins this defaults to "none": Remix 3 ships
+     * its own UI layer and does not depend on React, so defaulting to React
+     * would import a package the app may not have installed.
+     */
+    const load = createPalamedesRemixLoadHook(framework === undefined ? {} : { framework })
+    const loaded = load(new URL("file:///repo/app/routes/home.tsx").href, loadContext, () => ({
+      format: "module",
+      shortCircuit: true,
+      source: [
+        'import { t } from "@palamedes/core/macro"',
+        "export function label() {",
+        "  return t`Hello`",
+        "}",
+      ].join("\n"),
+    }))
+
+    expect(String(loaded.source)).toContain(`import { getI18n } from "${expected}"`)
+  })
+
   it("compiles PO catalog imports without delegating to the default loader", () => {
     const load = createPalamedesRemixLoadHook()
     const nextLoad = vi.fn()

--- a/packages/remix/src/index.ts
+++ b/packages/remix/src/index.ts
@@ -4,7 +4,12 @@ import type { registerHooks } from "node:module"
 
 import { loadPalamedesConfigSync, type LoadedPalamedesConfig } from "@palamedes/config"
 import { compileCatalogModule } from "@palamedes/core-node"
-import { transformPalamedesMacros, type SourceMap } from "@palamedes/transform"
+import {
+  resolveMacroRuntimeModule,
+  transformPalamedesMacros,
+  type PalamedesFramework,
+  type SourceMap,
+} from "@palamedes/transform"
 
 export type PalamedesRemixRegisterOptions = {
   /**
@@ -20,8 +25,19 @@ export type PalamedesRemixRegisterOptions = {
   exclude?: RegExp
 
   /**
-   * Module imported for the runtime i18n getter.
-   * @default "@palamedes/runtime"
+   * UI framework this app compiles for. Unlike the Vite and Next plugins this
+   * defaults to `"none"`: Remix 3 ships its own UI layer and does not depend
+   * on React, so assuming React here would pull in a package the app may not
+   * have. Set it explicitly to make inline `t` / `plural` follow a live locale
+   * switch.
+   * @default "none"
+   */
+  framework?: PalamedesFramework
+
+  /**
+   * Module imported for the runtime i18n getter. Overrides the module derived
+   * from `framework`.
+   * @default derived from `framework`
    */
   runtimeModule?: string
 
@@ -60,7 +76,10 @@ export function createPalamedesRemixLoadHook(
 ): LoadHook {
   const include = options.include ?? DEFAULT_INCLUDE
   const exclude = options.exclude ?? DEFAULT_EXCLUDE
-  const runtimeModule = options.runtimeModule ?? "@palamedes/runtime"
+  const runtimeModule = resolveMacroRuntimeModule(
+    options.framework ?? "none",
+    options.runtimeModule
+  )
   const configCache = new Map<string, LoadedPalamedesConfig>()
 
   return (url, context, nextLoad) => {

--- a/packages/transform/src/framework.ts
+++ b/packages/transform/src/framework.ts
@@ -1,0 +1,44 @@
+/**
+ * Framework selection shared by the bundler plugins.
+ *
+ * Which UI framework an app uses is a compilation concern, not a catalog one:
+ * extracted messages are identical for React and Solid, so `palamedes.yaml`
+ * deliberately says nothing about it. The plugins own the choice instead, and
+ * derive every framework-dependent default from this single option.
+ */
+
+/**
+ * UI framework a Palamedes plugin compiles for.
+ *
+ * `"none"` keeps the framework-agnostic runtime. Inline `t` / `plural` then do
+ * not follow a live locale switch — `<Trans>` and friends still do, because
+ * they subscribe on their own.
+ */
+export type PalamedesFramework = "react" | "solid" | "none"
+
+const FRAMEWORK_RUNTIME_MODULES: Record<PalamedesFramework, string> = {
+  react: "@palamedes/react/runtime",
+  solid: "@palamedes/solid/runtime",
+  none: "@palamedes/runtime",
+}
+
+/**
+ * Resolve the module the macro transform imports the runtime getter from.
+ *
+ * An explicit `runtimeModule` always wins, so existing configurations keep
+ * working unchanged.
+ */
+export function resolveMacroRuntimeModule(
+  framework: PalamedesFramework,
+  runtimeModule?: string
+): string {
+  return runtimeModule ?? FRAMEWORK_RUNTIME_MODULES[framework]
+}
+
+/**
+ * Framework value to hand to MDX compilation, or `undefined` when the plugin
+ * is not compiling for a UI framework and MDX should keep its own default.
+ */
+export function mdxFrameworkFor(framework: PalamedesFramework): "react" | "solid" | undefined {
+  return framework === "none" ? undefined : framework
+}

--- a/packages/transform/src/index.ts
+++ b/packages/transform/src/index.ts
@@ -9,6 +9,8 @@ export { transformPalamedesMacros } from "./transform"
 export type { TransformOptions, TransformResult, SourceMap } from "./types"
 export { PALAMEDES_MACRO_PACKAGES, JS_MACROS, JSX_MACROS } from "./types"
 export { mightContainPalamedesMacros, findMacroImports } from "./detect"
+export { resolveMacroRuntimeModule, mdxFrameworkFor } from "./framework"
+export type { PalamedesFramework } from "./framework"
 export {
   createCatalogLoaderResult,
   createCompileErrorMessage,

--- a/packages/vite-plugin/README.md
+++ b/packages/vite-plugin/README.md
@@ -65,7 +65,7 @@ import solid from "vite-plugin-solid"
 import { palamedes } from "@palamedes/vite-plugin"
 
 export default defineConfig({
-  plugins: [palamedes(), solid({ extensions: [".mdx"] })],
+  plugins: [palamedes({ framework: "solid" }), solid({ extensions: [".mdx"] })],
 })
 ```
 
@@ -97,9 +97,8 @@ palamedes({
   skipValidation: false,
   failOnMissing: false,
   failOnCompileError: false,
-  runtimeModule: "@palamedes/react/runtime",
+  framework: "react",
   mdx: {
-    framework: "react",
     translatableAttributes: ["alt", "title"],
     frontMatterFields: ["title", "description"],
   },
@@ -110,11 +109,15 @@ palamedes({
 sets the directory the config search starts from, and `skipValidation` loads
 partially-authored config files without validation (tooling only).
 
-The top-level `runtimeModule` configures the macro transform only — it is the
-opt-in that makes inline `t` / `plural` follow a live locale switch. Generated
-MDX modules are independent and already default to the framework's reactive
-runtime subpath; configure them with `mdx.runtimeModule` if you need a different
-target.
+`framework` says which UI framework the app compiles for. It selects the
+reactive runtime for macros, so inline `t` / `plural` follow a live locale
+switch, and the component contract for compiled `.mdx`. It defaults to
+`"react"`, so **Solid apps must set `framework: "solid"`**; use `"none"` for a
+project that is neither.
+
+The separate `runtimeModule` option overrides only the macro transform's module
+path. Generated MDX modules are independent; configure those through
+`mdx.runtimeModule`.
 
 When `failOnMissing` is enabled, MDX compiled IDs are validated against every
 target locale in the catalogs that include the source file, even before a

--- a/packages/vite-plugin/src/index.test.ts
+++ b/packages/vite-plugin/src/index.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
+import type * as PalamedesTransformModule from "@palamedes/transform"
+
 const mocks = vi.hoisted(() => ({
   loadPalamedesConfig: vi.fn(),
   analyzeMdxNative: vi.fn(),
@@ -19,11 +21,18 @@ vi.mock("@palamedes/core-node", () => ({
   compileCatalogModule: mocks.compileCatalogModule,
 }))
 
-vi.mock("@palamedes/transform", () => ({
-  PALAMEDES_MACRO_PACKAGES: ["@palamedes/core/macro", "@palamedes/react/macro"],
-  createMissingErrorMessage: mocks.createMissingErrorMessage,
-  transformPalamedesMacros: mocks.transformPalamedesMacros,
-}))
+vi.mock("@palamedes/transform", async (importOriginal) => {
+  // Framework resolution is pure and shared across plugins — exercise the real
+  // implementation so these tests pin the derived defaults, not a stub.
+  const actual = await importOriginal<typeof PalamedesTransformModule>()
+  return {
+    PALAMEDES_MACRO_PACKAGES: ["@palamedes/core/macro", "@palamedes/react/macro"],
+    createMissingErrorMessage: mocks.createMissingErrorMessage,
+    transformPalamedesMacros: mocks.transformPalamedesMacros,
+    resolveMacroRuntimeModule: actual.resolveMacroRuntimeModule,
+    mdxFrameworkFor: actual.mdxFrameworkFor,
+  }
+})
 
 import { palamedes } from "./index"
 
@@ -339,7 +348,78 @@ describe("palamedes vite plugin", () => {
     )
     expect(result).toMatchObject({ code: expect.stringContaining("translated") })
   })
+
+  it.each([
+    ["react", undefined, "@palamedes/react/runtime"],
+    ["solid", "solid", "@palamedes/solid/runtime"],
+    ["none", "none", "@palamedes/runtime"],
+  ] as const)(
+    "derives the macro runtime module for %s",
+    (_label, framework, expectedRuntimeModule) => {
+      runMacroTransform(framework === undefined ? {} : { framework })
+
+      expect(mocks.transformPalamedesMacros).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(String),
+        expect.objectContaining({ runtimeModule: expectedRuntimeModule })
+      )
+    }
+  )
+
+  it("lets an explicit runtime module override the framework default", () => {
+    runMacroTransform({ framework: "react", runtimeModule: "@acme/custom-runtime" })
+
+    expect(mocks.transformPalamedesMacros).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      expect.objectContaining({ runtimeModule: "@acme/custom-runtime" })
+    )
+  })
+
+  it("seeds MDX options from the framework option", async () => {
+    mocks.analyzeMdxNative.mockClear()
+    await runMdxTransform({}, { framework: "solid" })
+
+    expect(mocks.analyzeMdxNative).toHaveBeenCalledWith(
+      "# Welcome",
+      "/repo/src/guide.mdx",
+      expect.objectContaining({ framework: "solid" })
+    )
+  })
+
+  it("lets MDX configuration override the framework option", async () => {
+    mocks.analyzeMdxNative.mockClear()
+    await runMdxTransform({}, { framework: "solid", mdx: { framework: "react" } })
+
+    expect(mocks.analyzeMdxNative).toHaveBeenCalledWith(
+      "# Welcome",
+      "/repo/src/guide.mdx",
+      expect.objectContaining({ framework: "react" })
+    )
+  })
 })
+
+function runMacroTransform(options: Parameters<typeof palamedes>[0] = {}) {
+  mocks.transformPalamedesMacros.mockClear()
+  mocks.transformPalamedesMacros.mockReturnValue({
+    code: "transformed",
+    hasChanged: true,
+    compiledIds: [],
+    map: null,
+  })
+  const macroPlugin = palamedes(options).find((plugin) => plugin.name === "palamedes:transform")
+  const transform = macroPlugin?.transform
+
+  if (typeof transform !== "function") {
+    throw new TypeError("Expected macro transform hook")
+  }
+
+  return transform.call(
+    { error: vi.fn() } as never,
+    'import { t } from "@palamedes/core/macro"\nexport const label = t`Hello`',
+    "/repo/src/label.ts"
+  )
+}
 
 async function runPoTransform(
   context: Record<string, unknown> = {},

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -22,7 +22,12 @@ import {
   type CatalogArtifactConfig,
 } from "@palamedes/core-node"
 import { createMissingErrorMessage, transformPalamedesMacros } from "@palamedes/transform"
-import { PALAMEDES_MACRO_PACKAGES } from "@palamedes/transform"
+import {
+  PALAMEDES_MACRO_PACKAGES,
+  mdxFrameworkFor,
+  resolveMacroRuntimeModule,
+  type PalamedesFramework,
+} from "@palamedes/transform"
 
 const PO_FILE_REGEX = /(\.po|\?palamedes)$/
 const MDX_FILE_REGEX = /\.mdx$/i
@@ -149,11 +154,20 @@ export type PalamedesPluginOptions = {
   failOnCompileError?: boolean
 
   /**
-   * Module the macro transform imports the runtime getter from. Set it to a
-   * framework runtime subpath to make inline `t` / `plural` follow a live
-   * locale switch. Generated MDX modules are not affected; they default to the
-   * framework's reactive runtime and are configured through `mdx.runtimeModule`.
-   * @default "@palamedes/runtime"
+   * UI framework this app compiles for. Selects the reactive runtime for the
+   * macro transform and the component contract for generated MDX modules, so
+   * inline `t` / `plural` and MDX follow a live locale switch without naming
+   * module paths by hand. Use `"none"` for a project that is neither React nor
+   * Solid; inline macros then stop following a live switch.
+   * @default "react"
+   */
+  framework?: PalamedesFramework
+
+  /**
+   * Module the macro transform imports the runtime getter from. Overrides the
+   * module derived from `framework`. Generated MDX modules are not affected;
+   * configure those through `mdx.runtimeModule`.
+   * @default derived from `framework`
    */
   runtimeModule?: string
 
@@ -174,11 +188,12 @@ export function palamedes(options: PalamedesPluginOptions = {}): Plugin[] {
     enablePoLoader = true,
     failOnMissing = false,
     failOnCompileError = false,
+    framework = "react",
     runtimeModule,
     mdx: mdxOverride,
     ...configLoaderOptions
   } = options
-  const macroRuntimeModule = runtimeModule ?? "@palamedes/runtime"
+  const macroRuntimeModule = resolveMacroRuntimeModule(framework, runtimeModule)
 
   // Initialize lazily
   let config: LoadedPalamedesConfig | null = null
@@ -219,12 +234,17 @@ export function palamedes(options: PalamedesPluginOptions = {}): Plugin[] {
   function resolveMdxOptions(cfg: LoadedPalamedesConfig): PalamedesMdxConfig {
     /*
      * The macro `runtimeModule` is deliberately not a fallback here. It is an
-     * opt-in that trades the framework-agnostic default for a reactive one,
-     * while generated MDX modules already default to the framework's reactive
-     * runtime subpath. Letting the macro option leak in would silently
-     * downgrade MDX whenever a project pins the macro target.
+     * override for one specific module path, while generated MDX modules
+     * already default to the framework's reactive runtime subpath. Letting the
+     * macro option leak in would silently downgrade MDX whenever a project
+     * pins the macro target.
+     *
+     * `framework` is different: it states which framework the app compiles
+     * for, which is exactly what MDX needs, so it seeds the MDX options and
+     * stays overridable per config and per call.
      */
     return {
+      ...(mdxFrameworkFor(framework) ? { framework: mdxFrameworkFor(framework) } : {}),
       ...cfg.mdx,
       ...mdxOverride,
     }

--- a/site/app/routes.ts
+++ b/site/app/routes.ts
@@ -116,6 +116,10 @@ export default [
   route("decisions/017-cli-plugin-execution-boundary", "routes/decisions/017-cli-plugin-execution-boundary.md"),
   route("decisions/018-binary-plugin-protocol", "routes/decisions/018-binary-plugin-protocol.md"),
   route("decisions/019-extraction-cache", "routes/decisions/019-extraction-cache.md"),
+  route(
+    "decisions/020-framework-selection-lives-on-the-plugins",
+    "routes/decisions/020-framework-selection-lives-on-the-plugins.md"
+  ),
   route("docs/approach-comparison", "routes/docs/approach-comparison.md"),
   route("docs/backend-servers", "routes/docs/backend-servers.md"),
   route("docs/benchmark-e2e-workflow", "routes/docs/benchmark-e2e-workflow.md"),


### PR DESCRIPTION
## Summary

Follow-up to #478. Replaces two overlapping ways of saying "this app uses React/Solid" with one `framework` option on the bundler plugins.

Before, an app that wanted inline `t` / `plural` to follow a live locale switch had to write a module path by hand — seven of our own examples did:

```ts
palamedes({ runtimeModule: "@palamedes/react/runtime" })
```

MDX then added a second, separate notion of the same thing via `mdx.framework`. Now:

```ts
palamedes()                        // React
palamedes({ framework: "solid" })  // Solid
```

The option derives the macro transform's runtime module and seeds the MDX component contract. `runtimeModule` survives as a narrow override for the macro path, `mdx.framework` for MDX. **No example names a runtime module anymore.**

## Why not in `palamedes.yaml`

Extraction produces identical messages for React and Solid — `MdxOptions::extraction_stamp()` deliberately omits `framework` — so the catalog config has no reason to know. Sourcing it from there would also force `@palamedes/next-plugin` and `@palamedes/remix` to load a config on their macro path, which they do not do today, reintroducing the configless-startup coupling just removed in #478.

## Defaults differ per plugin

| Plugin | Default | Why |
| --- | --- | --- |
| `@palamedes/vite-plugin` | `react` | React and Solid hosts; React is the common case |
| `@palamedes/next-plugin` | `react` | Next.js is React by construction |
| `@palamedes/remix` | `none` | Remix 3 ships its own UI layer and has no React dependency |

The Remix exception is not a guess: `react` does not resolve from any `examples/remix-*` app, so a React default would import a package those projects do not have.

## Behavior changes

- **React and Next apps become reactive by default.** Safe because the React subpath resolves to a hook-free implementation under the `react-server` condition.
- **Solid apps must set `framework: "solid"`.** The previous neutral default no longer applies. `examples/solidstart-cookie` was the one example relying on it and is updated here.

Acceptable now because Palamedes has no significant adoption yet; documented in ADR-020 and in the migration-relevant docs.

## Validation

- `pnpm format:check`, `pnpm lint` — clean
- `tsc --noEmit` for every touched package and the site — clean
- Tests: transform 57, vite-plugin 27 (incl. 4 real React/Solid builds), next-plugin 16, remix 15, config 14, core-node 10, extractor 42 — all green
- New tests pin the derived module per framework in all three plugins, and were red/green verified against a deliberately broken mapping

## Notes

- `site/app/routes/decisions/` is generated by the site prebuild, so the ADR copy and index need no manual edit. `site/app/routes.ts` is generated by a separate tool that did not pick up the new ADR, so its route is added by hand — the same thing #478 did for `docs/mdx.md`.

Follow-up to #478

🤖 Generated with [Claude Code](https://claude.com/claude-code)