### PR TITLE
feat(vite-plugin): experimental graph splitting for localized messages

### DIFF
--- a/docs/plans/2026-08-01-code-splitting-localization-rfc.md
+++ b/docs/plans/2026-08-01-code-splitting-localization-rfc.md
@@ -52,10 +52,13 @@ that module is a branded map of executable message functions on the parser-free
 compiled ABI:
 
 ```js
-import{defineCompiledCatalog as __palamedesDefineCompiledCatalog}from"@palamedes/core/compiled";
-const __pm0=(v,r)=>r.join("Hallo ",r.value(v,"name"));
-export const messages=__palamedesDefineCompiledCatalog({["<idA>"]:"Konstante",["<idB>"]:__pm0});
-export default { messages };
+import { defineCompiledCatalog as __palamedesDefineCompiledCatalog } from "@palamedes/core/compiled"
+const __pm0 = (v, r) => r.join("Hallo ", r.value(v, "name"))
+export const messages = __palamedesDefineCompiledCatalog({
+  ["<idA>"]: "Konstante",
+  ["<idB>"]: __pm0,
+})
+export default { messages }
 ```
 
 rendered by the native module renderer in `crates/palamedes-node/src/catalog.rs`
@@ -91,14 +94,14 @@ place, unused:
   MDX. All three host adapters currently discard it
   (`packages/vite-plugin/src/index.ts:502-515`).
 - **Subset compilation.** `compileCatalogArtifactSelected(config, resourcePath,
-  compiledIds)` compiles exactly a given id subset of a catalog
+compiledIds)` compiles exactly a given id subset of a catalog
   (`packages/core-node/src/index.ts:580`, core at
   `crates/palamedes/src/catalog_artifact/mod.rs:88-146`). Today it only backs
   MDX missing-translation validation.
 - **Native module rendering for arbitrary maps.** Since ADR-022,
   `renderCatalogModule(messages)` renders any id→pattern map into the branded
   executable module source on the compiled ABI. Composed with the selected
-  compile, subset artifacts become subset *modules* in two existing calls —
+  compile, subset artifacts become subset _modules_ in two existing calls —
   precompiled, parser-free, and per locale.
 - **Additive runtime loading.** `i18n.load(locale, partial)` already merges
   (`packages/core/src/index.ts:189-192`), so chunked registration does not
@@ -213,7 +216,7 @@ native source map valid; imports hoist anyway):
 
 ```js
 // appended to Checkout.tsx after macro transform
-import "virtual:palamedes/messages/f3a9c1"   // hash of module id
+import "virtual:palamedes/messages/f3a9c1" // hash of module id
 ```
 
 The plugin resolves that id, calls `compileCatalogArtifactSelected` with the
@@ -258,7 +261,7 @@ sync keep code-chunk cache hits.
   reintroduces the `L` factor V1 removed. V4b below removes it cleanly; the
   two compose.
 - **Duplication across sidecars.** A message used in five files appears in
-  five sidecars. Bundler hoisting dedupes *modules*, not object entries.
+  five sidecars. Bundler hoisting dedupes _modules_, not object entries.
   Mitigation (a): accept and measure — shared strings tend to be short UI
   chrome, and chunk-level hoisting still collapses sidecars that end up in the
   same chunk only if identical. Mitigation (b), the **V2b refinement**: the
@@ -279,7 +282,7 @@ sync keep code-chunk cache hits.
   eager full catalogs in dev, split in build, is a legitimate simplification).
 - **Dynamic message ids.** `i18n._(someVariable)` cannot be attributed to a
   module's id set statically. Escape hatch: such messages fall into a
-  *residual catalog* loaded per locale like V1, and the audit surface reports
+  _residual catalog_ loaded per locale like V1, and the audit surface reports
   them (`pmds audit` already exists as the diagnostic home).
 - **ADR-011/022 alignment.** Subset selection, compilation, and module
   rendering all stay native (ADR-022 makes the native renderer the single
@@ -298,7 +301,7 @@ almost entirely from parts that already exist.
 
 ### V3 — Route-manifest artifacts (explicit, framework-driven)
 
-**Idea.** Attribute messages to *emitted chunks* rather than source modules:
+**Idea.** Attribute messages to _emitted chunks_ rather than source modules:
 collect `moduleId → compiledIds` during transform, then in `generateBundle`
 walk each chunk's module list, union the ids, and emit one asset per
 `(chunk × locale)` plus a manifest. Route loaders (TanStack/React Router
@@ -314,7 +317,7 @@ wiring, a manifest to version, an await on every route transition, and
 hand-rolled dedup (a "common" asset for messages shared above a threshold,
 i.e. reimplementing what the bundler does for free in V2).
 
-**Verdict.** Not the primary path, but the right *delivery mode* for two real
+**Verdict.** Not the primary path, but the right _delivery mode_ for two real
 cases: teams that want messages on a CDN outside the JS pipeline, and as the
 mechanical substrate for V6 (the server needs exactly this attribution to
 compute route payloads). Design the chunk-attribution pass once; let V3 and V6
@@ -328,7 +331,7 @@ The user-visible locale dimension, attacked at two different binding times.
 once per locale; the transform inlines translations at the call site
 (precompiled ICU: plain strings become literals, parameterized messages become
 compact precompiled patterns or functions). No catalogs, no lookup, no
-registry: message splitting is perfect *by construction* because messages are
+registry: message splitting is perfect _by construction_ because messages are
 code. Dead-locale elimination is automatic.
 
 Costs are equally structural: `L×` build time and artifact storage;
@@ -342,7 +345,7 @@ V4a no longer needs to invent precompilation — it needs to inline the
 already-compiled function at the call site instead of looking it up in a map.
 
 What redeems it: Palamedes already ships `subdomain` and `tld` locale
-strategies where each locale lives on its own origin and switching *is* a
+strategies where each locale lives on its own origin and switching _is_ a
 navigation. For those deployments, per-locale artifacts are not a workaround
 but the natural shape, and Vite's environments API (the road Paraglide 2 took
 with per-locale graphs) makes the build mechanics tractable. **Positioning:
@@ -351,7 +354,7 @@ mechanism.**
 
 **V4b — Load-time binding via import maps (per-locale sidecars, one app
 build).** Keep the app build locale-neutral (V2 sidecars), but emit the
-sidecar *contents* per locale and let the HTML bind the locale:
+sidecar _contents_ per locale and let the HTML bind the locale:
 
 - sidecar imports use a bare specifier per sidecar (`#pmds/f3a9c1`),
 - the build emits `f3a9c1.en.js`, `f3a9c1.de.js`, … (subset compile per
@@ -372,7 +375,7 @@ per-locale variants of sidecar chunks needs either bundler cooperation
 only. Browser support for import maps is no longer the constraint it was.
 
 **Verdict.** V4b is the designated endgame for SPA-shaped hosts, deliberately
-staged *after* V2 proves the sidecar mechanics; V4a is a niche mode that
+staged _after_ V2 proves the sidecar mechanics; V4a is a niche mode that
 shares the ICU-precompilation investment but should not gate anything.
 
 ### V5 — Per-message compiled functions (Paraglide-style)
@@ -429,7 +432,7 @@ but not graph splitting; not worth its own machinery beyond that.
   next-intl `pick`-per-page), which moves splitting into authoring and
   translation surfaces and rots as routes evolve.
 - **Parser-free discipline (ADR-023).** Every split delivery mechanism that
-  ships message *data* as JS must emit the branded compiled ABI via the native
+  ships message _data_ as JS must emit the branded compiled ABI via the native
   renderer; plain string maps would either re-import the ICU parser into the
   browser (defeating the parser-free win) or be rejected by the parser-free
   Core factory. Mechanisms that ship JSON over HTTP (V3/V6 delivery modes)
@@ -459,17 +462,17 @@ but not graph splitting; not worth its own machinery beyond that.
 
 ## Comparison at a glance
 
-| | First-load messages | Locale switch | Build cost | Hydration | Coupling | Author effort |
-|---|---|---|---|---|---|---|
-| Status quo | all locales × all messages | instant | — | sync | none | none |
-| V1 lazy locale | 1 locale × all | async fetch | none | needs Stage 0 | none | pattern change |
-| V2 sidecars | all locales × route | instant | plugin pass | sync ✓ | bundler only | none |
-| V2b + atoms | all locales × route, deduped | instant | + graph size | sync ✓ | bundler only | none |
-| V3 route manifest | 1 locale × route | async fetch | emit pass | needs await | per framework | none |
-| V4a permutation | 1 locale × route (inlined) | navigation | × L builds | sync ✓ | build infra | none |
-| V4b import maps | **1 locale × route** | reload or ensure | + per-locale emit | sync ✓ | SSR injects map | none |
-| V5 per-message fns | all locales × used | instant | compiler | sync ✓ | model shift | none |
-| V6 server inline | **exactly used client set** | server round trip | attribution pass | sync ✓ | deep per host | none |
+|                    | First-load messages          | Locale switch     | Build cost        | Hydration     | Coupling        | Author effort  |
+| ------------------ | ---------------------------- | ----------------- | ----------------- | ------------- | --------------- | -------------- |
+| Status quo         | all locales × all messages   | instant           | —                 | sync          | none            | none           |
+| V1 lazy locale     | 1 locale × all               | async fetch       | none              | needs Stage 0 | none            | pattern change |
+| V2 sidecars        | all locales × route          | instant           | plugin pass       | sync ✓        | bundler only    | none           |
+| V2b + atoms        | all locales × route, deduped | instant           | + graph size      | sync ✓        | bundler only    | none           |
+| V3 route manifest  | 1 locale × route             | async fetch       | emit pass         | needs await   | per framework   | none           |
+| V4a permutation    | 1 locale × route (inlined)   | navigation        | × L builds        | sync ✓        | build infra     | none           |
+| V4b import maps    | **1 locale × route**         | reload or ensure  | + per-locale emit | sync ✓        | SSR injects map | none           |
+| V5 per-message fns | all locales × used           | instant           | compiler          | sync ✓        | model shift     | none           |
+| V6 server inline   | **exactly used client set**  | server round trip | attribution pass  | sync ✓        | deep per host   | none           |
 
 Order-of-magnitude sizing, explicitly an estimate to be replaced by the
 benchmark lane: at the realistic-corpus scale (6,000 messages), a compiled
@@ -568,13 +571,13 @@ Measured on that example (2 routes, 3 locales, 37 messages), production build
 on `7e697a1`, fair baseline = same two-route app with eager static catalog
 imports, both sides on the compatibility factory (see the parser note below):
 
-| | eager baseline | graph splitting |
-|---|---|---|
-| shared chunk (`jsx-runtime`) | 139.65 kB (46.38 gzip) — carries **all** messages | 134.34 kB (44.21) — carries none |
-| `home` route chunk | 6.85 kB (1.85) | 11.37 kB (3.23) — its messages ride along |
-| `insights` route chunk | 2.46 kB (0.86) | 4.24 kB (1.52) — its messages ride along |
-| `LocaleSwitcher` shared chunk | 4.86 kB (2.28) | 4.97 kB (2.33) |
-| messages loaded on `/` | all routes × 3 locales | home's own × 3 locales |
+|                               | eager baseline                                    | graph splitting                           |
+| ----------------------------- | ------------------------------------------------- | ----------------------------------------- |
+| shared chunk (`jsx-runtime`)  | 139.65 kB (46.38 gzip) — carries **all** messages | 134.34 kB (44.21) — carries none          |
+| `home` route chunk            | 6.85 kB (1.85)                                    | 11.37 kB (3.23) — its messages ride along |
+| `insights` route chunk        | 2.46 kB (0.86)                                    | 4.24 kB (1.52) — its messages ride along  |
+| `LocaleSwitcher` shared chunk | 4.86 kB (2.28)                                    | 4.97 kB (2.33)                            |
+| messages loaded on `/`        | all routes × 3 locales                            | home's own × 3 locales                    |
 
 The dynamic messages inside those route chunks are the ADR-022 executable
 functions (`(v,r)=>r.plural(...)` visibly inline in the emitted chunks), not
@@ -588,7 +591,7 @@ dependency: swapping the example's `createI18n` to `@palamedes/core/compiled`
 moved the `[palamedes:icu-parser]` sentinel out of the shared chunk while all
 sidecar-fed messages (including plurals) kept rendering. The example
 nevertheless stays on the compatibility factory, because its proof panels
-format *raw* ICU patterns through the plain `Trans` component at runtime —
+format _raw_ ICU patterns through the plain `Trans` component at runtime —
 which is exactly the compatibility case ADR-023 keeps the parser for, and
 orthogonal to splitting. Fully parser-free split apps need both the compiled
 factory and no raw-ICU compatibility components.
@@ -620,7 +623,7 @@ Corrections the spike feeds back into the body above:
    render, so buffer + flush suffices. Stage 0 in full remains the
    prerequisite for V1/V3, not for V2.
 3. **Unrelated pre-existing finding**, hit while verifying: transformed macro
-   calls inside react-router *actions* crashed in production because
+   calls inside react-router _actions_ crashed in production because
    `@palamedes/react/runtime` exported a hook-shaped `getI18n`
    (`useSyncExternalStore` outside render). Reproduced identically on an
    unmodified eager build — and fixed on this branch: the hook exists only to

