### PR TITLE
feat(vite-plugin): import-map locale binding for graph splitting

### DIFF
--- a/docs/plans/2026-08-01-code-splitting-localization-rfc.md
+++ b/docs/plans/2026-08-01-code-splitting-localization-rfc.md
@@ -613,11 +613,16 @@ Corrections the spike feeds back into the body above:
 
 1. **Sidecars inline into their importer's chunk** when they have a single
    importer, so a translation-only change re-hashes the route chunks that use
-   the changed message — not a separate message asset. The "translation
-   changes never invalidate code chunks" property additionally needs sidecars
-   emitted as their own chunks (`manualChunks`, or V2b atoms which are shared
-   and therefore split naturally). Stage 2 should treat that as a follow-up
-   knob, not a given.
+   the changed message — not a separate message asset. A later design pass
+   sharpened this further: emitting sidecars as their own chunks does **not**
+   restore the cache property either, because ESM chunks reference each other
+   by hashed filename — a changed message chunk changes the import specifier
+   inside its importer, and the hash cascades up the static import chain. The
+   only thing that breaks that chain is name indirection: a bare specifier in
+   the code chunk plus an import map (or manifest-driven loader) carrying the
+   hash. In other words, the caching property and the load-time locale
+   binding are the _same_ mechanism — V4b is not an optimization on top of
+   separate message chunks; it is the step that makes them meaningful.
 2. **The runtime contract needed for V2 alone is smaller than Stage 0**: no
    async `ensureLocale`, no suspense — module evaluation always precedes
    render, so buffer + flush suffices. Stage 0 in full remains the
@@ -658,6 +663,49 @@ from the rebased state. What the upgrade changed:
 - The main-branch runtime refactors did **not** change the pre-existing
   hook-`getI18n` action crash; it reproduced identically on `7e697a1` and is
   now fixed on this branch (finding 3 above).
+
+## Appendix: Stage-3 spike results (2026-08-02, import-map binding)
+
+V4b works. Built on top of the Stage-2 sidecars, behind the extended flag
+`experimentalGraphSplitting: { localeBinding: "import-map" }`:
+
+- **Plugin.** In production client builds the aggregator imports one
+  locale-neutral bare specifier (`#pmds/<key>`), marked external; SSR builds
+  and dev servers keep the embedded form. `generateBundle` emits one
+  dependency-free message asset per (sidecar × locale) — derived from the
+  native renderer's output, with a `locale` export and no imports; branding
+  happens on receive in the aggregator via `defineCompiledCatalog` — plus one
+  import map per locale and a `palamedes-split-manifest.json`. Emission is
+  sorted for build determinism.
+- **Example.** The server splices the active locale's import map into the
+  HTML stream directly after `<head>`. That placement is load-bearing: React
+  19 hoists modulepreload links above anything a route component renders, and
+  an import map that loses that race is silently rejected, killing the module
+  graph — reproduced as an intermittent dead page before the injection moved
+  into `entry.server`. Locale switching became a document navigation
+  (`<Form reloadDocument>`), the documented V4b trade.
+
+Verified on the production build in a browser:
+
+- **`1 locale × route` is real.** First load of `/` fetches exactly the four
+  home-route message assets of the active locale — zero assets of other
+  locales. Client-side navigation to `/insights` fetches exactly one more
+  asset: that route's messages in the active locale. Locale switches load the
+  new locale's assets via the new document's import map; hydration and
+  client-side interactivity verified after warm-cache switches across
+  de/en/es.
+- **Translation-only deploys keep code chunks byte-identical.** Changing one
+  German translation and rebuilding changes exactly one `.de` message asset
+  and the `.de` import map; every code chunk, every other locale's assets and
+  maps keep their hashes. Rebuilding without changes reproduces the bundle
+  bit-for-bit (after sorting emission; unsorted, transform order leaked into
+  map hashes).
+
+Open follow-ups from this spike: no modulepreload hints for mapped assets yet
+(one extra request-waterfall step for messages — the server can emit
+`<link rel="modulepreload">` from the same map); the manifest-reading server
+helper is example-code that belongs in an adapter surface; and non-navigation
+locale switching would need an async ensure path (Stage 0 territory).
 
 ## Prior art (references, not blueprints)
 

--- a/examples/react-router-cookie/app/components/LocaleSwitcher.tsx
+++ b/examples/react-router-cookie/app/components/LocaleSwitcher.tsx
@@ -1,4 +1,4 @@
-import { useFetcher } from "react-router"
+import { Form, useNavigation } from "react-router"
 import { buildLocaleSwitchItems } from "@palamedes/react"
 import { Trans } from "@palamedes/react/macro"
 import type { Locale } from "~/lib/i18n"
