### PR TITLE
feat(vite-plugin): modulepreload hints for mapped message assets

### DIFF
--- a/docs/plans/2026-08-01-code-splitting-localization-rfc.md
+++ b/docs/plans/2026-08-01-code-splitting-localization-rfc.md
@@ -701,11 +701,14 @@ Verified on the production build in a browser:
   bit-for-bit (after sorting emission; unsorted, transform order leaked into
   map hashes).
 
-Open follow-ups from this spike: no modulepreload hints for mapped assets yet
-(one extra request-waterfall step for messages — the server can emit
-`<link rel="modulepreload">` from the same map); the manifest-reading server
-helper is example-code that belongs in an adapter surface; and non-navigation
-locale switching would need an async ensure path (Stage 0 territory).
+Follow-up done (2026-08-02): the manifest now records which chunk imports
+which bare specifier (`chunkImports`), and the example's stream injector
+emits `<link rel="modulepreload">` for the mapped assets of the chunks the
+document already preloads — measured in the browser, message assets start in
+the same millisecond as the route chunk instead of one waterfall step later.
+Still open: the manifest-reading server helper is example-code that belongs
+in an adapter surface, and non-navigation locale switching would need an
+async ensure path (Stage 0 territory).
 
 ## Prior art (references, not blueprints)
 

--- a/examples/react-router-cookie/app/entry.server.tsx
+++ b/examples/react-router-cookie/app/entry.server.tsx
@@ -7,7 +7,7 @@ import { isbot } from "isbot"
 import type { RenderToPipeableStreamOptions } from "react-dom/server"
 import { renderToPipeableStream } from "react-dom/server"
 import { resolveLocaleFromRequest } from "~/lib/i18n"
-import { getLocaleImportMap } from "~/lib/i18n.server"
+import { getLocaleBinding, type LocaleBinding } from "~/lib/i18n.server"
 
 export const streamTimeout = 5000
 
@@ -17,37 +17,58 @@ export const streamTimeout = 5000
  * module load starts, and React 19 hoists modulepreload links above anything
  * rendered from a route component, so injecting the map through the Layout is
  * a race. Splicing it into the stream directly after <head> is the only spot
- * that deterministically precedes every preload. Null map (dev) passes the
- * stream through untouched.
+ * that deterministically precedes every preload.
+ *
+ * The same pass adds modulepreload hints for the message assets belonging to
+ * the code chunks this document already preloads, so messages download in
+ * parallel with the code instead of one waterfall step behind it. Buffering
+ * ends at </head>; with onShellReady the head arrives in the first flush.
+ * Null binding (dev) passes the stream through untouched.
  */
