### PR TITLE
perf: profile-driven extract workflow speedups (post-Ferrocat 3.2.2)

### DIFF
--- a/benchmarks/e2e-workflow/src/corpus.mjs
+++ b/benchmarks/e2e-workflow/src/corpus.mjs
@@ -246,6 +246,12 @@ async function writeRealisticSourceFiles(rootDir, sourceMessages, profile, rende
   }
 
   const generatedDir = path.join(rootDir, "src", "generated")
+  /*
+   * Pending write thunks, flushed in bounded batches below. All four tool
+   * workspaces are generated concurrently, so an unbounded Promise.all here
+   * can hold thousands of file descriptors at once and fail with EMFILE on
+   * hosts with a conservative open-file limit.
+   */
   const writes = []
   let fileIndex = 0
 
@@ -253,8 +259,9 @@ async function writeRealisticSourceFiles(rootDir, sourceMessages, profile, rende
    * whereas .tsx + filler + <Trans> hits a JSX parse edge in the extractor. */
   for (let i = 0; i < profile.markedFiles; i += 1) {
     const filename = path.join(generatedDir, `fixture-${String(fileIndex).padStart(4, "0")}.ts`)
-    writes.push(
-      writeFile(filename, renderer(fileIndex, marked[i], "ts", profile.markedFileLines), "utf8")
+    const renderedIndex = fileIndex
+    writes.push(() =>
+      writeFile(filename, renderer(renderedIndex, marked[i], "ts", profile.markedFileLines), "utf8")
     )
     fileIndex += 1
   }
@@ -265,13 +272,17 @@ async function writeRealisticSourceFiles(rootDir, sourceMessages, profile, rende
       generatedDir,
       `fixture-${String(fileIndex).padStart(4, "0")}.${extension}`
     )
-    writes.push(
-      writeFile(filename, renderFillerModule(fileIndex, profile.unmarkedFileLines), "utf8")
+    const renderedIndex = fileIndex
+    writes.push(() =>
+      writeFile(filename, renderFillerModule(renderedIndex, profile.unmarkedFileLines), "utf8")
     )
     fileIndex += 1
   }
 
-  await Promise.all(writes)
+  const batchSize = 128
+  for (let start = 0; start < writes.length; start += batchSize) {
+    await Promise.all(writes.slice(start, start + batchSize).map((write) => write()))
+  }
 }
 
 const FILLER_UNIT_LINES = 13

--- a/crates/palamedes-cli/src/commands/extract/mod.rs
+++ b/crates/palamedes-cli/src/commands/extract/mod.rs
@@ -305,7 +305,10 @@ fn write_catalogs(
                             .skip(worker)
                             .step_by(worker_count)
                             .map(|(index, (catalog, messages, locale))| {
-                                (index, write_catalog(catalog, locale, messages, config, options))
+                                (
+                                    index,
+                                    write_catalog(catalog, locale, messages, config, options),
+                                )
                             })
                             .collect::<Vec<_>>()
                     })

--- a/crates/palamedes-cli/src/commands/extract/mod.rs
+++ b/crates/palamedes-cli/src/commands/extract/mod.rs
@@ -6,9 +6,9 @@ mod sources;
 mod test_support;
 mod watch;
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::Instant;
 
 use clap::Args;
@@ -22,7 +22,7 @@ use crate::command::{Command, Context};
 use crate::config::{ConfigCatalog, LoadedConfig};
 use crate::error::CliError;
 use cache::{load_extract_cache, persist_extract_cache};
-use sources::collect_source_files;
+use sources::{collect_source_files, sort_and_dedupe_paths};
 use watch::run_watch_mode;
 
 /// Prefix the benchmark harness looks for when `PALAMEDES_TIMING_JSON=1`