@@ -9,37 +9,41 @@ type LocaleSwitcherProps = {
 }
 
 export function LocaleSwitcher({ locale }: LocaleSwitcherProps) {
-  const fetcher = useFetcher()
-  const isPending = fetcher.state !== "idle"
+  const navigation = useNavigation()
+  const isPending = navigation.state !== "idle"
   const items = buildLocaleSwitchItems({
     locales: LOCALES,
     currentLocale: locale,
     labels: LOCALE_LABELS,
   })
 
-  function handleLocaleChange(nextLocale: Locale) {
-    fetcher.submit({ intent: "set-locale", locale: nextLocale }, { method: "post" })
-  }
-
   return (
     <div className="switcher">
       <span className="switcher-label">
         <Trans>Locale</Trans>
       </span>
-      <div className="seg" role="group" aria-label="Language">
+      {/*
+       * A document navigation, deliberately: with import-map locale binding
+       * the active locale's message assets are fixed by the import map in the
+       * document head, so switching locales means loading a new document with
+       * the new map. The action sets the cookie and redirects.
+       */}
+      <Form method="post" reloadDocument className="seg" role="group" aria-label="Language">
+        <input type="hidden" name="intent" value="set-locale" />
         {items.map((item) => (
           <button
             key={item.locale}
             data-testid={item.testId}
             aria-pressed={item.active}
             disabled={isPending}
-            onClick={() => handleLocaleChange(item.locale)}
-            type="button"
+            name="locale"
+            value={item.locale}
+            type="submit"
           >
             {item.locale.toUpperCase()}
           </button>
         ))}
-      </div>
+      </Form>
     </div>
   )
 }

--- a/examples/react-router-cookie/app/entry.server.tsx
+++ b/examples/react-router-cookie/app/entry.server.tsx
@@ -1,0 +1,133 @@
+import { PassThrough, Transform } from "node:stream"
+
+import type { EntryContext, RouterContextProvider } from "react-router"
+import { createReadableStreamFromReadable } from "@react-router/node"
+import { ServerRouter } from "react-router"
+import { isbot } from "isbot"
+import type { RenderToPipeableStreamOptions } from "react-dom/server"
+import { renderToPipeableStream } from "react-dom/server"
+import { resolveLocaleFromRequest } from "~/lib/i18n"
+import { getLocaleImportMap } from "~/lib/i18n.server"
+
+export const streamTimeout = 5000
+
+/*
+ * Import-map locale binding: the browser resolves per-route message assets
+ * through one import map per locale. The map must be registered before any
+ * module load starts, and React 19 hoists modulepreload links above anything
+ * rendered from a route component, so injecting the map through the Layout is
+ * a race. Splicing it into the stream directly after <head> is the only spot
+ * that deterministically precedes every preload. Null map (dev) passes the
+ * stream through untouched.
+ */
+function createImportMapInjector(importMap: string | null): Transform {
+  if (!importMap) {
+    return new PassThrough()
+  }
+  const injection = `<head><script type="importmap">${importMap}</script>`
+  let injected = false
+  let carry = ""
+  return new Transform({
+    transform(chunk, _encoding, callback) {
+      if (injected) {
+        callback(null, chunk)
+        return
+      }
+      const text = carry + String(chunk)
+      const index = text.indexOf("<head>")
+      if (index === -1) {
+        // Keep a tail that could contain a split "<head>" across chunks.
+        carry = text.slice(-6)
+        callback(null, text.slice(0, text.length - carry.length))
+        return
+      }
+      injected = true
+      carry = ""
+      callback(null, text.slice(0, index) + injection + text.slice(index + "<head>".length))
+    },
+    flush(callback) {
+      if (carry) {
+        this.push(carry)
+      }
+      callback()
+    },
+  })
+}
+
+export default function handleRequest(
+  request: Request,
+  responseStatusCode: number,
+  responseHeaders: Headers,
+  routerContext: EntryContext,
+  loadContext: RouterContextProvider
+) {
+  // https://httpwg.org/specs/rfc9110.html#HEAD
+  if (request.method.toUpperCase() === "HEAD") {
+    return new Response(null, {
+      status: responseStatusCode,
+      headers: responseHeaders,
+    })
+  }
+
+  return new Promise((resolve, reject) => {
+    let shellRendered = false
+    const userAgent = request.headers.get("user-agent")
+
+    // Ensure requests from bots and SPA Mode renders wait for all content to load before responding
+    // https://react.dev/reference/react-dom/server/renderToPipeableStream#waiting-for-all-content-to-load-for-crawlers-and-static-generation
+    const readyOption: keyof RenderToPipeableStreamOptions =
+      (userAgent && isbot(userAgent)) || routerContext.isSpaMode ? "onAllReady" : "onShellReady"
+
+    // Abort the rendering stream after the `streamTimeout` so it has time to
+    // flush down the rejected boundaries
+    let timeoutId: ReturnType<typeof setTimeout> | undefined = setTimeout(
+      () => abort(),
+      streamTimeout + 1000
+    )
+
+    const { pipe, abort } = renderToPipeableStream(
+      <ServerRouter context={routerContext} url={request.url} />,
+      {
+        [readyOption]() {
+          shellRendered = true
+          const body = new PassThrough({
+            final(callback) {
+              // Clear the timeout to prevent retaining the closure and memory leak
+              clearTimeout(timeoutId)
+              timeoutId = undefined
+              callback()
+            },
+          })
+          const stream = createReadableStreamFromReadable(body)
+
+          responseHeaders.set("Content-Type", "text/html")
+
+          const injector = createImportMapInjector(
+            getLocaleImportMap(resolveLocaleFromRequest(request).locale)
+          )
+          injector.pipe(body)
+          pipe(injector)
+
+          resolve(
+            new Response(stream, {
+              headers: responseHeaders,
+              status: responseStatusCode,
+            })
+          )
+        },
+        onShellError(error: unknown) {
+          reject(error)
+        },
+        onError(error: unknown) {
+          responseStatusCode = 500
+          // Log streaming rendering errors from inside the shell.  Don't log
+          // errors encountered during initial shell rendering since they'll
+          // reject and get logged in handleDocumentRequest.
+          if (shellRendered) {
+            console.error(error)
+          }
+        },
+      }
+    )
+  })
+}

