### PR TITLE
fix(catalog): apply catalog output rules to merged PO files, guard binary size

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,11 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v7
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@master
         with:
@@ -119,6 +124,13 @@ jobs:
 
       - name: Run Rust tests
         run: cargo test --workspace --locked
+
+      # Palamedes ships prebuilt binaries for five platforms, so anything baked
+      # into the executable multiplies. Checked once, on the pinned toolchain,
+      # because the number only has to be watched — not watched twice.
+      - name: Check shipped binary size
+        if: matrix.toolchain == '1.95'
+        run: node ./scripts/check-binary-size.mjs
 
   remix-next-canary:
     name: remix next canary

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,15 @@ cargo fmt --all --check
 cargo clippy --workspace --all-targets -- -D warnings
 pnpm verify:examples:smoke
 pnpm check:release-set
+pnpm check:binary-size
 ```
+
+`pnpm check:binary-size` builds the release CLI and holds it under a fixed
+ceiling. Palamedes ships prebuilt binaries for five platforms, so anything
+baked into the executable multiplies; the check exists because linking a full
+Unicode collator once added 1.3 MB and only surfaced when someone measured by
+hand. CI runs it on the pinned toolchain. Raising the ceiling is a deliberate
+edit to `scripts/check-binary-size.mjs`, not something to do in passing.
 
 Use `pnpm verify:examples` when a change touches framework integration,
 runtime wiring, or `.po` loading. It is intentionally broader and slower than

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ driver:
 
 ```bash
 git config merge.palamedes-catalog.driver \
