### PR TITLE
perf(extract): skip parsing files without i18n markers in batch extraction

### DIFF
--- a/crates/palamedes-cli/src/commands/extract/mod.rs
+++ b/crates/palamedes-cli/src/commands/extract/mod.rs
@@ -616,7 +616,13 @@ catalogs:
         let app = temp_dir("extract-failure");
         fs::create_dir_all(app.join("app")).expect("create app");
         write_config(&app, None);
-        fs::write(app.join("app/page.tsx"), "const broken =").expect("write invalid source");
+        // The macro import keeps the file on the parsing path; marker-free
+        // files skip the parse and can no longer fail extraction.
+        fs::write(
+            app.join("app/page.tsx"),
+            "import { t } from \"@palamedes/core/macro\"\nconst broken =",
+        )
+        .expect("write invalid source");
         fs::create_dir_all(app.join("locales/en")).expect("create source locale");
         let catalog_path = app.join("locales/en/messages.po");
         let original = "msgid \"Existing\"\nmsgstr \"Existing\"\n";
@@ -654,7 +660,11 @@ catalogs:
 "#,
         )
         .expect("write config");
-        fs::write(app.join("app/page.tsx"), "const broken =").expect("write invalid source");
+        fs::write(
+            app.join("app/page.tsx"),
+            "import { t } from \"@palamedes/core/macro\"\nconst broken =",
+        )
+        .expect("write invalid source");
 
         let config = load_config(&app, Some(&app.join("palamedes.yaml"))).expect("load config");
         let error = run_extraction(&config, &extract_options()).expect_err("extract should fail");

--- a/crates/palamedes-cli/src/commands/extract/watch.rs
+++ b/crates/palamedes-cli/src/commands/extract/watch.rs
@@ -253,7 +253,13 @@ mod tests {
         fs::create_dir_all(app.join("app")).expect("create app");
         write_config(&app, None);
         let source_path = app.join("app/page.tsx");
-        fs::write(&source_path, "const broken =").expect("write invalid source");
+        // The macro import keeps the broken file on the parsing path;
+        // marker-free files skip the parse and cannot fail extraction.
+        fs::write(
+            &source_path,
+            "import { t } from \"@palamedes/core/macro\"\nconst broken =",
+        )
+        .expect("write invalid source");
 
         let config = load_config(&app, Some(&app.join("palamedes.yaml"))).expect("load config");
         run_watch_extraction(&config, &extract_options(), &mut ExtractCache::disabled())

--- a/crates/palamedes/src/extract.rs
+++ b/crates/palamedes/src/extract.rs
@@ -1642,6 +1642,35 @@ fn extract_one_file(
         }
     };
 