--- a/examples/react-router-cookie/app/lib/i18n.server.ts
+++ b/examples/react-router-cookie/app/lib/i18n.server.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs"
+import path from "node:path"
 import type { CompiledCatalogMessages } from "@palamedes/core/compiled"
 import { setServerI18nGetter } from "@palamedes/runtime"
 import { messages as enMessages } from "../locales/en.po"
@@ -20,4 +22,31 @@ export function activateServerI18n(locale: Locale) {
   i18n.activate(locale)
   setServerI18nGetter(() => i18n)
   return i18n
+}
+
+// Import-map locale binding: the production client resolves its per-route
+// message assets through one import map per locale, emitted next to the
+// client assets. The document must carry the active locale's map before any
+// module loads, so the root loader reads it here. In dev the manifest does
+// not exist (dev serves the embedded form) and this returns null.
+const importMapCache = new Map<Locale, string | null>()
+
+function readLocaleImportMap(locale: Locale): string | null {
+  try {
+    const clientDir = path.resolve(import.meta.dirname, "../client")
+    const manifest = JSON.parse(
+      readFileSync(path.join(clientDir, "palamedes-split-manifest.json"), "utf8")
+    ) as { importMaps: Record<string, string> }
+    const mapFile = manifest.importMaps[locale]
+    return mapFile ? readFileSync(path.join(clientDir, mapFile), "utf8") : null
+  } catch {
+    return null
+  }
+}
+
+export function getLocaleImportMap(locale: Locale): string | null {
+  if (!importMapCache.has(locale)) {
+    importMapCache.set(locale, readLocaleImportMap(locale))
+  }
+  return importMapCache.get(locale) ?? null
 }

