### PR TITLE
feat(catalog): adopt Ferrocat 3.3.0 and skip write barriers for catalogs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -333,9 +333,9 @@ checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "ferrocat"
-version = "3.2.2"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1303066fe0186f74569e19c21ab6065749849a4e48e35670092eb8e9eb0a4bfc"
+checksum = "9dbbee8180d6dd69406136e56aeb33292054393f8299266e369905bc850c2f0f"
 dependencies = [
  "ferrocat-icu",
  "ferrocat-po",
@@ -343,9 +343,9 @@ dependencies = [
 
 [[package]]
 name = "ferrocat-icu"
-version = "3.2.2"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e438fc2eafdba23ea18c33d4c25fdbe7713459d7c0df7436cc306fc7b7770fb"
+checksum = "e56fc963d6da2e3dc3804202d52f48ce1049daa3e8b785845f305fdca8e4201b"
 dependencies = [
  "memchr",
  "serde",
@@ -353,9 +353,9 @@ dependencies = [
 
 [[package]]
 name = "ferrocat-po"
-version = "3.2.2"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d3b3f4a45250eacd418212d88c0b73cd031f1df8d46a2903896fda21a7b557e"
+checksum = "1543ac3b8874b658f2ac11737c42fa3610ed8ce2ceb288025adc722702562fd6"
 dependencies = [
  "ferrocat-icu",
  "icu_locale",

--- a/crates/palamedes/Cargo.toml
+++ b/crates/palamedes/Cargo.toml
@@ -8,9 +8,9 @@ rust-version.workspace = true
 description = "Rust core for Palamedes."
 
 [dependencies]
-ferrocat = "=3.2.2"
-ferrocat-icu = "=3.2.2"
-ferrocat-po = "=3.2.2"
+ferrocat = "=3.3.0"
+ferrocat-icu = "=3.3.0"
+ferrocat-po = "=3.3.0"
 ferromark = { version = "=0.7.0", features = ["mdx"] }
 oxc_allocator = "0.141.0"
 oxc_ast = "0.141.0"

--- a/crates/palamedes/src/catalog_update.rs
+++ b/crates/palamedes/src/catalog_update.rs
@@ -307,12 +307,20 @@ fn update_catalog_file_source_first(
         .with_overwrite_source_translations(true)
         .with_render(render)
         .with_now(&now);
+    /*
+     * Catalog files are repository-owned, regenerable artifacts, so the write
+     * skips Ferrocat's per-file durability barriers (File::sync_all is
+     * F_FULLFSYNC on macOS and was the dominant fixed cost of the write phase
+     * there). The rename stays atomic; after a crash the worst case is an old
+     * or missing catalog that the next extract rewrites.
+     */
     let file_options = UpdateCatalogFileOptions::new(
         &target_path,
         &request.source_locale,
         CatalogUpdateInput::default(),
     )
-    .with_options(update_options);
+    .with_options(update_options)
+    .with_durability(ferrocat::WriteDurability::Rename);
     let result = ferrocat_update_catalog_file(file_options).map_err(PalamedesError::from)?;
 
     Ok(public_update_result(result))

--- a/crates/palamedes/src/lib.rs
+++ b/crates/palamedes/src/lib.rs
@@ -98,7 +98,7 @@ pub use transform::{
 };
 
 /// Published `ferrocat` version used by the Rust core.
-pub const FERROCAT_VERSION: &str = "3.2.2";
+pub const FERROCAT_VERSION: &str = "3.3.0";
 
 /// Version metadata for the loaded native core.
 #[derive(Debug, Serialize)]


### PR DESCRIPTION
## Summary

Ferrocat 3.3.0 ships the catalog write durability option that came out of the write-phase profiling in #488 (upstream: sebastian-software/ferrocat#288). This adopts it:

- Pins bumped to `=3.3.0` (`ferrocat`, `ferrocat-po`, `ferrocat-icu`), `FERROCAT_VERSION` updated.
- Catalog updates in `catalog_update.rs` now write with `WriteDurability::Rename`: the write stays an atomic temp-file rename, but the per-file `File::sync_all` and the directory sync are skipped. Rationale (mirrors the upstream proposal): catalog files are repository-owned, regenerable artifacts — after a crash the worst case is an old or missing catalog that the next `pmds extract` rewrites.

On macOS, `sync_all` issues an F_FULLFSYNC barrier and an extract over `en`+`de` paid up to four of them per run — the dominant fixed cost of the write phase in the checked benchmark report, and the reason `writeMs` barely scaled with catalog size (23 ms at 640 messages vs 43 ms at 6,000). The parallel writes from #488 only overlapped these barriers; this removes them. Combined, the write phase on the reference machine should now be CPU-bound for the first time, so the Ferrocat 3.x allocation work finally shows up end-to-end.

## Issue

Follow-up to #488/#489; implements the "Ferrocat upstream" item from their Follow-up sections, now that upstream shipped it.

## Validation

- `cargo test -p palamedes -p palamedes-cli` — 251 tests green (including the `FERROCAT_VERSION`-matches-manifest pin test).
- `cargo fmt --all --check` and `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean.
- Byte-parity: cold catalogs on the realistic corpus diff identical against the merged-main binary.
- strace on Linux: the extract run previously issued 4 `fsync` calls (2 catalogs × file + directory); with this change the syscall profile contains none.
- The wall-clock win is macOS-specific (F_FULLFSYNC ≈ 5–15 ms per barrier on Apple SSDs; Linux fsync on this box was ~0.3 ms total, so no meaningful Linux delta to report). Please verify on the reference machine when re-recording `benchmarks/e2e-workflow/results/latest.*` — cold and warm `writeMs` should both drop noticeably.

## Follow-up

- Re-record `benchmarks/e2e-workflow/results/latest.*` on the reference machine (darwin/arm64); this covers the pending re-record for #488/#489 as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sp6XbiubucKK8YaPAh4Ku5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sp6XbiubucKK8YaPAh4Ku5)_