@@ -115,14 +115,11 @@ fn run_extraction_with_cache(
     cache: &mut ExtractCache,
 ) -> Result<(), CliError> {
     let started_at = Instant::now();
-    let mut total_write_ms = 0;
     let mut total_glob_ms = 0;
     let mut total_extract_ms = 0;
     let mut total_messages = 0;
-    // Catalogs may match overlapping file sets; count each source file once.
-    let mut unique_files = BTreeSet::new();
-    // Same for failures: an overlapping file must be reported and counted once,
-    // not once per catalog that matched it.
+    // Failures from overlapping catalogs must be reported and counted once,
+    // not once per catalog that matched the file.
     let mut unique_failures = BTreeMap::<String, String>::new();
     let mut results = Vec::with_capacity(config.catalogs.len());
 
@@ -131,7 +128,6 @@ fn run_extraction_with_cache(
         total_glob_ms += result.glob_ms;
         total_extract_ms += result.extract_ms;
         total_messages += result.messages.len();
-        unique_files.extend(result.files.iter().cloned());
         for failure in &result.failed_files {
             unique_failures
                 .entry(failure.path.clone())
@@ -139,6 +135,23 @@ fn run_extraction_with_cache(
         }
         results.push(result);
     }
+
+    /*
+     * Catalogs may match overlapping file sets; count each source file once.
+     * Every per-catalog list arrives sorted and deduped from
+     * collect_source_files, so the common single-catalog configuration needs
+     * no second pass at all.
+     */
+    let unique_files: Vec<&Path> = if results.len() == 1 {
+        results[0].files.iter().map(PathBuf::as_path).collect()
+    } else {
+        let mut merged: Vec<&Path> = results
+            .iter()
+            .flat_map(|result| result.files.iter().map(PathBuf::as_path))
+            .collect();
+        sort_and_dedupe_paths(&mut merged);
+        merged
+    };
     let total_files = unique_files.len();
 
     for (path, message) in &unique_failures {
@@ -167,11 +180,15 @@ fn run_extraction_with_cache(
         });
     }
 
+    let write_started_at = Instant::now();
+    let mut write_jobs = Vec::with_capacity(config.catalogs.len() * config.locales.len());
     for (catalog, result) in config.catalogs.iter().zip(&results) {
         for locale in &config.locales {
-            total_write_ms += write_catalog(catalog, locale, &result.messages, config, options)?;
+            write_jobs.push((catalog, &result.messages, locale.as_str()));
         }
     }
+    write_catalogs(&write_jobs, config, options)?;
+    let total_write_ms = write_started_at.elapsed().as_millis();
 
     let total_ms = started_at.elapsed().as_millis();
     println!("✓ Extracted {total_messages} messages from {total_files} files ({total_ms}ms)");
@@ -245,14 +262,81 @@ fn extract_from_catalog(
     })
 }
 
+/*
+ * Each (catalog, locale) write is independent work against a distinct target
+ * file, so the jobs run concurrently. That overlaps the CPU-bound
+ * parse/merge/serialize work in ferrocat across locales and — just as
+ * important on macOS, where `File::sync_all` issues an F_FULLFSYNC barrier
+ * per written catalog and its directory — the per-file durability stalls that
+ * dominate the write phase for small catalogs.
+ *
+ * Outcomes are collected per job and reported in job order afterwards, so
+ * verbose output and the first error stay deterministic regardless of how the
+ * work was scheduled. Unlike the former serial loop, later writes are still
+ * attempted when an earlier one fails; the first failure in job order is the
+ * one returned.
+ */
+fn write_catalogs(
+    write_jobs: &[(&ConfigCatalog, &Vec<CatalogUpdateMessage>, &str)],
+    config: &LoadedConfig,
+    options: &ExtractOptions,
+) -> Result<(), CliError> {
+    let worker_count = write_jobs.len().min(
+        std::thread::available_parallelism()
+            .map(std::num::NonZeroUsize::get)
+            .unwrap_or(1),
+    );
+
+    let mut outcomes: Vec<Option<Result<Vec<String>, CliError>>> = Vec::new();
+    outcomes.resize_with(write_jobs.len(), || None);
+
+    if worker_count <= 1 {
+        for (outcome, (catalog, messages, locale)) in outcomes.iter_mut().zip(write_jobs) {
+            *outcome = Some(write_catalog(catalog, locale, messages, config, options));
+        }
+    } else {
+        let collected = std::thread::scope(|scope| {
+            let handles = (0..worker_count)
+                .map(|worker| {
+                    scope.spawn(move || {
+                        write_jobs
+                            .iter()
+                            .enumerate()
+                            .skip(worker)
+                            .step_by(worker_count)
+                            .map(|(index, (catalog, messages, locale))| {
+                                (index, write_catalog(catalog, locale, messages, config, options))
+                            })
+                            .collect::<Vec<_>>()
+                    })
+                })
+                .collect::<Vec<_>>();
+            handles
+                .into_iter()
+                .flat_map(|handle| handle.join().expect("catalog write worker panicked"))
+                .collect::<Vec<_>>()
+        });
+        for (index, outcome) in collected {
+            outcomes[index] = Some(outcome);
+        }
+    }
+
+    for outcome in outcomes {
+        let lines = outcome.expect("every write job produces an outcome")?;
+        for line in lines {
+            eprintln!("{line}");
+        }
+    }
+    Ok(())
+}
+
 fn write_catalog(
     catalog: &ConfigCatalog,
     locale: &str,
     messages: &[CatalogUpdateMessage],
     config: &LoadedConfig,
     options: &ExtractOptions,
-) -> Result<u128, CliError> {
-    let started_at = Instant::now();
+) -> Result<Vec<String>, CliError> {
     let catalog_path = config
         .resolve_catalog_path(&catalog.path, locale)
         .with_extension(catalog.format.extension());
@@ -274,14 +358,18 @@ fn write_catalog(
         messages: messages.to_vec(),
     })?;
 
