### PR TITLE
fix(extract): preserve apostrophe translations

### DIFF
--- a/crates/palamedes-cli/src/commands/extract/mod.rs
+++ b/crates/palamedes-cli/src/commands/extract/mod.rs
@@ -475,6 +475,75 @@ catalogs:
     }
 
     #[test]
+    fn force_clean_keeps_lingui_apostrophe_translations_and_is_idempotent() {
+        let app = temp_dir("extract-apostrophe-migration");
+        fs::create_dir_all(app.join("app")).expect("create app");
+        fs::create_dir_all(app.join("locales/de")).expect("create target locale");
+        write_config(&app, Some("config"));
+        fs::write(
+            app.join("app/page.tsx"),
+            concat!(
+                "import { t } from \"@palamedes/core/macro\";\n",
+                "export function messages() {\n",
+                "  const contraction = t`don't stop`;\n",
+                "  const possessive = t`client's booking`;\n",
+                "  const summer = t`l'été`;\n",
+                "  const doubled = t`It''s ready`;\n",
+                "  const boundary = t`L'${title}`;\n",
+                "  return [contraction, possessive, summer, doubled, boundary];\n",
+                "}\n",
+            ),
+        )
+        .expect("write source");
+        fs::write(
+            app.join("locales/de/messages.po"),
+            concat!(
+                "msgid \"don't stop\"\n",
+                "msgstr \"nicht aufhören\"\n\n",
+                "msgid \"client's booking\"\n",
+                "msgstr \"Buchung des Kunden\"\n\n",
+                "msgid \"l'été\"\n",
+                "msgstr \"der Sommer\"\n",
+            ),
+        )
+        .expect("write Lingui target catalog");
+
+        let config = load_config(&app, Some(&app.join("palamedes.yaml"))).expect("load config");
+        let mut options = extract_options();
+        options.force_clean = true;
+        run_extraction(&config, &options).expect("force-clean extraction");
+
+        let source = fs::read_to_string(app.join("locales/en/messages.po")).expect("read source");
+        for identity in [
+            "don't stop",
+            "client's booking",
+            "l'été",
+            "It''s ready",
+            "L''{title}",
+        ] {
+            assert!(
+                source.contains(&format!("msgid \"{identity}\"")),
+                "missing source identity {identity:?}:\n{source}"
+            );
+        }
+
+        let target = fs::read_to_string(app.join("locales/de/messages.po")).expect("read target");
+        for translation in ["nicht aufhören", "Buchung des Kunden", "der Sommer"] {
+            assert!(
+                target.contains(&format!("msgstr \"{translation}\"")),
+                "{target}"
+            );
+        }
+        assert!(!target.contains("msgid \"don''t stop\""), "{target}");
+
+        run_extraction(&config, &options).expect("repeat force-clean extraction");
+        assert_eq!(
+            fs::read_to_string(app.join("locales/de/messages.po")).expect("read repeated target"),
+            target
+        );
+    }
+
+    #[test]
     fn extract_discovers_mdx_and_uses_shared_configured_semantics() {
         let app = temp_dir("extract-mdx");
         fs::create_dir_all(app.join("app")).expect("create app");

--- a/crates/palamedes/fixtures/lingui-apostrophes.de.po
+++ b/crates/palamedes/fixtures/lingui-apostrophes.de.po
@@ -1,0 +1,26 @@
+msgid ""
+msgstr ""
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"X-Generator: @lingui/cli\n"
+
+# Keep the contraction informal.
+#. Lingui extractor note
+#: src/App.tsx:4
+#, fuzzy, no-wrap
+#@ lock: {{DONT_LOCK}}
+#@ ai: openai/gpt-5.5-high:0.95
+msgid "don't stop"
+msgstr "nicht aufhören"
+
+# Customer-facing possessive.
+#: src/Client.tsx:8
+msgctxt "booking"
+msgid "client's booking"
+msgstr "Buchung des Kunden"
+
+# French source text carried through Lingui.
+#: src/Summer.tsx:12
+msgid "l'été"
+msgstr "der Sommer"

--- a/crates/palamedes/src/catalog_update.rs
+++ b/crates/palamedes/src/catalog_update.rs
@@ -1,5 +1,5 @@
-use std::collections::BTreeMap;
-use std::path::PathBuf;
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::diagnostic::CatalogDiagnostic;
@@ -263,7 +263,7 @@ pub fn parse_catalog(request: &CatalogParseRequest) -> PalamedesResult<CatalogPa
 }
 
 fn update_catalog_file_source_first(
-    request: CatalogUpdateRequest,
+    mut request: CatalogUpdateRequest,
 ) -> PalamedesResult<CatalogUpdateResponse> {
     let target_path = PathBuf::from(&request.target_path);
     if target_path.as_os_str().is_empty() {
@@ -272,6 +272,7 @@ fn update_catalog_file_source_first(
         )));
     }
     validate_po_options(request.format, request.po.as_ref())?;