-function createImportMapInjector(importMap: string | null): Transform {
-  if (!importMap) {
+function createLocaleBindingInjector(binding: LocaleBinding | null): Transform {
+  if (!binding) {
     return new PassThrough()
   }
-  const injection = `<head><script type="importmap">${importMap}</script>`
-  let injected = false
-  let carry = ""
+  let buffered = ""
+  let done = false
   return new Transform({
     transform(chunk, _encoding, callback) {
-      if (injected) {
+      if (done) {
         callback(null, chunk)
         return
       }
-      const text = carry + String(chunk)
-      const index = text.indexOf("<head>")
-      if (index === -1) {
-        // Keep a tail that could contain a split "<head>" across chunks.
-        carry = text.slice(-6)
-        callback(null, text.slice(0, text.length - carry.length))
+      buffered += String(chunk)
+      const headEnd = buffered.indexOf("</head>")
+      if (headEnd === -1) {
+        callback()
         return
       }
-      injected = true
-      carry = ""
-      callback(null, text.slice(0, index) + injection + text.slice(index + "<head>".length))
+      done = true
+      let html = buffered.replace(
+        "<head>",
+        `<head><script type="importmap">${binding.importMapJson}</script>`
+      )
+      const preloads = new Set<string>()
+      for (const match of html.matchAll(/<link rel="modulepreload" href="\/(assets\/[^"]+)"/g)) {
+        for (const bare of binding.chunkImports[match[1]!] ?? []) {
+          const asset = binding.imports[bare]
+          if (asset) {
+            preloads.add(asset)
+          }
+        }
+      }
+      if (preloads.size > 0) {
+        const links = [...preloads]
+          .map((href) => `<link rel="modulepreload" href="${href}"/>`)
+          .join("")
+        html = html.replace("</head>", `${links}</head>`)
+      }
+      buffered = ""
+      callback(null, html)
     },
     flush(callback) {
-      if (carry) {
-        this.push(carry)
+      if (!done && buffered) {
+        this.push(buffered)
       }
       callback()
     },
@@ -102,8 +123,8 @@ export default function handleRequest(
 
           responseHeaders.set("Content-Type", "text/html")
 
-          const injector = createImportMapInjector(
-            getLocaleImportMap(resolveLocaleFromRequest(request).locale)
+          const injector = createLocaleBindingInjector(
+            getLocaleBinding(resolveLocaleFromRequest(request).locale)
           )
           injector.pipe(body)
           pipe(injector)

--- a/examples/react-router-cookie/app/lib/i18n.server.ts
+++ b/examples/react-router-cookie/app/lib/i18n.server.ts
@@ -27,26 +27,42 @@ export function activateServerI18n(locale: Locale) {
 // Import-map locale binding: the production client resolves its per-route
 // message assets through one import map per locale, emitted next to the
 // client assets. The document must carry the active locale's map before any
-// module loads, so the root loader reads it here. In dev the manifest does
-// not exist (dev serves the embedded form) and this returns null.
-const importMapCache = new Map<Locale, string | null>()
+// module loads, and can preload the mapped assets of the chunks it serves so
+// messages download in parallel with the code. In dev the manifest does not
+// exist (dev serves the embedded form) and this returns null.
+export type LocaleBinding = {
+  importMapJson: string
+  imports: Record<string, string>
+  chunkImports: Record<string, string[]>
+}
 
-function readLocaleImportMap(locale: Locale): string | null {
+const bindingCache = new Map<Locale, LocaleBinding | null>()
+
+function readLocaleBinding(locale: Locale): LocaleBinding | null {
   try {
     const clientDir = path.resolve(import.meta.dirname, "../client")
     const manifest = JSON.parse(
       readFileSync(path.join(clientDir, "palamedes-split-manifest.json"), "utf8")
-    ) as { importMaps: Record<string, string> }
+    ) as { importMaps: Record<string, string>; chunkImports?: Record<string, string[]> }
     const mapFile = manifest.importMaps[locale]
-    return mapFile ? readFileSync(path.join(clientDir, mapFile), "utf8") : null
+    if (!mapFile) {
+      return null
+    }
+    const importMapJson = readFileSync(path.join(clientDir, mapFile), "utf8")
+    const parsed = JSON.parse(importMapJson) as { imports: Record<string, string> }
+    return {
+      importMapJson,
+      imports: parsed.imports,
+      chunkImports: manifest.chunkImports ?? {},
+    }
   } catch {
     return null
   }
 }
 
-export function getLocaleImportMap(locale: Locale): string | null {
-  if (!importMapCache.has(locale)) {
-    importMapCache.set(locale, readLocaleImportMap(locale))
+export function getLocaleBinding(locale: Locale): LocaleBinding | null {
+  if (!bindingCache.has(locale)) {
+    bindingCache.set(locale, readLocaleBinding(locale))
   }
-  return importMapCache.get(locale) ?? null
+  return bindingCache.get(locale) ?? null
 }

--- a/packages/vite-plugin/src/index.test.ts
+++ b/packages/vite-plugin/src/index.test.ts
@@ -621,10 +621,18 @@ describe("experimental graph splitting", () => {
       { pluginOptions: IMPORT_MAP_OPTIONS, command: "build" }
     )
     const emitted: { fileName: string; source: string }[] = []
-    await sidecarPlugin.generateBundle.call({
-      environment: { name: "client" },
-      emitFile: (file: { fileName: string; source: string }) => emitted.push(file),
-    } as never)
+    await sidecarPlugin.generateBundle.call(
+      {
+        environment: { name: "client" },
+        emitFile: (file: { fileName: string; source: string }) => emitted.push(file),
+      } as never,
+      {},
+      {
+        "assets/home-abc.js": { type: "chunk", imports: [`#pmds/${key}`, "assets/vendor.js"] },
+        "assets/vendor.js": { type: "chunk", imports: [] },
+        "assets/style.css": { type: "asset" },
+      }
+    )
 
     // One dependency-free asset per (sidecar x locale); pseudo is skipped.
     const assets = emitted.filter((file) => file.fileName.startsWith("assets/palamedes-m-"))
@@ -644,6 +652,9 @@ describe("experimental graph splitting", () => {
     const parsed = JSON.parse(manifest!.source)
     expect(parsed.locales).toEqual(["en", "de"])
     expect(parsed.importMaps.de).toBe(deMap!.fileName)
+    // Only chunks with bare message imports appear, so servers can preload
+    // the mapped assets of the chunks they serve.
+    expect(parsed.chunkImports).toEqual({ "assets/home-abc.js": [`#pmds/${key}`] })
   })
 
   it("skips asset emission for SSR bundles", async () => {
@@ -653,10 +664,14 @@ describe("experimental graph splitting", () => {
       { pluginOptions: IMPORT_MAP_OPTIONS, command: "build" }
     )
     const emitFile = vi.fn()
-    await sidecarPlugin.generateBundle.call({
-      environment: { name: "ssr" },
-      emitFile,
-    } as never)
+    await sidecarPlugin.generateBundle.call(
+      {
+        environment: { name: "ssr" },
+        emitFile,
+      } as never,
+      {},
+      {}
+    )
 
     expect(emitFile).not.toHaveBeenCalled()
   })

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -770,7 +770,7 @@ export function palamedes(options: PalamedesPluginOptions = {}): Plugin[] {
         return { code: renderCatalogModule(selected ?? {}), map: null }
       },
 
-      async generateBundle() {
+      async generateBundle(_options, bundle) {
         const environmentName = (this as { environment?: { name?: string } }).environment?.name
         if (!importMapBinding || environmentName === "ssr" || sidecarModules.size === 0) {
           return
@@ -797,9 +797,32 @@ export function palamedes(options: PalamedesPluginOptions = {}): Plugin[] {
           }
         }
 
-        const manifest: { locales: string[]; importMaps: Record<string, string> } = {
+        // Which chunk imports which bare message specifier, so servers can
+        // emit modulepreload hints for the mapped assets of the chunks they
+        // are about to serve and message assets load in parallel with the
+        // code instead of one waterfall step behind it.
+        const chunkImports: Record<string, string[]> = {}
+        for (const fileName of Object.keys(bundle).sort()) {
+          const output = bundle[fileName]
+          if (!output || output.type !== "chunk") {
+            continue
+          }
+          const bareImports = output.imports
+            .filter((imported) => imported.startsWith(BARE_MESSAGES_PREFIX))
+            .sort()
+          if (bareImports.length > 0) {
+            chunkImports[fileName] = bareImports
+          }
+        }
+
+        const manifest: {
+          locales: string[]
+          importMaps: Record<string, string>
+          chunkImports: Record<string, string[]>
+        } = {
           locales,
           importMaps: {},
+          chunkImports,
         }
         for (const [locale, imports] of importMaps) {
           const source = JSON.stringify({ imports })


### PR DESCRIPTION
## What this is

Follow-up to #503: **modulepreload hints for mapped message assets**, removing the one remaining request-waterfall step of import-map locale binding.

With bare-specifier binding the browser discovers a chunk's message imports only after parsing the chunk. Now:

- The split manifest records `chunkImports` — which emitted chunk imports which `#pmds/` bare specifier (sorted, reproducible).
- The example's stream injector, in the same `</head>`-bounded pass that splices the import map after `<head>`, scans the modulepreload links the document already carries, resolves their chunks through `chunkImports` × the active locale's import map, and appends `<link rel="modulepreload">` for exactly those message assets — active locale only, only for chunks the document actually serves (lazy routes' assets are correctly not preloaded).

## Measured

Browser resource timing on the production build, first load of `/`: the four home-route message assets start at **20–21 ms — the same millisecond as the route chunk** (previously one waterfall step after chunk parse). Hydration and interactivity verified; the served HTML carries exactly the active locale's four preload links and the import map.

## Notes

- `@palamedes/vite-plugin`: 43 tests green (manifest assertion extended), tsc/oxlint/oxfmt clean, example typecheck green.
- RFC appendix updated: this follow-up checked off; remaining ones (adapter surface for the manifest-reading helper, async ensure for non-navigation switches) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