+    let mut lines = Vec::new();
     if options.verbose {
-        eprintln!("  -> {}", catalog_path.display());
+        lines.push(format!("  -> {}", catalog_path.display()));
         for diagnostic in result.diagnostics {
-            eprintln!("Warning: {}: {}", diagnostic.code, diagnostic.message);
+            lines.push(format!(
+                "Warning: {}: {}",
+                diagnostic.code, diagnostic.message
+            ));
         }
     }
 
-    Ok(started_at.elapsed().as_millis())
+    Ok(lines)
 }
 
 #[cfg(test)]

--- a/crates/palamedes-cli/src/commands/extract/sources.rs
+++ b/crates/palamedes-cli/src/commands/extract/sources.rs
@@ -140,6 +140,32 @@ pub(super) fn walk_roots_for_patterns(patterns: &[String], fallback: &Path) -> V
     roots.into_iter().collect()
 }
 
+pub(super) fn build_exclude_set(
+    catalog: &ConfigCatalog,
+    config: &LoadedConfig,
+) -> Result<GlobSet, CliError> {
+    let mut builder = GlobSetBuilder::new();
+    let excludes = if catalog.exclude.is_empty() {
+        vec!["**/node_modules/**".to_owned()]
+    } else {
+        catalog.exclude.clone()
+    };
+    for pattern in excludes {
+        let resolved = config.resolve_pattern(&pattern);
+        let normalized = resolved.to_string_lossy().into_owned();
+        builder.add(
+            Glob::new(&normalized).map_err(|source| CliError::GlobPattern {
+                pattern: normalized,
+                source,
+            })?,
+        );
+    }
+    builder.build().map_err(|source| CliError::GlobPattern {
+        pattern: "exclude".to_owned(),
+        source,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
@@ -170,30 +196,4 @@ mod tests {
 
         assert_eq!(paths, expected);
     }
-}
-
-pub(super) fn build_exclude_set(
-    catalog: &ConfigCatalog,
-    config: &LoadedConfig,
-) -> Result<GlobSet, CliError> {
-    let mut builder = GlobSetBuilder::new();
-    let excludes = if catalog.exclude.is_empty() {
-        vec!["**/node_modules/**".to_owned()]
-    } else {
-        catalog.exclude.clone()
-    };
-    for pattern in excludes {
-        let resolved = config.resolve_pattern(&pattern);
-        let normalized = resolved.to_string_lossy().into_owned();
-        builder.add(
-            Glob::new(&normalized).map_err(|source| CliError::GlobPattern {
-                pattern: normalized,
-                source,
-            })?,
-        );
-    }
-    builder.build().map_err(|source| CliError::GlobPattern {
-        pattern: "exclude".to_owned(),
-        source,
-    })
 }

--- a/crates/palamedes-cli/src/commands/extract/sources.rs
+++ b/crates/palamedes-cli/src/commands/extract/sources.rs
@@ -17,7 +17,7 @@ pub(super) fn collect_source_files(
     let include_patterns = normalized_include_patterns(catalog, config);
     let include = build_glob_set(&include_patterns, "include")?;
     let exclude = build_exclude_set(catalog, config)?;
-    let mut files = BTreeSet::new();
+    let mut files = Vec::new();
 
     for root in walk_roots_for_patterns(&include_patterns, &config.root_dir) {
         for entry in WalkBuilder::new(root)
@@ -36,12 +36,43 @@ pub(super) fn collect_source_files(
                 continue;
             }
             if include.is_match(path) {
-                files.insert(path.to_path_buf());
+                files.push(path.to_path_buf());
             }
         }
     }
 
-    Ok(files.into_iter().collect())
+    sort_and_dedupe_paths(&mut files);
+    Ok(files)
+}
+
+/*
+ * Path::cmp compares component-by-component and re-parses both paths on every
+ * comparison, which made the former BTreeSet<PathBuf> collection the single
+ * most expensive main-thread item after the catalog writes (~25% of
+ * main-thread instructions on the realistic benchmark corpus). Sorting on a
+ * cached byte key computes the ordering key once per path instead.
+ *
+ * On Unix the key maps the separator to 0x00, which is below every byte a
+ * component can contain, so byte order on the mapped key equals component
+ * order and the resulting file order — and with it catalog origin order — is
+ * unchanged. Other platforms keep Path's own ordering.
+ */
+pub(super) fn sort_and_dedupe_paths<P: AsRef<Path> + Ord>(paths: &mut Vec<P>) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStrExt;
+        paths.sort_by_cached_key(|path| {
+            path.as_ref()
+                .as_os_str()
+                .as_bytes()
+                .iter()
+                .map(|&byte| if byte == b'/' { 0 } else { byte })
+                .collect::<Vec<u8>>()
+        });
+    }
+    #[cfg(not(unix))]
+    paths.sort_unstable();
+    paths.dedup_by(|left, right| left.as_ref() == right.as_ref());
 }
 
 pub(super) fn build_include_set(
@@ -107,6 +138,38 @@ pub(super) fn walk_roots_for_patterns(patterns: &[String], fallback: &Path) -> V
         roots.insert(fallback.to_path_buf());
     }
     roots.into_iter().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::sort_and_dedupe_paths;
