### PR TITLE
fix(runtime): resolve server-side getI18n without a React hook

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -68,7 +68,7 @@
   ],
   "scripts": {
     "build": "unbuild",
-    "test": "vitest run --globals src/index.test.tsx && node --test scripts/exports.test.mjs",
+    "test": "vitest run --globals src/index.test.tsx src/runtime.test.ts && node --test scripts/exports.test.mjs",
     "stub": "unbuild --stub"
   },
   "engines": {

--- a/packages/react/src/runtime.test.ts
+++ b/packages/react/src/runtime.test.ts
@@ -1,0 +1,24 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest"
+
+import { resetI18nRuntime, setServerI18nGetter, type I18nInstance } from "@palamedes/runtime"
+
+import { getI18n } from "./runtime"
+
+describe("@palamedes/react/runtime on the server", () => {
+  it("resolves the request-local instance outside component rendering", () => {
+    // Route actions and loaders call transformed macros outside any React
+    // render. In a server environment this must reach the runtime getter
+    // directly instead of a hook, which would crash on React's null
+    // production dispatcher.
+    const i18n: I18nInstance = { locale: "de", _: () => "" }
+    setServerI18nGetter(() => i18n)
+
+    try {
+      expect(getI18n()).toBe(i18n)
+      expect(getI18n()).toBe(i18n)
+    } finally {
+      resetI18nRuntime()
+    }
+  })
+})

--- a/packages/react/src/runtime.ts
+++ b/packages/react/src/runtime.ts
@@ -23,4 +23,16 @@ function useReactiveI18n<T extends I18nInstance = I18nInstance>(): T {
   return getRuntimeI18n<T>()
 }
 
-export { useReactiveI18n as getI18n }
+/*
+ * The hook exists only to subscribe: its return value is unused and the
+ * instance always comes from the runtime getter. On the server there is
+ * nothing to subscribe to, but translated code does run outside component
+ * rendering — route actions and loaders — where calling a hook crashes on a
+ * null dispatcher. Server environments therefore resolve the runtime getter
+ * directly; only browsers take the reactive hook path. The `react-server`
+ * export condition already maps RSC bundles to ./runtime-server; this branch
+ * covers non-RSC SSR bundles, which resolve this default entry.
+ */
+const getI18n = typeof window === "undefined" ? getRuntimeI18n : useReactiveI18n
+
+export { getI18n }


### PR DESCRIPTION
## Problem

Transformed macro calls target `@palamedes/react/runtime`, which exported `useReactiveI18n` as `getI18n`. Route actions and loaders run translated code outside component rendering, where calling `useSyncExternalStore` crashes on React's null production dispatcher:

```
TypeError: Cannot read properties of null (reading 'useSyncExternalStore')
```

Reproduce on an unmodified build: `examples/react-router-cookie`, production build, then POST to the home action (the proof panel's auto-fetch triggers it on page load, taking the whole page into the route error boundary). The failing call is the action's ``t`Server action confirmed locale ...` `` macro.

## Fix

The hook exists only to subscribe for client re-renders; its return value is unused and the instance always comes from the framework-agnostic runtime getter. Server environments now resolve the runtime getter directly through a module-scope environment branch:

```ts
const getI18n = typeof window === "undefined" ? getRuntimeI18n : useReactiveI18n
```

This mirrors what the `react-server` export condition already does for RSC bundles, covers non-RSC SSR bundles regardless of which export conditions a bundler resolves, and leaves the browser's reactive hook path unchanged. Solid is unaffected; its binding reads a signal and needs no dispatcher.

## Verification

- New node-environment test: `getI18n()` outside any React render resolves the request-local server instance.
- End to end on the react-router example in a production build: the server action's translated proof message renders instead of crashing into the error boundary; SSR, hydration, and client locale switching unchanged.
- `tsc`, vitest (31 tests), exports test, oxlint, oxfmt all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