--- a/examples/react-router-cookie/vite.config.ts
+++ b/examples/react-router-cookie/vite.config.ts
@@ -3,7 +3,10 @@ import { palamedes } from "@palamedes/vite-plugin"
 import { defineConfig } from "vite"
 
 export default defineConfig({
-  plugins: [palamedes({ experimentalGraphSplitting: true }), reactRouter()],
+  plugins: [
+    palamedes({ experimentalGraphSplitting: { localeBinding: "import-map" } }),
+    reactRouter(),
+  ],
   resolve: {
     tsconfigPaths: true,
   },

--- a/packages/vite-plugin/src/index.test.ts
+++ b/packages/vite-plugin/src/index.test.ts
@@ -531,15 +531,149 @@ describe("experimental graph splitting", () => {
     expect(result?.code).toContain("export const messages")
     expect(warn).toHaveBeenCalledWith(expect.stringContaining("/repo/src/label.ts"))
   })
+
+  const IMPORT_MAP_OPTIONS = {
+    experimentalGraphSplitting: { localeBinding: "import-map" as const },
+  }
+
+  function nativeModuleShape(map: string): string {
+    return (
+      `import{defineCompiledCatalog as __palamedesDefineCompiledCatalog}from"@palamedes/core/compiled";` +
+      `export const messages=__palamedesDefineCompiledCatalog(${map});export default { messages };`
+    )
+  }
+
+  it("binds client aggregators to bare specifiers under import-map binding", async () => {
+    const { load, key } = await runSidecarLoad(
+      ["id-a"],
+      {},
+      { pluginOptions: IMPORT_MAP_OPTIONS, command: "build" }
+    )
+    const result = await load(`\0palamedes:messages/${key}`, { ssr: false })
+
+    expect(result?.code).toBe(
+      `import { locale as l, messages as m } from "#pmds/${key}";\n` +
+        `import { defineCompiledCatalog } from "@palamedes/core/compiled";\n` +
+        `import { registerMessages } from "@palamedes/runtime";\n` +
+        `registerMessages({ [l]: defineCompiledCatalog(m) });\n`
+    )
+  })
+
+  it("keeps SSR aggregators on the embedded form under import-map binding", async () => {
+    const { load, key } = await runSidecarLoad(
+      ["id-a"],
+      {},
+      { pluginOptions: IMPORT_MAP_OPTIONS, command: "build" }
+    )
+    const result = await load(`\0palamedes:messages/${key}`, { ssr: true })
+
+    expect(result?.code).toContain(`virtual:palamedes-messages/${key}/en`)
+    expect(result?.code).toContain(`virtual:palamedes-messages/${key}/de`)
+    expect(result?.code).not.toContain("#pmds/")
+  })
+
+  it("keeps dev-server aggregators on the embedded form under import-map binding", async () => {
+    const { load, key } = await runSidecarLoad(
+      ["id-a"],
+      {},
+      { pluginOptions: IMPORT_MAP_OPTIONS, command: "serve" }
+    )
+    const result = await load(`\0palamedes:messages/${key}`, { ssr: false })
+
+    expect(result?.code).toContain(`virtual:palamedes-messages/${key}/en`)
+    expect(result?.code).not.toContain("#pmds/")
+  })
+
+  it("externalizes bare message specifiers under import-map binding", async () => {
+    const { sidecarPlugin } = await runSidecarLoad(
+      ["id-a"],
+      {},
+      { pluginOptions: IMPORT_MAP_OPTIONS, command: "build" }
+    )
+    const configResult = sidecarPlugin.config.call({} as never)
+    const external = configResult?.build?.rollupOptions?.external as (id: string) => boolean
+
+    expect(external("#pmds/abc123")).toBe(true)
+    expect(external("react")).toBe(false)
+
+    const { sidecarPlugin: embeddedPlugin } = await runSidecarLoad(["id-a"])
+    expect(embeddedPlugin.config.call({} as never)).toBeUndefined()
+  })
+
+  it("emits per-locale message assets, import maps, and the manifest", async () => {
+    mocks.renderCatalogModule.mockImplementation((messages: Record<string, string>) =>
+      nativeModuleShape(JSON.stringify(messages))
+    )
+    mocks.compileCatalogArtifactSelected.mockImplementation(
+      (_config: unknown, resourcePath: string) => ({
+        messages:
+          resourcePath === "/repo/src/locales/de.po" ? { "id-a": "Hallo" } : { "id-a": "Hello" },
+        missing: [],
+        diagnostics: [],
+        watchFiles: [],
+        resolvedLocaleChain: [],
+      })
+    )
+
+    const { key, sidecarPlugin } = await runSidecarLoad(
+      ["id-a"],
+      {},
+      { pluginOptions: IMPORT_MAP_OPTIONS, command: "build" }
+    )
+    const emitted: { fileName: string; source: string }[] = []
+    await sidecarPlugin.generateBundle.call({
+      environment: { name: "client" },
+      emitFile: (file: { fileName: string; source: string }) => emitted.push(file),
+    } as never)
+
+    // One dependency-free asset per (sidecar x locale); pseudo is skipped.
+    const assets = emitted.filter((file) => file.fileName.startsWith("assets/palamedes-m-"))
+    expect(assets).toHaveLength(2)
+    const deAsset = assets.find((file) => file.fileName.includes(".de-"))
+    expect(deAsset?.source).toBe(
+      `export const locale="de";export const messages=({"id-a":"Hallo"});`
+    )
+    expect(deAsset?.source).not.toContain("import")
+
+    const maps = emitted.filter((file) => file.fileName.startsWith("assets/palamedes-importmap."))
+    expect(maps).toHaveLength(2)
+    const deMap = maps.find((file) => file.fileName.includes(".de-"))
+    expect(JSON.parse(deMap!.source).imports[`#pmds/${key}`]).toBe(`/${deAsset!.fileName}`)
+
+    const manifest = emitted.find((file) => file.fileName === "palamedes-split-manifest.json")
+    const parsed = JSON.parse(manifest!.source)
+    expect(parsed.locales).toEqual(["en", "de"])
+    expect(parsed.importMaps.de).toBe(deMap!.fileName)
+  })
+
+  it("skips asset emission for SSR bundles", async () => {
+    const { sidecarPlugin } = await runSidecarLoad(
+      ["id-a"],
+      {},
+      { pluginOptions: IMPORT_MAP_OPTIONS, command: "build" }
+    )
+    const emitFile = vi.fn()
+    await sidecarPlugin.generateBundle.call({
+      environment: { name: "ssr" },
+      emitFile,
+    } as never)
+
+    expect(emitFile).not.toHaveBeenCalled()
+  })
 })
 
 async function runSidecarLoad(
   compiledIds: string[],
-  context: Record<string, unknown> = {}
+  context: Record<string, unknown> = {},
+  setup: {
+    pluginOptions?: Parameters<typeof palamedes>[0]
+    command?: "build" | "serve"
+  } = {}
 ): Promise<{
-  load: (id: string) => Promise<any>
+  load: (id: string, loadOptions?: { ssr?: boolean }) => Promise<any>
   key: string
   addWatchFile: ReturnType<typeof vi.fn>
+  sidecarPlugin: any
 }> {
   mocks.transformPalamedesMacros.mockClear()
   mocks.compileCatalogArtifactSelected.mockClear()
@@ -550,13 +684,24 @@ async function runSidecarLoad(
     compiledIds,
     map: null,
   })