+
+    /*
+     * The byte-key sort must reproduce Path::cmp's component order exactly,
+     * including the case where a directory name is a prefix of a sibling's
+     * ("app" vs "app-shared"): plain byte order on the unmapped path would put
+     * "app-shared" first because '-' sorts below '/'.
+     */
+    #[test]
+    fn sorts_in_component_order_and_dedupes() {
+        let mut paths = vec![
+            PathBuf::from("/repo/app-shared/x.ts"),
+            PathBuf::from("/repo/app/y.ts"),
+            PathBuf::from("/repo/app/y.ts"),
+            PathBuf::from("/repo/app.ts"),
+            PathBuf::from("/repo/app/b-c/d.ts"),
+            PathBuf::from("/repo/app/b.ts"),
+        ];
+        let mut expected = paths.clone();
+        expected.sort();
+        expected.dedup();
+
+        sort_and_dedupe_paths(&mut paths);
+
+        assert_eq!(paths, expected);
+    }
 }
 
 pub(super) fn build_exclude_set(

--- a/crates/palamedes/src/extract.rs
+++ b/crates/palamedes/src/extract.rs
@@ -144,8 +144,10 @@ struct LineLocator {
 impl LineLocator {
     fn new(source: &str) -> Self {
         let mut line_starts = vec![0];
-        for (index, ch) in source.char_indices() {
-            if ch == '\n' {
+        // A byte scan: '\n' cannot occur inside a multi-byte UTF-8 sequence,
+        // and decoding every char just to find newlines showed up in profiles.
+        for (index, &byte) in source.as_bytes().iter().enumerate() {
+            if byte == b'\n' {
                 line_starts.push(index + 1);
             }
         }
@@ -1385,10 +1387,29 @@ fn extract_messages_in(
         return Err(PalamedesError::ParseSource { messages });
     }
 
-    let line_locator = LineLocator::new(source);
     let mut collector = MacroCollector::new();
     collector.visit_program(&parsed.program);
 
+    /*
+     * Without a single imported Palamedes macro, the only remaining extraction
+     * surface is the `i18n._`/`i18n.t` runtime-call form, and every spelling of
+     * it necessarily contains the text `i18n`. When neither is present nothing
+     * can be extracted and none of the macro-shape diagnostics below can fire:
+     * the scope validator and the extraction visitor resolve identifiers
+     * through the import map before doing anything else. On real trees most
+     * files carry no i18n at all, so skipping their remaining two AST walks and
+     * the line index is a large share of the extraction pass. A file that
+     * merely mentions `i18n` somewhere takes the normal path; the check is an
+     * over-approximation, never a behavior change.
+     */
+    if collector.imported_macros.is_empty()
+        && collector.removed_macro_import.is_none()
+        && !source.contains("i18n")
+    {
+        return Ok(Vec::new());
+    }
+
+    let line_locator = LineLocator::new(source);
     if let Some((macro_name, offset)) = collector.removed_macro_import.as_ref() {
         let (line, column) = line_locator.get_location(*offset);
         return Err(PalamedesError::UnsupportedMacroSyntax {


### PR DESCRIPTION
## Summary

The Ferrocat 3.1/3.2 performance work (borrowed PO parser, allocation cuts, collation prefixes) did not visibly move the Palamedes end-to-end extract numbers. Profiling `pmds extract` on the checked benchmark corpora (callgrind + strace on Linux, cross-checked against the recorded macOS phase breakdowns) explains why and finds the headroom on the Palamedes side:

- **The write phase is dominated by fixed per-file costs, not catalog CPU.** `writeMs` barely scales with catalog size in the checked report (23 ms at 640 messages vs 43 ms at 6,000). On macOS, Ferrocat's `atomic_write` issues `File::sync_all` — an F_FULLFSYNC barrier — for every catalog file *and* its directory, serially per locale. Ferrocat's CPU savings hide behind those barriers.
- **~25% of main-thread instructions went into `BTreeSet<PathBuf>`** for file-set dedupe/ordering (`Path::cmp` re-parses components on every comparison) — pure CLI overhead.
- **Every source file paid three full AST walks plus a `char_indices` line scan**, including the majority of files on real trees that contain no i18n at all.

Changes (catalog output stays byte-identical; verified against the pre-change binary on the realistic corpus plus the harness's semantic validation):

- `crates/palamedes-cli`: catalog writes for each (catalog × locale) pair now run concurrently, with outcomes collected and reported in job order so verbose output and the first error stay deterministic. Overlaps ferrocat's parse/merge/serialize across locales and, on macOS, the F_FULLFSYNC stalls. `writeMs` now reports the wall time of the write phase.
- `crates/palamedes-cli`: file-set dedupe/ordering switched from `BTreeSet<PathBuf>` to one sort over cached separator-mapped byte keys (identical component order on Unix, covered by a new test), with a no-op fast path for single-catalog configs.
- `crates/palamedes`: files whose imports carry no Palamedes macro and whose text cannot contain the `i18n._`/`i18n.t` runtime form return after the first AST walk, skipping the scope-validation walk, the extraction walk, and the line index. The line index is now built lazily and scans bytes instead of decoding chars. Parse errors in such files are reported exactly as before — the gate sits after parsing.
- `benchmarks/e2e-workflow`: corpus generation bounds its write concurrency; the realistic profile previously held up to ~6,000 fds open at once and died with EMFILE on hosts with a 4,096 open-file limit.

## Issue

No issue exists; this came out of a profiling request after adopting Ferrocat 3.2.2 (04625e5) showed no e2e movement.

## Validation

- `cargo test -p palamedes -p palamedes-cli` — 249 tests green (a new test covers the byte-key path ordering; the existing runtime-call tests caught and shaped the fast-path gate).
- `cargo clippy -p palamedes -p palamedes-cli` — clean.
- `node --test benchmarks/e2e-workflow/src/run.test.mjs` — green.
- Byte-parity: cold `pmds extract` output on the realistic corpus diffed identical between the pre-change and post-change binaries.
- Full harness (`--warmup 2 --runs 5`, Linux x86_64, 4 cores, tmpfs), cold medians before → after:

| Profile | Before | After | Phase timings before → after |
| --- | ---: | ---: | --- |
| small | 15.8 ms | 15.4 ms | write 8 → 7 ms (outer median is startup-dominated) |
| realistic | 171.9 ms | 102.8 ms | glob 6→4, extract 97→47, write 62→29 ms |

Warm lane (extraction cache): realistic 90.1 → 60.3 ms.

The checked-in `results/latest.*` are deliberately untouched — they are recorded on the reference machine (darwin/arm64) and should be re-recorded there after this lands, per `docs/benchmark-e2e-workflow.md`. The macOS write-phase gain should exceed the Linux one, since the serialized F_FULLFSYNC barriers are the dominant fixed cost there.

## Follow-up

- **Ferrocat upstream:** expose a durability option on `update_catalog_file` (or let callers own the file write around `update_catalog`) so regenerable, git-tracked catalogs can opt out of per-file F_FULLFSYNC. Parallel writes only overlap the barriers; they don't remove them.
- **Extraction cache persistence** is ~10% of main-thread instructions (serde_json over ~1.9 MB on the realistic corpus) — outside `totalMs` but inside the process time the harness measures.
- **Pre-parse marker scan:** skipping the oxc parse entirely for files without `@palamedes/` / `i18n` text would cut roughly another quarter of the extract phase, but it changes diagnostics (syntax errors in marker-free files would no longer fail `pmds extract`), so it needs a product decision first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sp6XbiubucKK8YaPAh4Ku5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sp6XbiubucKK8YaPAh4Ku5)_