-  'pmds catalog merge --format=po --conflict-strategy=use-first --output %A %A %B'
+  'pmds catalog merge --format=po --conflict-strategy=use-first --output %A --path %P %A %B'
 ```
 
 For the full copy-paste path, including `.po` loading and the first translated

--- a/crates/palamedes-cli/src/commands/catalog/convert.rs
+++ b/crates/palamedes-cli/src/commands/catalog/convert.rs
@@ -167,6 +167,7 @@ fn convert_one_catalog(
         source_locale: source_locale.to_owned(),
         locale: locale.map(str::to_owned),
         conflict_strategy: CatalogConflictStrategy::UseFirst,
+        po: None,
     })?;
     Ok(())
 }

--- a/crates/palamedes-cli/src/commands/catalog/merge.rs
+++ b/crates/palamedes-cli/src/commands/catalog/merge.rs
@@ -38,6 +38,11 @@ pub struct MergeOptions {
     /// Locale of the merged catalog.
     #[arg(long)]
     locale: Option<String>,
+    /// Real catalog pathname. Git merge drivers hand the driver temporary
+    /// files, so `--output` cannot identify which configured catalog is being
+    /// merged; pass `%P` here. Defaults to `--output`.
+    #[arg(long)]
+    path: Option<PathBuf>,
 }
 
 #[derive(Clone, Copy, Debug, ValueEnum)]
@@ -60,22 +65,36 @@ impl Command for MergeOptions {
         if self.inputs.len() != 2 {
             return Err(CliError::InvalidMergeInputCount(self.inputs.len()));
         }
+        /*
+         * A Git merge driver runs wherever the conflicted worktree is, which
+         * need not be a Palamedes project. Only an explicit --config makes a
+         * missing config fatal; otherwise carry on without one rather than
+         * refusing the merge.
+         */
+        let config = match context.load_config(self.config.as_deref()) {
+            Ok(config) => Some(config),
+            Err(CliError::Config(ConfigError::NotFound)) if self.config.is_none() => None,
+            Err(error) => return Err(error),
+        };
+
         let source_locale = match &self.source_locale {
             Some(source_locale) => source_locale.clone(),
-            /*
-             * A Git merge driver runs wherever the conflicted worktree is, which
-             * need not be a Palamedes project. Only an explicit --config makes a
-             * missing config fatal; otherwise fall back to the default source
-             * locale rather than refusing the merge.
-             */
-            None => match context.load_config(self.config.as_deref()) {
-                Ok(config) => config.source_locale,
-                Err(CliError::Config(ConfigError::NotFound)) if self.config.is_none() => {
-                    "en".to_owned()
-                }
-                Err(error) => return Err(error),
-            },
+            None => config
+                .as_ref()
+                .map_or_else(|| "en".to_owned(), |config| config.source_locale.clone()),
         };
+
+        /*
+         * Without the catalog's own options a merged catalog comes back folded
+         * differently than the project writes it, and the next extraction
+         * turns that into a diff.
+         */
+        let po = config.as_ref().and_then(|config| {
+            config
+                .catalog_for_path(self.path.as_deref().unwrap_or(&self.output))
+                .and_then(|catalog| catalog.po.clone())
+                .map(Into::into)
+        });
 
         let mut input_paths = self.inputs.clone();
         if let Some(base) = &self.base {
@@ -96,6 +115,7 @@ impl Command for MergeOptions {
                 MergeConflictStrategy::UseLast => CatalogConflictStrategy::UseLast,
                 MergeConflictStrategy::Error => CatalogConflictStrategy::Error,
             },
+            po,
         })?)
     }
 

--- a/crates/palamedes-cli/src/config.rs
+++ b/crates/palamedes-cli/src/config.rs
@@ -254,6 +254,27 @@ impl LoadedConfig {
         self.root_dir.join(catalog_path.replace("{locale}", locale))
     }
 
+    /// Finds the configured catalog a file belongs to.
+    ///
+    /// Commands that receive a catalog by path rather than by config entry —
+    /// a Git merge driver, for one — need this to apply that catalog's output
+    /// options. Relative paths resolve against the config root, which is where
+    /// catalog paths are anchored.
+    pub fn catalog_for_path(&self, path: &Path) -> Option<&ConfigCatalog> {
+        let target = if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            self.root_dir.join(path)
+        };
+        self.catalogs.iter().find(|catalog| {
+            self.locales.iter().any(|locale| {
+                self.resolve_catalog_path(&catalog.path, locale)
+                    .with_extension(catalog.format.extension())
+                    == target
+            })
+        })
+    }
+
     pub fn resolve_pattern(&self, pattern: &str) -> PathBuf {
         self.root_dir.join(pattern)
     }
@@ -581,6 +602,62 @@ catalogs:
         let config = load_config(&app, None).expect("load config");
         let po = config.catalogs[0].po.as_ref().expect("PO options");
         assert_eq!(po.line_breaks, palamedes::PoLineBreaks::Off);
+    }
+
+    /*
+     * A Git merge driver is handed temporary files, so the catalog it is
+     * merging can only be identified by the real pathname passed alongside
+     * them. Resolution has to work for every locale of every catalog, and has
+     * to reject paths that belong to no catalog rather than guessing.
+     */
+    #[test]
+    fn resolves_the_catalog_a_path_belongs_to() {
+        let app = temp_dir("catalog-for-path");
+        fs::write(
+            app.join(CONFIG_FILENAME),
+            r#"
+locales: [en, de]
+source-locale: en
+catalogs:
+  - path: src/locales/{locale}/messages
+    include: [src]
+    po:
+      line-breaks: "off"
+  - path: docs/locales/{locale}
+    format: fcl
+    include: [docs]
+"#,
+        )
+        .expect("write config");
+
+        let config = load_config(&app, None).expect("load config");
+
+        let po_catalog = config
+            .catalog_for_path(&app.join("src/locales/de/messages.po"))
+            .expect("catalog for a target locale");
+        assert_eq!(po_catalog.path, "src/locales/{locale}/messages");
+        assert_eq!(
+            po_catalog.po.as_ref().expect("PO options").line_breaks,
+            palamedes::PoLineBreaks::Off
+        );
+
+        // Relative paths anchor at the config root, which is what a merge
+        // driver's `%P` hands over.
+        assert!(config
+            .catalog_for_path(std::path::Path::new("src/locales/en/messages.po"))
+            .is_some());
+
+        assert_eq!(
+            config
+                .catalog_for_path(&app.join("docs/locales/en.fcl"))
+                .map(|catalog| catalog.path.as_str()),
+            Some("docs/locales/{locale}")
+        );
+
+        assert!(config
+            .catalog_for_path(&app.join("src/locales/fr/messages.po"))
+            .is_none());
+        assert!(config.catalog_for_path(&app.join("README.md")).is_none());
     }
 
     /*

--- a/crates/palamedes-node/src/catalog.rs
+++ b/crates/palamedes-node/src/catalog.rs
@@ -177,6 +177,7 @@ pub struct CatalogFileCombineRequest {
     pub source_locale: String,
     pub locale: Option<String>,
     pub conflict_strategy: Option<CatalogConflictStrategy>,
+    pub po: Option<PoOutputOptions>,
 }
 
 #[napi(object)]
@@ -710,6 +711,7 @@ impl From<CatalogFileCombineRequest> for palamedes::CatalogFileCombineRequest {
             conflict_strategy: value
                 .conflict_strategy
                 .map_or(palamedes::CatalogConflictStrategy::UseFirst, Into::into),
+            po: value.po.map(Into::into),
         }
     }
 }

--- a/crates/palamedes/src/catalog_combine.rs
+++ b/crates/palamedes/src/catalog_combine.rs
@@ -6,6 +6,7 @@ use ferrocat::{
     CatalogMode, CombineCatalogFilesOptions, CombineCatalogOptions, OrderBy,
 };
 
+use crate::catalog_update::{atomic_write_catalog, finalize_rendered_po, PoOutputOptions};
 use crate::error::{PalamedesError, PalamedesResult};
 
 pub use ferrocat::{
@@ -84,6 +85,9 @@ pub struct CatalogFileCombineRequest {
     pub locale: Option<String>,
     /// Strategy for resolving conflicting non-empty translations.
     pub conflict_strategy: CatalogConflictStrategy,
+    /// Optional PO-specific output controls, applied when the combined catalog
+    /// is written as PO.
+    pub po: Option<PoOutputOptions>,
 }
 
 /// Combines multiple catalogs into one deterministic catalog.
@@ -123,6 +127,21 @@ fn combine_catalog_contents(
     ferrocat_combine_catalogs(options).map_err(PalamedesError::from)
 }
 
+/// Rewrites a freshly combined PO file in the order and shape Palamedes
+/// writes, so a merged catalog matches what the next extraction produces.
+fn finalize_combined_po(
+    output_path: &std::path::Path,
+    po: Option<&PoOutputOptions>,
+) -> PalamedesResult<()> {
+    let combined = std::fs::read_to_string(output_path)
+        .map_err(|error| ferrocat::ApiError::io_with_path(output_path, error))?;
+    let finalized = finalize_rendered_po(&combined, po)?;
+    if finalized != combined {
+        atomic_write_catalog(output_path, &finalized)?;
+    }
+    Ok(())
+}
+
 /// Combines catalog files and atomically replaces the requested output path.
 ///
 /// # Errors
@@ -157,6 +176,16 @@ pub fn combine_catalog_files(
     }
 
     let result = ferrocat_combine_catalog_files(options).map_err(PalamedesError::from)?;
+
+    /*
+     * Ferrocat writes in code-point order, which is never what Palamedes puts
+     * in a PO catalog. Without this pass a merge would hand back a fully
+     * re-sorted file and the next extraction would sort it right back.
+     */
+    if matches!(result.format, ferrocat::CatalogFileFormat::Po) {
+        finalize_combined_po(&request.output_path, request.po.as_ref())?;
+    }
+
     Ok(CatalogFileCombineResult {
         output_path: result.output_path,
         format: match result.format {
@@ -240,6 +269,85 @@ mod tests {
         assert!(!result.content.contains("Shared"));
     }
 
+    /*
+     * A merged catalog has to come back in the order an extraction writes, or
+     * the merge commit carries a full re-sort that the next extraction undoes.
+     * Code-point order would put "Zebra" ahead of "Álgebra".
+     */
+    #[test]
+    fn writes_merged_po_files_in_collation_order() {
+        let dir = temp_dir("po-merge-order");
+        let ours = dir.join("ours.po");
+        let theirs = dir.join("theirs.po");
+        fs::write(
+            &ours,
+            "msgid \"\"\nmsgstr \"\"\n\"Language: de\\n\"\n\nmsgid \"Zebra\"\nmsgstr \"Zebra\"\n\nmsgid \"über\"\nmsgstr \"über\"\n",
+        )
+        .expect("write ours");
+        fs::write(
+            &theirs,
+            "msgid \"\"\nmsgstr \"\"\n\"Language: de\\n\"\n\nmsgid \"Álgebra\"\nmsgstr \"Álgebra\"\n\nmsgid \"Uber\"\nmsgstr \"Uber\"\n",
+        )
+        .expect("write theirs");
+
+        combine_catalog_files(CatalogFileCombineRequest {
+            input_paths: vec![ours.clone(), theirs],
+            output_path: ours.clone(),
+            format: None,
+            source_locale: "en".to_owned(),
+            locale: Some("de".to_owned()),
+            conflict_strategy: CatalogConflictStrategy::UseFirst,
+            po: None,
+        })
+        .expect("merge");
+
+        let parsed = ferrocat::parse_po(&fs::read_to_string(&ours).expect("read output"))
+            .expect("parse output");
+        assert_eq!(
+            parsed
+                .items
+                .iter()
+                .map(|item| item.msgid.as_str())
+                .collect::<Vec<_>>(),
+            vec!["Álgebra", "Uber", "über", "Zebra"]
+        );
+    }
+
+    #[test]
+    fn applies_po_line_break_options_to_merged_output() {
+        let dir = temp_dir("po-merge-line-breaks");
+        let ours = dir.join("ours.po");
+        let theirs = dir.join("theirs.po");
+        let long = "A deliberately long translation value that Ferrocat would fold at its default output width.";
+        fs::write(
+            &ours,
+            format!("msgid \"\"\nmsgstr \"\"\n\"Language: de\\n\"\n\nmsgid \"{long}\"\nmsgstr \"{long}\"\n"),
+        )
+        .expect("write ours");
+        fs::write(&theirs, "msgid \"\"\nmsgstr \"\"\n\"Language: de\\n\"\n").expect("write theirs");
+
+        combine_catalog_files(CatalogFileCombineRequest {
+            input_paths: vec![ours.clone(), theirs],
+            output_path: ours.clone(),
+            format: None,
+            source_locale: "en".to_owned(),
+            locale: Some("de".to_owned()),
+            conflict_strategy: CatalogConflictStrategy::UseFirst,
+            po: Some(crate::PoOutputOptions {
+                line_breaks: crate::PoLineBreaks::Off,
+            }),
+        })
+        .expect("merge");
+
+        let output = fs::read_to_string(&ours).expect("read output");
+        assert!(
+            output
+                .lines()
+                .any(|line| line == format!("msgid \"{long}\"")),
+            "{output}"
+        );
+    }
+
     #[test]
     fn merges_po_files_with_use_first_and_preserves_first_header() {
         let dir = temp_dir("po-use-first");
@@ -277,6 +385,7 @@ mod tests {
             source_locale: "en".to_owned(),
             locale: Some("de".to_owned()),
             conflict_strategy: CatalogConflictStrategy::UseFirst,
+            po: None,
         })
         .expect("merge");
 
@@ -336,6 +445,7 @@ mod tests {
             source_locale: "en".to_owned(),
             locale: Some("de".to_owned()),
             conflict_strategy: CatalogConflictStrategy::UseFirst,
+            po: None,
         })
         .expect("merge");
 
@@ -376,6 +486,7 @@ mod tests {
             source_locale: "en".to_owned(),
             locale: Some("de".to_owned()),
             conflict_strategy: CatalogConflictStrategy::UseFirst,
+            po: None,
         })
         .expect("merge");
 
@@ -404,6 +515,7 @@ mod tests {
             source_locale: "en".to_owned(),
             locale: Some("de".to_owned()),
             conflict_strategy: CatalogConflictStrategy::UseFirst,
+            po: None,
         })
         .expect_err("mixed formats");
 
@@ -431,6 +543,7 @@ mod tests {
             source_locale: "en".to_owned(),
             locale: Some("de".to_owned()),
             conflict_strategy: CatalogConflictStrategy::UseFirst,
+            po: None,
         })
         .expect_err("unsupported format");
 

--- a/crates/palamedes/src/catalog_update.rs
+++ b/crates/palamedes/src/catalog_update.rs
@@ -433,6 +433,17 @@ fn read_existing_catalog(
     }))
 }
 
+/// Rewrites already-rendered PO output the way Palamedes writes catalogs:
+/// collation order plus the requested folding, with no preserved metadata to
+/// restore. Used by paths that hand off rendering to Ferrocat and need the
+/// result to match what an extraction would have produced.
+pub(crate) fn finalize_rendered_po(
+    rendered: &str,
+    options: Option<&PoOutputOptions>,
+) -> PalamedesResult<String> {
+    finalize_po_output(rendered, None, options)
+}
+
 fn finalize_po_output(
     updated: &str,
     metadata: Option<&BTreeMap<PoMessageKey, PreservedPoMetadata>>,
@@ -545,7 +556,7 @@ fn sort_po_items_collated(items: &mut [ferrocat::PoItem]) {
     }
 }
 
-fn atomic_write_catalog(target_path: &Path, content: &str) -> PalamedesResult<()> {
+pub(crate) fn atomic_write_catalog(target_path: &Path, content: &str) -> PalamedesResult<()> {
     let directory = target_path.parent().unwrap_or_else(|| Path::new("."));
     std::fs::create_dir_all(directory).map_err(|error| ApiError::io_with_path(directory, error))?;
     let mut temporary = tempfile::NamedTempFile::new_in(directory)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -101,11 +101,18 @@ Git merge-driver workflows.
 
 ```bash
 pmds catalog merge ours.po theirs.po --output merged.po