+    /*
+     * Batch fast path: every extractable construct requires one of two textual
+     * markers. Macro imports name a `@palamedes/...` package as a literal
+     * import specifier, and the runtime-call form spells an `i18n` member
+     * somewhere. A file containing neither cannot produce messages or
+     * macro-shape diagnostics, so the parse is skipped entirely; on real trees
+     * most files carry no i18n at all, and parsing them is the bulk of the
+     * extraction pass. MDX files always take the full path.
+     *
+     * Deliberate trade-off, scoped to batch extraction (`pmds extract` and the
+     * binding): a syntax-broken file without any i18n marker no longer fails
+     * the run — the same posture other extractors take for non-matching files.
+     * Files with a marker keep exact parse diagnostics, and the single-file
+     * `extract_messages` API still parses everything.
+     */
+    let is_mdx = Path::new(file)
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| extension.eq_ignore_ascii_case("mdx"));
+    if !is_mdx && !source.contains("@palamedes") && !source.contains("i18n") {
+        return FileExtraction::Extracted {
+            path: file.clone(),
+            relative_file: relative_origin_file(root_dir, file),
+            messages: Vec::new(),
+            fresh: true,
+            fingerprint,
+        };
+    }
+
     let extracted = EXTRACT_ARENA.with(|arena| {
         let mut arena = arena.borrow_mut();
         let extracted = extract_messages_in(&arena, &source, file, reference_scopes, mdx_options);
@@ -2976,7 +3005,13 @@ const message = t({ message })
         let root = temp_root("batch-failure");
         fs::create_dir_all(&root).expect("root dir");
         let invalid = root.join("invalid.ts");
-        fs::write(&invalid, "const broken =").expect("invalid source");
+        // The i18n marker keeps the file on the parsing path; marker-free
+        // files skip the parse entirely and are covered by the test below.
+        fs::write(
+            &invalid,
+            "import { t } from \"@palamedes/core/macro\"\nconst broken =",
+        )
+        .expect("invalid source");
 
         let result = extract_catalog_messages_from_files(ExtractCatalogMessagesRequest {
             root_dir: root.to_string_lossy().into_owned(),
@@ -2988,6 +3023,32 @@ const message = t({ message })
         assert_eq!(result.file_count, 1);
         assert_eq!(result.failed_files.len(), 1);
         assert!(result.failed_files[0].message.contains("Parse error"));
+
+        fs::remove_dir_all(root).expect("cleanup");
+    }
+
+    /*
+     * The batch fast path must not report syntax errors in files that carry no
+     * i18n marker at all: they cannot produce messages, and failing the run on
+     * them would make `pmds extract` a project-wide syntax check.
+     */
+    #[test]
+    fn batch_skips_broken_files_without_i18n_markers() {
+        let root = temp_root("batch-skip-markerless");
+        fs::create_dir_all(&root).expect("root dir");
+        let invalid = root.join("invalid.ts");
+        fs::write(&invalid, "const broken =").expect("invalid source");
+
+        let result = extract_catalog_messages_from_files(ExtractCatalogMessagesRequest {
+            root_dir: root.to_string_lossy().into_owned(),
+            files: vec![invalid.to_string_lossy().into_owned()],
+            max_threads: None,
+        })
+        .expect("batch extraction should continue");
+
+        assert_eq!(result.file_count, 1);
+        assert!(result.failed_files.is_empty());
+        assert!(result.messages.is_empty());
 
         fs::remove_dir_all(root).expect("cleanup");
     }


### PR DESCRIPTION
## Summary

Follow-up to #488, working through the items listed there under "Follow-up" with a strict keep-only-if-measurably-faster rule. One made the cut:

**Pre-parse marker scan.** Every extractable construct requires one of two textual markers: macro imports name a `@palamedes/...` package as a literal import specifier (`PALAMEDES_MACRO_PACKAGES`), and the runtime-call form spells an `i18n` member somewhere. Batch extraction now skips the oxc parse entirely for files containing neither marker — on real trees most files carry no i18n at all (the realistic corpus models half). MDX files always take the full path, and the single-file `extract_messages` API still parses everything.

**Deliberate behavior change**, scoped to batch extraction (`pmds extract` and the binding): a syntax-broken file *without any i18n marker* no longer fails the run — the same posture Lingui/formatjs take for non-matching files, and it stops `pmds extract` from acting as a project-wide syntax check. Files *with* a marker keep exact parse diagnostics; the failure-path tests (`batch_reports_non_fatal_file_failures`, `extraction_failures_leave_existing_catalogs_unchanged`, `overlapping_catalogs_count_a_failing_file_once`, watch-mode recovery) now pin that guarantee on marker-carrying files, and a new test pins the skip for marker-free ones. If this posture is unwanted, say so and I'll gate it behind config instead.

**Measured and rejected** (not in this PR): serializing the extraction cache without deep-cloning the entry map (`CachePayloadRef` borrow-serialize). Median 82 vs 81 ms over the same protocol — no wall-clock gain, dropped.

**Not measurable from here:** the Ferrocat durability option (F_FULLFSYNC opt-out). On this Linux/tmpfs box fsync is ~0.3 ms total, so no local proof is possible; the win is macOS-specific (F_FULLFSYNC per catalog + directory). That one stays an upstream `ferrocat` proposal rather than code in this repo.

## Issue

No issue exists; continuation of the profiling work merged in #488.

## Validation

- `cargo test -p palamedes -p palamedes-cli` — 251 tests green (one new test; four fixtures updated to keep their guarantee on marker-carrying files).
- `cargo fmt --all --check` and `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean (CI-equivalent flags).
- Byte-parity: cold catalogs on the realistic corpus diff identical between the merged-main binary and this branch.
- A/B measurement, realistic corpus (1,500 files / 6,000 messages), 4-core Linux, interleaved rounds, 18 cold runs per side: cold end-to-end median **94 → 84 ms**, extract phase median **46 → 37 ms** (−20%). Warm lane unchanged (cache hits skip the read anyway), as expected.

## Follow-up

- Upstream `ferrocat`: durability option on `update_catalog_file` so regenerable, git-tracked catalogs can opt out of per-file F_FULLFSYNC — the remaining fixed cost in the write phase on macOS, only overlapped (not removed) by the parallel writes from #488.
- Re-record `benchmarks/e2e-workflow/results/latest.*` on the reference machine (darwin/arm64) after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sp6XbiubucKK8YaPAh4Ku5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sp6XbiubucKK8YaPAh4Ku5)_