-  const plugins = palamedes({ experimentalGraphSplitting: true })
+  const plugins = palamedes(setup.pluginOptions ?? { experimentalGraphSplitting: true })
   const macroPlugin = plugins.find((plugin) => plugin.name === "palamedes:transform")
   const sidecarPlugin = plugins.find((plugin) => plugin.name === "palamedes:message-sidecars")
   const transform = macroPlugin?.transform
   const load = sidecarPlugin?.load
   if (typeof transform !== "function" || typeof load !== "function") {
     throw new TypeError("Expected transform and sidecar load hooks")
+  }
+
+  if (setup.command && typeof macroPlugin?.config === "function") {
+    macroPlugin.config.call(
+      {} as any,
+      {} as any,
+      {
+        command: setup.command,
+        mode: setup.command === "serve" ? "development" : "production",
+      } as any
+    )
   }
 
   const transformed = (await transform.call(
@@ -570,7 +715,7 @@ async function runSidecarLoad(
   }
 
   const addWatchFile = vi.fn()
-  const boundLoad = (id: string) =>
+  const boundLoad = (id: string, loadOptions?: { ssr?: boolean }) =>
     Promise.resolve(
       load.call(
         {
@@ -581,11 +726,12 @@ async function runSidecarLoad(
           warn() {},
           ...context,
         } as any,
-        id
+        id,
+        loadOptions
       )
     )
 
-  return { load: boundLoad, key, addWatchFile }
+  return { load: boundLoad, key, addWatchFile, sidecarPlugin }
 }
 
 function runMacroTransform(

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -36,6 +36,37 @@ const MDX_FILE_REGEX = /\.mdx$/i
 const VIRTUAL_MACRO_ERROR_PREFIX = "\0palamedes:macro-error:"
 const VIRTUAL_MESSAGES_PREFIX = "virtual:palamedes-messages/"
 const RESOLVED_MESSAGES_PREFIX = "\0palamedes:messages/"
+const BARE_MESSAGES_PREFIX = "#pmds/"
+const SPLIT_MANIFEST_NAME = "palamedes-split-manifest.json"
+const RENDERED_CATALOG_IMPORT =
+  'import{defineCompiledCatalog as __palamedesDefineCompiledCatalog}from"@palamedes/core/compiled";'
+const RENDERED_CATALOG_DEFAULT_EXPORT = "export default { messages };"
+
+/*
+ * Rewrite the native renderer's module source into a dependency-free message
+ * asset for import-map delivery: no imports (the aggregator re-brands on
+ * receive), plus a `locale` export so the aggregator learns which locale the
+ * import map delivered. The exact-string operations are deliberately strict —
+ * if the native output shape changes, emitting fails loudly instead of
+ * shipping broken assets. The shape is pinned by @palamedes/transform's
+ * catalogLoader tests.
+ */
+function bareMessageAsset(rendered: string, locale: string): string {
+  if (
+    !rendered.startsWith(RENDERED_CATALOG_IMPORT) ||
+    !rendered.includes("__palamedesDefineCompiledCatalog(") ||
+    !rendered.trimEnd().endsWith(RENDERED_CATALOG_DEFAULT_EXPORT)
+  ) {
+    throw new Error(
+      "Palamedes graph splitting: the native catalog module shape changed; cannot derive a bare message asset."
+    )
+  }
+  const body = rendered
+    .slice(RENDERED_CATALOG_IMPORT.length)
+    .replace("__palamedesDefineCompiledCatalog(", "(")
+  const withoutDefault = body.slice(0, body.lastIndexOf(RENDERED_CATALOG_DEFAULT_EXPORT))
+  return `export const locale=${JSON.stringify(locale)};${withoutDefault}`
+}
 const MISSING_CONFIG_ERROR_PREFIX = "Could not find a Palamedes config."
 const VITE_MAJOR = Number.parseInt(viteVersion.split(".")[0] ?? "0", 10)
 function stripQuery(id: string): string {
@@ -195,9 +226,24 @@ export type PalamedesPluginOptions = {
    * so route-level code splitting splits messages without any route
    * configuration. Requires the application to install its client instance
    * with `setClientI18n` instead of importing `.po` catalogs eagerly.
+   *
+   * The object form selects how the locale dimension binds:
+   *
+   * - `localeBinding: "embed"` (default) — every sidecar embeds all locales;
+   *   simplest, works everywhere, ships `locales ×` the route's messages.
+   * - `localeBinding: "import-map"` — production client builds import each
+   *   sidecar through a bare `#pmds/<key>` specifier and the build emits one
+   *   dependency-free message asset per (sidecar × locale) plus one import
+   *   map per locale and a `palamedes-split-manifest.json`. The server must
+   *   inject the active locale's import map into the HTML before any module
+   *   loads; the browser then downloads only the active locale's messages,
+   *   and translation-only deploys change message assets and import maps
+   *   while code chunks keep their hashes. Locale switching requires a
+   *   document navigation. Dev servers and SSR builds keep the embedded
+   *   form.
    * @default false
    */
-  experimentalGraphSplitting?: boolean
+  experimentalGraphSplitting?: boolean | { localeBinding?: "embed" | "import-map" }
 }
 
 /**
@@ -218,8 +264,14 @@ export function palamedes(options: PalamedesPluginOptions = {}): Plugin[] {
     ...configLoaderOptions
   } = options
   const macroRuntimeModule = resolveMacroRuntimeModule(framework, runtimeModule)
+  const graphSplitting = experimentalGraphSplitting !== false
+  const importMapBinding =
+    typeof experimentalGraphSplitting === "object" &&
+    experimentalGraphSplitting.localeBinding === "import-map"
   let resolvedKeepSourceFallbacks = keepSourceFallbacks ?? false
   let stripNonEssentialProps = true
+  let isBuildCommand = false
+  let resolvedBase = "/"
 
   // Initialize lazily
   let config: LoadedPalamedesConfig | null = null
@@ -500,6 +552,8 @@ export function palamedes(options: PalamedesPluginOptions = {}): Plugin[] {
     config(viteConfig, env) {
       resolvedKeepSourceFallbacks = keepSourceFallbacks ?? env.command === "serve"
       stripNonEssentialProps = env.command === "build"
+      isBuildCommand = env.command === "build"
+      resolvedBase = typeof viteConfig.base === "string" ? viteConfig.base : "/"
       const ids = new Set(PALAMEDES_MACRO_PACKAGES)
       macroIds = ids
 
@@ -541,7 +595,7 @@ export function palamedes(options: PalamedesPluginOptions = {}): Plugin[] {
           return null
         }
 
-        if (experimentalGraphSplitting && result.compiledIds.length > 0) {
+        if (graphSplitting && result.compiledIds.length > 0) {
           const key = sidecarKey(cleanId)
           sidecarModules.set(key, { sourceId: cleanId, compiledIds: result.compiledIds })
           return {
@@ -568,9 +622,74 @@ export function palamedes(options: PalamedesPluginOptions = {}): Plugin[] {
   // artifacts stay on the branded parser-free compiled ABI) plus one
   // aggregator that registers the branded exports with the runtime. The
   // bundler then distributes messages along the module graph.
-  if (experimentalGraphSplitting) {
+  if (graphSplitting) {
+    type SidecarEntry = { sourceId: string; compiledIds: string[] }
+
+    function compileSidecarLocale(
+      cfg: LoadedPalamedesConfig,
+      entry: SidecarEntry,
+      locale: string,
+      context: { addWatchFile?: (file: string) => void; warn?: (message: string) => void }
+    ): Record<string, string> | null {
+      const catalogs = cfg.catalogs.filter((catalog) =>
+        catalogMatchesSource(cfg, catalog, entry.sourceId)
+      )
+      if (catalogs.length === 0) {
+        context.warn?.(
+          `Palamedes graph splitting: ${entry.sourceId} uses messages but is not included in any configured catalog; its messages will be missing at runtime.`
+        )
+        return null
+      }
+
+      const selected: Record<string, string> = {}
+      for (const catalog of catalogs) {
+        const artifactConfig = catalogArtifactConfig(cfg, [catalog])
+        const resourcePath = catalogResourcePath(cfg, catalog, locale)
+        const result = compileCatalogArtifactSelected(
+          artifactConfig,
+          resourcePath,
+          entry.compiledIds
+        )
+        result.watchFiles.forEach((file: string) => context.addWatchFile?.(file))
+        if (result.missing.length > 0 && context.warn) {
+          const message =
+            `${createMissingErrorMessage(locale, result.missing)}\n\n` +
+            `Referenced by ${entry.sourceId}.`
+          if (failOnMissing) {
+            throw new Error(message)
+          }
+          context.warn(message)
+        }
+        Object.assign(selected, result.messages)
+      }
+      return selected
+    }
+
+    function splitLocales(cfg: LoadedPalamedesConfig): string[] {
+      // Pseudo-locale catalogs are generated, not stored; the selected
+      // compile has no pseudo path yet. Split mode skips them for now.
+      return cfg.locales.filter((candidate) => candidate !== cfg.pseudoLocale)
+    }
+
     plugins.push({
       name: "palamedes:message-sidecars",
+
+      config() {
+        if (!importMapBinding) {
+          return
+        }
+        // Bare #pmds/ specifiers stay external in client builds; the emitted
+        // per-locale import map resolves them in the browser. SSR aggregators
+        // never emit these specifiers, so the external filter cannot match
+        // there.
+        return {
+          build: {
+            rollupOptions: {
+              external: (id: string) => id.startsWith(BARE_MESSAGES_PREFIX),
+            },
+          },
+        }
+      },
 
       resolveId(id) {
         if (id.startsWith(VIRTUAL_MESSAGES_PREFIX)) {
@@ -578,7 +697,7 @@ export function palamedes(options: PalamedesPluginOptions = {}): Plugin[] {
         }
       },
 
-      async load(id) {
+      async load(id, loadOptions) {
         if (!id.startsWith(RESOLVED_MESSAGES_PREFIX)) {
           return null
         }
@@ -594,12 +713,30 @@ export function palamedes(options: PalamedesPluginOptions = {}): Plugin[] {
 
         const cfg = await getConfigLazy()
         this.addWatchFile(cfg.configPath)
-        // Pseudo-locale catalogs are generated, not stored; the selected
-        // compile has no pseudo path yet. Split mode skips them for now.
-        const locales = cfg.locales.filter((candidate) => candidate !== cfg.pseudoLocale)
+        const locales = splitLocales(cfg)
 
         if (locale === undefined) {
-          // Aggregator: import each branded per-locale module and register it.
+          const ssr =
+            loadOptions?.ssr === true ||
+            (this as { environment?: { name?: string } }).environment?.name === "ssr"
+
+          if (importMapBinding && isBuildCommand && !ssr) {
+            // Import-map binding: the client aggregator imports one
+            // locale-neutral bare specifier. The per-locale import map decides
+            // which emitted message asset answers it, so only the active
+            // locale downloads, and the asset name's hash never appears in
+            // this module or its importers. The asset ships unbranded
+            // (dependency-free); branding happens on receive.
+            const boundCode =
+              `import { locale as l, messages as m } from "${BARE_MESSAGES_PREFIX}${key}";\n` +
+              `import { defineCompiledCatalog } from "@palamedes/core/compiled";\n` +
+              `import { registerMessages } from "@palamedes/runtime";\n` +
+              `registerMessages({ [l]: defineCompiledCatalog(m) });\n`
+            return { code: boundCode, map: null, moduleSideEffects: true }
+          }
+
+          // Embedded binding: import each branded per-locale module and
+          // register it.
           const imports = locales
             .map(
               (localeName, index) =>
@@ -620,39 +757,62 @@ export function palamedes(options: PalamedesPluginOptions = {}): Plugin[] {
           this.error(`Palamedes message sidecar "${key}" requested unknown locale "${locale}".`)
         }
 
-        const catalogs = cfg.catalogs.filter((catalog) =>
-          catalogMatchesSource(cfg, catalog, entry.sourceId)
+        let selected: Record<string, string> | null = null
+        try {
+          selected = compileSidecarLocale(cfg, entry, locale, {
+            addWatchFile: (file) => this.addWatchFile(file),
+            warn: (message) => this.warn(message),
+          })
+        } catch (error) {
+          this.error(error instanceof Error ? error.message : String(error))
+        }
+
+        return { code: renderCatalogModule(selected ?? {}), map: null }
+      },
+
+      async generateBundle() {
+        const environmentName = (this as { environment?: { name?: string } }).environment?.name
+        if (!importMapBinding || environmentName === "ssr" || sidecarModules.size === 0) {
+          return
+        }
+
+        const cfg = await getConfigLazy()
+        const locales = splitLocales(cfg)
+        const importMaps = new Map<string, Record<string, string>>(
+          locales.map((locale) => [locale, {}])
         )
-        if (catalogs.length === 0) {
-          this.warn(
-            `Palamedes graph splitting: ${entry.sourceId} uses messages but is not included in any configured catalog; its messages will be missing at runtime.`
-          )
-          return { code: renderCatalogModule({}), map: null }
-        }
 
-        const selected: Record<string, string> = {}
-        for (const catalog of catalogs) {
-          const artifactConfig = catalogArtifactConfig(cfg, [catalog])
-          const resourcePath = catalogResourcePath(cfg, catalog, locale)
-          const result = compileCatalogArtifactSelected(
-            artifactConfig,
-            resourcePath,
-            entry.compiledIds
-          )
-          result.watchFiles.forEach((file: string) => this.addWatchFile(file))
-          if (result.missing.length > 0) {
-            const message =
-              `${createMissingErrorMessage(locale, result.missing)}\n\n` +
-              `Referenced by ${entry.sourceId}.`
-            if (failOnMissing) {
-              this.error(message)
-            }
-            this.warn(message)
+        // Sorted for determinism: sidecarModules fills in transform order,
+        // which varies between builds; unsorted emission would re-hash the
+        // import maps of untouched locales on every build.
+        const sortedSidecars = [...sidecarModules.entries()].sort(([a], [b]) => a.localeCompare(b))
+        for (const [key, entry] of sortedSidecars) {
+          for (const locale of locales) {
+            const selected = compileSidecarLocale(cfg, entry, locale, {})
+            const asset = bareMessageAsset(renderCatalogModule(selected ?? {}), locale)
+            const contentHash = createHash("sha256").update(asset).digest("hex").slice(0, 8)
+            const fileName = `assets/palamedes-m-${key}.${locale}-${contentHash}.js`
+            this.emitFile({ type: "asset", fileName, source: asset })
+            importMaps.get(locale)![`${BARE_MESSAGES_PREFIX}${key}`] = `${resolvedBase}${fileName}`
           }
-          Object.assign(selected, result.messages)
         }
 
-        return { code: renderCatalogModule(selected), map: null }
+        const manifest: { locales: string[]; importMaps: Record<string, string> } = {
+          locales,
+          importMaps: {},
+        }
+        for (const [locale, imports] of importMaps) {
+          const source = JSON.stringify({ imports })
+          const contentHash = createHash("sha256").update(source).digest("hex").slice(0, 8)
+          const fileName = `assets/palamedes-importmap.${locale}-${contentHash}.json`
+          this.emitFile({ type: "asset", fileName, source })
+          manifest.importMaps[locale] = fileName
+        }
+        this.emitFile({
+          type: "asset",
+          fileName: SPLIT_MANIFEST_NAME,
+          source: JSON.stringify(manifest, null, 2),
+        })
       },
     })
   }


### PR DESCRIPTION
## What this is

Stage 3 of the code-splitting RFC: **load-time locale binding through import maps**, on top of the graph-splitting sidecars from #502. With `experimentalGraphSplitting: { localeBinding: "import-map" }` the browser downloads **only the active locale's messages for the current route** — the theoretical optimum for a catalog-based runtime — and **translation-only deploys keep every code chunk's hash stable**.

## The insight that shaped it

Separate message chunks alone cannot deliver the caching property: ESM chunks reference each other by **hashed filename**, so a changed message chunk changes the import specifier inside its importer and the hash cascades up the static import chain. The only thing that breaks the chain is name indirection — a bare specifier in the code chunk plus an import map carrying the hash. That makes the caching property and the locale binding the *same* mechanism, not two features. (Recorded in the RFC's correction list.)

## How it works

- Production client builds bind each sidecar through a locale-neutral bare specifier (`#pmds/<key>`), kept external — route chunks are translation- and locale-independent.
- `generateBundle` emits one **dependency-free message asset** per (sidecar × locale), derived from the native renderer's output with a `locale` export; the aggregator brands on receive via `defineCompiledCatalog`. Plus one import map per locale and a `palamedes-split-manifest.json` for servers.
- The example's server splices the active locale's import map into the HTML stream **directly after `<head>`**. That placement is load-bearing: React 19 hoists modulepreload links above anything a route component renders, and an import map that loses that race is silently rejected — reproduced as an intermittently dead (unhydrated) page before the injection moved into `entry.server`.
- SSR builds and dev servers keep the embedded form; locale switching becomes a document navigation (`<Form reloadDocument>`).
- Emission is sorted, so rebuilds are bit-for-bit reproducible.

## Verified (production build, browser-driven)

- First load of `/` fetches exactly the four home-route message assets of the active locale — zero assets of any other locale. Client-side navigation to `/insights` fetches exactly one more asset (that route's messages, active locale).
- Warm-cache locale switches across en/de/es hydrate cleanly (interactivity + compiled-plural rendering checked after each switch).
- Changing one German translation and rebuilding changes exactly **one** `.de` message asset and the `.de` import map; every code chunk and every other locale's files keep their hashes. A rebuild without changes reproduces the bundle exactly.

## Scope and known follow-ups (also in the RFC appendix)

- No modulepreload hints for mapped assets yet (one extra waterfall step; the server can emit them from the same map).
- The manifest-reading helper is example code that wants an adapter surface.
- Non-navigation locale switching would need an async ensure path (Stage 0 territory).
- `@palamedes/vite-plugin`: 43 tests (6 new for this mode), tsc/oxlint/oxfmt clean, example typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