-pmds catalog merge %A %B --base %O --output %A --format po --conflict-strategy use-first
+pmds catalog merge %A %B --base %O --output %A --path %P --format po --conflict-strategy use-first
 pmds catalog merge ours.fcl theirs.fcl --output merged.fcl --format fcl
 ```
 
 `pmds catalog merge` requires exactly two input catalogs in precedence order.
+
+Merged PO catalogs are written in the same order and shape as an extraction
+produces, so a resolved conflict does not land as a fully re-sorted file that
+the next `pmds extract` sorts back. Applying the catalog's own `po` options
+needs to know which configured catalog is being merged, and a Git merge driver
+only ever sees temporary files — pass `%P` through `--path` for that. Without
+it the output path is used, which is enough outside a merge driver.
 
 Options:
 
@@ -118,6 +125,7 @@ Options:
 | `--conflict-strategy <strategy>` | `use-first`, `use-last`, or `error`. Default: `use-first`.       |
 | `--source-locale <locale>`       | Source locale for catalog semantics. Defaults to config or `en`. |
 | `--locale <locale>`              | Locale of the merged catalog.                                    |
+| `--path <path>`                  | Real catalog pathname; pass `%P` in a Git merge driver.          |
 
 ## `pmds catalog convert`
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "proof:icu": "pnpm build && node ./scripts/proof-icu-semantics.mjs",
     "proof:icu:check": "node ./scripts/proof-icu-semantics.mjs",
     "test": "pnpm -r --filter \"./packages/**\" --if-present test",
+    "check:binary-size": "node ./scripts/check-binary-size.mjs",
     "check:collation-table": "node ./scripts/generate-collation-table.mjs --check",
     "check:native-types": "pnpm --filter @palamedes/core-node check-native-types",
     "check:published-types": "node ./scripts/check-published-types.mjs",

--- a/packages/core-node/src/generated/palamedes-node-types.ts
+++ b/packages/core-node/src/generated/palamedes-node-types.ts
@@ -113,6 +113,7 @@ export interface CatalogFileCombineRequest {
   sourceLocale: string;
   locale?: string;
   conflictStrategy?: CatalogConflictStrategy;
+  po?: PoOutputOptions;
 }
 export interface CatalogFileCombineResult {
   outputPath: string;

--- a/packages/core-node/src/index.ts
+++ b/packages/core-node/src/index.ts
@@ -129,6 +129,7 @@ export type CatalogFileCombineRequest = {
   sourceLocale: string
   locale?: string
   conflictStrategy?: CatalogConflictStrategy
+  po?: PoOutputOptions
 }
 export type CatalogFileCombineResult = Omit<
   GeneratedCatalogFileCombineResult,
@@ -456,6 +457,16 @@ function toNativeFileCombineRequest(
     conflictStrategy: request.conflictStrategy
       ? toNativeConflictStrategy(request.conflictStrategy)
       : undefined,
+    po: toNativePoOptions(request.po),
+  }
+}
+
+function toNativePoOptions(po: PoOutputOptions | undefined): NativeCatalogUpdateRequest["po"] {
+  if (!po) {
+    return undefined
+  }
+  return {
+    lineBreaks: po.lineBreaks ? toNativePoLineBreaks(po.lineBreaks) : undefined,
   }
 }
 
@@ -482,13 +493,7 @@ function toNativeUpdateRequest(request: CatalogUpdateRequest): NativeCatalogUpda
   return {
     ...request,
     format: request.format ? toNativeConfigFormat(request.format) : undefined,
-    po: request.po
-      ? {
-          lineBreaks: request.po.lineBreaks
-            ? toNativePoLineBreaks(request.po.lineBreaks)
-            : undefined,
-        }
-      : undefined,
+    po: toNativePoOptions(request.po),
   }
 }
 

--- a/scripts/check-binary-size.mjs
+++ b/scripts/check-binary-size.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+/*
+ * Guards the size of the shipped CLI binary.
+ *
+ * Palamedes ships prebuilt binaries for five platforms, so a dependency that
+ * bakes data into the executable multiplies across all of them. That is easy to
+ * add without noticing: linking a full Unicode collator once cost 1.3 MB and
+ * only came to light because someone measured by hand.
+ *
+ * This is a ceiling rather than a comparison against a stored baseline. Exact
+ * sizes differ between toolchain patch releases, linkers and platforms, so a
+ * recorded number would drift and report growth that is not there. A ceiling
+ * with headroom stays quiet through ordinary change and still catches the jump
+ * worth catching. Raising it is a deliberate edit, which is the point.
+ */
+
+import { execFileSync } from "node:child_process"
+import { statSync } from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), "..")
+
+const BUDGETS = [
+  {
+    label: "pmds (release)",
+    crate: "palamedes-cli",
+    binary: path.join("target", "release", "pmds"),
+    maxBytes: 9_500_000,
+  },
+]
+
+const format = (bytes) =>
+  `${(bytes / 1_000_000).toFixed(2)} MB (${bytes.toLocaleString("en-US")} B)`
+
+let failed = false
+
+for (const budget of BUDGETS) {
+  execFileSync("cargo", ["build", "--release", "--locked", "-p", budget.crate], {
+    cwd: ROOT,
+    stdio: "inherit",
+  })
+
+  const binaryPath = path.join(ROOT, budget.binary)
+  const { size } = statSync(binaryPath)
+  const headroom = budget.maxBytes - size
+
+  if (headroom < 0) {
+    failed = true
+    console.error(
+      `${budget.label}: ${format(size)} exceeds the budget of ${format(budget.maxBytes)} by ${format(-headroom)}.\n` +
+        `Either shrink it, or raise maxBytes in scripts/check-binary-size.mjs and say why in the commit.`
+    )
+    continue
+  }
+
+  const used = ((size / budget.maxBytes) * 100).toFixed(1)
+  console.log(
+    `${budget.label}: ${format(size)} of ${format(budget.maxBytes)} (${used} %), ${format(headroom)} to spare.`
+  )
+}
+
+process.exit(failed ? 1 : 0)


### PR DESCRIPTION
## Summary

Two follow-ups left open by #481. They are independent; the first is the one that matters.

### `pmds catalog merge` wrote catalogs nothing else writes

`combine_catalog_files` handed its output to Ferrocat, which renders in code-point order. Since #481 made collation order unconditional for PO, every resolved merge conflict landed as a fully re-sorted file — which the next `pmds extract` then sorted straight back. The catalog's `line-breaks` setting was dropped the same way. For a project using Palamedes as a Git merge driver that turns each conflict into two large mechanical diffs, which is the churn #479 set out to remove.

Combined PO output now goes through the same final pass as an extraction. Ordering needs no configuration, so it applies to every caller including the Node API.

Applying the catalog's own options does need to know *which* configured catalog is being merged, and that is the awkward part: a Git merge driver only ever sees temporary files — `%A`, `%B` and `%O` are all throwaway paths, so `--output` cannot identify the catalog. `--path` takes the real pathname (`%P` in a driver) and resolves it against the configured catalogs; without it the output path is used, which is enough outside a driver. The documented driver command in the README and the CLI reference now passes it.

`catalog convert` turned out to be unaffected — it only ever writes FCL. The #481 description claimed otherwise; that was wrong.

### CI had no binary size budget

Palamedes ships prebuilt binaries for five platforms, so anything baked into the executable multiplies. Nothing watched that: linking a full Unicode collator in #481 added 1,301,440 B and only came to light because someone measured by hand.

`pnpm check:binary-size` builds the release CLI and holds it under a fixed ceiling — 9.5 MB against 8.79 MB in use, so about 700 KB of headroom. CI runs it once, on the pinned toolchain.

A ceiling rather than a comparison against a recorded baseline: exact sizes differ between toolchain patch releases, linkers and platforms, so a stored number would drift and report growth that is not there. CI measured 8,791,760 B against 8,793,104 B locally on the same toolchain — 1.3 KB apart, which a stored baseline would have reported as growth. A ceiling with headroom stays quiet through ordinary change and still catches the megabyte-class jump worth catching. It is kept out of `agent:check` so the common local loop does not pay for a release build.

## Issue

Follow-up to #481. Refs #479.

## Validation

- `cargo test --workspace --locked` — 223 core (two new combine tests, one new config test), 33 CLI
- `cargo clippy --workspace --all-targets --locked -- -D warnings`, `cargo fmt --all --check`
- `pnpm test` (335), `pnpm lint`, `pnpm check-types`, `pnpm format:check`, `pnpm check:collation-table`
- `pnpm check:binary-size` — 8.79 MB of 9.50 MB
- `@palamedes/core-node` tests against a locally built addon; `generate-native-types.mjs --check` confirms the checked-in types

The new tests cover what was actually broken: that a merged PO file comes back in collation order rather than code-point order, that `line-breaks` reaches the merged output, and that a path resolves to the right configured catalog across locales and formats while rejecting paths that belong to none.

## Follow-up

**Catalog ordering belongs in Ferrocat, and this fix is a workaround until it moves there.**

Ferrocat is `sebastian-software/ferrocat` — the same organisation, not a third-party upstream, so this is a decision rather than a request. Earlier notes on #481 framed it as an external constraint; that was too passive.

Palamedes orders catalogs in a post-pass only because `RenderOptions::order_by` is an enum of `Msgid | Origin` with no way to express anything else. Ordering is catalog semantics, which principle 4 puts in Ferrocat. Moving it there would:

- remove the parse/serialize round trip, roughly 1.7 ms of the 3.9 ms final pass per catalog file, since Ferrocat already sorts before rendering;
- make this merge fix unnecessary — `combine_catalog_files` would order correctly on its own;
- fix FCL, which is currently the same content in a different order. The same six messages extract as `Álgebra, apple, Apple, Uber, über, Zebra` in PO and `Apple, Uber, Zebra, apple, Álgebra, über` in FCL, so `Apple` and `apple` sit at opposite ends of the FCL file. Sorting FCL in Palamedes would mean a second post-pass, repeating the mistake rather than fixing it.

An `OrderBy::Collated` carrying the collation would suit better than a caller-supplied comparator, which would push semantics back out to callers. The ~20 KB table, its generator and its documented limits could move over whole.

Remaining, also Ferrocat-side: multiline values diverge from `pofile` — Ferrocat puts the first chunk on the keyword line where GNU gettext and `pofile` open with an empty string. Both parse identically, but the spelling differs, so multiline messages still diff across tool chains. Pinned by a test and documented; zero of the 1937 entries in this repo's catalogs are affected.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P7CWcasodoYvSB3b3R37Ce