### PR TITLE
feat(catalog): adopt Ferrocat 3.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -333,9 +333,9 @@ checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "ferrocat"
-version = "3.1.0"
+version = "3.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8bee4cb203a5fd5e0ef9b8357ffb0f2cc6ee87e9a56e4d2d1b23bbf9bc590f4"
+checksum = "1303066fe0186f74569e19c21ab6065749849a4e48e35670092eb8e9eb0a4bfc"
 dependencies = [
  "ferrocat-icu",
  "ferrocat-po",
@@ -343,9 +343,9 @@ dependencies = [
 
 [[package]]
 name = "ferrocat-icu"
-version = "3.1.0"
+version = "3.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da2a6b657284360b280774bf374e097b38c2b7b1f23471332a1b9317a22a1004"
+checksum = "5e438fc2eafdba23ea18c33d4c25fdbe7713459d7c0df7436cc306fc7b7770fb"
 dependencies = [
  "memchr",
  "serde",
@@ -353,9 +353,9 @@ dependencies = [
 
 [[package]]
 name = "ferrocat-po"
-version = "3.1.0"
+version = "3.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edb5d31b674f9efe4b5b873017cef93b715c6ae2399f07b09cde85fd18c7dd74"
+checksum = "7d3b3f4a45250eacd418212d88c0b73cd031f1df8d46a2903896fda21a7b557e"
 dependencies = [
  "ferrocat-icu",
  "icu_locale",

--- a/crates/palamedes-cli/src/commands/catalog/convert.rs
+++ b/crates/palamedes-cli/src/commands/catalog/convert.rs
@@ -4,12 +4,9 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use clap::{Args, ValueEnum};
-use palamedes::{
-    combine_catalog_files, CatalogConflictStrategy, CatalogFileCombineRequest, CatalogFileFormat,
-};
+use palamedes::{convert_catalog_file, CatalogFileConvertRequest, CatalogFileFormat};
 
 use crate::command::{Command, Context};
-use crate::commands::read_po;
 use crate::error::CliError;
 
 #[derive(Debug, Args)]
@@ -151,43 +148,65 @@ fn convert_one_catalog(
     if input.extension().and_then(|ext| ext.to_str()) != Some("po") {
         return Err(CliError::UnsupportedConvertSource);
     }
-    reject_fuzzy_po(input)?;
-    if let Some(parent) = output.parent() {
+    if let Some(parent) = output
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
         fs::create_dir_all(parent).map_err(|source| CliError::Io {
             path: parent.to_path_buf(),
             source,
         })?;
     }
-    combine_catalog_files(CatalogFileCombineRequest {
-        input_paths: vec![input.to_path_buf()],
+    convert_catalog_file(CatalogFileConvertRequest {
+        input_path: input.to_path_buf(),
         output_path: output.to_path_buf(),
-        format: Some(match to {
+        source_format: CatalogFileFormat::Po,
+        target_format: match to {
             ConvertFormat::Fcl => CatalogFileFormat::Fcl,
-        }),
+        },
         source_locale: source_locale.to_owned(),
         locale: locale.map(str::to_owned),
-        conflict_strategy: CatalogConflictStrategy::UseFirst,
-        po: None,
     })?;
-    Ok(())
-}
-
-fn reject_fuzzy_po(path: &Path) -> Result<(), CliError> {
-    let catalog = read_po(path)?;
-    if catalog
-        .items
-        .iter()
-        .any(|item| item.flags.get("fuzzy").copied().unwrap_or(false))
-    {
-        return Err(CliError::FuzzyCatalogInput {
-            path: path.to_path_buf(),
-        });
-    }
     Ok(())
 }
 
 const fn convert_extension(to: ConvertFormat) -> &'static str {
     match to {
         ConvertFormat::Fcl => "fcl",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use super::{convert_one_catalog, ConvertFormat};
+    use crate::commands::test_support::temp_dir;
+
+    #[test]
+    fn fuzzy_po_conversion_preserves_review_metadata_in_fcl() {
+        let fixture = temp_dir("convert-fuzzy-po");
+        let input = fixture.join("de.po");
+        let output = fixture.join("de.fcl");
+        fs::write(
+            &input,
+            concat!(
+                "msgid \"\"\n",
+                "msgstr \"\"\n",
+                "\"Language: de\\n\"\n\n",
+                "# Translator note\n",
+                "#, fuzzy\n",
+                "msgid \"Hello\"\n",
+                "msgstr \"Hallo\"\n",
+            ),
+        )
+        .expect("write input");
+
+        convert_one_catalog(&input, &output, "en", Some("de"), ConvertFormat::Fcl)
+            .expect("convert fuzzy catalog");
+
+        let converted = fs::read_to_string(output).expect("read output");
+        assert!(converted.contains("tc=Translator note"));
+        assert!(converted.contains("f=fuzzy"));
     }
 }

--- a/crates/palamedes-cli/src/commands/mod.rs
+++ b/crates/palamedes-cli/src/commands/mod.rs
@@ -1,12 +1,6 @@
 //! The built-in `pmds` commands, one module per namespace.
 
 use std::collections::BTreeSet;
-use std::fs;
-use std::path::Path;
-
-use palamedes::parse_po;
-
-use crate::error::CliError;
 
 pub mod audit;
 pub mod catalog;
@@ -29,15 +23,4 @@ pub fn normalize_locale_list(values: &[String]) -> Vec<String> {
         .collect::<BTreeSet<_>>()
         .into_iter()
         .collect()
-}
-
-/// Reads a PO file for the two places that need PO-only metadata the
-/// format-neutral catalog parser does not expose: fuzzy flags, which `report`
-/// counts as untranslated and `catalog convert` refuses outright.
-pub fn read_po(path: &Path) -> Result<palamedes::JsPoFile, CliError> {
-    let source = fs::read_to_string(path).map_err(|source| CliError::Io {
-        path: path.to_path_buf(),
-        source,
-    })?;
-    Ok(parse_po(&source)?)
 }

--- a/crates/palamedes-cli/src/commands/report.rs
+++ b/crates/palamedes-cli/src/commands/report.rs
@@ -1,14 +1,12 @@
 //! `pmds report` — per-locale catalog translation completeness.
 
-use std::collections::{BTreeMap, BTreeSet};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use clap::Args;
-use palamedes::{parse_catalog, CatalogParseRequest};
-use serde::Serialize;
+use palamedes::{measure_catalog_coverage, CatalogCoverageRequest, CatalogCoverageResult};
 
 use crate::command::{render_json, Command, Context};
-use crate::commands::{normalize_locale_list, read_po};
+use crate::commands::normalize_locale_list;
 use crate::config::LoadedConfig;
 use crate::error::CliError;
 
@@ -28,38 +26,8 @@ pub struct ReportOptions {
     fail_if_below: Option<f64>,
 }
 
-#[derive(Debug, Serialize)]
-pub struct CompletenessReport {
-    locales: Vec<LocaleCompletenessReport>,
-}
-
-#[derive(Debug, Serialize)]
-struct LocaleCompletenessReport {
-    locale: String,
-    total: usize,
-    translated: usize,
-    missing: usize,
-    fuzzy: usize,
-    percent: f64,
-}
-
-#[derive(Debug, Clone, Eq, Ord, PartialEq, PartialOrd)]
-struct MessageKey {
-    message: String,
-    context: Option<String>,
-}
-
-#[derive(Debug)]
-struct MutableLocaleStats {
-    locale: String,
-    total: usize,
-    translated: usize,
-    missing: usize,
-    fuzzy: usize,
-}
-
 impl Command for ReportOptions {
-    type Output = CompletenessReport;
+    type Output = CatalogCoverageResult;
 
     fn run(&self, context: &Context) -> Result<Self::Output, CliError> {
         // Reject an out-of-range threshold before doing any work: the run
@@ -103,148 +71,15 @@ impl Command for ReportOptions {
     }
 }
 
-fn build_report(config: &LoadedConfig, locales: &[String]) -> Result<CompletenessReport, CliError> {
-    let mut stats = locales
-        .iter()
-        .map(|locale| {
-            (
-                locale.clone(),
-                MutableLocaleStats {
-                    locale: locale.clone(),
-                    total: 0,
-                    translated: 0,
-                    missing: 0,
-                    fuzzy: 0,
-                },
-            )
-        })
-        .collect::<BTreeMap<_, _>>();
-
-    for catalog in &config.catalogs {
-        let source_path = config
-            .resolve_catalog_path(&catalog.path, &config.source_locale)
-            .with_extension(catalog.format.extension());
-        let source_catalog = read_catalog_for_report(
-            &source_path,
-            &config.source_locale,
-            &config.source_locale,
-            catalog.format,
-        )?;
-        let source_messages = source_catalog
-            .into_iter()
-            .filter(|message| !message.obsolete)
-            .map(|message| MessageKey {
-                message: message.message,
-                context: message.context,
-            })
-            .collect::<Vec<_>>();
-
-        for locale in locales {
-            let Some(locale_stats) = stats.get_mut(locale) else {
-                continue;
-            };
-            locale_stats.total += source_messages.len();
-
-            if locale == &config.source_locale {
-                locale_stats.translated += source_messages.len();
-                continue;
-            }
-
-            let target_path = config
-                .resolve_catalog_path(&catalog.path, locale)
-                .with_extension(catalog.format.extension());
-            /*
-             * Fuzzy entries carry a translation that needs review; gettext
-             * tooling treats them as untranslated, and so does this report.
-             * The flag only exists in the PO storage format.
-             */
-            let fuzzy_keys = if catalog.format == palamedes::PalamedesCatalogFormat::Po
-                && target_path.exists()
-            {
-                read_po(&target_path)?
-                    .items
-                    .into_iter()
-                    .filter(|item| item.flags.get("fuzzy").copied().unwrap_or(false))
-                    .map(|item| MessageKey {
-                        message: item.msgid,
-                        context: item.msgctxt,
-                    })
-                    .collect::<BTreeSet<_>>()
-            } else {
-                BTreeSet::new()
-            };
-            let target_messages = if target_path.exists() {
-                read_catalog_for_report(
-                    &target_path,
-                    &config.source_locale,
-                    locale,
-                    catalog.format,
-                )?
-                .into_iter()
-                .filter(|message| !message.obsolete)
-                .map(|message| {
-                    (
-                        MessageKey {
-                            message: message.message,
-                            context: message.context,
-                        },
-                        message.translated,
-                    )
-                })
-                .collect::<BTreeMap<_, _>>()
-            } else {
-                BTreeMap::new()
-            };
-
-            for source_message in &source_messages {
-                let Some(target) = target_messages.get(source_message) else {
-                    locale_stats.missing += 1;
-                    continue;
-                };
-                if fuzzy_keys.contains(source_message) {
-                    locale_stats.fuzzy += 1;
-                    locale_stats.missing += 1;
-                } else if *target {
-                    locale_stats.translated += 1;
-                } else {
-                    locale_stats.missing += 1;
-                }
-            }
-        }
-    }
-
-    Ok(CompletenessReport {
-        locales: stats
-            .into_values()
-            .map(|locale| LocaleCompletenessReport {
-                percent: if locale.total == 0 {
-                    100.0
-                } else {
-                    (locale.translated as f64 / locale.total as f64) * 100.0
-                },
-                locale: locale.locale,
-                total: locale.total,
-                translated: locale.translated,
-                missing: locale.missing,
-                fuzzy: locale.fuzzy,
-            })
-            .collect(),
+fn build_report(
+    config: &LoadedConfig,
+    locales: &[String],
+) -> Result<CatalogCoverageResult, CliError> {
+    measure_catalog_coverage(CatalogCoverageRequest {
+        config: config.artifact_config(),
+        locales: locales.to_vec(),
     })
-}
-
-fn read_catalog_for_report(
-    path: &Path,
-    source_locale: &str,
-    locale: &str,
-    format: palamedes::PalamedesCatalogFormat,
-) -> Result<Vec<palamedes::ParsedCatalogMessage>, CliError> {
-    let result = parse_catalog(&CatalogParseRequest {
-        target_path: path.to_string_lossy().into_owned(),
-        locale: locale.to_owned(),
-        source_locale: source_locale.to_owned(),
-        format,
-    })?;
-    Ok(result.messages)
+    .map_err(CliError::from)
 }
 
 fn resolve_report_locales(config: &LoadedConfig, selected: &[String]) -> Vec<String> {
@@ -261,7 +96,7 @@ fn resolve_report_locales(config: &LoadedConfig, selected: &[String]) -> Vec<Str
         .collect()
 }
 
-fn print_report(result: &CompletenessReport) {
+fn print_report(result: &CatalogCoverageResult) {
     if result.locales.is_empty() {
         println!("No target locales configured.");
         return;

--- a/crates/palamedes-cli/src/error.rs
+++ b/crates/palamedes-cli/src/error.rs
@@ -30,8 +30,6 @@ pub enum CliError {
     InvalidConvertOutput,
     #[error("Catalog convert --to=fcl only supports PO source catalogs.")]
     UnsupportedConvertSource,
-    #[error("Catalog convert refused {path} because fuzzy PO entries are not supported for FCL conversion.")]
-    FuzzyCatalogInput { path: PathBuf },
     #[error("Invalid --fail-if-below value. Expected a percent from 0 to 100.")]
     InvalidThreshold,
     #[error("Catalog audit failed with {errors} error(s).")]

--- a/crates/palamedes-node/src/catalog.rs
+++ b/crates/palamedes-node/src/catalog.rs
@@ -217,6 +217,7 @@ pub struct CatalogAuditCheckOptions {
     pub icu_compatibility: Option<bool>,
     pub semantic_metadata: Option<bool>,
     pub obsolete_entries: Option<bool>,
+    pub fuzzy_flags: Option<bool>,
 }
 
 #[napi(object)]
@@ -766,6 +767,7 @@ impl From<CatalogAuditCheckOptions> for palamedes::CatalogAuditCheckOptions {
             icu_compatibility: value.icu_compatibility,
             semantic_metadata: value.semantic_metadata,
             obsolete_entries: value.obsolete_entries,
+            fuzzy_flags: value.fuzzy_flags,
         }
     }
 }

--- a/crates/palamedes/Cargo.toml
+++ b/crates/palamedes/Cargo.toml
@@ -8,9 +8,9 @@ rust-version.workspace = true
 description = "Rust core for Palamedes."
 
 [dependencies]
-ferrocat = "=3.1.0"
-ferrocat-icu = "=3.1.0"
-ferrocat-po = "=3.1.0"
+ferrocat = "=3.2.2"
+ferrocat-icu = "=3.2.2"
+ferrocat-po = "=3.2.2"
 ferromark = { version = "=0.7.0", features = ["mdx"] }
 oxc_allocator = "0.141.0"
 oxc_ast = "0.141.0"

--- a/crates/palamedes/src/catalog_artifact/compile.rs
+++ b/crates/palamedes/src/catalog_artifact/compile.rs
@@ -15,21 +15,12 @@ use super::types::{
 /// ICU options that model the JS runtime parser
 /// (`packages/core/src/messageFormat.ts`).
 ///
-/// Catalog texts are canonicalized into strict ICU quoting when they are loaded
-/// (see the `icu_text` module), so [`IcuSyntaxPolicy::Strict`] reads `''`,
-/// `'{`/`'}`, and a plural `'#'` exactly the way the runtime does.
-/// `RuntimeLiteralApostrophes` doubles every apostrophe before parsing instead,
-/// which models `L'{title}` as a live argument, `''` as two apostrophes, and
-/// `'#'` as an active pound — all cases where validation stayed green while the
-/// runtime rendered something else.
-///
-/// Residual divergence: Ferrocat has no lenient-quoting policy, so the parity
-/// comes from the canonicalization pass. Message texts that reach Ferrocat
-/// without going through it (should any future call site skip it) are read with
-/// strict rules, where a bare `don't` is an unterminated quote.
+/// Ferrocat owns the policy-aware canonical form for natural apostrophes and
+/// meaningful ICU quotes, so parsing, artifact text, and compiled IDs stay on
+/// the same contract.
 pub(super) fn runtime_icu_options() -> CompileCatalogArtifactIcuOptions {
     CompileCatalogArtifactIcuOptions::new()
-        .with_syntax_policy(IcuSyntaxPolicy::Strict)
+        .with_syntax_policy(IcuSyntaxPolicy::RuntimeLiteralApostrophes)
         .with_formatter_support(runtime_icu_formatter_support)
 }
 
@@ -43,7 +34,7 @@ pub(super) fn build_artifact_result(
     let artifact = if pseudo_locale == Some(locale) {
         let options = CompiledCatalogPseudolocalizationOptions::new()
             .with_icu_options(IcuPseudolocalizationOptions::new())
-            .with_syntax_policy(IcuSyntaxPolicy::Strict);
+            .with_syntax_policy(IcuSyntaxPolicy::RuntimeLiteralApostrophes);
         pseudolocalize_compiled_catalog_artifact(&artifact, &options)
             .map_err(PalamedesError::PseudolocalizeCatalogArtifact)?
     } else {

--- a/crates/palamedes/src/catalog_artifact/load.rs
+++ b/crates/palamedes/src/catalog_artifact/load.rs
@@ -4,11 +4,9 @@ use std::path::Path;
 
 use ferrocat::{parse_catalog, NormalizedParsedCatalog, ParseCatalogOptions};
 
-use crate::error::{PalamedesError, PalamedesResult};
-use crate::icu_text::canonicalize_catalog_quoting;
-
 use super::resolve::normalize_path;
 use super::types::{CatalogArtifactConfig, CatalogConfig};
+use crate::error::{PalamedesError, PalamedesResult};
 
 pub(super) type LocaleCatalogs = BTreeMap<String, NormalizedParsedCatalog>;
 
@@ -38,11 +36,10 @@ pub(super) fn load_catalogs(
             .with_locale(locale.as_str())
             .with_mode(catalog.format.ferrocat_mode());
 
-        let mut parsed = parse_catalog(options).map_err(|source| PalamedesError::ParseCatalog {
+        let parsed = parse_catalog(options).map_err(|source| PalamedesError::ParseCatalog {
             path: file.clone(),
             source,
         })?;
-        canonicalize_catalog_quoting(&mut parsed);
 
         loaded.insert(
             locale,

--- a/crates/palamedes/src/catalog_artifact/mod.rs
+++ b/crates/palamedes/src/catalog_artifact/mod.rs
@@ -6,7 +6,7 @@ mod types;
 #[cfg(test)]
 mod tests;
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use ferrocat::{
     compile_catalog_artifact as ferrocat_compile_catalog_artifact,
@@ -26,6 +26,16 @@ pub use self::types::{
     CatalogArtifactSelectedRequest, CatalogArtifactSourceKey, CatalogConfig, FallbackLocales,
     PalamedesCatalogFormat,
 };
+
+pub(crate) fn resolve_catalog_path(
+    config: &CatalogArtifactConfig,
+    catalog: &CatalogConfig,
+    locale: &str,
+) -> PathBuf {
+    Path::new(&config.root_dir)
+        .join(catalog.path.replace("{locale}", locale))
+        .with_extension(catalog.format.extension())
+}
 
 struct PreparedCompilation {
     locale: String,
@@ -88,8 +98,12 @@ pub fn compile_catalog_artifact_selected(
 ) -> PalamedesResult<CatalogArtifactResult> {
     let prepared = prepare_compilation(&request.config, &request.resource_path)?;
     let catalogs = prepared.loaded.values().collect::<Vec<_>>();
-    let compiled_id_index = CompiledCatalogIdIndex::new(&catalogs, CompiledKeyStrategy::FerrocatV1)
-        .map_err(PalamedesError::BuildCompiledIdIndex)?;
+    let compiled_id_index = CompiledCatalogIdIndex::new_with_policy(
+        &catalogs,
+        CompiledKeyStrategy::FerrocatV1,
+        ferrocat::IcuSyntaxPolicy::RuntimeLiteralApostrophes,
+    )
+    .map_err(PalamedesError::BuildCompiledIdIndex)?;
     let ferrocat_fallback_chain = ferrocat_fallback_chain(
         &prepared.fallback_chain,
         &prepared.locale,

--- a/crates/palamedes/src/catalog_artifact/resolve.rs
+++ b/crates/palamedes/src/catalog_artifact/resolve.rs
@@ -6,7 +6,7 @@ use crate::error::{PalamedesError, PalamedesResult};
 
 use super::load::load_catalogs;
 use super::types::{CatalogArtifactConfig, FallbackLocales};
-use super::PreparedCompilation;
+use super::{resolve_catalog_path, PreparedCompilation};
 
 #[derive(Debug, Clone)]
 struct ResolvedCatalogRequest {
@@ -156,9 +156,7 @@ fn collect_watch_files(
 
         if matcher.is_match(&primary_pattern) {
             for locale in locale_chain {
-                let candidate = root_dir
-                    .join(catalog.path.replace("{locale}", locale))
-                    .with_extension(catalog.format.extension());
+                let candidate = resolve_catalog_path(config, catalog, locale);
                 if !files.contains(&candidate) {
                     files.push(candidate);
                 }

--- a/crates/palamedes/src/catalog_artifact/tests.rs
+++ b/crates/palamedes/src/catalog_artifact/tests.rs
@@ -3,7 +3,6 @@ use super::{
     CatalogArtifactDiagnosticSeverity, CatalogArtifactRequest, CatalogArtifactSelectedRequest,
     CatalogConfig, PalamedesCatalogFormat,
 };
-use crate::icu_text::canonicalize_runtime_quoting;
 use crate::test_support::scope_macro_test_source;
 use ferrocat::compiled_key;
 use std::collections::BTreeSet;
@@ -409,7 +408,7 @@ msgstr "Konnte {firstName}'s Daten nicht laden"
         .diagnostics
         .iter()
         .any(|diagnostic| diagnostic.code == "icu.missing_argument"
-            && diagnostic.source_key.message == "Couldn''t load {name}"
+            && diagnostic.source_key.message == "Couldn't load {name}"
             && diagnostic.locale == "de"));
     assert!(result
         .diagnostics
@@ -1015,13 +1014,15 @@ const authored = t`L'${title} est prêt`;
     );
 
     // Each translation is actually reachable, not just present as some key.
-    // The compiled value is the canonical form of the catalog text, which the
-    // runtime parser reads back as the translator wrote it.
-    for (id, translation) in transformed.compiled_ids.iter().zip(&translations) {
-        assert_eq!(
-            result.messages.get(id).map(String::as_str),
-            Some(canonicalize_runtime_quoting(translation).as_str())
-        );
+    // Keep the expected canonical strings independent of Ferrocat's helper so
+    // a future policy change cannot silently move both sides of this test.
+    let expected_translations = [
+        "DE Don''t greet {name}",
+        "DE Don''t wave at {name}",
+        "DE L''{title} est prêt",
+    ];
+    for (id, expected) in transformed.compiled_ids.iter().zip(expected_translations) {
+        assert_eq!(result.messages.get(id).map(String::as_str), Some(expected));
     }
 
     // The raw-ICU surfaces resolve through the canonical form of their text ...

--- a/crates/palamedes/src/catalog_audit.rs
+++ b/crates/palamedes/src/catalog_audit.rs
@@ -1,9 +1,9 @@
 use std::collections::BTreeMap;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use ferrocat::{
-    parse_catalog, CatalogAuditIcuOptions, CatalogAuditOptions, IcuSyntaxPolicy,
+    parse_catalog_for_review, CatalogAuditIcuOptions, CatalogAuditOptions, IcuSyntaxPolicy,
     NormalizedParsedCatalog, ParseCatalogOptions,
 };
 use ferrocat_po::audit_catalogs as ferrocat_audit_catalogs;
@@ -11,10 +11,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::diagnostic::{CatalogDiagnosticSeverity, CatalogDiagnosticSourceKey};
 use crate::error::{PalamedesError, PalamedesResult};
-use crate::icu_text::canonicalize_catalog_quoting;
 use crate::message_metadata::MessageMetadataInput;
 
-use super::catalog_artifact::{CatalogArtifactConfig, CatalogConfig};
+use super::catalog_artifact::{resolve_catalog_path, CatalogArtifactConfig, CatalogConfig};
 
 /// Request for auditing configured catalogs.
 #[derive(Debug, Deserialize)]
@@ -55,6 +54,9 @@ pub struct CatalogAuditCheckOptions {
     /// Report obsolete entries.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub obsolete_entries: Option<bool>,
+    /// Report entries carrying a fuzzy review marker.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fuzzy_flags: Option<bool>,
 }
 
 /// Aggregate catalog audit result.
@@ -139,12 +141,8 @@ pub fn audit_catalogs(request: CatalogAuditRequest) -> PalamedesResult<CatalogAu
             .iter()
             .map(String::as_str)
             .collect::<Vec<_>>();
-        // Catalog texts are canonicalized into strict ICU quoting at load time
-        // (see `icu_text`), so the strict parser reads them exactly the way the
-        // JS runtime does. `RuntimeLiteralApostrophes` would instead double
-        // every apostrophe and model `L'{title}` as a live argument that the
-        // runtime actually swallows.
-        let icu_options = CatalogAuditIcuOptions::new().with_syntax_policy(IcuSyntaxPolicy::Strict);
+        let icu_options = CatalogAuditIcuOptions::new()
+            .with_syntax_policy(IcuSyntaxPolicy::RuntimeLiteralApostrophes);
         let options = CatalogAuditOptions::new(&request.config.source_locale)
             .with_locales(&locale_refs)
             .with_metadata(&metadata)
@@ -211,6 +209,9 @@ impl CatalogAuditCheckOptions {
         if let Some(value) = self.obsolete_entries {
             checks.obsolete_entries = value;
         }
+        if let Some(value) = self.fuzzy_flags {
+            checks.fuzzy_flags = value;
+        }
         checks
     }
 }
@@ -246,7 +247,7 @@ fn load_audit_catalogs(
 
     let mut loaded = Vec::new();
     for locale in locales {
-        let path = catalog_path(config, catalog, &locale);
+        let path = resolve_catalog_path(config, catalog, &locale);
         if !path.exists() {
             continue;
         }
@@ -258,18 +259,11 @@ fn load_audit_catalogs(
             .with_locale(locale.as_str())
             .with_mode(catalog.format.ferrocat_mode());
 
-        let mut parsed = parse_catalog(options).map_err(|source| PalamedesError::ParseCatalog {
-            path: path.clone(),
-            source,
-        })?;
-        canonicalize_catalog_quoting(&mut parsed);
         let catalog =
-            parsed
-                .into_normalized_view()
-                .map_err(|source| PalamedesError::NormalizeCatalog {
-                    path: path.clone(),
-                    source,
-                })?;
+            parse_catalog_for_review(options).map_err(|source| PalamedesError::ParseCatalog {
+                path: path.clone(),
+                source,
+            })?;
         loaded.push(LoadedAuditCatalog { catalog });
     }
 
@@ -283,18 +277,17 @@ fn paths_by_locale(
     config
         .locales
         .iter()
-        .map(|locale| (locale.clone(), catalog_path(config, catalog, locale)))
+        .map(|locale| {
+            (
+                locale.clone(),
+                resolve_catalog_path(config, catalog, locale),
+            )
+        })
         .collect()
 }
 
-fn catalog_path(config: &CatalogArtifactConfig, catalog: &CatalogConfig, locale: &str) -> PathBuf {
-    Path::new(&config.root_dir)
-        .join(catalog.path.replace("{locale}", locale))
-        .with_extension(catalog.format.extension())
-}
-
 fn source_catalog_path(config: &CatalogArtifactConfig, catalog: &CatalogConfig) -> PathBuf {
-    catalog_path(config, catalog, &config.source_locale)
+    resolve_catalog_path(config, catalog, &config.source_locale)
 }
 
 fn diagnostic_locale_from_name(code: &str, name: Option<&str>) -> Option<String> {
@@ -460,6 +453,37 @@ msgstr "L'{title} est bereit"
             .diagnostics
             .iter()
             .any(|diagnostic| diagnostic.code == "icu.missing_argument"
+                && diagnostic.locale.as_deref() == Some("de")));
+    }
+
+    #[test]
+    fn reports_fuzzy_entries_through_the_review_aware_catalog() {
+        let fixture = create_fixture_dir("catalog-audit-fuzzy");
+        let locale_dir = fixture.join("src/locales");
+        fs::create_dir_all(&locale_dir).expect("locale dir");
+        fs::write(
+            locale_dir.join("en.po"),
+            "msgid \"Hello\"\nmsgstr \"Hello\"\n",
+        )
+        .expect("write en");
+        fs::write(
+            locale_dir.join("de.po"),
+            "#, fuzzy\nmsgid \"Hello\"\nmsgstr \"Hallo\"\n",
+        )
+        .expect("write de");
+
+        let result = audit_catalogs(CatalogAuditRequest {
+            config: config(&fixture),
+            locales: vec!["de".to_owned()],
+            checks: CatalogAuditCheckOptions::default(),
+            metadata: Vec::new(),
+        })
+        .expect("audit");
+
+        assert!(result
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "catalog.fuzzy_flag"
                 && diagnostic.locale.as_deref() == Some("de")));
     }
 

--- a/crates/palamedes/src/catalog_convert.rs
+++ b/crates/palamedes/src/catalog_convert.rs
@@ -1,0 +1,125 @@
+use std::path::PathBuf;
+
+use ferrocat::{ConvertCatalogFileOptions, OrderBy};
+
+use crate::catalog_combine::CatalogFileFormat;
+use crate::error::{PalamedesError, PalamedesResult};
+
+/// Request for converting one catalog file into another storage format.
+#[derive(Debug)]
+pub struct CatalogFileConvertRequest {
+    /// Input catalog path.
+    pub input_path: PathBuf,
+    /// Output catalog path to replace atomically.
+    pub output_path: PathBuf,
+    /// Explicit source storage format.
+    pub source_format: CatalogFileFormat,
+    /// Explicit target storage format.
+    pub target_format: CatalogFileFormat,
+    /// Source locale used for catalog semantics and validation.
+    pub source_locale: String,
+    /// Optional expected catalog locale.
+    pub locale: Option<String>,
+}
+
+/// Result returned by a catalog file conversion.
+#[derive(Debug)]
+pub struct CatalogFileConvertResult {
+    /// Output path replaced by the operation.
+    pub output_path: PathBuf,
+    /// Number of converted messages, including obsolete entries.
+    pub message_count: usize,
+    /// Non-fatal diagnostics collected during conversion.
+    pub diagnostics: Vec<ferrocat::Diagnostic>,
+}
+
+/// Converts a catalog file through Ferrocat's format-aware, atomic conversion
+/// boundary.
+///
+/// Review metadata such as fuzzy flags and translator comments is preserved
+/// when both formats can represent it.
+///
+/// # Errors
+///
+/// Returns an error when the input cannot be read or parsed, the requested
+/// formats are incompatible, or the output cannot be replaced atomically.
+pub fn convert_catalog_file(
+    request: CatalogFileConvertRequest,
+) -> PalamedesResult<CatalogFileConvertResult> {
+    let mut options = ConvertCatalogFileOptions::new(
+        &request.input_path,
+        &request.output_path,
+        &request.source_locale,
+    )
+    .with_source_format(request.source_format.into())
+    .with_target_format(request.target_format.into())
+    .with_order_by(OrderBy::Msgid);
+    if let Some(locale) = request.locale.as_deref() {
+        options = options.with_locale(locale);
+    }
+
+    let result = ferrocat::convert_catalog_file(options).map_err(PalamedesError::from)?;
+    Ok(CatalogFileConvertResult {
+        output_path: result.output_path,
+        message_count: result.message_count,
+        diagnostics: result.diagnostics,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use super::{convert_catalog_file, CatalogFileConvertRequest};
+    use crate::CatalogFileFormat;
+
+    #[test]
+    fn converts_po_to_fcl_and_preserves_review_metadata() {
+        let fixture = create_fixture_dir("catalog-convert");
+        let input = fixture.join("de.po");
+        let output = fixture.join("de.fcl");
+        fs::write(
+            &input,
+            concat!(
+                "msgid \"\"\n",
+                "msgstr \"\"\n",
+                "\"Language: de\\n\"\n\n",
+                "# Translator note\n",
+                "#, fuzzy\n",
+                "msgid \"Hello\"\n",
+                "msgstr \"Hallo\"\n",
+            ),
+        )
+        .expect("write PO");
+
+        let result = convert_catalog_file(CatalogFileConvertRequest {
+            input_path: input,
+            output_path: output.clone(),
+            source_format: CatalogFileFormat::Po,
+            target_format: CatalogFileFormat::Fcl,
+            source_locale: "en".to_owned(),
+            locale: Some("de".to_owned()),
+        })
+        .expect("convert");
+
+        let converted = fs::read_to_string(&output).expect("read FCL");
+        assert_eq!(result.message_count, 1);
+        assert!(converted.starts_with("%FCL1"));
+        assert!(converted.contains("tc=Translator note"));
+        assert!(converted.contains("f=fuzzy"));
+        assert!(converted.contains("Hallo"));
+    }
+
+    fn create_fixture_dir(label: &str) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let path =
+            std::env::temp_dir().join(format!("palamedes-{label}-{}-{unique}", std::process::id()));
+        fs::create_dir_all(&path).expect("fixture dir");
+        path
+    }
+}

--- a/crates/palamedes/src/catalog_coverage.rs
+++ b/crates/palamedes/src/catalog_coverage.rs
@@ -1,0 +1,246 @@
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+
+use ferrocat::{parse_catalog_for_review, CatalogCoverageOptions, NormalizedParsedCatalog};
+use ferrocat_po::measure_catalog_coverage as ferrocat_measure_catalog_coverage;
+use serde::Serialize;
+
+use crate::catalog_artifact::{resolve_catalog_path, CatalogArtifactConfig, CatalogConfig};
+use crate::error::{PalamedesError, PalamedesResult};
+
+/// Request for measuring configured catalog coverage.
+#[derive(Debug)]
+pub struct CatalogCoverageRequest {
+    /// Catalog configuration used to resolve files and formats.
+    pub config: CatalogArtifactConfig,
+    /// Locales to report. The source locale may be included explicitly.
+    pub locales: Vec<String>,
+}
+
+/// Aggregate catalog coverage result.
+#[derive(Debug, Serialize)]
+pub struct CatalogCoverageResult {
+    /// Per-locale coverage in deterministic locale order.
+    pub locales: Vec<CatalogLocaleCoverageResult>,
+}
+
+/// Product-facing coverage counters for one locale.
+#[derive(Debug, Serialize)]
+pub struct CatalogLocaleCoverageResult {
+    /// Locale represented by these counters.
+    pub locale: String,
+    /// Active source messages expected for the locale.
+    pub total: usize,
+    /// Expected messages with complete, non-fuzzy translations.
+    pub translated: usize,
+    /// Expected messages that still need translator attention.
+    pub missing: usize,
+    /// Expected messages carrying a fuzzy review marker.
+    pub fuzzy: usize,
+    /// Completion as a `0.0..=100.0` percentage.
+    pub percent: f64,
+}
+
+#[derive(Debug)]
+struct MutableLocaleCoverage {
+    locale: String,
+    total: usize,
+    translated: usize,
+    missing: usize,
+    fuzzy: usize,
+}
+
+/// Measures completeness for configured catalogs through Ferrocat's
+/// review-aware coverage classifier.
+///
+/// Missing target files count every active source message as incomplete.
+/// Fuzzy markers in PO and FCL are classified identically.
+///
+/// # Errors
+///
+/// Returns an error when a source catalog or an existing target catalog cannot
+/// be read, parsed, or normalized.
+pub fn measure_catalog_coverage(
+    request: CatalogCoverageRequest,
+) -> PalamedesResult<CatalogCoverageResult> {
+    let mut coverage = request
+        .locales
+        .iter()
+        .map(|locale| {
+            (
+                locale.clone(),
+                MutableLocaleCoverage {
+                    locale: locale.clone(),
+                    total: 0,
+                    translated: 0,
+                    missing: 0,
+                    fuzzy: 0,
+                },
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+
+    for catalog_config in &request.config.catalogs {
+        let source_path = resolve_catalog_path(
+            &request.config,
+            catalog_config,
+            &request.config.source_locale,
+        );
+        let source_catalog = load_catalog(
+            &source_path,
+            &request.config.source_locale,
+            &request.config.source_locale,
+            catalog_config,
+        )?;
+        let source_messages = source_catalog
+            .parsed_catalog()
+            .messages
+            .iter()
+            .filter(|message| message.obsolete.is_none())
+            .count();
+
+        for locale in &request.locales {
+            let Some(locale_coverage) = coverage.get_mut(locale) else {
+                continue;
+            };
+            locale_coverage.total += source_messages;
+
+            if locale == &request.config.source_locale {
+                locale_coverage.translated += source_messages;
+                continue;
+            }
+
+            let target_path = resolve_catalog_path(&request.config, catalog_config, locale);
+            if !target_path.exists() {
+                locale_coverage.missing += source_messages;
+                continue;
+            }
+            let target_catalog = load_catalog(
+                &target_path,
+                &request.config.source_locale,
+                locale,
+                catalog_config,
+            )?;
+            let report = ferrocat_measure_catalog_coverage(
+                &[&source_catalog, &target_catalog],
+                &CatalogCoverageOptions::new(&request.config.source_locale),
+            )
+            .map_err(PalamedesError::from)?;
+            let target = report
+                .locales
+                .iter()
+                .find(|entry| entry.locale == *locale)
+                .ok_or_else(|| {
+                    ferrocat::ApiError::InvalidArguments(format!(
+                        "measure_catalog_coverage did not return requested locale {locale:?}"
+                    ))
+                })
+                .map_err(PalamedesError::from)?;
+            locale_coverage.translated += target.translated;
+            locale_coverage.missing += target.incomplete();
+            locale_coverage.fuzzy += target.fuzzy();
+        }
+    }
+
+    Ok(CatalogCoverageResult {
+        locales: coverage
+            .into_values()
+            .map(|locale| CatalogLocaleCoverageResult {
+                percent: if locale.total == 0 {
+                    100.0
+                } else {
+                    (locale.translated as f64 / locale.total as f64) * 100.0
+                },
+                locale: locale.locale,
+                total: locale.total,
+                translated: locale.translated,
+                missing: locale.missing,
+                fuzzy: locale.fuzzy,
+            })
+            .collect(),
+    })
+}
+
+fn load_catalog(
+    path: &Path,
+    source_locale: &str,
+    locale: &str,
+    catalog: &CatalogConfig,
+) -> PalamedesResult<NormalizedParsedCatalog> {
+    let content = fs::read_to_string(path).map_err(|source| PalamedesError::ReadFile {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    parse_catalog_for_review(
+        ferrocat::ParseCatalogOptions::new(&content, source_locale)
+            .with_locale(locale)
+            .with_mode(catalog.format.ferrocat_mode()),
+    )
+    .map_err(|source| PalamedesError::ParseCatalog {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use super::{measure_catalog_coverage, CatalogCoverageRequest};
+    use crate::{CatalogArtifactConfig, CatalogConfig, PalamedesCatalogFormat};
+
+    #[test]
+    fn classifies_fcl_fuzzy_and_missing_catalogs_as_incomplete() {
+        let fixture = create_fixture_dir("catalog-coverage");
+        let locale_dir = fixture.join("locales");
+        fs::create_dir_all(&locale_dir).expect("locale dir");
+        fs::write(
+            locale_dir.join("en.fcl"),
+            "%FCL1\tsource=en\nHello\t\tHello\n",
+        )
+        .expect("write source");
+        fs::write(
+            locale_dir.join("de.fcl"),
+            "%FCL1\tsource=en\nHello\t\tHallo\tf=fuzzy\n",
+        )
+        .expect("write target");
+
+        let result = measure_catalog_coverage(CatalogCoverageRequest {
+            config: CatalogArtifactConfig {
+                root_dir: fixture.to_string_lossy().into_owned(),
+                locales: vec!["en".to_owned(), "de".to_owned(), "fr".to_owned()],
+                source_locale: "en".to_owned(),
+                fallback_locales: None,
+                pseudo_locale: None,
+                catalogs: vec![CatalogConfig {
+                    path: "locales/{locale}".to_owned(),
+                    format: PalamedesCatalogFormat::Fcl,
+                }],
+            },
+            locales: vec!["de".to_owned(), "fr".to_owned()],
+        })
+        .expect("coverage");
+
+        assert_eq!(result.locales[0].locale, "de");
+        assert_eq!(result.locales[0].translated, 0);
+        assert_eq!(result.locales[0].missing, 1);
+        assert_eq!(result.locales[0].fuzzy, 1);
+        assert_eq!(result.locales[1].locale, "fr");
+        assert_eq!(result.locales[1].missing, 1);
+        assert_eq!(result.locales[1].fuzzy, 0);
+    }
+
+    fn create_fixture_dir(label: &str) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let path =
+            std::env::temp_dir().join(format!("palamedes-{label}-{}-{unique}", std::process::id()));
+        fs::create_dir_all(&path).expect("fixture dir");
+        path
+    }
+}

--- a/crates/palamedes/src/icu_text.rs
+++ b/crates/palamedes/src/icu_text.rs
@@ -9,15 +9,9 @@
 //! * Every other apostrophe is ordinary text (`don't` renders verbatim).
 //! * An unterminated quote auto-closes at the end of the pattern.
 //!
-//! Two things follow from that, and both live here so the extractor, the
-//! transform, and catalog validation cannot drift apart:
-//!
-//! * [`escape_icu_literal`] escapes authored literal segments (template literal
-//!   quasis, JSX text, choice option strings) so an authored apostrophe never
-//!   turns into a quote that swallows the following placeholder.
-//! * [`canonicalize_runtime_quoting`] rewrites a runtime-dialect pattern into
-//!   the equivalent strictly quoted pattern that Ferrocat's ICU parser reads the
-//!   same way the runtime does.
+//! [`escape_icu_literal`] escapes authored literal segments (template literal
+//! quasis, JSX text, choice option strings) so an authored apostrophe never
+//! turns into a quote that swallows the following placeholder.
 
 /// Escapes authored literal text for embedding into an ICU message pattern.
 ///
@@ -33,220 +27,22 @@ pub(crate) fn escape_icu_literal(text: &str) -> String {
     }
 }
 
-/// Rewrites a runtime-dialect ICU pattern into strict ICU quoting.
-///
-/// Ferrocat parses ICU MessageFormat v1 with strict apostrophe rules, where any
-/// apostrophe opens a quoted literal. Feeding it the runtime dialect directly
-/// either rejects natural apostrophes (`don't`) or — with Ferrocat's
-/// `RuntimeLiteralApostrophes` policy, which doubles every apostrophe first —
-/// silently models `L'{title}` as a live argument that the runtime actually
-/// swallows. Canonicalizing first gives both parsers the same reading:
-///
-/// * ordinary apostrophes are doubled (`don't` -> `don''t`),
-/// * runtime quotes are re-emitted terminated (`L'{title}` -> `L'{title}'`),
-/// * `''` stays a single escaped apostrophe.
-///
-/// The result is a fixed point: every apostrophe in the output is either
-/// doubled or opens a terminated quote whose first character is `{`, `}`, or a
-/// plural `#`, which the strict and the lenient parser read identically.
-pub(crate) fn canonicalize_runtime_quoting(pattern: &str) -> String {
-    if !pattern.contains('\'') {
-        return pattern.to_owned();
-    }
-
-    let bytes = pattern.as_bytes();
-    let mut out = String::with_capacity(pattern.len() + 8);
-    // Stack of "is `#` syntax here" flags, one per open brace group.
-    let mut pound_stack = vec![false];
-    let mut index = 0usize;
-
-    while index < bytes.len() {
-        match bytes[index] {
-            b'\'' => index = push_apostrophe(pattern, index, pound_active(&pound_stack), &mut out),
-            b'{' => {
-                let inherited = pound_active(&pound_stack);
-                pound_stack.push(inherited || opens_plural_argument(pattern, index));
-                out.push('{');
-                index += 1;
-            }
-            b'}' => {
-                if pound_stack.len() > 1 {
-                    pound_stack.pop();
-                }
-                out.push('}');
-                index += 1;
-            }
-            _ => {
-                let start = index;
-                index += 1;
-                while index < bytes.len() && !matches!(bytes[index], b'\'' | b'{' | b'}') {
-                    index += 1;
-                }
-                out.push_str(&pattern[start..index]);
-            }
-        }
-    }
-
-    out
-}
-
-/// Canonicalizes every message text of a parsed catalog in place.
-///
-/// Catalog validation (audit, artifact compilation, pseudo-localization) runs on
-/// Ferrocat's strict ICU parser, so the runtime dialect has to be translated
-/// once, right after parsing, for both sides of a message: the `msgid` that the
-/// authoring pipeline produced and the translations that came back from
-/// translators.
-///
-/// Canonicalizing the `msgid` also rewrites the compiled-id input for catalogs
-/// that still carry unescaped apostrophes from an older extractor; those ids
-/// move to the value the current extractor and transform produce, which is
-/// exactly what the runtime bundle asks for.
-pub(crate) fn canonicalize_catalog_quoting(catalog: &mut ferrocat::ParsedCatalog) {
-    for message in &mut catalog.messages {
-        canonicalize_in_place(&mut message.msgid);
-        match &mut message.translation {
-            ferrocat::TranslationShape::Singular { value } => canonicalize_in_place(value),
-            ferrocat::TranslationShape::Plural {
-                source,
-                translation,
-                ..
-            } => {
-                if let Some(one) = source.one.as_mut() {
-                    canonicalize_in_place(one);
-                }
-                canonicalize_in_place(&mut source.other);
-                for value in translation.values_mut() {
-                    canonicalize_in_place(value);
-                }
-            }
-        }
-    }
-}
-
 /// Derives the compiled lookup id for a message text.
 ///
-/// Catalog compilation canonicalizes every catalog text on load (see
-/// [`canonicalize_catalog_quoting`]) and only then hands the `msgid` to
-/// Ferrocat's key derivation, so a compiled artifact is always keyed by the
-/// hash of the *canonical* text. Every other derivation of the same id — the
-/// lookup key the transform embeds in `getI18n()._("…")`, the ids it reports as
-/// `compiled_ids`, extractor-side parity checks — has to go through this helper
-/// so it hashes the same string.
-///
-/// Without it the raw-ICU authoring surfaces (descriptor string literals and
-/// the `<Trans message>` attribute, where authors write ICU quoting themselves
-/// and neither extractor nor transform escapes anything) hash a text the
-/// compiled catalog never contains, and the runtime silently falls back to the
-/// source message.
-///
-/// Only the message text is canonicalized: `context` is a plain disambiguation
-/// string, not ICU, and catalog loading leaves it untouched as well.
-///
-/// Because [`canonicalize_runtime_quoting`] is a fixed point, already-escaped
-/// authored text (`don''t`) keeps exactly the id it had before, so ids for the
-/// escaping paths are unchanged.
+/// The runtime syntax policy keeps transform-side IDs aligned with Ferrocat's
+/// policy-aware artifact compilation. Context is not ICU and stays untouched.
 pub(crate) fn compiled_message_key(message: &str, context: Option<&str>) -> String {
-    ferrocat::compiled_key(&canonicalize_runtime_quoting(message), context)
-}
-
-fn canonicalize_in_place(value: &mut String) {
-    if value.contains('\'') {
-        *value = canonicalize_runtime_quoting(value);
-    }
-}
-
-fn pound_active(stack: &[bool]) -> bool {
-    stack.last().copied().unwrap_or(false)
-}
-
-/// Emits the canonical form of the apostrophe at `index` and returns the next
-/// index to read.
-fn push_apostrophe(pattern: &str, index: usize, pound_active: bool, out: &mut String) -> usize {
-    let bytes = pattern.as_bytes();
-    let next = bytes.get(index + 1).copied();
-
-    if next == Some(b'\'') {
-        out.push_str("''");
-        return index + 2;
-    }
-
-    let starts_quote =
-        matches!(next, Some(b'{') | Some(b'}')) || (pound_active && next == Some(b'#'));
-    if !starts_quote {
-        // Ordinary text apostrophe: the runtime renders it verbatim, so escape
-        // it for the strict parser.
-        out.push_str("''");
-        return index + 1;
-    }
-
-    let (literal, end) = read_quoted_literal(pattern, index + 1);
-    out.push('\'');
-    out.push_str(&literal.replace('\'', "''"));
-    out.push('\'');
-    end
-}
-
-/// Reads a runtime quoted literal starting after the opening apostrophe,
-/// mirroring `parseQuotedLiteral` in the runtime parser: `''` is a literal
-/// apostrophe, a lone `'` closes the quote, and the end of the pattern
-/// auto-closes it.
-fn read_quoted_literal(pattern: &str, start: usize) -> (String, usize) {
-    let bytes = pattern.as_bytes();
-    let mut literal = String::new();
-    let mut index = start;
-
-    while index < bytes.len() {
-        if bytes[index] != b'\'' {
-            let chunk_start = index;
-            index += 1;
-            while index < bytes.len() && bytes[index] != b'\'' {
-                index += 1;
-            }
-            literal.push_str(&pattern[chunk_start..index]);
-            continue;
-        }
-
-        if bytes.get(index + 1).copied() == Some(b'\'') {
-            literal.push('\'');
-            index += 2;
-            continue;
-        }
-
-        return (literal, index + 1);
-    }
-
-    (literal, index)
-}
-
-/// Reports whether the brace group opening at `index` is a plural or
-/// selectordinal argument, whose branches make `#` syntax.
-fn opens_plural_argument(pattern: &str, index: usize) -> bool {
-    let rest = &pattern[index + 1..];
-    let Some((_, after_name)) = split_argument_part(rest) else {
-        return false;
-    };
-    let Some((kind, _)) = split_argument_part(after_name) else {
-        return false;
-    };
-
-    matches!(kind.trim(), "plural" | "selectordinal")
-}
-
-/// Splits `input` at the next `,`, returning the part before it and the rest.
-/// Returns `None` when the argument ends (`}`) or is unterminated.
-fn split_argument_part(input: &str) -> Option<(&str, &str)> {
-    let stop = input.find([',', '}', '{'])?;
-    if input.as_bytes()[stop] != b',' {
-        return None;
-    }
-
-    Some((&input[..stop], &input[stop + 1..]))
+    ferrocat::compiled_key_with_policy(
+        message,
+        context,
+        ferrocat::IcuSyntaxPolicy::RuntimeLiteralApostrophes,
+    )
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{canonicalize_runtime_quoting, compiled_message_key, escape_icu_literal};
+    use super::{compiled_message_key, escape_icu_literal};
+    use ferrocat::{canonicalize_icu_with_policy, IcuSyntaxPolicy};
 
     #[test]
     fn doubles_authored_apostrophes() {
@@ -256,44 +52,46 @@ mod tests {
     }
 
     #[test]
-    fn canonicalizes_natural_apostrophes() {
-        assert_eq!(canonicalize_runtime_quoting("don't"), "don''t");
-        assert_eq!(
-            canonicalize_runtime_quoting("no apostrophe"),
-            "no apostrophe"
-        );
+    fn runtime_apostrophe_policy_keeps_stable_golden_values() {
+        let cases = [
+            ("don't", "don''t"),
+            ("don''t", "don''t"),
+            ("L'{title} est prêt", "L'{title} est prêt'"),
+            (
+                "{count, plural, other {'#' items}}",
+                "{count, plural, other {'#' items}}",
+            ),
+            ("'#' items", "''#'' items"),
+            (
+                "{count, select, other {'#' items}}",
+                "{count, select, other {''#'' items}}",
+            ),
+        ];
+
+        for (pattern, expected) in cases {
+            let canonical =
+                canonicalize_icu_with_policy(pattern, IcuSyntaxPolicy::RuntimeLiteralApostrophes);
+            assert_eq!(canonical.as_ref(), expected, "pattern: {pattern}");
+        }
     }
 
     #[test]
-    fn keeps_escaped_apostrophes_single() {
-        assert_eq!(canonicalize_runtime_quoting("don''t"), "don''t");
-    }
-
-    #[test]
-    fn terminates_runtime_quotes_that_swallow_placeholders() {
-        assert_eq!(
-            canonicalize_runtime_quoting("L'{title} est prêt"),
-            "L'{title} est prêt'"
-        );
-        assert_eq!(
-            canonicalize_runtime_quoting("'{name}' stays"),
-            "'{name}' stays"
-        );
-    }
-
-    #[test]
-    fn treats_pound_quotes_as_syntax_only_inside_plural_branches() {
-        assert_eq!(
-            canonicalize_runtime_quoting("{count, plural, other {'#' items}}"),
-            "{count, plural, other {'#' items}}"
-        );
-        // Outside a plural branch `#` is ordinary text, so both apostrophes are
-        // literal characters.
-        assert_eq!(canonicalize_runtime_quoting("'#' items"), "''#'' items");
-        assert_eq!(
-            canonicalize_runtime_quoting("{count, select, other {'#' items}}"),
-            "{count, select, other {''#'' items}}"
-        );
+    fn runtime_apostrophe_policy_is_idempotent() {
+        for pattern in [
+            "don't",
+            "L'{title} est prêt",
+            "{count, plural, other {'#' items}}",
+            "'#' items",
+            "''",
+        ] {
+            let canonical =
+                canonicalize_icu_with_policy(pattern, IcuSyntaxPolicy::RuntimeLiteralApostrophes);
+            let repeated = canonicalize_icu_with_policy(
+                canonical.as_ref(),
+                IcuSyntaxPolicy::RuntimeLiteralApostrophes,
+            );
+            assert_eq!(repeated, canonical, "pattern: {pattern}");
+        }
     }
 
     #[test]
@@ -320,23 +118,5 @@ mod tests {
             compiled_message_key("Hello", Some("don't touch")),
             ferrocat::compiled_key("Hello", Some("don't touch"))
         );
-    }
-
-    #[test]
-    fn is_idempotent() {
-        for pattern in [
-            "don't",
-            "L'{title} est prêt",
-            "{count, plural, other {'#' items}}",
-            "'#' items",
-            "''",
-        ] {
-            let once = canonicalize_runtime_quoting(pattern);
-            assert_eq!(
-                canonicalize_runtime_quoting(&once),
-                once,
-                "pattern: {pattern}"
-            );
-        }
     }
 }

--- a/crates/palamedes/src/lib.rs
+++ b/crates/palamedes/src/lib.rs
@@ -21,6 +21,8 @@ use std::collections::BTreeMap;
 mod catalog_artifact;
 mod catalog_audit;
 mod catalog_combine;
+mod catalog_convert;
+mod catalog_coverage;
 mod catalog_update;
 mod choice;
 mod descriptor;
@@ -57,6 +59,13 @@ pub use catalog_combine::{
     CatalogCombineResult, CatalogCombineSelection, CatalogCombineStats, CatalogConflictStrategy,
     CatalogFileCombineRequest, CatalogFileCombineResult, CatalogFileFormat,
 };
+pub use catalog_convert::{
+    convert_catalog_file, CatalogFileConvertRequest, CatalogFileConvertResult,
+};
+pub use catalog_coverage::{
+    measure_catalog_coverage, CatalogCoverageRequest, CatalogCoverageResult,
+    CatalogLocaleCoverageResult,
+};
 pub use catalog_update::{
     parse_catalog, update_catalog_file, AiProvenance, CatalogOriginMetadata, CatalogParseRequest,
     CatalogParseResult, CatalogUpdateMessage, CatalogUpdateOrigin, CatalogUpdateRequest,
@@ -89,7 +98,7 @@ pub use transform::{
 };
 
 /// Published `ferrocat` version used by the Rust core.
-pub const FERROCAT_VERSION: &str = "3.1.0";
+pub const FERROCAT_VERSION: &str = "3.2.2";
 
 /// Version metadata for the loaded native core.
 #[derive(Debug, Serialize)]

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -51,7 +51,8 @@ Options:
 
 ## `pmds audit`
 
-Audits catalogs for missing translations and ICU authoring issues.
+Audits catalogs for missing translations, fuzzy review markers, and ICU
+authoring issues across PO and FCL.
 
 ```bash
 pmds audit
@@ -74,9 +75,9 @@ Options:
 
 Reports per-locale translation completeness from configured catalogs. Source
 locale entries count as translated; target locales are compared against the
-source catalog messages that are not obsolete. PO entries flagged `fuzzy`
-need review and count as untranslated (reported in a separate `fuzzy`
-column), matching gettext conventions.
+source catalog messages that are not obsolete. PO and FCL entries marked
+`fuzzy` need review and count as untranslated (reported in a separate `fuzzy`
+column).
 
 ```bash
 pmds report
@@ -129,8 +130,9 @@ Options:
 
 ## `pmds catalog convert`
 
-Converts supported PO catalogs to Ferrocat Catalog Lines (FCL). Conversion
-fails before writing output when a PO source contains raw `fuzzy` flags.
+Converts supported PO catalogs to Ferrocat Catalog Lines (FCL). Translator
+comments, obsolete state, and review markers such as `fuzzy` are preserved.
+The output file is replaced only after conversion succeeds.
 
 ```bash
 pmds catalog convert src/locales/de.po --to fcl --output src/locales/de.fcl

--- a/docs/migrations/1.0.0.md
+++ b/docs/migrations/1.0.0.md
@@ -90,8 +90,9 @@ Convert every configured PO catalog:
 pmds catalog convert --config palamedes.yaml --to fcl
 ```
 
-Conversion fails before writing output when a PO source contains raw `fuzzy`
-flags. Reverse FCL-to-PO conversion is not part of 1.0.
+Palamedes 1.0 originally rejected PO catalogs containing raw `fuzzy` flags.
+Current releases preserve those review markers when converting to FCL.
+Reverse FCL-to-PO conversion is not exposed by the Palamedes CLI.
 
 ## Metadata Shape
 
@@ -145,7 +146,8 @@ undated entries.
 - `CatalogFileFormat` no longer accepts `ndjson`.
 - Native catalog format enums expose `Po | Fcl`.
 - TypeScript wrapper APIs expose `"po" | "fcl"`.
-- `fuzzyFlags` and fuzzy report columns are removed.
+- Palamedes 1.0 removed `fuzzyFlags` and fuzzy report columns. Current releases
+  expose both again through Ferrocat's format-neutral review semantics.
 
 ## More Detail
 

--- a/docs/plans/2026-06-30-ferrocat-2-migration-rfc.md
+++ b/docs/plans/2026-06-30-ferrocat-2-migration-rfc.md
@@ -1,9 +1,13 @@
 # RFC: Ferrocat 2.x Migration
 
-**Status:** Active plan
+**Status:** Superseded by the Ferrocat 3.2 integration (2026-07-31)
 **Date:** 2026-06-30 (updated 2026-07-03 for the Ferrocat 2.1.1 baseline)
 **Owner:** Palamedes maintainers
 **Tracking issue:** [palamedes#285](https://github.com/sebastian-software/palamedes/issues/285)
+
+> Historical note: Ferrocat 3.2 supersedes this RFC's fuzzy and conversion
+> constraints. Current Palamedes releases preserve review markers across PO/FCL
+> conversion and use Ferrocat's format-neutral audit and coverage semantics.
 
 ## Summary
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -67,8 +67,11 @@ pnpm exec pmds catalog convert src/locales/de.po --to fcl --output src/locales/d
 ```
 
 `pmds audit` reports missing translations, extra catalog entries, obsolete
-messages, and ICU compatibility issues through the same `ferrocat`
+messages, fuzzy review markers, and ICU compatibility issues through the same `ferrocat`
 catalog engine that powers Palamedes builds.
+
+`pmds catalog convert` preserves translator comments, obsolete state, and
+review markers such as `fuzzy` when converting PO catalogs to FCL.
 
 `--threads <COUNT>` sets the worker threads for the parallel extraction pass,
 overriding `extract-threads` in the config; it defaults to `4` and `1` runs

--- a/packages/core-node/src/generated/palamedes-node-types.ts
+++ b/packages/core-node/src/generated/palamedes-node-types.ts
@@ -139,6 +139,7 @@ export interface CatalogAuditCheckOptions {
   icuCompatibility?: boolean;
   semanticMetadata?: boolean;
   obsoleteEntries?: boolean;
+  fuzzyFlags?: boolean;
 }
 export interface CatalogAuditRequest {
   config: CatalogArtifactConfig;


### PR DESCRIPTION
## Summary

- pin `ferrocat`, `ferrocat-icu`, and `ferrocat-po` to 3.2.2
- replace Palamedes' local ICU apostrophe canonicalizer with Ferrocat's runtime syntax policy for compilation, selected IDs, pseudolocalization, and audits
- route `pmds catalog convert` through Ferrocat's atomic PO/FCL conversion so translator comments, obsolete state, and `fuzzy` review markers survive
- route `pmds report` through Ferrocat's review-aware coverage classifier, including format-neutral PO/FCL fuzzy handling while keeping the existing CLI/JSON counters
- restore `fuzzyFlags` in the high-level audit options across Rust, N-API, and generated TypeScript types
- update current docs and mark the Ferrocat 2 migration RFC's fuzzy/conversion constraints as superseded

## Why

Ferrocat 3.2.2 now owns the policy-aware ICU canonical form, semantic review metadata, catalog coverage, and explicit format conversion boundaries that Palamedes previously approximated locally. Adopting those APIs removes duplicated behavior and fixes PO-to-FCL conversion of fuzzy catalogs.

## Validation

- `cargo +1.95 fmt --all --check`
- `cargo +1.95 clippy --workspace --all-targets --locked -- -D warnings`
- `cargo +1.95 test --workspace --locked`
- `RUSTUP_TOOLCHAIN=1.95 pnpm build`
- `RUSTUP_TOOLCHAIN=1.95 pnpm check-types`
- `RUSTUP_TOOLCHAIN=1.95 pnpm test`
- `pnpm format:check`
- `pnpm lint`
- `pnpm check:published-types`
- `pnpm check:release-set`
- generated N-API type check repeated after rebasing onto Palamedes 1.9.0