--- a/docs/plans/2026-08-01-code-splitting-localization-rfc.md
+++ b/docs/plans/2026-08-01-code-splitting-localization-rfc.md
@@ -1,0 +1,673 @@
+# RFC: Code Splitting for Localized Messages
+
+**Status:** Draft / Exploration
+**Date:** 2026-08-01
+**Owner:** Palamedes maintainers
+
+## Summary
+
+Palamedes applications code-split their functionality, but not their messages.
+Today every locale's full compiled catalog lands in the first client bundle,
+whether the first route uses those messages or not. The client payload for
+messages scales with `locales × total app messages` instead of
+`1 × messages of the current view`.
+
+This RFC maps the design space for changing that. It grounds every variant in
+what the codebase already provides, because the exploration surfaced something
+encouraging: the two hardest ingredients for automatic message splitting —
+per-module message usage data and subset catalog compilation — already exist in
+the toolchain and are currently discarded or used only for validation.
+
+The headline recommendation is a staged path:
+
+0. give the runtime an explicit loading contract (the real root blocker),
+1. make lazy per-locale catalogs the documented default (`L× → 1×`),
+2. make messages follow the code through the bundler graph via generated
+   sidecar modules — automatic, sync, hydration-safe, no authoring changes,
+3. bind the locale dimension at load time (import maps / per-locale sidecar
+   emission) so the client fetches `active locale × current route` only,
+   with a server-computed inline payload as the equivalent for RSC-style hosts.
+
+Full per-locale build permutation (Angular-style) is kept as an optional
+deployment mode that pairs naturally with the `subdomain`/`tld` locale
+strategies, not as the primary mechanism. Author-facing namespaces
+(the Lingui/next-intl answer) are explicitly rejected.
+
+## Where the weight comes from today
+
+Three layers stack on top of each other. Only the first is app code; the other
+two are the library's ceiling on what an app can do about it.
+
+**1. The app layer imports everything eagerly.** Every example ships a
+hand-written `lib/i18n.ts` that statically imports all locale `.po` files and
+builds an eager `CATALOGS` record reachable from the client entry
+(`examples/react-router-cookie/app/lib/i18n.ts:5-35`, repeated across ~20
+examples). The Next examples split server from client: the server path already
+lazy-imports per locale (`examples/nextjs-cookie/src/lib/i18n.ts:22-25`), the
+client path stays deliberately eager.
+
+**2. The module shape is opaque to tree shaking.** A `.po` file compiles to
+exactly one module per `(catalog × locale)`. Since ADR-022/023 (2026-08-01/02)
+that module is a branded map of executable message functions on the parser-free
+compiled ABI:
+
+```js
+import{defineCompiledCatalog as __palamedesDefineCompiledCatalog}from"@palamedes/core/compiled";
+const __pm0=(v,r)=>r.join("Hallo ",r.value(v,"name"));
+export const messages=__palamedesDefineCompiledCatalog({["<idA>"]:"Konstante",["<idB>"]:__pm0});
+export default { messages };
+```
+
+rendered by the native module renderer in `crates/palamedes-node/src/catalog.rs`
+(per ADR-022 the single catalog-module generator) and forwarded verbatim by the
+Vite plugin, the Next loader, and the Remix load hook. The splitting problem is
+unchanged by that upgrade: the catalog is still one branded map literal per
+locale, which no bundler can tree-shake per entry, so per-locale dynamic import
+remains the best an application can reach — and even that still ships every
+message of the locale to every route. What the upgrade does change is the
+constraint set for splitting: any split artifact must stay on the compiled ABI
+(branded, executable), because the generated production runtime is parser-free
+(ADR-023) and rejects unbranded string catalogs.
+
+**3. The runtime has no loading contract.** `load()` is synchronous and
+additive, `activate()` assigns a string (`packages/core/src/index.ts:189-196`).
+There is no async activation path, no "ensure locale loaded" primitive, no
+suspense integration, and no re-render signal when messages arrive after
+render. The eager static import in every example is the only hydration-safe
+option — the Next client comment says it outright: without it, hydration
+throws `"No active client i18n instance"`. Production output strips source
+fallbacks by default (ADR-004), so messages that miss their loading window fail
+visibly. **Every variant below depends on fixing this layer first.**
+
+### Building blocks that already exist
+
+The exploration found the raw material for automatic splitting already in
+place, unused:
+
+- **Per-module usage sets.** `transformMacros(...)` returns `compiledIds` — the
+  deduplicated list of every lookup key one source file references
+  (`crates/palamedes/src/transform/mod.rs:98-116`, surfaced at
+  `packages/transform/src/transform.ts:13`). `analyzeMdx` returns the same for
+  MDX. All three host adapters currently discard it
+  (`packages/vite-plugin/src/index.ts:502-515`).
+- **Subset compilation.** `compileCatalogArtifactSelected(config, resourcePath,
+  compiledIds)` compiles exactly a given id subset of a catalog
+  (`packages/core-node/src/index.ts:580`, core at
+  `crates/palamedes/src/catalog_artifact/mod.rs:88-146`). Today it only backs
+  MDX missing-translation validation.
+- **Native module rendering for arbitrary maps.** Since ADR-022,
+  `renderCatalogModule(messages)` renders any id→pattern map into the branded
+  executable module source on the compiled ABI. Composed with the selected
+  compile, subset artifacts become subset *modules* in two existing calls —
+  precompiled, parser-free, and per locale.
+- **Additive runtime loading.** `i18n.load(locale, partial)` already merges
+  (`packages/core/src/index.ts:189-192`), so chunked registration does not
+  clobber earlier chunks.
+- **A reserved injection point.** `NativeTransformResult.prepend_text` exists
+  and is always `None` — a natural home for injecting a sidecar import during
+  transform, on the Rust side of the source-map generation.
+- **Per-file extraction data.** The extraction cache (ADR-019) and PO `#:`
+  references both map files to messages, though in source-string space and
+  with durability caveats; `compiledIds` from the transform is the
+  authoritative signal because the plugin computes it anyway, per module, in
+  compiled-key space.
+
+What does **not** exist anywhere: a route concept, a module-graph view (only
+the bundler has one), any persisted manifest, any config surface for output
+granularity, and any CLI compile command (compilation happens only inside
+bundler loaders via NAPI).
+
+## Design axes
+
+Every proposal below is a point in a small number of dimensions. Naming them
+keeps the variants comparable:
+
+1. **When the locale binds.** At build time (one artifact set per locale), at
+   load time (locale-neutral code selects locale-specific message assets), or
+   at runtime (all locales shipped; the status quo).
+2. **The split unit.** Whole app → locale → route → chunk → module → single
+   message.
+3. **Who decides membership.** The author (namespace declarations), the
+   framework (route manifests), the bundler (module graph), or the toolchain
+   (per-module usage sets). Palamedes' model rules out the first: source-string
+   identity deliberately has no author-facing grouping key (ADR-003/004), and
+   adding one would reintroduce exactly the ID sprawl the product removed.
+4. **The delivery channel.** Static import (sync, hydration-safe by
+   construction), dynamic import (async, needs a loading contract), HTTP JSON
+   (cacheable, CDN-friendly, async), server-inlined payload (zero extra
+   requests, server-first hosts), or import-map indirection (static import
+   syntax, load-time binding).
+5. **Deduplication.** Messages shared across split units: duplicate them,
+   hoist them into shared assets (bundlers do this for modules), or refuse to
+   split below the sharing boundary.
+
+Constraints carried over from the ADRs: identity stays source-string-first
+(ADR-003), compiled keys stay internal (ADR-004), the runtime primitive stays
+`getI18n()` (ADR-005), Rust compiles artifacts while adapters render modules
+(ADR-011), and adapters stay thin orchestration layers (ADR-008). Translator
+workflow is a hard invariant: catalogs remain whole `.po`/FCL files; splitting
+is a compile/build concern and must never leak into authoring or translation.
+
+## Stage 0 (prerequisite): a runtime loading contract
+
+Not a variant — the enabler for all of them. Smallest sufficient surface:
+
+- **A shared message store with a revision.** Message registration moves to a
+  store that instances read through (today catalogs live inside the
+  `createI18n` closure). `load()` keeps its signature, bumps a revision, and
+  the existing `subscribeClientI18n` reactivity
+  (`packages/runtime/src/index.ts`) notifies on message arrival, not only on
+  instance replacement. This makes late-arriving chunks re-render correctly
+  and lets sidecar modules register messages before any instance exists.
+- **A loader registry + `ensureLocale(locale): Promise<void>`.** Adapters (or
+  apps) register how a locale's messages are fetched; the runtime dedupes and
+  tracks in-flight loads. `activate()` stays sync; an async `activateLocale()`
+  convenience awaits `ensureLocale` first.
+- **Framework wiring.** React: a suspense-compatible read (throw the in-flight
+  promise) plus the existing `useSyncExternalStore` bridge. Solid: the signal
+  bridge already exists. Server entries for the initial locale must resolve
+  before hydration — route loaders or inline bootstrap, per adapter.
+
+This stage has standalone value even if no further splitting ships: it is what
+the "Larger apps would dynamically import per-locale chunks instead" comment in
+twenty examples silently assumes and the runtime currently cannot honor.
+
+## Variant catalogue
+
+### V1 — Lazy per-locale catalogs
+
+**Idea.** Keep one module per `(catalog × locale)`, stop importing all of them.
+`await import(`../locales/${locale}.po`)` behind `ensureLocale`; other locales
+load on switch.
+
+**Payload.** `L× → 1×` on first load. All messages of the app still ship for
+the active locale.
+
+**Cost.** Small: Stage 0 plus adapter helpers plus rewriting the example
+`i18n.ts` pattern. No bundler machinery, framework-neutral, works everywhere
+including Remix's Node loader. `docs/troubleshooting.md` and
+`examples/README.md` already recommend exactly this without the runtime
+support to make it hydration-safe.
+
+**What this stage actually is.** Not a new capability — real applications
+hand-roll this today, and the bundler side works fine. What they carry
+themselves, because the library offers no contract for it: hydration ordering
+(load+activate must complete before `hydrate()`), a re-render signal for
+late-arriving messages (`load()` bumps no revision, so post-render locale
+switches only repaint via re-installing the instance or a full reload),
+in-flight dedup for rapid switches, and the failed-fetch error path. Stage 1
+is the library catching up with its users — and the examples catching up with
+the docs, which recommend the lazy pattern the examples themselves avoid.
+
+**Verdict.** Not the destination, but the correct first step and the fallback
+story for hosts where graph-based splitting is unavailable. For teams already
+hand-rolling lazy locales, the payload win starts at Stage 2, not here. The
+eager pattern remains valid for tiny catalogs; the docs should present both as
+sanctioned modes with a size threshold rule of thumb.
+
+### V2 — Messages follow the code (bundler-graph sidecar modules)
+
+**Idea.** During transform, every module that uses messages gets one appended
+import of a generated sidecar module (append rather than prepend keeps the
+native source map valid; imports hoist anyway):
+
+```js
+// appended to Checkout.tsx after macro transform
+import "virtual:palamedes/messages/f3a9c1"   // hash of module id
+```
+
+The plugin resolves that id, calls `compileCatalogArtifactSelected` with the
+module's `compiledIds`, renders each locale's subset through the native
+`renderCatalogModule` (one per-locale virtual module, so the artifact stays on
+the branded parser-free compiled ABI of ADR-022/023), and aggregates them in a
+registration module:
+
+```js
+import { messages as en } from "virtual:palamedes-messages/f3a9c1/en"
+import { messages as de } from "virtual:palamedes-messages/f3a9c1/de"
+import { registerMessages } from "@palamedes/runtime"
+registerMessages({ en, de })
+```
+
+The per-locale granularity is not incidental: those per-locale modules are
+exactly the unit V4b later binds through import maps.
+
+**Why this shape wins mechanically.** The bundler now treats messages as what
+they are: dependencies of the code that uses them. Route-level code splitting
+splits messages with zero route knowledge in Palamedes; dynamically imported
+features carry their messages in their own chunk; eagerly imported code keeps
+its messages in the entry. Registration happens at module evaluation, so by
+the time a component renders, its messages are present — synchronous,
+hydration-safe by construction, no suspense needed for the code-split path.
+`compiledIds` and subset compilation make the per-module artifact cheap, and
+the extraction cache discipline (ADR-019) already establishes the invalidation
+pattern: on a `.po` change, invalidate only the sidecars whose id sets
+intersect the changed entries (the plugin holds `moduleId → compiledIds` and
+can invert it).
+
+**Caching behavior** is a quiet highlight: translation-only changes invalidate
+only sidecar chunks, never code chunks, so app deploys after a translation
+sync keep code-chunk cache hits.
+
+**Open problems, honestly stated:**
+
+- **Locale dimension.** The plain form embeds all locales in each sidecar. The
+  route subset shrinks, but each subset ships `L` times. With 2–3 locales and
+  route subsets around 10–20% of the app's messages this already beats V1
+  (e.g. 3 locales × 15% = 45% of one full catalog vs. V1's 100%), but it
+  reintroduces the `L` factor V1 removed. V4b below removes it cleanly; the
+  two compose.
+- **Duplication across sidecars.** A message used in five files appears in
+  five sidecars. Bundler hoisting dedupes *modules*, not object entries.
+  Mitigation (a): accept and measure — shared strings tend to be short UI
+  chrome, and chunk-level hoisting still collapses sidecars that end up in the
+  same chunk only if identical. Mitigation (b), the **V2b refinement**: the
+  sidecar imports one generated atom module per message
+  (`virtual:palamedes/m/<compiledId>`), each registering a single message.
+  Atoms have module identity, so the bundler hoists a shared message into a
+  shared chunk exactly once — Paraglide's message-modules insight transplanted
+  into the registry model without touching authoring or runtime contracts. The
+  price is module-graph size: one module per used message (6,000 messages =
+  6,000 graph nodes). Rollup/Rolldown handle this scale, but build time and
+  dev-server module counts need a measured verdict, not a guess. A pragmatic
+  middle: atoms only for messages referenced by more than one module —
+  computable from the inverted id index.
+- **Module count.** One sidecar per message-bearing file. On the benchmark
+  corpus (1,500 files) that roughly doubles the transformed-module count.
+  Needs measurement in the spike; Vite dev with per-file sidecars may want the
+  dev server to skip splitting entirely (dev already keeps source fallbacks —
+  eager full catalogs in dev, split in build, is a legitimate simplification).
+- **Dynamic message ids.** `i18n._(someVariable)` cannot be attributed to a
+  module's id set statically. Escape hatch: such messages fall into a
+  *residual catalog* loaded per locale like V1, and the audit surface reports
+  them (`pmds audit` already exists as the diagnostic home).
+- **ADR-011/022 alignment.** Subset selection, compilation, and module
+  rendering all stay native (ADR-022 makes the native renderer the single
+  catalog-module generator); the adapter only orchestrates — transform,
+  selected compile, native render, and the thin registration wrapper. No
+  second JavaScript module generator appears.
+- **Brand preservation.** Registration must not degrade the branded compiled
+  catalogs to plain maps: the parser-free runtime rejects unbranded string
+  catalogs (ADR-023), so `registerMessages` and any buffer merge must keep
+  the `defineCompiledCatalog` brand intact (register per branded map rather
+  than spread-merging into anonymous objects). This is a real constraint the
+  spike below did not yet meet.
+
+**Verdict.** The core of the proposal. Automatic, model-preserving, and built
+almost entirely from parts that already exist.
+
+### V3 — Route-manifest artifacts (explicit, framework-driven)
+
+**Idea.** Attribute messages to *emitted chunks* rather than source modules:
+collect `moduleId → compiledIds` during transform, then in `generateBundle`
+walk each chunk's module list, union the ids, and emit one asset per
+`(chunk × locale)` plus a manifest. Route loaders (TanStack/React Router
+loaders, Next segment loading) call `ensureMessages(chunkOrRoute)` before
+render; assets can be JS modules or plain JSON on a CDN.
+
+**Compared to V2.** Same data, different delivery: V2 lets the module graph do
+the distribution implicitly and synchronously; V3 makes it explicit, async,
+and framework-wired. That buys HTTP/CDN delivery, per-locale assets without
+import-map machinery (the loader interpolates the locale into the asset URL),
+and independence from module evaluation order — at the cost of per-framework
+wiring, a manifest to version, an await on every route transition, and
+hand-rolled dedup (a "common" asset for messages shared above a threshold,
+i.e. reimplementing what the bundler does for free in V2).
+
+**Verdict.** Not the primary path, but the right *delivery mode* for two real
+cases: teams that want messages on a CDN outside the JS pipeline, and as the
+mechanical substrate for V6 (the server needs exactly this attribution to
+compute route payloads). Design the chunk-attribution pass once; let V3 and V6
+share it.
+
+### V4 — Binding the locale earlier
+
+The user-visible locale dimension, attacked at two different binding times.
+
+**V4a — Full per-locale build permutation (Angular-style).** Run the bundler
+once per locale; the transform inlines translations at the call site
+(precompiled ICU: plain strings become literals, parameterized messages become
+compact precompiled patterns or functions). No catalogs, no lookup, no
+registry: message splitting is perfect *by construction* because messages are
+code. Dead-locale elimination is automatic.
+
+Costs are equally structural: `L×` build time and artifact storage;
+translation changes invalidate code chunks (bad deploy-cache behavior — the
+mirror image of V2's caching win); locale switching becomes a full
+navigation; and the transform needs catalog access at transform time (today
+the two pipelines are deliberately separate). The heaviest ingredient,
+however, already landed independently: ADR-022's message-program lowering
+compiles ICU into executable JavaScript functions in the native renderer, so
+V4a no longer needs to invent precompilation — it needs to inline the
+already-compiled function at the call site instead of looking it up in a map.
+
+What redeems it: Palamedes already ships `subdomain` and `tld` locale
+strategies where each locale lives on its own origin and switching *is* a
+navigation. For those deployments, per-locale artifacts are not a workaround
+but the natural shape, and Vite's environments API (the road Paraglide 2 took
+with per-locale graphs) makes the build mechanics tractable. **Positioning:
+an optional deployment mode for origin-per-locale setups, not the general
+mechanism.**
+
+**V4b — Load-time binding via import maps (per-locale sidecars, one app
+build).** Keep the app build locale-neutral (V2 sidecars), but emit the
+sidecar *contents* per locale and let the HTML bind the locale:
+
+- sidecar imports use a bare specifier per sidecar (`#pmds/f3a9c1`),
+- the build emits `f3a9c1.en.js`, `f3a9c1.de.js`, … (subset compile per
+  locale — the primitive already takes a locale-specific resource path),
+- the server/adapter injects a per-locale import map resolving each specifier
+  to the locale's file; SSR knows the locale before it writes the HTML in
+  every supported strategy (cookie, route, subdomain, tld).
+
+Result: static import syntax (sync, hydration-safe), bundler-driven
+membership, and the client downloads `1 locale × current route's messages` —
+the theoretical optimum for a catalog-based runtime — from a single app
+build. Costs: import maps must be injected before any module loads (fine for
+SSR'd documents; harder for pure static hosting of a locale-agnostic
+`index.html`); locale switching without navigation needs a fallback (accept a
+reload, or fall back to dynamic ensure for post-load switches); and emitting
+per-locale variants of sidecar chunks needs either bundler cooperation
+(emit-per-locale in `generateBundle`) or a cheap secondary pass over sidecars
+only. Browser support for import maps is no longer the constraint it was.
+
+**Verdict.** V4b is the designated endgame for SPA-shaped hosts, deliberately
+staged *after* V2 proves the sidecar mechanics; V4a is a niche mode that
+shares the ICU-precompilation investment but should not gate anything.
+
+### V5 — Per-message compiled functions (Paraglide-style)
+
+**Idea.** Compile every message into its own exported function; the transform
+rewrites call sites to import and call it. Tree shaking then operates at
+message granularity and the "loading" question dissolves — messages are code.
+
+**Why not as the primary model.** It replaces the catalog-registry runtime
+with a distributed one: `getMessageNodes`/`<Trans>` rich-text rendering, the
+`onMissing`/`reportError` surface, pseudo-locale, and the loading contract all
+have to be rethought per generated function, and the runtime contract of
+ADR-005 stops being the single seam. Payload-wise it embeds all locales at
+each function (or reopens the same per-locale binding question as V4b) and
+pays function boilerplate per message. Its genuine advantage — bundler-native
+dedup of shared messages — is available inside the catalog model as V2b atoms.
+
+**Verdict.** Mined for its insight, rejected as a model shift with marginal
+residual benefit over V2b + V4b.
+
+### V6 — Server-computed payloads (RSC / server-first inline)
+
+**Idea.** On server-first hosts, stop shipping message JS to the client
+entirely. Server-rendered text needs no client messages at all; what
+hydrating client components need is exactly the union of `compiledIds` of the
+client modules in the current route tree — computable at build from the same
+attribution pass as V3. The adapter emits that subset per
+`(route segment × locale)` and the server inlines it into the HTML/RSC payload
+as bootstrap data; `setClientI18n` initializes from it. Zero extra requests,
+exact used-set, hydration-safe by construction.
+
+**Cost.** Per-framework integration depth (Next App Router first — its
+examples already split server/client instances and lazy-load on the server;
+then Waku, then server-first Remix v3). Client-side navigations must deliver
+segment payload deltas the same way the host delivers RSC payloads.
+
+**Verdict.** The correct shape for the RSC end of the framework matrix — where
+V2's "messages ride in code chunks" partially dissolves because much of the
+code never reaches the client. Shares its attribution machinery with V3.
+
+### V7 — Critical-path inlining (sketch only)
+
+Inline the first-paint message subset into the HTML (computed from the entry
+chunk's ids, or measured), defer the rest as one lazy per-locale chunk. A
+pragmatic 80/20 that composes with V1 and needs almost nothing new. Worth
+keeping in the drawer as an interim optimization for apps that adopt Stage 0/1
+but not graph splitting; not worth its own machinery beyond that.
+
+## Cross-cutting concerns
+
+- **Translator workflow is untouched by design.** Every variant splits at
+  compile/build time; `.po`/FCL catalogs stay whole. This is the deliberate
+  contrast to the namespace-declaration answer (Lingui catalogs config,
+  next-intl `pick`-per-page), which moves splitting into authoring and
+  translation surfaces and rots as routes evolve.
+- **Parser-free discipline (ADR-023).** Every split delivery mechanism that
+  ships message *data* as JS must emit the branded compiled ABI via the native
+  renderer; plain string maps would either re-import the ICU parser into the
+  browser (defeating the parser-free win) or be rejected by the parser-free
+  Core factory. Mechanisms that ship JSON over HTTP (V3/V6 delivery modes)
+  need an explicit answer: either server-side rendering into compiled modules,
+  or a deliberate opt-in to the compatibility parser path.
+- **Fallback chains.** Subset compilation must resolve `fallbackLocales` at
+  build into each emitted artifact (the primitive already resolves chains —
+  `resolved_locale_chain` in `CatalogArtifactResult`), so the runtime never
+  needs a second request to satisfy a fallback.
+- **Missing translations.** Production strips source fallbacks by default, so
+  split artifacts inherit the existing `failOnMissing` gate; nothing new, but
+  the gate must run per emitted artifact, not only per whole catalog.
+- **Dev mode.** Dev keeps source fallbacks and tiny latencies; serving eager
+  full catalogs in dev and splitting only in build is a legitimate and much
+  simpler default, provided a `build --debug`-style path exists to debug the
+  split output itself.
+- **Pseudo-locale** rides the same rails as any locale in every variant except
+  V4a, where it doubles build permutations — one more reason V4a stays
+  optional.
+- **Watch/HMR.** The inverted index (`compiledId → sidecars`) scopes `.po`
+  edits to affected sidecars; the extraction cache already demonstrates the
+  per-file invalidation discipline and holds in watch mode.
+- **Proof.** The repo's culture is checked-in evidence. This work should land
+  with a bundle-size lane in the benchmark/report structure: first-load
+  message bytes (raw + gzip) per example, before/after per stage, so the
+  website can quote measured numbers instead of the estimates below.
+
+## Comparison at a glance
+
+| | First-load messages | Locale switch | Build cost | Hydration | Coupling | Author effort |
+|---|---|---|---|---|---|---|
+| Status quo | all locales × all messages | instant | — | sync | none | none |
+| V1 lazy locale | 1 locale × all | async fetch | none | needs Stage 0 | none | pattern change |
+| V2 sidecars | all locales × route | instant | plugin pass | sync ✓ | bundler only | none |
+| V2b + atoms | all locales × route, deduped | instant | + graph size | sync ✓ | bundler only | none |
+| V3 route manifest | 1 locale × route | async fetch | emit pass | needs await | per framework | none |
+| V4a permutation | 1 locale × route (inlined) | navigation | × L builds | sync ✓ | build infra | none |
+| V4b import maps | **1 locale × route** | reload or ensure | + per-locale emit | sync ✓ | SSR injects map | none |
+| V5 per-message fns | all locales × used | instant | compiler | sync ✓ | model shift | none |
+| V6 server inline | **exactly used client set** | server round trip | attribution pass | sync ✓ | deep per host | none |
+
+Order-of-magnitude sizing, explicitly an estimate to be replaced by the
+benchmark lane: at the realistic-corpus scale (6,000 messages), a compiled
+per-locale catalog is roughly 400–500 KB of module source, on the order of
+60–100 KB gzipped. Three eager locales put all of that ×3 in the entry today.
+V1 divides by the locale count; V2/V4b reduce the remainder to the current
+route's share — commonly 10–20% for a first route in a route-split app.
+
+## Recommendation and staging
+
+Each stage ships value alone and none forecloses the later ones:
+
+- **Stage 0 — runtime loading contract.** Shared message store with revision,
+  `ensureLocale` + loader registry, suspense/await wiring per framework.
+  Unblocks everything; fixes the documented-but-unsupported lazy pattern.
+- **Stage 1 — V1 as the sanctioned default.** Adapter helpers, docs, examples
+  flipped to lazy per-locale with an explicit "tiny catalogs may stay eager"
+  rule. Cuts the locale factor with trivial machinery.
+- **Stage 2 — V2 sidecar splitting in the Vite plugin** behind a config flag
+  (working name: `splitting: "graph"`), all-locales-embedded first because it
+  is sync and simple; spike measures module-count overhead, sidecar
+  duplication rate, and dev-server impact on a real example; V2b atoms if the
+  duplication measurement says so. Next/Turbopack follows once the Vite shape
+  settles.
+- **Stage 3 — bind the locale.** V4b import-map binding for SPA-shaped hosts;
+  V6 server-inlined payloads for the RSC end, sharing the chunk-attribution
+  pass with a V3-style manifest mode for CDN delivery.
+- **Optional, later.** V4a permutation builds as a deployment mode for
+  `subdomain`/`tld` setups; V7 critical-path inlining if real apps want a
+  cheaper interim step.
+- **Explicitly not doing.** Author-facing namespaces or catalog-per-route
+  authoring conventions (violates the source-string-first model and rots);
+  V5 as a runtime-model replacement.
+
+The through-line: **membership is decided by the bundler graph, locale binding
+is decided by the host, authors decide nothing.** That division is what the
+existing architecture — per-module `compiledIds`, subset compilation, thin
+adapters, one runtime — was already shaped for, even if nothing wires it
+together yet.
+
+## Open questions
+
+1. NAPI call granularity for sidecar compilation: one
+   `compileCatalogArtifactSelected` per module is the simple start; a batched
+   `compileCatalogArtifactsForModules(map)` may be warranted — measure before
+   adding surface (ADR-009 favors workflow-shaped native ops).
+2. Where sidecar import injection lives: fill `prepend_text` natively
+   (source-map-clean, one less JS concern) or append in the plugin
+   (source-map-neutral at EOF). Leaning native.
+3. Whether `registerMessages` becomes public API or stays an internal runtime
+   entry only generated code imports (ADR-004 suggests internal).
+4. Chunk-attribution timing in Vite: `generateBundle` sees final chunks but
+   runs late; Rolldown/Vite 8 environment hooks may offer a cleaner seam —
+   verify against the Vite versions the plugin supports.
+5. Remix v3's Node loader has no bundler graph; V1 + V6-style server payloads
+   are likely its whole story — confirm with the smoke setup.
+6. Interaction with `keepSourceFallbacks: true` apps: sidecars make fallback
+   stripping safer (messages provably arrive with the code) — could stripping
+   become unconditional in split mode?
+7. Sidecar × locale module fan-out on the ADR-022 renderer: one
+   `renderCatalogModule` call and one virtual module per (source file ×
+   locale) is the composable start, but a batched native "render registration
+   module for these locales" op would halve the module count — same
+   measure-before-adding-surface rule as question 1.
+
+## Appendix: Stage-2 spike results (2026-08-01)
+
+A working V2 prototype exists on this branch, built against the ADR-022/023
+runtime (rebased onto `7e697a1`). What was built:
+
+- **Runtime**: `registerMessages(catalogs)` in `@palamedes/runtime` — loads
+  into the active client instance when one is installed, buffers otherwise;
+  `setClientI18n` flushes the buffer. Each registered map is buffered and
+  loaded **as-is, never copied or merged** — generated catalogs carry the
+  compiled-catalog brand and the parser-free runtime rejects unbranded
+  copies; cross-registration merging is `load()`'s job (which the ADR-022
+  core already does per entry). Registrations survive `resetI18nRuntime()`
+  (module-evaluation facts, mirroring the framework bindings' listener
+  stores). Five new tests.
+- **Vite plugin**: `experimentalGraphSplitting` option — the transform hook
+  records each module's `compiledIds` and appends a
+  `import "virtual:palamedes-messages/<hash>"` (append keeps the native source
+  map valid). The sidecar plugin serves two module levels: per (source file ×
+  locale) a subset module produced by `compileCatalogArtifactSelected` + the
+  native `renderCatalogModule` — so split artifacts are branded, precompiled,
+  and parser-free — plus one aggregator that imports the per-locale modules
+  and registers their exports. `failOnMissing` and watch files honored;
+  pseudo-locale skipped for now (the selected compile has no generated-pseudo
+  path). Six new tests.
+- **Example**: `examples/react-router-cookie` gained a second route
+  (`/insights`) with its own messages, a shared message with home, client
+  bootstrap without any catalog import (`lib/i18n.ts`), and server-only eager
+  catalogs in `lib/i18n.server.ts`.
+
+Measured on that example (2 routes, 3 locales, 37 messages), production build
+on `7e697a1`, fair baseline = same two-route app with eager static catalog
+imports, both sides on the compatibility factory (see the parser note below):
+
+| | eager baseline | graph splitting |
+|---|---|---|
+| shared chunk (`jsx-runtime`) | 139.65 kB (46.38 gzip) — carries **all** messages | 134.34 kB (44.21) — carries none |
+| `home` route chunk | 6.85 kB (1.85) | 11.37 kB (3.23) — its messages ride along |
+| `insights` route chunk | 2.46 kB (0.86) | 4.24 kB (1.52) — its messages ride along |
+| `LocaleSwitcher` shared chunk | 4.86 kB (2.28) | 4.97 kB (2.33) |
+| messages loaded on `/` | all routes × 3 locales | home's own × 3 locales |
+
+The dynamic messages inside those route chunks are the ADR-022 executable
+functions (`(v,r)=>r.plural(...)` visibly inline in the emitted chunks), not
+ICU strings. Summed route-side message payload (4.52 + 1.78 + 0.11 kB) versus
+the shared-chunk delta (5.31 kB) puts the split overhead — cross-route
+duplication ×3 locales plus aggregator imports — at roughly 1.1 kB raw here;
+it amortizes as the route count grows.
+
+**Parser note.** With splitting active, the catalog path contributes no parser
+dependency: swapping the example's `createI18n` to `@palamedes/core/compiled`
+moved the `[palamedes:icu-parser]` sentinel out of the shared chunk while all
+sidecar-fed messages (including plurals) kept rendering. The example
+nevertheless stays on the compatibility factory, because its proof panels
+format *raw* ICU patterns through the plain `Trans` component at runtime —
+which is exactly the compatibility case ADR-023 keeps the parser for, and
+orthogonal to splitting. Fully parser-free split apps need both the compiled
+factory and no raw-ICU compatibility components.
+
+Absolute deltas are tiny at demo scale; the structural property is the point:
+`/` no longer downloads `/insights`' messages, and message payload now scales
+with the route instead of the app. Sidecar stats: 5 sidecars over 12 app
+files; 41 references to 37 unique messages; 4 messages (10.8%) live in two
+modules each — two of those collapse into the same chunk anyway, and the
+remaining cross-route duplication is the V2b atom candidate.
+
+Browser-verified on the production build: SSR renders localized, hydration is
+clean (no console errors), a client-side locale switch re-renders without a
+reload from sidecar-registered messages (buffer flush path), and navigating to
+the other route lazy-loads that route's chunk together with its messages
+(network-verified).
+
+Corrections the spike feeds back into the body above:
+
+1. **Sidecars inline into their importer's chunk** when they have a single
+   importer, so a translation-only change re-hashes the route chunks that use
+   the changed message — not a separate message asset. The "translation
+   changes never invalidate code chunks" property additionally needs sidecars
+   emitted as their own chunks (`manualChunks`, or V2b atoms which are shared
+   and therefore split naturally). Stage 2 should treat that as a follow-up
+   knob, not a given.
+2. **The runtime contract needed for V2 alone is smaller than Stage 0**: no
+   async `ensureLocale`, no suspense — module evaluation always precedes
+   render, so buffer + flush suffices. Stage 0 in full remains the
+   prerequisite for V1/V3, not for V2.
+3. **Unrelated pre-existing finding**, hit while verifying: transformed macro
+   calls inside react-router *actions* crashed in production because
+   `@palamedes/react/runtime` exported a hook-shaped `getI18n`
+   (`useSyncExternalStore` outside render). Reproduced identically on an
+   unmodified eager build — and fixed on this branch: the hook exists only to
+   subscribe and its return value is unused, so server environments now
+   resolve the runtime getter directly (`typeof window` branch at module
+   scope), mirroring what the `react-server` condition already does for RSC.
+   Verified end to end: the example's server action renders its translated
+   proof message in the production build. Solid is unaffected (signal read,
+   no dispatcher).
+
+### Addendum (2026-08-02): rebased onto ADR-022/023 and reworked
+
+The spike originally ran against the pre-ADR-022 base (`488caaf`); main then
+moved generated catalogs to branded executable message functions with a
+parser-free production runtime (`6f5c55f`…`7e697a1`). The branch was rebased
+onto `7e697a1` and the spike reworked; the numbers and description above are
+from the rebased state. What the upgrade changed:
+
+- **The mechanism came out stronger.** The two-call pipeline the sidecars
+  need — `compileCatalogArtifactSelected` + `renderCatalogModule` — now
+  exists natively end to end, and main independently built the precompilation
+  half that this RFC's V4a/V2 sections previously listed as new machinery.
+- **Two spike pieces had to change shape**, both now done: sidecar rendering
+  moved from plugin-rendered JSON (unbranded — rejected by the parser-free
+  runtime) to native-rendered per-locale modules plus an aggregator, and the
+  `registerMessages` buffer became brand-preserving (maps buffered and loaded
+  as-is instead of spread-merged; the ADR-022 `load()` merges per entry).
+- **Browser-verified again on the rebased production build**: SSR localized,
+  hydration clean, client-side locale switch without reload through the
+  buffered branded catalogs, route navigation lazy-loading the route chunk
+  with its messages, plurals rendering from compiled functions.
+- The main-branch runtime refactors did **not** change the pre-existing
+  hook-`getI18n` action crash; it reproduced identically on `7e697a1` and is
+  now fixed on this branch (finding 3 above).
+
+## Prior art (references, not blueprints)
+
+- **Paraglide JS 2** — message-modules build output for tree shaking;
+  experimental per-locale builds on Vite environments; middleware locale
+  splitting for SSR. Closest relative of V2b/V4a; differs by having no
+  catalog runtime at all.
+- **Lingui** — per-locale compiled catalogs, lazy activation, optional
+  multiple catalogs via path-scoped config (author-declared grouping).
+  V1's shape; the grouping approach this RFC rejects.
+- **next-intl** — runtime JSON messages, author-side `pick` per
+  page/namespace. The maintenance profile the through-line above avoids.
+- **Angular `$localize`** — the canonical V4a: build-time inlining, one
+  artifact set per locale.
+- **Import maps** — the load-time binding mechanism behind V4b; widely
+  supported in current browsers.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -10,4 +10,7 @@ Rules:
 
 Current state:
 
-- no active plan documents are checked in
+- [2026-06-30 Ferrocat 2 migration RFC](2026-06-30-ferrocat-2-migration-rfc.md)
+- [2026-07-01 Headless locale controls RFC](2026-07-01-locale-controls-library-rfc.md)
+- [2026-07-06 Remix v3 support spike](2026-07-06-remix-v3-support-spike.md)
+- [2026-08-01 Code splitting for localized messages RFC](2026-08-01-code-splitting-localization-rfc.md)

--- a/examples/react-router-cookie/app/lib/i18n.server.ts
+++ b/examples/react-router-cookie/app/lib/i18n.server.ts
@@ -1,0 +1,23 @@
+import type { CompiledCatalogMessages } from "@palamedes/core/compiled"
+import { setServerI18nGetter } from "@palamedes/runtime"
+import { messages as enMessages } from "../locales/en.po"
+import { messages as deMessages } from "../locales/de.po"
+import { messages as esMessages } from "../locales/es.po"
+import { createExampleI18n, type Locale } from "./i18n"
+
+// The server renders every route and locale, so it keeps the full catalogs.
+// Bundle size is a client concern; the client receives its messages through
+// generated sidecar modules instead (see lib/i18n.ts).
+const CATALOGS: Record<Locale, CompiledCatalogMessages> = {
+  en: enMessages,
+  de: deMessages,
+  es: esMessages,
+}
+
+export function activateServerI18n(locale: Locale) {
+  const i18n = createExampleI18n()
+  i18n.load(locale, CATALOGS[locale])
+  i18n.activate(locale)
+  setServerI18nGetter(() => i18n)
+  return i18n
+}

--- a/examples/react-router-cookie/app/lib/i18n.ts
+++ b/examples/react-router-cookie/app/lib/i18n.ts
@@ -1,10 +1,11 @@
+// The compatibility factory, deliberately: the demo panels format raw ICU
+// patterns at runtime through the plain `Trans` component, which needs the
+// parser. Apps without raw-ICU usage can import createI18n from
+// "@palamedes/core/compiled" instead and drop the parser from the bundle;
+// the generated message sidecars work identically with both factories.
 import { createI18n } from "@palamedes/core"
-import type { CompiledCatalogMessages } from "@palamedes/core/compiled"
-import { setClientI18n, setServerI18nGetter } from "@palamedes/runtime"
+import { setClientI18n } from "@palamedes/runtime"
 import { defineLocaleControls } from "@palamedes/core/locale"
-import { messages as enMessages } from "../locales/en.po"
-import { messages as deMessages } from "../locales/de.po"
-import { messages as esMessages } from "../locales/es.po"
 
 export const LOCALES = ["en", "de", "es"] as const
 export const DEFAULT_LOCALE = "en"
@@ -24,32 +25,16 @@ export function getLocaleLabel(locale: Locale): string {
   return locales.label(locale)
 }
 
-// Demo catalogs are tiny, so they ship statically. That keeps client locale
-// activation synchronous, which matters during hydration: translated components
-// render in the same pass as the activation call, before any async load could
-// resolve. Larger apps would dynamically import per-locale chunks instead.
-const CATALOGS: Record<Locale, CompiledCatalogMessages> = {
-  en: enMessages,
-  de: deMessages,
-  es: esMessages,
-}
-
-export function loadMessages(locale: Locale): CompiledCatalogMessages {
-  return CATALOGS[locale]
-}
-
 export function createExampleI18n() {
   return createI18n()
 }
 
-export function activateServerI18n(locale: Locale) {
-  const i18n = createExampleI18n()
-  i18n.load(locale, loadMessages(locale))
-  i18n.activate(locale)
-  setServerI18nGetter(() => i18n)
-  return i18n
-}
-
+// This example uses experimental graph splitting: no catalog is imported here.
+// Every code chunk registers the messages it uses through a generated sidecar
+// module at evaluation time, so activation stays synchronous and
+// hydration-safe, and `setClientI18n` flushes registrations that arrived
+// before the instance was installed. Server rendering keeps its full catalogs
+// in lib/i18n.server.ts.
 const clientI18n = createExampleI18n()
 
 export function syncClientI18n(locale: Locale) {
@@ -57,7 +42,6 @@ export function syncClientI18n(locale: Locale) {
     return
   }
 
-  clientI18n.load(locale, loadMessages(locale))
   clientI18n.activate(locale)
   setClientI18n(clientI18n)
 }

--- a/examples/react-router-cookie/app/locales/de.po
+++ b/examples/react-router-cookie/app/locales/de.po
@@ -6,86 +6,162 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "X-Generator: palamedes\n"
 
-msgid "Add to cart"
-msgstr "In den Warenkorb"
-
-msgid "Attendees"
-msgstr "Teilnehmer"
-
-msgid "Availability"
-msgstr "Verfügbarkeit"
-
-msgid "Behind the scenes"
-msgstr "Hinter den Kulissen"
-
-msgid "Berlin, Germany"
-msgstr "Berlin, Deutschland"
-
-msgid "Book your seat at Frontend Stage 2026"
-msgstr "Sichere dir deinen Platz bei Frontend Stage 2026"
-
-msgid "Conference pass"
-msgstr "Konferenzpass"
-
-msgid "Currency"
-msgstr "Währung"
-
-msgid "Date"
-msgstr "Datum"
-
-msgid "Fewer tickets"
-msgstr "Weniger Tickets"
-
-msgid "Locale"
-msgstr "Sprache"
-
-msgid "Localized live with Palamedes"
-msgstr "Live lokalisiert mit Palamedes"
-
-msgid "More tickets"
-msgstr "Mehr Tickets"
-
-msgid "Number"
-msgstr "Zahl"
-
-msgid "Plural"
-msgstr "Plural"
-
-msgid "Refresh server result"
-msgstr "Serverergebnis aktualisieren"
-
-msgid "Rendered with React Router"
-msgstr "Gerendert mit React Router"
-
-msgid "Server"
-msgstr "Server"
-
-msgid "Server action confirmed locale {locale}."
-msgstr "Serveraktion bestätigte Sprache {locale}."
-
-msgid "Three days of talks on the craft of building for the web. Choose your tickets below."
-msgstr "Drei Tage Talks über das Handwerk moderner Web-Entwicklung. Wähle unten deine Tickets."
-
-msgid "Total"
-msgstr "Gesamt"
-
-msgid "Venue"
-msgstr "Ort"
-
-msgid "Welcome back, {attendeeName}."
-msgstr "Willkommen zurück, {attendeeName}."
-
-msgid "each"
-msgstr "pro Stück"
-
-msgid "one switch, every format"
-msgstr "ein Klick, alle Formate"
-
-msgid "server locale"
-msgstr "Server-Sprache"
-
+#: examples/react-router-cookie/app/components/TicketPanel.tsx#TicketPanel
 msgid "{quantity, plural, one {# ticket} other {# tickets}}"
 msgstr "{quantity, plural, one {# Ticket} other {# Tickets}}"
 
+#: examples/react-router-cookie/app/components/ProofPanel.tsx#ProofPanel
+#: examples/react-router-cookie/app/components/TicketPanel.tsx#TicketPanel
 msgid "{seats, plural, one {# seat left} other {# seats left}}"
 msgstr "{seats, plural, one {# Platz frei} other {# Plätze frei}}"
+
+#: examples/react-router-cookie/app/routes/insights.tsx
+msgid ""
+"{workshops, plural, one {# workshop still has open seats} other {# workshops "
+"still have open seats}}"
+msgstr ""
+"{workshops, plural, one {# Workshop hat noch freie Plätze} other {# Workshops "
+"haben noch freie Plätze}}"
+
+#: examples/react-router-cookie/app/components/TicketPanel.tsx#TicketPanel
+msgid "Add to cart"
+msgstr "In den Warenkorb"
+
+#: examples/react-router-cookie/app/routes/insights.tsx
+msgid "Attendance insights"
+msgstr "Teilnahme im Überblick"
+
+#: examples/react-router-cookie/app/components/TicketPanel.tsx#TicketPanel
+msgid "Attendees"
+msgstr "Teilnehmer"
+
+#: examples/react-router-cookie/app/components/TicketPanel.tsx#TicketPanel
+msgid "Availability"
+msgstr "Verfügbarkeit"
+
+#: examples/react-router-cookie/app/routes/insights.tsx
+msgid "Back to ticket sale"
+msgstr "Zurück zum Ticketverkauf"
+
+#: examples/react-router-cookie/app/components/ProofPanel.tsx#ProofPanel
+msgid "Behind the scenes"
+msgstr "Hinter den Kulissen"
+
+#: examples/react-router-cookie/app/components/TicketPanel.tsx#TicketPanel
+msgid "Berlin, Germany"
+msgstr "Berlin, Deutschland"
+
+#: examples/react-router-cookie/app/routes/home.tsx
+msgid "Book your seat at Frontend Stage 2026"
+msgstr "Sichere dir deinen Platz bei Frontend Stage 2026"
+
+#: examples/react-router-cookie/app/components/TicketPanel.tsx#TicketPanel
+msgid "Conference pass"
+msgstr "Konferenzpass"
+
+#: examples/react-router-cookie/app/routes/insights.tsx
+msgid "Countries represented"
+msgstr "Vertretene Länder"
+
+#: examples/react-router-cookie/app/components/ProofPanel.tsx#ProofPanel
+msgid "Currency"
+msgstr "Währung"
+
+#: examples/react-router-cookie/app/components/ProofPanel.tsx#ProofPanel
+#: examples/react-router-cookie/app/components/TicketPanel.tsx#TicketPanel
+msgid "Date"
+msgstr "Datum"
+
+#: examples/react-router-cookie/app/components/TicketPanel.tsx#TicketPanel
+msgid "each"
+msgstr "pro Stück"
+
+#: examples/react-router-cookie/app/components/TicketPanel.tsx#TicketPanel
+msgid "Fewer tickets"
+msgstr "Weniger Tickets"
+
+#: examples/react-router-cookie/app/routes/insights.tsx
+msgid "Live numbers for the current ticket sale, rendered on their own route."
+msgstr "Live-Zahlen zum laufenden Ticketverkauf, gerendert auf einer eigenen Route."
+
+#: examples/react-router-cookie/app/components/LocaleSwitcher.tsx#LocaleSwitcher
+msgid "Locale"
+msgstr "Sprache"
+
+#: examples/react-router-cookie/app/routes/home.tsx
+#: examples/react-router-cookie/app/routes/insights.tsx
+msgid "Localized live with Palamedes"
+msgstr "Live lokalisiert mit Palamedes"
+
+#: examples/react-router-cookie/app/components/TicketPanel.tsx#TicketPanel
+msgid "More tickets"
+msgstr "Mehr Tickets"
+
+#: examples/react-router-cookie/app/components/ProofPanel.tsx#ProofPanel
+msgid "Number"
+msgstr "Zahl"
+
+#: examples/react-router-cookie/app/components/ProofPanel.tsx#ProofPanel
+msgid "one switch, every format"
+msgstr "ein Klick, alle Formate"
+
+#: examples/react-router-cookie/app/components/ProofPanel.tsx#ProofPanel
+msgid "Plural"
+msgstr "Plural"
+
+#: examples/react-router-cookie/app/components/ProofPanel.tsx#ProofPanel
+msgid "Refresh server result"
+msgstr "Serverergebnis aktualisieren"
+
+#: examples/react-router-cookie/app/routes/insights.tsx
+msgid "Registered attendees"
+msgstr "Angemeldete Teilnehmer"
+
+#: examples/react-router-cookie/app/routes/home.tsx
+msgid "Rendered with React Router"
+msgstr "Gerendert mit React Router"
+
+#: examples/react-router-cookie/app/components/ProofPanel.tsx#ProofPanel
+msgid "Server"
+msgstr "Server"
+
+#: examples/react-router-cookie/app/routes/home.tsx#action
+msgid "Server action confirmed locale {locale}."
+msgstr "Serveraktion bestätigte Sprache {locale}."
+
+#: examples/react-router-cookie/app/routes/home.tsx
+#: examples/react-router-cookie/app/routes/insights.tsx
+msgid "server locale"
+msgstr "Server-Sprache"
+
+#: examples/react-router-cookie/app/routes/insights.tsx
+msgid "Talks scheduled"
+msgstr "Geplante Talks"
+
+#: examples/react-router-cookie/app/routes/home.tsx
+msgid ""
+"Three days of talks on the craft of building for the web. Choose your tickets "
+"below."
+msgstr ""
+"Drei Tage Talks über das Handwerk moderner Web-Entwicklung. Wähle unten "
+"deine Tickets."
+
+#: examples/react-router-cookie/app/components/TicketPanel.tsx#TicketPanel
+msgid "Total"
+msgstr "Gesamt"
+
+#: examples/react-router-cookie/app/components/TicketPanel.tsx#TicketPanel
+msgid "Venue"
+msgstr "Ort"
+
+#: examples/react-router-cookie/app/routes/home.tsx
+msgid "View attendance insights"
+msgstr "Teilnahme im Überblick ansehen"
+
+#: examples/react-router-cookie/app/routes/home.tsx
+msgid "Welcome back, {attendeeName}."
+msgstr "Willkommen zurück, {attendeeName}."
+
+#: examples/react-router-cookie/app/routes/insights.tsx
+msgid "Workshop capacity"
+msgstr "Workshop-Kapazität"

--- a/examples/react-router-cookie/app/locales/en.po
+++ b/examples/react-router-cookie/app/locales/en.po
@@ -6,86 +6,162 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "X-Generator: palamedes\n"
 
-msgid "Add to cart"
-msgstr "Add to cart"
-
-msgid "Attendees"
-msgstr "Attendees"
-
-msgid "Availability"
-msgstr "Availability"
-
-msgid "Behind the scenes"
-msgstr "Behind the scenes"
-
-msgid "Berlin, Germany"
-msgstr "Berlin, Germany"
-
-msgid "Book your seat at Frontend Stage 2026"
-msgstr "Book your seat at Frontend Stage 2026"
-
-msgid "Conference pass"
-msgstr "Conference pass"
-
-msgid "Currency"
-msgstr "Currency"
-
-msgid "Date"
-msgstr "Date"
-
-msgid "Fewer tickets"
-msgstr "Fewer tickets"
-
-msgid "Locale"
-msgstr "Locale"
-
-msgid "Localized live with Palamedes"
-msgstr "Localized live with Palamedes"
-
-msgid "More tickets"
-msgstr "More tickets"
-
-msgid "Number"
-msgstr "Number"
-
-msgid "Plural"
-msgstr "Plural"
-
-msgid "Refresh server result"
-msgstr "Refresh server result"
-
-msgid "Rendered with React Router"
-msgstr "Rendered with React Router"
-
-msgid "Server"
-msgstr "Server"
-
-msgid "Server action confirmed locale {locale}."
-msgstr "Server action confirmed locale {locale}."
-
-msgid "Three days of talks on the craft of building for the web. Choose your tickets below."
-msgstr "Three days of talks on the craft of building for the web. Choose your tickets below."
-
-msgid "Total"
-msgstr "Total"
-
-msgid "Venue"
-msgstr "Venue"
-
-msgid "Welcome back, {attendeeName}."
-msgstr "Welcome back, {attendeeName}."
-
-msgid "each"
-msgstr "each"
-
-msgid "one switch, every format"
-msgstr "one switch, every format"
-
-msgid "server locale"
-msgstr "server locale"
-
+#: examples/react-router-cookie/app/components/TicketPanel.tsx#TicketPanel
 msgid "{quantity, plural, one {# ticket} other {# tickets}}"
 msgstr "{quantity, plural, one {# ticket} other {# tickets}}"
 
+#: examples/react-router-cookie/app/components/ProofPanel.tsx#ProofPanel
+#: examples/react-router-cookie/app/components/TicketPanel.tsx#TicketPanel
 msgid "{seats, plural, one {# seat left} other {# seats left}}"
 msgstr "{seats, plural, one {# seat left} other {# seats left}}"
+
+#: examples/react-router-cookie/app/routes/insights.tsx
+msgid ""
+"{workshops, plural, one {# workshop still has open seats} other {# workshops "
+"still have open seats}}"
+msgstr ""
+"{workshops, plural, one {# workshop still has open seats} other {# workshops "
+"still have open seats}}"
+
+#: examples/react-router-cookie/app/components/TicketPanel.tsx#TicketPanel
+msgid "Add to cart"
+msgstr "Add to cart"
+
+#: examples/react-router-cookie/app/routes/insights.tsx
+msgid "Attendance insights"
+msgstr "Attendance insights"
+
+#: examples/react-router-cookie/app/components/TicketPanel.tsx#TicketPanel
+msgid "Attendees"
+msgstr "Attendees"
+
+#: examples/react-router-cookie/app/components/TicketPanel.tsx#TicketPanel
+msgid "Availability"
+msgstr "Availability"
+
+#: examples/react-router-cookie/app/routes/insights.tsx
+msgid "Back to ticket sale"
+msgstr "Back to ticket sale"
+
+#: examples/react-router-cookie/app/components/ProofPanel.tsx#ProofPanel
+msgid "Behind the scenes"
+msgstr "Behind the scenes"
+
+#: examples/react-router-cookie/app/components/TicketPanel.tsx#TicketPanel
+msgid "Berlin, Germany"
+msgstr "Berlin, Germany"
+
+#: examples/react-router-cookie/app/routes/home.tsx
+msgid "Book your seat at Frontend Stage 2026"
+msgstr "Book your seat at Frontend Stage 2026"
+
+#: examples/react-router-cookie/app/components/TicketPanel.tsx#TicketPanel
+msgid "Conference pass"
+msgstr "Conference pass"
+
+#: examples/react-router-cookie/app/routes/insights.tsx
+msgid "Countries represented"
+msgstr "Countries represented"
+
+#: examples/react-router-cookie/app/components/ProofPanel.tsx#ProofPanel
+msgid "Currency"
+msgstr "Currency"
+
+#: examples/react-router-cookie/app/components/ProofPanel.tsx#ProofPanel
+#: examples/react-router-cookie/app/components/TicketPanel.tsx#TicketPanel
+msgid "Date"
+msgstr "Date"
+
+#: examples/react-router-cookie/app/components/TicketPanel.tsx#TicketPanel
+msgid "each"
+msgstr "each"
+
+#: examples/react-router-cookie/app/components/TicketPanel.tsx#TicketPanel
+msgid "Fewer tickets"
+msgstr "Fewer tickets"
+
+#: examples/react-router-cookie/app/routes/insights.tsx
+msgid "Live numbers for the current ticket sale, rendered on their own route."
+msgstr "Live numbers for the current ticket sale, rendered on their own route."
+
+#: examples/react-router-cookie/app/components/LocaleSwitcher.tsx#LocaleSwitcher
+msgid "Locale"
+msgstr "Locale"
+
+#: examples/react-router-cookie/app/routes/home.tsx
+#: examples/react-router-cookie/app/routes/insights.tsx
+msgid "Localized live with Palamedes"
+msgstr "Localized live with Palamedes"
+
+#: examples/react-router-cookie/app/components/TicketPanel.tsx#TicketPanel
+msgid "More tickets"
+msgstr "More tickets"
+
+#: examples/react-router-cookie/app/components/ProofPanel.tsx#ProofPanel
+msgid "Number"
+msgstr "Number"
+
+#: examples/react-router-cookie/app/components/ProofPanel.tsx#ProofPanel
+msgid "one switch, every format"
+msgstr "one switch, every format"
+
+#: examples/react-router-cookie/app/components/ProofPanel.tsx#ProofPanel
+msgid "Plural"
+msgstr "Plural"
+
+#: examples/react-router-cookie/app/components/ProofPanel.tsx#ProofPanel
+msgid "Refresh server result"
+msgstr "Refresh server result"
+
+#: examples/react-router-cookie/app/routes/insights.tsx
+msgid "Registered attendees"
+msgstr "Registered attendees"
+
+#: examples/react-router-cookie/app/routes/home.tsx
+msgid "Rendered with React Router"
+msgstr "Rendered with React Router"
+
+#: examples/react-router-cookie/app/components/ProofPanel.tsx#ProofPanel
+msgid "Server"
+msgstr "Server"
+
+#: examples/react-router-cookie/app/routes/home.tsx#action
+msgid "Server action confirmed locale {locale}."
+msgstr "Server action confirmed locale {locale}."
+
+#: examples/react-router-cookie/app/routes/home.tsx
+#: examples/react-router-cookie/app/routes/insights.tsx
+msgid "server locale"
+msgstr "server locale"
+
+#: examples/react-router-cookie/app/routes/insights.tsx
+msgid "Talks scheduled"
+msgstr "Talks scheduled"
+
+#: examples/react-router-cookie/app/routes/home.tsx
+msgid ""
+"Three days of talks on the craft of building for the web. Choose your tickets "
+"below."
+msgstr ""
+"Three days of talks on the craft of building for the web. Choose your tickets "
+"below."
+
+#: examples/react-router-cookie/app/components/TicketPanel.tsx#TicketPanel
+msgid "Total"
+msgstr "Total"
+
+#: examples/react-router-cookie/app/components/TicketPanel.tsx#TicketPanel
+msgid "Venue"
+msgstr "Venue"
+
+#: examples/react-router-cookie/app/routes/home.tsx
+msgid "View attendance insights"
+msgstr "View attendance insights"
+
+#: examples/react-router-cookie/app/routes/home.tsx
+msgid "Welcome back, {attendeeName}."
+msgstr "Welcome back, {attendeeName}."
+
+#: examples/react-router-cookie/app/routes/insights.tsx
+msgid "Workshop capacity"
+msgstr "Workshop capacity"

--- a/examples/react-router-cookie/app/locales/es.po
+++ b/examples/react-router-cookie/app/locales/es.po
@@ -6,86 +6,162 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "X-Generator: palamedes\n"
 
-msgid "Add to cart"
-msgstr "Añadir al carrito"
-
-msgid "Attendees"
-msgstr "Asistentes"
-
-msgid "Availability"
-msgstr "Disponibilidad"
-
-msgid "Behind the scenes"
-msgstr "Entre bastidores"
-
-msgid "Berlin, Germany"
-msgstr "Berlín, Alemania"
-
-msgid "Book your seat at Frontend Stage 2026"
-msgstr "Reserva tu plaza en Frontend Stage 2026"
-
-msgid "Conference pass"
-msgstr "Pase de conferencia"
-
-msgid "Currency"
-msgstr "Moneda"
-
-msgid "Date"
-msgstr "Fecha"
-
-msgid "Fewer tickets"
-msgstr "Menos entradas"
-
-msgid "Locale"
-msgstr "Idioma"
-
-msgid "Localized live with Palamedes"
-msgstr "Localizado en vivo con Palamedes"
-
-msgid "More tickets"
-msgstr "Más entradas"
-
-msgid "Number"
-msgstr "Número"
-
-msgid "Plural"
-msgstr "Plural"
-
-msgid "Refresh server result"
-msgstr "Actualizar resultado del servidor"
-
-msgid "Rendered with React Router"
-msgstr "Renderizado con React Router"
-
-msgid "Server"
-msgstr "Servidor"
-
-msgid "Server action confirmed locale {locale}."
-msgstr "La acción de servidor confirmó el idioma {locale}."
-
-msgid "Three days of talks on the craft of building for the web. Choose your tickets below."
-msgstr "Tres días de charlas sobre el oficio de construir para la web. Elige tus entradas abajo."
-
-msgid "Total"
-msgstr "Total"
-
-msgid "Venue"
-msgstr "Lugar"
-
-msgid "Welcome back, {attendeeName}."
-msgstr "Hola de nuevo, {attendeeName}."
-
-msgid "each"
-msgstr "cada una"
-
-msgid "one switch, every format"
-msgstr "un clic, todos los formatos"
-
-msgid "server locale"
-msgstr "idioma del servidor"
-
+#: examples/react-router-cookie/app/components/TicketPanel.tsx#TicketPanel
 msgid "{quantity, plural, one {# ticket} other {# tickets}}"
 msgstr "{quantity, plural, one {# entrada} other {# entradas}}"
 
+#: examples/react-router-cookie/app/components/ProofPanel.tsx#ProofPanel
+#: examples/react-router-cookie/app/components/TicketPanel.tsx#TicketPanel
 msgid "{seats, plural, one {# seat left} other {# seats left}}"
 msgstr "{seats, plural, one {queda # plaza} other {quedan # plazas}}"
+
+#: examples/react-router-cookie/app/routes/insights.tsx
+msgid ""
+"{workshops, plural, one {# workshop still has open seats} other {# workshops "
+"still have open seats}}"
+msgstr ""
+"{workshops, plural, one {# taller aún tiene plazas libres} other {# talleres "
+"aún tienen plazas libres}}"
+
+#: examples/react-router-cookie/app/components/TicketPanel.tsx#TicketPanel
+msgid "Add to cart"
+msgstr "Añadir al carrito"
+
+#: examples/react-router-cookie/app/routes/insights.tsx
+msgid "Attendance insights"
+msgstr "Resumen de asistencia"
+
+#: examples/react-router-cookie/app/components/TicketPanel.tsx#TicketPanel
+msgid "Attendees"
+msgstr "Asistentes"
+
+#: examples/react-router-cookie/app/components/TicketPanel.tsx#TicketPanel
+msgid "Availability"
+msgstr "Disponibilidad"
+
+#: examples/react-router-cookie/app/routes/insights.tsx
+msgid "Back to ticket sale"
+msgstr "Volver a la venta de entradas"
+
+#: examples/react-router-cookie/app/components/ProofPanel.tsx#ProofPanel
+msgid "Behind the scenes"
+msgstr "Entre bastidores"
+
+#: examples/react-router-cookie/app/components/TicketPanel.tsx#TicketPanel
+msgid "Berlin, Germany"
+msgstr "Berlín, Alemania"
+
+#: examples/react-router-cookie/app/routes/home.tsx
+msgid "Book your seat at Frontend Stage 2026"
+msgstr "Reserva tu plaza en Frontend Stage 2026"
+
+#: examples/react-router-cookie/app/components/TicketPanel.tsx#TicketPanel
+msgid "Conference pass"
+msgstr "Pase de conferencia"
+
+#: examples/react-router-cookie/app/routes/insights.tsx
+msgid "Countries represented"
+msgstr "Países representados"
+
+#: examples/react-router-cookie/app/components/ProofPanel.tsx#ProofPanel
+msgid "Currency"
+msgstr "Moneda"
+
+#: examples/react-router-cookie/app/components/ProofPanel.tsx#ProofPanel
+#: examples/react-router-cookie/app/components/TicketPanel.tsx#TicketPanel
+msgid "Date"
+msgstr "Fecha"
+
+#: examples/react-router-cookie/app/components/TicketPanel.tsx#TicketPanel
+msgid "each"
+msgstr "cada una"
+
+#: examples/react-router-cookie/app/components/TicketPanel.tsx#TicketPanel
+msgid "Fewer tickets"
+msgstr "Menos entradas"
+
+#: examples/react-router-cookie/app/routes/insights.tsx
+msgid "Live numbers for the current ticket sale, rendered on their own route."
+msgstr "Cifras en directo de la venta de entradas actual, renderizadas en su propia ruta."
+
+#: examples/react-router-cookie/app/components/LocaleSwitcher.tsx#LocaleSwitcher
+msgid "Locale"
+msgstr "Idioma"
+
+#: examples/react-router-cookie/app/routes/home.tsx
+#: examples/react-router-cookie/app/routes/insights.tsx
+msgid "Localized live with Palamedes"
+msgstr "Localizado en vivo con Palamedes"
+
+#: examples/react-router-cookie/app/components/TicketPanel.tsx#TicketPanel
+msgid "More tickets"
+msgstr "Más entradas"
+
+#: examples/react-router-cookie/app/components/ProofPanel.tsx#ProofPanel
+msgid "Number"
+msgstr "Número"
+
+#: examples/react-router-cookie/app/components/ProofPanel.tsx#ProofPanel
+msgid "one switch, every format"
+msgstr "un clic, todos los formatos"
+
+#: examples/react-router-cookie/app/components/ProofPanel.tsx#ProofPanel
+msgid "Plural"
+msgstr "Plural"
+
+#: examples/react-router-cookie/app/components/ProofPanel.tsx#ProofPanel
+msgid "Refresh server result"
+msgstr "Actualizar resultado del servidor"
+
+#: examples/react-router-cookie/app/routes/insights.tsx
+msgid "Registered attendees"
+msgstr "Asistentes registrados"
+
+#: examples/react-router-cookie/app/routes/home.tsx
+msgid "Rendered with React Router"
+msgstr "Renderizado con React Router"
+
+#: examples/react-router-cookie/app/components/ProofPanel.tsx#ProofPanel
+msgid "Server"
+msgstr "Servidor"
+
+#: examples/react-router-cookie/app/routes/home.tsx#action
+msgid "Server action confirmed locale {locale}."
+msgstr "La acción de servidor confirmó el idioma {locale}."
+
+#: examples/react-router-cookie/app/routes/home.tsx
+#: examples/react-router-cookie/app/routes/insights.tsx
+msgid "server locale"
+msgstr "idioma del servidor"
+
+#: examples/react-router-cookie/app/routes/insights.tsx
+msgid "Talks scheduled"
+msgstr "Charlas programadas"
+
+#: examples/react-router-cookie/app/routes/home.tsx
+msgid ""
+"Three days of talks on the craft of building for the web. Choose your tickets "
+"below."
+msgstr ""
+"Tres días de charlas sobre el oficio de construir para la web. Elige tus "
+"entradas abajo."
+
+#: examples/react-router-cookie/app/components/TicketPanel.tsx#TicketPanel
+msgid "Total"
+msgstr "Total"
+
+#: examples/react-router-cookie/app/components/TicketPanel.tsx#TicketPanel
+msgid "Venue"
+msgstr "Lugar"
+
+#: examples/react-router-cookie/app/routes/home.tsx
+msgid "View attendance insights"
+msgstr "Ver el resumen de asistencia"
+
+#: examples/react-router-cookie/app/routes/home.tsx
+msgid "Welcome back, {attendeeName}."
+msgstr "Hola de nuevo, {attendeeName}."
+
+#: examples/react-router-cookie/app/routes/insights.tsx
+msgid "Workshop capacity"
+msgstr "Capacidad de talleres"

--- a/examples/react-router-cookie/app/routes.ts
+++ b/examples/react-router-cookie/app/routes.ts
@@ -1,3 +1,6 @@
-import { type RouteConfig, index } from "@react-router/dev/routes"
+import { type RouteConfig, index, route } from "@react-router/dev/routes"
 
-export default [index("routes/home.tsx")] satisfies RouteConfig
+export default [
+  index("routes/home.tsx"),
+  route("insights", "routes/insights.tsx"),
+] satisfies RouteConfig

--- a/examples/react-router-cookie/app/routes/home.tsx
+++ b/examples/react-router-cookie/app/routes/home.tsx
@@ -1,4 +1,4 @@
-import { redirect } from "react-router"
+import { Link, redirect } from "react-router"
 import { t } from "@palamedes/core/macro"
 import { useClientLocale } from "@palamedes/react/client"
 import { Trans } from "@palamedes/react/macro"
@@ -8,13 +8,8 @@ import { ClientReady } from "~/components/ClientReady"
 import { LocaleSwitcher } from "~/components/LocaleSwitcher"
 import { ProofPanel } from "~/components/ProofPanel"
 import { TicketPanel } from "~/components/TicketPanel"
-import {
-  LOCALE_COOKIE,
-  activateServerI18n,
-  getLocaleLabel,
-  resolveLocaleFromRequest,
-  syncClientI18n,
-} from "~/lib/i18n"
+import { LOCALE_COOKIE, getLocaleLabel, resolveLocaleFromRequest, syncClientI18n } from "~/lib/i18n"
+import { activateServerI18n } from "~/lib/i18n.server"
 
 export function meta(_args: Route.MetaArgs) {
   return [
@@ -98,6 +93,12 @@ export default function Home({ loaderData }: Route.ComponentProps) {
         <TicketPanel locale={locale} />
         <ProofPanel locale={locale} />
       </div>
+
+      <p className="lede">
+        <Link data-testid="insights-link" to="/insights">
+          <Trans>View attendance insights</Trans>
+        </Link>
+      </p>
 
       <footer className="foot">
         <span className="foot-badge">Palamedes</span>

--- a/examples/react-router-cookie/app/routes/insights.tsx
+++ b/examples/react-router-cookie/app/routes/insights.tsx
@@ -1,0 +1,134 @@
+import { Link, redirect } from "react-router"
+import { plural } from "@palamedes/core/macro"
+import { useClientLocale } from "@palamedes/react/client"
+import { Trans as Fmt } from "@palamedes/react"
+import { Trans } from "@palamedes/react/macro"
+import { EVENT } from "@palamedes/example-ui"
+import type { Route } from "./+types/insights"
+import { LocaleSwitcher } from "~/components/LocaleSwitcher"
+import { LOCALE_COOKIE, getLocaleLabel, resolveLocaleFromRequest, syncClientI18n } from "~/lib/i18n"
+import { activateServerI18n } from "~/lib/i18n.server"
+
+const TALKS_SCHEDULED = 48
+const WORKSHOPS_WITH_SEATS = 3
+const COUNTRIES_REPRESENTED = 26
+
+export function meta(_args: Route.MetaArgs) {
+  return [
+    { title: "Attendance Insights - React Router Cookie Locale Example" },
+    {
+      name: "description",
+      content: "Route-level message splitting proof for Palamedes graph splitting.",
+    },
+  ]
+}
+
+export async function loader({ request }: Route.LoaderArgs) {
+  const resolved = resolveLocaleFromRequest(request)
+  activateServerI18n(resolved.locale)
+
+  return {
+    locale: resolved.locale,
+    localeLabel: getLocaleLabel(resolved.locale),
+  }
+}
+
+export async function action({ request }: Route.ActionArgs) {
+  const formData = await request.formData()
+  const intent = formData.get("intent")
+  const resolved = resolveLocaleFromRequest(request)
+
+  if (intent === "set-locale") {
+    const locale = String(formData.get("locale") ?? resolved.locale)
+    return redirect("/insights", {
+      headers: {
+        "Set-Cookie": `${LOCALE_COOKIE}=${locale}; Path=/; Max-Age=31536000; SameSite=Lax`,
+      },
+    })
+  }
+
+  return null
+}
+
+export default function Insights({ loaderData }: Route.ComponentProps) {
+  const { locale, localeLabel } = loaderData
+  const workshops = WORKSHOPS_WITH_SEATS
+
+  useClientLocale(locale, syncClientI18n)
+
+  return (
+    <main className="page-shell">
+      <header className="topbar">
+        <div className="brand">
+          <b>Frontend Stage</b>
+          <span className="brand-meta">Berlin · 2026</span>
+        </div>
+        <LocaleSwitcher locale={locale} />
+      </header>
+
+      <section className="hero">
+        <p className="eyebrow">
+          <span className="dot" aria-hidden="true" />
+          <Trans>Localized live with Palamedes</Trans>
+        </p>
+        <h1 data-testid="insights-heading">
+          <Trans>Attendance insights</Trans>
+        </h1>
+        <p className="lede">
+          <Trans>Live numbers for the current ticket sale, rendered on their own route.</Trans>
+        </p>
+      </section>
+
+      <div className="facts">
+        <div className="fact">
+          <p className="fact-label">
+            <Trans>Registered attendees</Trans>
+          </p>
+          <p className="fact-value">
+            <Fmt message="{count, number}" values={{ count: EVENT.attendeeCount }} />
+          </p>
+        </div>
+
+        <div className="fact">
+          <p className="fact-label">
+            <Trans>Talks scheduled</Trans>
+          </p>
+          <p className="fact-value">
+            <Fmt message="{count, number}" values={{ count: TALKS_SCHEDULED }} />
+          </p>
+        </div>
+
+        <div className="fact">
+          <p className="fact-label">
+            <Trans>Countries represented</Trans>
+          </p>
+          <p className="fact-value">
+            <Fmt message="{count, number}" values={{ count: COUNTRIES_REPRESENTED }} />
+          </p>
+        </div>
+
+        <div className="fact">
+          <p className="fact-label">
+            <Trans>Workshop capacity</Trans>
+          </p>
+          <p className="fact-value" data-testid="insights-workshops">
+            {plural(workshops, {
+              one: "# workshop still has open seats",
+              other: "# workshops still have open seats",
+            })}
+          </p>
+        </div>
+      </div>
+
+      <footer className="foot">
+        <span className="foot-badge">Palamedes</span>
+        <Link to="/">
+          <Trans>Back to ticket sale</Trans>
+        </Link>
+        {" · "}
+        <Trans>server locale</Trans>{" "}
+        <strong data-testid="server-locale-value">{localeLabel}</strong>
+      </footer>
+    </main>
+  )
+}

--- a/examples/react-router-cookie/vite.config.ts
+++ b/examples/react-router-cookie/vite.config.ts
@@ -3,7 +3,7 @@ import { palamedes } from "@palamedes/vite-plugin"
 import { defineConfig } from "vite"
 
 export default defineConfig({
-  plugins: [palamedes(), reactRouter()],
+  plugins: [palamedes({ experimentalGraphSplitting: true }), reactRouter()],
   resolve: {
     tsconfigPaths: true,
   },

--- a/packages/runtime/src/index.test.ts
+++ b/packages/runtime/src/index.test.ts
@@ -6,6 +6,7 @@ import {
   type I18nInstance,
   getClientI18nSnapshot,
   getI18n,
+  registerMessages,
   resetI18nRuntime,
   setClientI18n,
   setServerI18nGetter,
@@ -117,5 +118,81 @@ describe("@palamedes/runtime", () => {
         expect(getI18n()).toBe(enI18n)
       }),
     ])
+  })
+})
+
+describe("registerMessages", () => {
+  // The registration buffer is deliberately global and survives resetI18nRuntime,
+  // so every test here uses locale keys unique to that test.
+  afterEach(() => {
+    resetI18nRuntime()
+    delete (globalThis as Record<string, unknown>).window
+  })
+
+  function createLoadableI18n(locale = "en") {
+    const loaded: Record<string, Record<string, string>[]> = {}
+    return {
+      locale,
+      _: (message: string) => message,
+      load(loadLocale: string, messages: Record<string, string>) {
+        ;(loaded[loadLocale] ??= []).push(messages)
+      },
+      loaded,
+    }
+  }
+
+  it("flushes registrations buffered before the client instance is installed", () => {
+    ;(globalThis as Record<string, unknown>).window = {}
+    registerMessages({ "reg-flush": { keyA: "A" } })
+
+    const i18n = createLoadableI18n("reg-flush")
+    setClientI18n(i18n)
+
+    expect(i18n.loaded["reg-flush"]).toEqual([{ keyA: "A" }])
+  })
+
+  it("loads directly into an already-installed client instance", () => {
+    ;(globalThis as Record<string, unknown>).window = {}
+    const i18n = createLoadableI18n("reg-direct")
+    setClientI18n(i18n)
+
+    registerMessages({ "reg-direct": { keyB: "B" } })
+
+    expect(i18n.loaded["reg-direct"]).toEqual([{ keyB: "B" }])
+  })
+
+  it("flushes registrations for the same locale individually and in order", () => {
+    ;(globalThis as Record<string, unknown>).window = {}
+    // Never merged into a copy: generated catalogs carry the compiled-catalog
+    // brand, and the parser-free runtime rejects unbranded copies.
+    const first = { keyC: "C" }
+    const second = { keyD: "D" }
+    registerMessages({ "reg-merge": first })
+    registerMessages({ "reg-merge": second })
+
+    const i18n = createLoadableI18n("reg-merge")
+    setClientI18n(i18n)
+
+    expect(i18n.loaded["reg-merge"]).toEqual([{ keyC: "C" }, { keyD: "D" }])
+    expect(i18n.loaded["reg-merge"]?.[0]).toBe(first)
+    expect(i18n.loaded["reg-merge"]?.[1]).toBe(second)
+  })
+
+  it("survives resetI18nRuntime, because registering modules evaluate only once", () => {
+    ;(globalThis as Record<string, unknown>).window = {}
+    registerMessages({ "reg-reset": { keyE: "E" } })
+    resetI18nRuntime()
+
+    const i18n = createLoadableI18n("reg-reset")
+    setClientI18n(i18n)
+
+    expect(i18n.loaded["reg-reset"]).toEqual([{ keyE: "E" }])
+  })
+
+  it("ignores instances without a load method", () => {
+    ;(globalThis as Record<string, unknown>).window = {}
+    registerMessages({ "reg-plain": { keyF: "F" } })
+
+    expect(() => setClientI18n(createTestI18n("reg-plain"))).not.toThrow()
   })
 })

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -10,8 +10,15 @@ const CLIENT_I18N_SNAPSHOT_KEY = Symbol.for("palamedes.runtime.clientI18nSnapsho
 const CLIENT_I18N_LISTENERS_KEY = Symbol.for("palamedes.runtime.clientI18nListeners")
 const SERVER_I18N_GETTER_KEY = Symbol.for("palamedes.runtime.serverI18nGetter")
 const SERVER_SCOPE_STATE_KEY = Symbol.for("palamedes.runtime.serverI18nScopeState")
+const REGISTERED_MESSAGES_KEY = Symbol.for("palamedes.runtime.registeredMessages")
 
 type ClientI18nListener = (i18n: I18nInstance) => void
+
+export type RegisteredMessages = Record<string, Record<string, unknown>>
+
+type MessageLoadingI18n = I18nInstance & {
+  load?: (locale: string, messages: Record<string, unknown>) => void
+}
 
 export type ClientI18nSnapshot = Readonly<{
   i18n: I18nInstance | undefined
@@ -35,6 +42,7 @@ type GlobalRuntimeState = typeof globalThis & {
       getStore(): I18nInstance | undefined
     }
   }
+  [REGISTERED_MESSAGES_KEY]?: Map<string, Record<string, unknown>[]>
 }
 
 function globalRuntimeState(): GlobalRuntimeState {
@@ -56,8 +64,66 @@ function isServerEnvironment(): boolean {
   return typeof window === "undefined"
 }
 
+function getRegisteredMessages(
+  state = globalRuntimeState()
+): Map<string, Record<string, unknown>[]> {
+  const existing = state[REGISTERED_MESSAGES_KEY]
+  if (existing) {
+    return existing
+  }
+
+  const registered = new Map<string, Record<string, unknown>[]>()
+  state[REGISTERED_MESSAGES_KEY] = registered
+  return registered
+}
+
+/**
+ * Register compiled messages at module-evaluation time. Generated message
+ * sidecar modules (experimental graph splitting) call this so messages travel
+ * with the code chunks that use them: registration loads into the active
+ * client instance immediately when one is installed, and buffers otherwise so
+ * `setClientI18n` can flush before the first render.
+ *
+ * Each registered map is buffered and loaded as-is, never copied or merged:
+ * generated catalogs carry the compiled-catalog brand, and the parser-free
+ * runtime rejects unbranded copies. Merging across registrations is the
+ * instance's `load()` responsibility.
+ *
+ * Registrations are module-evaluation facts, not instance state: like the
+ * framework bindings' listener stores, they survive `resetI18nRuntime()`,
+ * because the registering modules will not evaluate a second time.
+ */
+export function registerMessages(catalogs: RegisteredMessages): void {
+  const state = globalRuntimeState()
+  const registered = getRegisteredMessages(state)
+  for (const [locale, messages] of Object.entries(catalogs)) {
+    const existing = registered.get(locale)
+    if (existing) {
+      existing.push(messages)
+    } else {
+      registered.set(locale, [messages])
+    }
+  }
+
+  const active = state[CLIENT_I18N_KEY] as MessageLoadingI18n | undefined
+  if (active?.load) {
+    for (const [locale, messages] of Object.entries(catalogs)) {
+      active.load(locale, messages)
+    }
+  }
+}
+
 export function setClientI18n<T extends I18nInstance>(i18n: T): T {
   const state = globalRuntimeState()
+  const registered = state[REGISTERED_MESSAGES_KEY]
+  const loadable = i18n as MessageLoadingI18n
+  if (registered && loadable.load) {
+    for (const [locale, maps] of registered) {
+      for (const messages of maps) {
+        loadable.load(locale, messages)
+      }
+    }
+  }
   const previousSnapshot = getClientI18nSnapshot()
   const nextSnapshot: ClientI18nSnapshot = {
     i18n,

--- a/packages/vite-plugin/src/index.test.ts
+++ b/packages/vite-plugin/src/index.test.ts
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   compileCatalogArtifactSelected: vi.fn(),
   compileCatalogModule: vi.fn(),
   createMissingErrorMessage: vi.fn(),
+  renderCatalogModule: vi.fn(),
   transformPalamedesMacros: vi.fn(),
 }))
 
@@ -19,6 +20,7 @@ vi.mock("@palamedes/core-node", () => ({
   analyzeMdxNative: mocks.analyzeMdxNative,
   compileCatalogArtifactSelected: mocks.compileCatalogArtifactSelected,
   compileCatalogModule: mocks.compileCatalogModule,
+  renderCatalogModule: mocks.renderCatalogModule,
 }))
 
 vi.mock("@palamedes/transform", async (importOriginal) => {
@@ -73,6 +75,10 @@ beforeEach(() => {
   mocks.createMissingErrorMessage.mockImplementation(
     (locale: string, missing: unknown[]) =>
       `Missing ${missing.length} translation(s) for locale ${locale}`
+  )
+  mocks.renderCatalogModule.mockImplementation(
+    (messages: Record<string, string>) =>
+      `/*rendered*/export const messages=${JSON.stringify(messages)};export default { messages };`
   )
   vi.spyOn(console, "warn").mockImplementation(() => {})
 })
@@ -438,15 +444,160 @@ describe("palamedes vite plugin", () => {
   })
 })
 
+describe("experimental graph splitting", () => {
+  it("appends a sidecar import to modules that reference messages", async () => {
+    const result = (await runMacroTransform({ experimentalGraphSplitting: true }, undefined, [
+      "id-a",
+      "id-b",
+    ])) as { code?: string } | null
+
+    expect(result?.code).toMatch(
+      /^transformed\nimport "virtual:palamedes-messages\/[0-9a-f]{12}";\n$/
+    )
+  })
+
+  it("leaves modules without message references untouched", async () => {
+    const result = (await runMacroTransform(
+      { experimentalGraphSplitting: true },
+      undefined,
+      []
+    )) as { code?: string } | null
+
+    expect(result?.code).toBe("transformed")
+  })
+
+  it("does not append sidecar imports when the flag is off", async () => {
+    const result = (await runMacroTransform({}, undefined, ["id-a"])) as { code?: string } | null
+
+    expect(result?.code).toBe("transformed")
+  })
+
+  it("aggregates branded per-locale modules into one registration, skipping pseudo", async () => {
+    const { load, key } = await runSidecarLoad(["id-a"])
+    const result = await load(`\0palamedes:messages/${key}`)
+
+    expect(result?.code).toBe(
+      `import { messages as m0 } from "virtual:palamedes-messages/${key}/en";\n` +
+        `import { messages as m1 } from "virtual:palamedes-messages/${key}/de";\n` +
+        `import { registerMessages } from "@palamedes/runtime";\n` +
+        `registerMessages({ "en": m0, "de": m1 });\n`
+    )
+    expect(result?.moduleSideEffects).toBe(true)
+    // Message compilation happens in the per-locale modules, not the aggregator.
+    expect(mocks.compileCatalogArtifactSelected).not.toHaveBeenCalled()
+  })
+
+  it("renders per-locale modules through the native catalog renderer", async () => {
+    mocks.compileCatalogArtifactSelected.mockImplementation(
+      (_config: unknown, resourcePath: string) => ({
+        messages:
+          resourcePath === "/repo/src/locales/de.po" ? { "id-a": "Hallo" } : { "id-a": "Hello" },
+        missing: [],
+        diagnostics: [],
+        watchFiles: [resourcePath],
+        resolvedLocaleChain: [],
+      })
+    )
+
+    const { load, key, addWatchFile } = await runSidecarLoad(["id-a"])
+    const result = await load(`\0palamedes:messages/${key}/de`)
+
+    expect(mocks.compileCatalogArtifactSelected).toHaveBeenCalledTimes(1)
+    expect(mocks.compileCatalogArtifactSelected).toHaveBeenCalledWith(
+      expect.objectContaining({ rootDir: "/repo" }),
+      "/repo/src/locales/de.po",
+      ["id-a"]
+    )
+    expect(mocks.renderCatalogModule).toHaveBeenCalledWith({ "id-a": "Hallo" })
+    expect(result?.code).toBe(
+      `/*rendered*/export const messages={"id-a":"Hallo"};export default { messages };`
+    )
+    expect(addWatchFile).toHaveBeenCalledWith("/repo/src/locales/de.po")
+  })
+
+  it("warns on missing translations and keeps the sidecar buildable", async () => {
+    mocks.compileCatalogArtifactSelected.mockReturnValue({
+      messages: {},
+      missing: [{ id: "id-a", message: "Hello" }],
+      diagnostics: [],
+      watchFiles: [],
+      resolvedLocaleChain: [],
+    })
+
+    const warn = vi.fn()
+    const { load, key } = await runSidecarLoad(["id-a"], { warn })
+    const result = await load(`\0palamedes:messages/${key}/de`)
+
+    expect(result?.code).toContain("export const messages")
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("/repo/src/label.ts"))
+  })
+})
+
+async function runSidecarLoad(
+  compiledIds: string[],
+  context: Record<string, unknown> = {}
+): Promise<{
+  load: (id: string) => Promise<any>
+  key: string
+  addWatchFile: ReturnType<typeof vi.fn>
+}> {
+  mocks.transformPalamedesMacros.mockClear()
+  mocks.compileCatalogArtifactSelected.mockClear()
+  mocks.renderCatalogModule.mockClear()
+  mocks.transformPalamedesMacros.mockReturnValue({
+    code: "transformed",
+    hasChanged: true,
+    compiledIds,
+    map: null,
+  })
+  const plugins = palamedes({ experimentalGraphSplitting: true })
+  const macroPlugin = plugins.find((plugin) => plugin.name === "palamedes:transform")
+  const sidecarPlugin = plugins.find((plugin) => plugin.name === "palamedes:message-sidecars")
+  const transform = macroPlugin?.transform
+  const load = sidecarPlugin?.load
+  if (typeof transform !== "function" || typeof load !== "function") {
+    throw new TypeError("Expected transform and sidecar load hooks")
+  }
+
+  const transformed = (await transform.call(
+    { error: vi.fn() } as never,
+    'import { t } from "@palamedes/core/macro"\nexport const label = t`Hello`',
+    "/repo/src/label.ts"
+  )) as { code?: string } | null
+  const key = /virtual:palamedes-messages\/([0-9a-f]{12})/.exec(transformed?.code ?? "")?.[1]
+  if (!key) {
+    throw new Error("Expected a sidecar import in the transformed output")
+  }
+
+  const addWatchFile = vi.fn()
+  const boundLoad = (id: string) =>
+    Promise.resolve(
+      load.call(
+        {
+          addWatchFile,
+          error(message: unknown) {
+            throw message instanceof Error ? message : new Error(String(message))
+          },
+          warn() {},
+          ...context,
+        } as any,
+        id
+      )
+    )
+
+  return { load: boundLoad, key, addWatchFile }
+}
+
 function runMacroTransform(
   options: Parameters<typeof palamedes>[0] = {},
-  command?: "build" | "serve"
+  command?: "build" | "serve",
+  compiledIds: string[] = []
 ) {
   mocks.transformPalamedesMacros.mockClear()
   mocks.transformPalamedesMacros.mockReturnValue({
     code: "transformed",
     hasChanged: true,
-    compiledIds: [],
+    compiledIds,
     map: null,
   })
   const macroPlugin = palamedes(options).find((plugin) => plugin.name === "palamedes:transform")

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -5,6 +5,7 @@
  * No Babel required!
  */
 
+import { createHash } from "node:crypto"
 import { realpathSync, statSync } from "node:fs"
 import path from "node:path"
 import type { Plugin, FilterPattern } from "vite"
@@ -19,6 +20,7 @@ import {
   analyzeMdxNative,
   compileCatalogArtifactSelected,
   compileCatalogModule,
+  renderCatalogModule,
   type CatalogArtifactConfig,
 } from "@palamedes/core-node"
 import { createMissingErrorMessage, transformPalamedesMacros } from "@palamedes/transform"
@@ -32,6 +34,8 @@ import {
 const PO_FILE_REGEX = /(\.po|\?palamedes)$/
 const MDX_FILE_REGEX = /\.mdx$/i
 const VIRTUAL_MACRO_ERROR_PREFIX = "\0palamedes:macro-error:"
+const VIRTUAL_MESSAGES_PREFIX = "virtual:palamedes-messages/"
+const RESOLVED_MESSAGES_PREFIX = "\0palamedes:messages/"
 const MISSING_CONFIG_ERROR_PREFIX = "Could not find a Palamedes config."
 const VITE_MAJOR = Number.parseInt(viteVersion.split(".")[0] ?? "0", 10)
 function stripQuery(id: string): string {
@@ -182,6 +186,18 @@ export type PalamedesPluginOptions = {
    * @default configuration `mdx` values with React framework defaults
    */
   mdx?: PalamedesMdxConfig | false
+
+  /**
+   * EXPERIMENTAL: emit one generated message sidecar module per transformed
+   * source file, containing only the compiled messages that file references,
+   * and append a static import of it to the transformed output. Messages then
+   * travel through the bundler's module graph with the code that uses them,
+   * so route-level code splitting splits messages without any route
+   * configuration. Requires the application to install its client instance
+   * with `setClientI18n` instead of importing `.po` catalogs eagerly.
+   * @default false
+   */
+  experimentalGraphSplitting?: boolean
 }
 
 /**
@@ -198,6 +214,7 @@ export function palamedes(options: PalamedesPluginOptions = {}): Plugin[] {
     runtimeModule,
     keepSourceFallbacks,
     mdx: mdxOverride,
+    experimentalGraphSplitting = false,
     ...configLoaderOptions
   } = options
   const macroRuntimeModule = resolveMacroRuntimeModule(framework, runtimeModule)
@@ -210,6 +227,21 @@ export function palamedes(options: PalamedesPluginOptions = {}): Plugin[] {
   let mdxFilter: ReturnType<typeof createFilter> | null = null
   let macroIds: Set<string> | null = null
   const mdxModuleIds = new Set<string>()
+
+  /*
+   * Message sidecar registry for experimental graph splitting, keyed by a
+   * short hash of the source module id. Entries are written when a module is
+   * transformed and read when the bundler loads the sidecar it imports, so
+   * population always precedes the read within one build. Entries are
+   * overwritten on re-transform and deliberately never cleared: a stale entry
+   * for an untouched module keeps dev-server requests working across config
+   * reloads.
+   */
+  const sidecarModules = new Map<string, { sourceId: string; compiledIds: string[] }>()
+
+  function sidecarKey(sourceId: string): string {
+    return createHash("sha256").update(sourceId).digest("hex").slice(0, 12)
+  }
 
   async function getConfigLazy() {
     if (!config) {
@@ -509,6 +541,16 @@ export function palamedes(options: PalamedesPluginOptions = {}): Plugin[] {
           return null
         }
 
+        if (experimentalGraphSplitting && result.compiledIds.length > 0) {
+          const key = sidecarKey(cleanId)
+          sidecarModules.set(key, { sourceId: cleanId, compiledIds: result.compiledIds })
+          return {
+            // Appending keeps the native source map valid; imports hoist anyway.
+            code: `${result.code}\nimport "${VIRTUAL_MESSAGES_PREFIX}${key}";\n`,
+            map: result.map as any,
+          }
+        }
+
         return {
           code: result.code,
           map: result.map as any,
@@ -519,6 +561,101 @@ export function palamedes(options: PalamedesPluginOptions = {}): Plugin[] {
       }
     },
   })
+
+  // Plugin 4b: message sidecar modules for experimental graph splitting.
+  // Per message-bearing source file, one per-locale module rendered by the
+  // native catalog-module renderer (ADR-022: the single generator, so split
+  // artifacts stay on the branded parser-free compiled ABI) plus one
+  // aggregator that registers the branded exports with the runtime. The
+  // bundler then distributes messages along the module graph.
+  if (experimentalGraphSplitting) {
+    plugins.push({
+      name: "palamedes:message-sidecars",
+
+      resolveId(id) {
+        if (id.startsWith(VIRTUAL_MESSAGES_PREFIX)) {
+          return `${RESOLVED_MESSAGES_PREFIX}${id.slice(VIRTUAL_MESSAGES_PREFIX.length)}`
+        }
+      },
+
+      async load(id) {
+        if (!id.startsWith(RESOLVED_MESSAGES_PREFIX)) {
+          return null
+        }
+
+        const [key, locale] = id.slice(RESOLVED_MESSAGES_PREFIX.length).split("/", 2)
+        const entry = key === undefined ? undefined : sidecarModules.get(key)
+        if (!entry || key === undefined) {
+          this.error(
+            `Palamedes message sidecar "${key}" was requested before its source module was transformed. ` +
+              "This indicates a plugin ordering problem; please report it."
+          )
+        }
+
+        const cfg = await getConfigLazy()
+        this.addWatchFile(cfg.configPath)
+        // Pseudo-locale catalogs are generated, not stored; the selected
+        // compile has no pseudo path yet. Split mode skips them for now.
+        const locales = cfg.locales.filter((candidate) => candidate !== cfg.pseudoLocale)
+
+        if (locale === undefined) {
+          // Aggregator: import each branded per-locale module and register it.
+          const imports = locales
+            .map(
+              (localeName, index) =>
+                `import { messages as m${index} } from "${VIRTUAL_MESSAGES_PREFIX}${key}/${localeName}";`
+            )
+            .join("\n")
+          const registration = locales
+            .map((localeName, index) => `${JSON.stringify(localeName)}: m${index}`)
+            .join(", ")
+          const code =
+            `${imports}\n` +
+            `import { registerMessages } from "@palamedes/runtime";\n` +
+            `registerMessages({ ${registration} });\n`
+          return { code, map: null, moduleSideEffects: true }
+        }
+
+        if (!locales.includes(locale)) {
+          this.error(`Palamedes message sidecar "${key}" requested unknown locale "${locale}".`)
+        }
+
+        const catalogs = cfg.catalogs.filter((catalog) =>
+          catalogMatchesSource(cfg, catalog, entry.sourceId)
+        )
+        if (catalogs.length === 0) {
+          this.warn(
+            `Palamedes graph splitting: ${entry.sourceId} uses messages but is not included in any configured catalog; its messages will be missing at runtime.`
+          )
+          return { code: renderCatalogModule({}), map: null }
+        }
+
+        const selected: Record<string, string> = {}
+        for (const catalog of catalogs) {
+          const artifactConfig = catalogArtifactConfig(cfg, [catalog])
+          const resourcePath = catalogResourcePath(cfg, catalog, locale)
+          const result = compileCatalogArtifactSelected(
+            artifactConfig,
+            resourcePath,
+            entry.compiledIds
+          )
+          result.watchFiles.forEach((file: string) => this.addWatchFile(file))
+          if (result.missing.length > 0) {
+            const message =
+              `${createMissingErrorMessage(locale, result.missing)}\n\n` +
+              `Referenced by ${entry.sourceId}.`
+            if (failOnMissing) {
+              this.error(message)
+            }
+            this.warn(message)
+          }
+          Object.assign(selected, result.messages)
+        }
+
+        return { code: renderCatalogModule(selected), map: null }
+      },
+    })
+  }
 
   // Plugin 4: PO file loader
   if (enablePoLoader) {


### PR DESCRIPTION
## What this is

Experimental **graph splitting for localized messages**: behind a new `experimentalGraphSplitting` flag in the Vite plugin, messages travel through the bundler's module graph with the code that uses them, instead of shipping as whole per-locale catalogs in the first bundle. Route-level code splitting then splits messages with **zero route configuration and zero authoring changes** — eager code keeps its messages in the entry chunk, lazy routes carry theirs in their own chunk, shared modules hoist like any other module.

The design exploration behind it — variants, trade-offs, staged recommendation — ships as an RFC in `docs/plans/2026-08-01-code-splitting-localization-rfc.md`, including the measured spike results below. The through-line: membership is decided by the bundler graph, locale binding by the host, authors decide nothing (deliberately no Lingui/next-intl-style namespace declarations).

## How it works

1. The macro transform already reports `compiledIds` per module; the plugin stops discarding them and appends a static import of a generated sidecar to each message-bearing file (append keeps the native source map valid).
2. Per (source file × locale), the sidecar plugin compiles the id subset with the existing `compileCatalogArtifactSelected` and renders it through the native `renderCatalogModule` — split artifacts stay on the **branded, parser-free compiled ABI** (ADR-022/023); the native renderer remains the single catalog-module generator (ADR-011/022).
3. An aggregator module registers the per-locale exports via the new `registerMessages()` in `@palamedes/runtime`: loads into the active client instance, buffers otherwise, flushed by `setClientI18n`. Maps are buffered **as-is, never copied** — the parser-free runtime rejects unbranded copies; merging is `load()`'s per-entry job. Registration happens at module evaluation, so activation stays synchronous and hydration-safe by construction.

## Measured (react-router-cookie, 2 routes, 3 locales, 37 messages, production)

| | eager baseline | graph splitting |
|---|---|---|
| shared chunk | 139.65 kB (46.38 gzip) — all messages | 134.34 kB (44.21) — none |
| `home` chunk | 6.85 kB (1.85) | 11.37 kB (3.23) — own messages |
| `insights` chunk | 2.46 kB (0.86) | 4.24 kB (1.52) — own messages |
| messages on `/` | all routes × 3 locales | home's own × 3 locales |

Absolute deltas are tiny at demo scale; the structural property is the point: message payload scales with the route, not the app. Dynamic messages appear as ADR-022 executable functions inline in the route chunks. Browser-verified on the production build: localized SSR, clean hydration, client-side locale switch without reload, lazy-loaded route messages on navigation.

## Scope and known limits (also in the RFC)

- Experimental, Vite-only for now; Next/Turbopack follows once the shape settles.
- Pseudo-locale is skipped in split mode (the selected compile has no generated-pseudo path yet).
- Sidecars with a single importer inline into their importer's chunk, so translation-only changes re-hash route chunks; emitting sidecars as own chunks (or per-message atoms for cross-route dedup) is a follow-up knob.
- Dev server behavior is unchanged-by-design candidates for follow-ups; the flag currently applies wherever the plugin transforms.

## Verification

- `@palamedes/runtime`: 24 tests (5 new), `@palamedes/vite-plugin`: 37 tests (6 new), tsc, oxlint, oxfmt clean; example typecheck incl. `react-router typegen` green.
- Example built and driven in a real browser against the production server (SSR, hydration, locale switch EN/DE/ES, route navigation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