+    preserve_existing_po_apostrophe_identities(&mut request, &target_path)?;
     let custom_header_attributes =
         BTreeMap::from([("X-Generator".to_owned(), "palamedes".to_owned())]);
     let input = CatalogUpdateInput::SourceFirst(
@@ -324,6 +325,121 @@ fn update_catalog_file_source_first(
     let result = ferrocat_update_catalog_file(file_options).map_err(PalamedesError::from)?;
 
     Ok(public_update_result(result))
+}
+
+/// Keeps a translated PO entry attached when an extractor upgrade only changes
+/// the apostrophe spelling of its identity.
+///
+/// Ferrocat deliberately treats `(msgid, msgctxt)` as exact identity. The
+/// compatibility policy here is therefore applied before projection, at the
+/// Palamedes integration boundary: an extracted message reuses one existing
+/// spelling only when both canonicalize to the same runtime-literal ICU text.
+/// Exact identities win, and ambiguous candidates are left alone rather than
+/// silently merging distinct catalog entries.
+fn preserve_existing_po_apostrophe_identities(
+    request: &mut CatalogUpdateRequest,
+    target_path: &Path,
+) -> PalamedesResult<()> {
+    if request.format != super::catalog_artifact::PalamedesCatalogFormat::Po {
+        return Ok(());
+    }
+    if !request
+        .messages
+        .iter()
+        .any(|message| message.message.contains('\''))
+    {
+        return Ok(());
+    }
+
+    let content = match std::fs::read_to_string(target_path) {
+        Ok(content) => content,
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(source) => {
+            return Err(PalamedesError::ReadFile {
+                path: target_path.to_path_buf(),
+                source,
+            });
+        }
+    };
+    if content.is_empty() || request.messages.is_empty() {
+        return Ok(());
+    }
+
+    let parsed = ferrocat_parse_catalog(
+        ParseCatalogOptions::new(&content, &request.source_locale)
+            .with_locale(&request.locale)
+            .with_mode(request.format.ferrocat_mode()),
+    )
+    .map_err(PalamedesError::from)?;
+    let existing = parsed
+        .messages
+        .into_iter()
+        .map(|message| (message.msgid, message.msgctxt))
+        .collect::<Vec<_>>();
+    let extracted_identities = request
+        .messages
+        .iter()
+        .map(|message| (message.message.clone(), message.context.clone()))
+        .collect::<BTreeSet<_>>();
+
+    let mut proposed = Vec::new();
+    for (message_index, message) in request.messages.iter().enumerate() {
+        let exact = existing
+            .iter()
+            .any(|identity| identity.0 == message.message && identity.1 == message.context);
+        if exact {
+            continue;
+        }
+
+        let candidates = existing
+            .iter()
+            .enumerate()
+            .filter(|(_, identity)| {
+                identity.1 == message.context
+                    && !extracted_identities.contains(identity)
+                    && apostrophe_canonical_equivalent(&identity.0, &message.message)
+            })
+            .map(|(index, _)| index)
+            .collect::<Vec<_>>();
+        if let [existing_index] = candidates.as_slice() {
+            proposed.push((message_index, *existing_index));
+        }
+    }
+
+    let mut candidate_inputs = BTreeMap::<usize, BTreeSet<(String, Option<String>)>>::new();
+    for (message_index, existing_index) in &proposed {
+        let message = &request.messages[*message_index];
+        candidate_inputs
+            .entry(*existing_index)
+            .or_default()
+            .insert((message.message.clone(), message.context.clone()));
+    }
+    for (message_index, existing_index) in proposed {
+        if candidate_inputs
+            .get(&existing_index)
+            .is_some_and(|identities| identities.len() == 1)
+        {
+            request.messages[message_index]
+                .message
+                .clone_from(&existing[existing_index].0);
+        }
+    }
+
+    Ok(())
+}
+
+fn apostrophe_canonical_equivalent(left: &str, right: &str) -> bool {
+    if left == right || (!left.contains('\'') && !right.contains('\'')) {
+        return false;
+    }
+
+    ferrocat::canonicalize_icu_with_policy(
+        left,
+        ferrocat::IcuSyntaxPolicy::RuntimeLiteralApostrophes,
+    ) == ferrocat::canonicalize_icu_with_policy(
+        right,
+        ferrocat::IcuSyntaxPolicy::RuntimeLiteralApostrophes,
+    )
 }
 
 fn validate_po_options(
@@ -796,11 +912,17 @@ msgstr "apple"
 msgid "Apple"
 msgstr "Apple"
 
+msgid "client's booking"
+msgstr "client's booking"
+
 msgid "co-op"
 msgstr "co-op"
 
 msgid "coop"
 msgstr "coop"
+
+msgid "don't stop"
+msgstr "don't stop"
 
 msgid "eclair"
 msgstr "eclair"
@@ -813,6 +935,9 @@ msgstr "Item 10"
 
 msgid "Item 2"
 msgstr "Item 2"
+
+msgid "l'été"
+msgstr "l'été"
 
 msgid "MiXeD CaSe"
 msgstr "MiXeD CaSe"
@@ -853,6 +978,9 @@ msgstr "Zebra""#;
             ("Item 2", None),
             ("co-op", None),
             ("coop", None),
+            ("don't stop", None),
+            ("client's booking", None),
+            ("l'été", None),
             ("naïve", None),
             ("résumé", None),
             ("MiXeD CaSe", None),
@@ -1334,6 +1462,238 @@ msgstr "Zebra""#;
 
         let output = std::fs::read_to_string(&path).expect("read");
         assert!(!output.contains("Old"));
+    }
+
+    #[test]
+    fn force_clean_preserves_lingui_apostrophe_translations_and_metadata() {
+        let path = temp_file("lingui-apostrophe-migration");
+        let lock = machine_translation_hash(EffectiveTranslationRef::Singular("nicht aufhören"));
+        let fixture =
+            include_str!("../fixtures/lingui-apostrophes.de.po").replace("{{DONT_LOCK}}", &lock);
+        std::fs::write(&path, fixture).expect("write Lingui fixture");
+
+        let request = || CatalogUpdateRequest {
+            target_path: path.clone(),
+            locale: "de".to_owned(),
+            source_locale: "en".to_owned(),
+            clean: false,
+            force_clean: true,
+            format: crate::PalamedesCatalogFormat::Po,
+            po: None,
+            messages: vec![
+                message("don''t stop", None, "src/App.tsx"),
+                message("client''s booking", Some("booking"), "src/Client.tsx"),
+                message("l''été", None, "src/Summer.tsx"),
+            ],
+        };
+
+        let migrated = update_catalog_file(request()).expect("migrate Lingui catalog");
+        assert_eq!(migrated.stats.total, 3);
+        assert_eq!(migrated.stats.added, 0);
+        assert_eq!(migrated.stats.obsolete_removed, 0);
+
+        let output = std::fs::read_to_string(&path).expect("read migrated output");
+        let po = parse_po(&output).expect("parse migrated output");
+        assert_eq!(po.items.len(), 3);
+        let dont = po
+            .items
+            .iter()
+            .find(|item| item.msgid == "don't stop")
+            .expect("natural-apostrophe identity survives");
+        assert_eq!(
+            dont.msgstr.first().map(String::as_str),
+            Some("nicht aufhören")
+        );
+        assert_eq!(dont.comments.as_slice(), ["Keep the contraction informal."]);
+        assert_eq!(
+            dont.flags,
+            BTreeMap::from([("fuzzy".to_owned(), true), ("no-wrap".to_owned(), true)])
+        );
+        assert!(output.contains(&format!("#@ lock: {lock}")));
+        assert!(output.contains("#@ ai: openai/gpt-5.5-high:0.95"));
+
+        let clients = po
+            .items
+            .iter()
+            .find(|item| item.msgid == "client's booking")
+            .expect("possessive identity survives");
+        assert_eq!(clients.msgctxt.as_deref(), Some("booking"));
+        assert_eq!(
+            clients.msgstr.first().map(String::as_str),
+            Some("Buchung des Kunden")
+        );
+        let summer = po
+            .items
+            .iter()
+            .find(|item| item.msgid == "l'été")
+            .expect("Unicode apostrophe identity survives");
+        assert_eq!(
+            summer.msgstr.first().map(String::as_str),
+            Some("der Sommer")
+        );
+
+        let repeated = update_catalog_file(request()).expect("repeat migration");
+        assert!(!repeated.updated);
+        assert_eq!(
+            std::fs::read_to_string(&path).expect("read repeated output"),
+            output
+        );
+    }
+
+    #[test]
+    fn force_clean_reuses_palamedes_1_9_canonical_identity_for_new_raw_source() {
+        let path = temp_file("palamedes-1-9-apostrophe-migration");
+        let lock = machine_translation_hash(EffectiveTranslationRef::Singular("nicht aufhören"));
+        std::fs::write(
+            &path,
+            format!(
+                "# Existing translator note\n\
+                 #, fuzzy\n\
+                 #@ lock: {lock}\n\
+                 #@ ai: openai/gpt-5.5-high:0.95\n\
+                 msgid \"don''t stop\"\n\
+                 msgstr \"nicht aufhören\"\n"
+            ),
+        )
+        .expect("write Palamedes 1.9 catalog");
+
+        let request = || CatalogUpdateRequest {
+            target_path: path.clone(),
+            locale: "de".to_owned(),
+            source_locale: "en".to_owned(),
+            clean: false,
+            force_clean: true,
+            format: crate::PalamedesCatalogFormat::Po,
+            po: None,
+            messages: vec![message("don't stop", None, "src/App.tsx")],
+        };
+        let migrated = update_catalog_file(request()).expect("reuse canonical identity");
+        assert_eq!(migrated.stats.added, 0);
+        assert_eq!(migrated.stats.obsolete_removed, 0);
+
+        let output = std::fs::read_to_string(&path).expect("read migrated output");
+        let po = parse_po(&output).expect("parse migrated output");
+        assert_eq!(po.items.len(), 1);
+        assert_eq!(po.items[0].msgid, "don''t stop");
+        assert_eq!(
+            po.items[0].msgstr.first().map(String::as_str),
+            Some("nicht aufhören")
+        );
+        assert_eq!(
+            po.items[0].comments.as_slice(),
+            ["Existing translator note"]
+        );
+        assert_eq!(
+            po.items[0].flags,
+            BTreeMap::from([("fuzzy".to_owned(), true)])
+        );
+        assert!(output.contains(&format!("#@ lock: {lock}")));
+        assert!(output.contains("#@ ai: openai/gpt-5.5-high:0.95"));
+
+        let repeated = update_catalog_file(request()).expect("repeat canonical reuse");
+        assert!(!repeated.updated);
+        assert_eq!(
+            std::fs::read_to_string(path).expect("read repeated output"),
+            output
+        );
+    }
+
+    #[test]
+    fn exact_apostrophe_identity_wins_without_merging_an_equivalent_entry() {
+        let path = temp_file("apostrophe-exact-wins");
+        std::fs::write(
+            &path,
+            concat!(
+                "msgid \"don't\"\n",
+                "msgstr \"exact translation\"\n\n",
+                "msgid \"don''t\"\n",
+                "msgstr \"canonical translation\"\n",
+            ),
+        )
+        .expect("write existing catalog");
+
+        let result = update_catalog_file(CatalogUpdateRequest {
+            target_path: path.clone(),
+            locale: "de".to_owned(),
+            source_locale: "en".to_owned(),
+            clean: false,
+            force_clean: true,
+            format: crate::PalamedesCatalogFormat::Po,
+            po: None,
+            messages: vec![message("don't", None, "src/App.tsx")],
+        })
+        .expect("update exact identity");
+
+        let po =
+            parse_po(&std::fs::read_to_string(path).expect("read output")).expect("parse output");
+        assert_eq!(po.items.len(), 1);
+        assert_eq!(po.items[0].msgid, "don't");
+        assert_eq!(
+            po.items[0].msgstr.first().map(String::as_str),
+            Some("exact translation")
+        );
+        assert_eq!(result.stats.obsolete_removed, 1);
+    }
+
+    #[test]
+    fn apostrophe_migration_never_crosses_context_and_deduplicates_identical_inputs() {
+        let context_path = temp_file("apostrophe-context-separated");
+        std::fs::write(
+            &context_path,
+            concat!(
+                "msgctxt \"menu\"\n",
+                "msgid \"don't\"\n",
+                "msgstr \"menu translation\"\n",
+            ),
+        )
+        .expect("write contextual catalog");
+        update_catalog_file(CatalogUpdateRequest {
+            target_path: context_path.clone(),
+            locale: "de".to_owned(),
+            source_locale: "en".to_owned(),
+            clean: false,
+            force_clean: true,
+            format: crate::PalamedesCatalogFormat::Po,
+            po: None,
+            messages: vec![message("don''t", Some("dialog"), "src/App.tsx")],
+        })
+        .expect("update separate context");
+        let context_po =
+            parse_po(&std::fs::read_to_string(context_path).expect("read contextual output"))
+                .expect("parse contextual output");
+        assert_eq!(context_po.items.len(), 1);
+        assert_eq!(context_po.items[0].msgctxt.as_deref(), Some("dialog"));
+        assert!(context_po.items[0].msgstr.iter().all(String::is_empty));
+
+        let collision_path = temp_file("apostrophe-duplicate-input");
+        std::fs::write(
+            &collision_path,
+            "msgid \"don't\"\nmsgstr \"duplicate-safe translation\"\n",
+        )
+        .expect("write duplicate-input catalog");
+        update_catalog_file(CatalogUpdateRequest {
+            target_path: collision_path.clone(),
+            locale: "de".to_owned(),
+            source_locale: "en".to_owned(),
+            clean: false,
+            force_clean: true,
+            format: crate::PalamedesCatalogFormat::Po,
+            po: None,
+            messages: vec![
+                message("don''t", None, "src/One.tsx"),
+                message("don''t", None, "src/Two.tsx"),
+            ],
+        })
+        .expect("update duplicate inputs");
+        let collision_po =
+            parse_po(&std::fs::read_to_string(collision_path).expect("read collision output"))
+                .expect("parse collision output");
+        assert_eq!(collision_po.items.len(), 1);
+        assert_eq!(collision_po.items[0].msgid, "don't");
+        assert_eq!(
+            collision_po.items[0].msgstr.first().map(String::as_str),
+            Some("duplicate-safe translation")
+        );
     }
 
     #[test]

--- a/crates/palamedes/src/extract.rs
+++ b/crates/palamedes/src/extract.rs
@@ -12,7 +12,7 @@ use crate::descriptor::{
 };
 use crate::error::{PalamedesError, PalamedesResult};
 use crate::extract_cache::{ExtractCache, ReadStartFingerprint};
-use crate::icu_text::escape_icu_literal;
+use crate::icu_text::escape_icu_source_literal;
 use crate::jsx_entities::decode_jsx_entities;
 use crate::jsx_message::{
     clean_jsx_text, join_jsx_message_parts, JoinedJsxMessage, JsxMessagePart,
@@ -643,9 +643,7 @@ fn extract_choice_options_from_object(
             return Err(invalid_choice_option(macro_name, location, &key));
         };
         let (value, option_placeholders) = match property.value.without_parentheses() {
-            Expression::StringLiteral(literal) => {
-                (escape_icu_literal(literal.value.as_str()), BTreeMap::new())
-            }
+            Expression::StringLiteral(literal) => (literal.value.to_string(), BTreeMap::new()),
             Expression::TemplateLiteral(template) => template_to_message_with_state(
                 template,
                 source,
@@ -1018,12 +1016,10 @@ fn template_to_message_with_state(
     let mut placeholders = BTreeMap::new();
 
     for (index, quasi) in template.quasis.iter().enumerate() {
-        // Authored literal text: escape before appending so an apostrophe at a
-        // segment boundary cannot quote the placeholder that follows.
         if let Some(value) = quasi.value.cooked {
-            message.push_str(&escape_icu_literal(value.as_str()));
+            message.push_str(value.as_str());
         } else {
-            message.push_str(&escape_icu_literal(quasi.value.raw.as_str()));
+            message.push_str(quasi.value.raw.as_str());
         }
 
         if let Some(expr) = template.expressions.get(index) {
@@ -1041,7 +1037,7 @@ fn template_to_message_with_state(
         }
     }
 
-    Ok((message, placeholders))
+    Ok((escape_icu_source_literal(&message), placeholders))
 }
 
 fn make_unique_placeholder_name(
@@ -1156,7 +1152,9 @@ fn extract_jsx_children_as_message(
 ) -> PalamedesResult<String> {
     let mut next_component_index = 0usize;
 
-    Ok(extract_jsx_children_as_message_with_state(children, &mut next_component_index)?.message)
+    Ok(escape_icu_source_literal(
+        &extract_jsx_children_as_message_with_state(children, &mut next_component_index)?.message,
+    ))
 }
 
 fn extract_jsx_children_as_message_with_state(
@@ -1168,7 +1166,7 @@ fn extract_jsx_children_as_message_with_state(
     for child in children {
         match child {
             JSXChild::Text(text) => {
-                let value = escape_icu_literal(&clean_jsx_text(text.value.as_str()));
+                let value = clean_jsx_text(text.value.as_str());
                 if !value.is_empty() {
                     parts.push(JsxMessagePart::Text(value));
                 }
@@ -1176,9 +1174,7 @@ fn extract_jsx_children_as_message_with_state(
             JSXChild::ExpressionContainer(container) => match &container.expression {
                 JSXExpression::EmptyExpression(_) => {}
                 JSXExpression::StringLiteral(literal) => {
-                    parts.push(JsxMessagePart::Text(escape_icu_literal(
-                        literal.value.as_str(),
-                    )));
+                    parts.push(JsxMessagePart::Text(literal.value.to_string()));
                 }
                 expr => {
                     let Some(name) = jsx_expression_name(expr) else {
@@ -1266,13 +1262,12 @@ fn extract_choice_options_from_jsx(
             continue;
         };
         let (value, option_placeholders) = match attr_value {
-            JSXAttributeValue::StringLiteral(literal) => (
-                escape_icu_literal(&decode_jsx_entities(literal.value.as_str())),
-                BTreeMap::new(),
-            ),
+            JSXAttributeValue::StringLiteral(literal) => {
+                (decode_jsx_entities(literal.value.as_str()), BTreeMap::new())
+            }
             JSXAttributeValue::ExpressionContainer(container) => match &container.expression {
                 JSXExpression::StringLiteral(literal) => {
-                    (escape_icu_literal(literal.value.as_str()), BTreeMap::new())
+                    (literal.value.to_string(), BTreeMap::new())
                 }
                 JSXExpression::TemplateLiteral(template) => template_to_message_with_state(
                     template,
@@ -1311,7 +1306,9 @@ fn build_icu_message(
         .map(|value| format!(" offset:{value}"))
         .unwrap_or_default();
 
-    format!("{{{value_name}, {format},{offset_part} {option_parts}}}")
+    escape_icu_source_literal(&format!(
+        "{{{value_name}, {format},{offset_part} {option_parts}}}"
+    ))
 }
 
 fn argument_expression_name(arg: &Argument<'_>) -> Option<String> {
@@ -2580,9 +2577,7 @@ const message = t({ message })
             vec![
                 "Allocate energy usage to business units for {locationName} ({periodLabel}). Total: {totalMwh} MWh",
                 "Match Score: {matchPercentage}%",
-                // The authored apostrophe is escaped so the runtime renders it
-                // literally instead of opening an ICU quote.
-                "We just need a few details to connect you with {clientCompanyName}''s sustainability program.",
+                "We just need a few details to connect you with {clientCompanyName}'s sustainability program.",
             ]
         );
     }

--- a/crates/palamedes/src/icu_text.rs
+++ b/crates/palamedes/src/icu_text.rs
@@ -9,22 +9,60 @@
 //! * Every other apostrophe is ordinary text (`don't` renders verbatim).
 //! * An unterminated quote auto-closes at the end of the pattern.
 //!
-//! [`escape_icu_literal`] escapes authored literal segments (template literal
-//! quasis, JSX text, choice option strings) so an authored apostrophe never
-//! turns into a quote that swallows the following placeholder.
+//! [`escape_icu_literal`] escapes authored literal segments for runtime use,
+//! while [`escape_icu_source_literal`] preserves natural apostrophes in catalog
+//! identities and only escapes a run that could start ICU syntax.
 
 /// Escapes authored literal text for embedding into an ICU message pattern.
 ///
-/// Doubling every apostrophe (the Lingui-compatible rule) is what makes the
-/// escaping robust across segment boundaries: an authored segment ending in `'`
-/// followed by a `{placeholder}` cannot form a quote, because the segment is
-/// escaped before the placeholder is appended.
+/// Odd apostrophe runs are doubled; already doubled ICU apostrophes stay a
+/// fixed point. Escaping before a placeholder is appended prevents a trailing
+/// apostrophe from turning into a quote that swallows the placeholder.
 pub(crate) fn escape_icu_literal(text: &str) -> String {
-    if text.contains('\'') {
-        text.replace('\'', "''")
-    } else {
-        text.to_owned()
+    escape_apostrophe_runs(text, |_| true)
+}
+
+/// Escapes authored text for a persisted source identity.
+///
+/// The runtime parser already treats ordinary prose apostrophes literally, so
+/// changing `don't` into `don''t` in a gettext `msgid` is unnecessary and
+/// breaks upgrades from Lingui and older Palamedes catalogs. A single
+/// apostrophe is escaped only before ICU syntax. Callers assemble generated
+/// placeholders before applying this helper so a final prose apostrophe is not
+/// changed merely because it ended one parser segment. Existing pairs stay
+/// unchanged.
+pub(crate) fn escape_icu_source_literal(text: &str) -> String {
+    escape_apostrophe_runs(text, |next| {
+        next.is_some_and(|character| matches!(character, '{' | '}' | '#'))
+    })
+}
+
+fn escape_apostrophe_runs(
+    text: &str,
+    should_escape_odd_run: impl Fn(Option<char>) -> bool,
+) -> String {
+    if !text.contains('\'') {
+        return text.to_owned();
     }
+
+    let mut output = String::with_capacity(text.len() + 2);
+    let mut characters = text.chars().peekable();
+    while let Some(character) = characters.next() {
+        if character != '\'' {
+            output.push(character);
+            continue;
+        }
+
+        let mut count = 1usize;
+        while characters.next_if_eq(&'\'').is_some() {
+            count += 1;
+        }
+        output.extend(std::iter::repeat_n('\'', count));
+        if count % 2 == 1 && should_escape_odd_run(characters.peek().copied()) {
+            output.push('\'');
+        }
+    }
+    output
 }
 
 /// Derives the compiled lookup id for a message text.
@@ -41,14 +79,30 @@ pub(crate) fn compiled_message_key(message: &str, context: Option<&str>) -> Stri
 
 #[cfg(test)]
 mod tests {
-    use super::{compiled_message_key, escape_icu_literal};
+    use super::{compiled_message_key, escape_icu_literal, escape_icu_source_literal};
     use ferrocat::{canonicalize_icu_with_policy, IcuSyntaxPolicy};
 
     #[test]
     fn doubles_authored_apostrophes() {
         assert_eq!(escape_icu_literal("L'"), "L''");
         assert_eq!(escape_icu_literal("don't"), "don''t");
+        assert_eq!(escape_icu_literal("It''s"), "It''s");
         assert_eq!(escape_icu_literal("plain"), "plain");
+    }
+
+    #[test]
+    fn source_literals_preserve_natural_and_already_doubled_apostrophes() {
+        assert_eq!(escape_icu_source_literal("don't"), "don't");
+        assert_eq!(escape_icu_source_literal("client's"), "client's");
+        assert_eq!(escape_icu_source_literal("l'été"), "l'été");
+        assert_eq!(escape_icu_source_literal("It''s"), "It''s");
+    }
+
+    #[test]
+    fn source_literals_still_escape_icu_boundaries() {
+        assert_eq!(escape_icu_source_literal("L'"), "L'");
+        assert_eq!(escape_icu_source_literal("L'{title}"), "L''{title}");
+        assert_eq!(escape_icu_source_literal("'#' don't"), "''#' don't");
     }
 
     #[test]

--- a/crates/palamedes/src/mdx.rs
+++ b/crates/palamedes/src/mdx.rs
@@ -12,7 +12,7 @@ use ferromark::{BlockEvent, InlineEvent, Range};
 use serde::{Deserialize, Serialize};
 
 use crate::extract::ExtractedMessageRecord;
-use crate::icu_text::{compiled_message_key, escape_icu_literal};
+use crate::icu_text::{compiled_message_key, escape_icu_literal, escape_icu_source_literal};
 use crate::jsx_entities::decode_jsx_entities;
 use crate::jsx_message::{clean_jsx_text, join_jsx_message_parts, JsxMessagePart};
 use crate::transform::NativeTransformSourceMap;
@@ -872,6 +872,8 @@ impl<'a> MdxCompiler<'a> {
         let joined = rich_message(
             &unit.roots,
             self.options.framework,
+            IcuLiteralTarget::Runtime,
+            true,
             &mut next_component,
             &mut components,
         );
@@ -881,7 +883,22 @@ impl<'a> MdxCompiler<'a> {
             return true;
         }
 
-        let reference = self.push_message(joined.message, unit.values.clone(), source_offset);
+        let mut ignored_source_components = Vec::new();
+        let mut source_component_index = 0usize;
+        let source_joined = rich_message(
+            &unit.roots,
+            self.options.framework,
+            IcuLiteralTarget::Catalog,
+            false,
+            &mut source_component_index,
+            &mut ignored_source_components,
+        );
+        let reference = self.push_message_with_runtime(
+            source_joined.message,
+            joined.message,
+            unit.values.clone(),
+            source_offset,
+        );
         self.needs_trans = true;
         let mut props = vec![
             format!("id={{{}}}", js_string(&reference.id)),
@@ -917,6 +934,16 @@ impl<'a> MdxCompiler<'a> {
         placeholders: BTreeMap<String, String>,
         source_offset: usize,
     ) -> MessageReference {
+        self.push_message_with_runtime(message.clone(), message, placeholders, source_offset)
+    }
+
+    fn push_message_with_runtime(
+        &mut self,
+        message: String,
+        runtime_message: String,
+        placeholders: BTreeMap<String, String>,
+        source_offset: usize,
+    ) -> MessageReference {
         let id = compiled_message_key(&message, None);
         if !self.compiled_ids.iter().any(|existing| existing == &id) {
             self.compiled_ids.push(id.clone());
@@ -931,7 +958,10 @@ impl<'a> MdxCompiler<'a> {
             origin: (self.filename.to_owned(), line, Some(column)),
             scope: None,
         });
-        MessageReference { message, id }
+        MessageReference {
+            message: runtime_message,
+            id,
+        }
     }
 
     fn rewrite_jsx_tag(&mut self, range: Range) -> String {
@@ -1188,9 +1218,26 @@ struct RichComponent {
     fixed: bool,
 }
 
+#[derive(Clone, Copy)]
+enum IcuLiteralTarget {
+    Catalog,
+    Runtime,
+}
+
+impl IcuLiteralTarget {
+    fn escape(self, text: &str) -> String {
+        match self {
+            Self::Catalog => text.to_owned(),
+            Self::Runtime => escape_icu_literal(text),
+        }
+    }
+}
+
 fn rich_message(
     nodes: &[RichNode],
     framework: MdxFramework,
+    target: IcuLiteralTarget,
+    collect_components: bool,
     next_component: &mut usize,
     components: &mut Vec<(String, String)>,
 ) -> crate::jsx_message::JoinedJsxMessage {
@@ -1198,7 +1245,7 @@ fn rich_message(
     for node in nodes {
         match node {
             RichNode::Text(text, _) => {
-                parts.push(JsxMessagePart::Text(escape_icu_literal(text)));
+                parts.push(JsxMessagePart::Text(target.escape(text)));
             }
             RichNode::Value { name, .. } => {
                 parts.push(JsxMessagePart::ValuePlaceholder(format!("{{{name}}}")));
@@ -1206,8 +1253,14 @@ fn rich_message(
             RichNode::Component(component) => {
                 let name = next_component.to_string();
                 *next_component += 1;
-                let joined =
-                    rich_message(&component.children, framework, next_component, components);
+                let joined = rich_message(
+                    &component.children,
+                    framework,
+                    target,
+                    collect_components,
+                    next_component,
+                    components,
+                );
                 let is_empty = component.fixed || joined.message.is_empty();
                 let value = if is_empty {
                     format!("<{name}/>")
@@ -1215,12 +1268,18 @@ fn rich_message(
                     format!("<{name}>{}</{name}>", joined.message)
                 };
                 parts.push(JsxMessagePart::ComponentPlaceholder { value, is_empty });
-                let expression = component_expression(component, framework);
-                components.push((name, expression));
+                if collect_components {
+                    let expression = component_expression(component, framework);
+                    components.push((name, expression));
+                }
             }
         }
     }
-    join_jsx_message_parts(&parts)
+    let mut joined = join_jsx_message_parts(&parts);
+    if matches!(target, IcuLiteralTarget::Catalog) {
+        joined.message = escape_icu_source_literal(&joined.message);
+    }
+    joined
 }
 
 fn component_expression(component: &RichComponent, framework: MdxFramework) -> String {
@@ -1885,6 +1944,34 @@ const untranslated = "code";
         assert!(code.contains("<__PalamedesTrans"));
         assert!(code.contains(r#"<pre><code className={"language-ts"}>"#));
         assert!(result.map.is_some());
+    }
+
+    #[test]
+    fn separates_mdx_catalog_apostrophes_from_runtime_escaping() {
+        let result = analyze_valid(
+            "don't client's l'été It''s L'{title}",
+            MdxOptions::default(),
+        );
+        assert_eq!(
+            result
+                .messages
+                .iter()
+                .map(|message| message.message.as_str())
+                .collect::<Vec<_>>(),
+            ["don't client's l'été It''s L''{title}"]
+        );
+        assert_eq!(
+            result.compiled_ids,
+            [compiled_message_key(
+                "don't client's l'été It''s L''{title}",
+                None,
+            )]
+        );
+        let code = result.code.expect("valid MDX should compile");
+        assert!(
+            code.contains("don''t client''s l''été It''s L''{title}"),
+            "runtime message must escape natural apostrophes without re-doubling pairs:\n{code}"
+        );
     }
 
     #[test]

--- a/crates/palamedes/src/transform/tests.rs
+++ b/crates/palamedes/src/transform/tests.rs
@@ -339,7 +339,7 @@ const richChoice = <Plural value={props.quantity()} one="# task" other="# tasks"
 }
 
 #[test]
-fn extractor_and_transform_share_escaped_apostrophes() {
+fn extractor_preserves_source_apostrophes_while_transform_escapes_runtime_text() {
     let source = r##"import { plural, t } from "@palamedes/core/macro";
 import { Trans } from "@palamedes/react/macro";
 
@@ -347,6 +347,7 @@ const tagged = t`L'${title} est prêt`;
 const rich = <Trans>l'{item}</Trans>;
 const choice = plural(count, { one: "'#' don't item", other: "# don't items" });
 const plain = t`don't`;
+const doubled = t`client''s l''été`;
 "##;
     let scoped_source = scope_macro_test_source(source, "test.tsx");
     let extracted = crate::extract::extract_messages(&scoped_source, "test.tsx")
@@ -354,8 +355,8 @@ const plain = t`don't`;
     let transformed =
         transform_macros(source, "test.tsx", None).expect("apostrophe messages should transform");
 
-    // Authored apostrophes are doubled so the runtime parser renders them
-    // literally instead of quoting the placeholder that follows.
+    // Catalog identities preserve natural and already doubled apostrophes.
+    // Only a literal/placeholder boundary needs escaping in persisted ICU.
     assert_eq!(
         extracted
             .iter()
@@ -364,22 +365,30 @@ const plain = t`don't`;
         vec![
             "L''{title} est prêt",
             "l''{item}",
-            "{count, plural, one {''#'' don''t item} other {# don''t items}}",
-            "don''t",
+            "{count, plural, one {''#' don't item} other {# don't items}}",
+            "don't",
+            "client''s l''été",
         ]
     );
 
-    // Byte-identical message text on both sides keeps the compiled ids aligned.
+    // Runtime messages may use stricter apostrophe escaping, but policy-aware
+    // key derivation still maps both spellings to the same compiled ids.
     let extracted_ids = extracted
         .iter()
         .map(|message| compiled_message_key(&message.message, message.context.as_deref()))
         .collect::<Vec<_>>();
     assert_eq!(transformed.compiled_ids, extracted_ids);
-    for message in &extracted {
+    for runtime_message in [
+        "L''{title} est prêt",
+        "l''{item}",
+        "{count, plural, one {''#'' don''t item} other {# don''t items}}",
+        "don''t",
+        "client''s l''été",
+    ] {
         assert!(
-            transformed.code.contains(message.message.as_str()),
+            transformed.code.contains(runtime_message),
             "transform output should embed {:?}",
-            message.message
+            runtime_message
         );
     }
 }

--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -254,11 +254,14 @@ show placeholder syntax to the reader:
 
 Quoted runs become `MessageLiteralNode` entries in `getMessageNodes()` output.
 
-Application authors do not need to think about any of this: the macros and the
-extractor escape authored apostrophes on the way into the catalog, so a source
-message written as `Ada's file` is stored as a pattern that renders it back
-unchanged. The rules above matter for translators hand-editing `.po` files, for
-catalogs imported from a TMS, and for patterns passed directly to
+Application authors do not need to think about any of this. Runtime descriptors
+escape authored apostrophes, while extracted catalog identities keep natural
+prose such as `Ada's file` unchanged. The extractor only doubles an apostrophe
+when it directly precedes generated ICU syntax: `` t`L'${title}` `` therefore
+produces the catalog pattern `L''{title}` so the placeholder remains live.
+Policy-aware compiled keys keep the catalog and runtime spellings aligned.
+The rules above matter for translators hand-editing `.po` files, for catalogs
+imported from a TMS, and for patterns passed directly to
 `formatMessagePattern()` — all of which use standard ICU quoting.
 
 One deliberate exception: a descriptor whose `message` is a **string literal**

--- a/docs/migrate-from-lingui.md
+++ b/docs/migrate-from-lingui.md
@@ -260,9 +260,17 @@ ICU diagnostics with the current native core and `ferrocat`.
 Existing translations carried over from Lingui or a TMS keep their ICU quoting.
 Doubled apostrophes (`Ada''s`) render as a single `'`, and `'{'` still emits a
 literal brace — this used to be a documented divergence in the Palamedes
-runtime and is no longer one. Plain apostrophes in prose (`don't`) are left
-alone rather than treated as quote openers, so catalogs that mix both
-conventions migrate without a rewrite. See
+runtime and is no longer one. Plain apostrophes in prose (`don't`, `client's`,
+and `l'été`) stay unchanged in newly extracted PO identities. An apostrophe
+immediately before generated ICU syntax is still escaped, so `` t`L'${title}` ``
+is stored as `L''{title}` and the placeholder remains live at runtime.
+
+When an existing PO catalog uses the other spelling solely because an older
+Palamedes extractor doubled its natural apostrophes, `pmds extract` reuses the
+unique matching `(msgid, msgctxt)` entry. Its translation, translator comments,
+flags, and machine metadata survive, including with `--force-clean`, and
+repeated extraction is stable. Exact identities always win; Palamedes does not
+merge ambiguous entries or entries with different contexts. See
 [Quoting and literal text](api/core.md#quoting-and-literal-text).
 
 ## Common Migration Errors


### PR DESCRIPTION
## Summary

- Keep natural apostrophes unchanged in extracted PO identities while retaining runtime-safe escaping at ICU boundaries.
- Reuse unambiguous apostrophe-equivalent PO entries so translations and translator-owned metadata survive upgrades and `--force-clean`.
- Add Lingui migration, CLI, MDX, runtime, and golden regressions, plus migration documentation.

## Issue

Closes #492

## Validation

- `cargo +stable clippy --workspace --all-targets --locked -- -D warnings`
- `cargo +stable test --workspace --locked`
- `cargo +stable fmt --all --check`
- `cargo +1.95 check -p palamedes --locked`
- `/Users/sebastian/Workspace/palamedes/node_modules/.bin/oxfmt --check --ignore-path .gitignore --ignore-path .oxfmtignore .`
- `git diff --check`

## Follow-up

None.
