### PR TITLE
Add native source-authoring diagnostics and lint workflow

### DIFF
--- a/adr/019-extraction-cache.md
+++ b/adr/019-extraction-cache.md
@@ -1,6 +1,6 @@
 # ADR-019: Extraction Cache
 
-**Status:** Accepted
+**Status:** Accepted (extended to shared source analysis)
 
 ## Context
 
@@ -33,18 +33,23 @@ non-i18n files stop being reported. It is not in the codebase.
 
 ## Decision
 
-Extraction keeps a per-file cache of its own results, validated by `stat`.
+Native source analysis keeps a per-file cache of its results, validated by
+`stat`. Extraction and source lint share it.
 
-An entry stores the extracted messages and the origin path for one source file,
-keyed by absolute path and guarded by size plus modification time. A hit skips
-both the read and the parse. The cache lives at `.palamedes/extract-cache.json`
-under the project root and is written atomically through a temporary file.
+An entry stores the extracted messages, source-authoring diagnostics, and the
+origin path for one source file, keyed by absolute path and guarded by size plus
+modification time. A compatible hit skips the parse; extraction also skips the
+read, while lint still reads the small source text needed to apply inline
+suppressions. The cache keeps its established location at
+`.palamedes/extract-cache.json` under the project root and is written atomically
+through a temporary file.
 
 Validation is deliberately `stat`-based rather than content-hashed. Hashing
 requires reading the file, which is the cost being avoided.
 
-The same cache serves both shapes of use. A single `pmds extract` loads it,
-uses it, and saves it. Watch mode loads it once and holds it for the life of the
+The same cache serves all three shapes of use. `pmds extract` and `pmds lint`
+load, use, and save it, so either command can reuse a compatible analysis
+produced by the other. Watch mode loads it once and holds it for the life of the
 process, so every rebuild after the first skips unchanged files without touching
 disk for them.
 
@@ -55,11 +60,11 @@ trusted is simply not used.
 
 Correctness rests on discarding aggressively rather than reasoning cleverly:
 
-- A stamp covering the schema version, the extractor version, and the source
-  reference root is compared on load. Any mismatch discards everything. The
-  extractor version matters because a release can legitimately change what a
-  given file extracts to; the reference root matters because it determines the
-  stored origin paths.
+- A stamp covering the schema version, extractor version, source reference
+  root, reference-scope behavior, MDX options, and source-rule levels is
+  compared on load. Any mismatch discards everything. The extractor version
+  matters because a release can legitimately change what a given file produces;
+  the remaining fields determine stored origins, messages, or diagnostics.
 - The file identity is captured before the contents are read and re-checked
   before the entry is stored; if it moved in between, the file is not cached.
   Storing the identity observed only after extraction would pair the contents
@@ -70,15 +75,18 @@ Correctness rests on discarding aggressively rather than reasoning cleverly:
   modification time cannot be distinguished from an edit landing immediately
   afterwards — the hazard Git documents as racy timestamps. Nanosecond
   timestamps make the window small; refusing to cache closes it.
-- Failed files are never cached, so a file that stops parsing is retried on the
-  next run rather than remembered as broken.
+- Read failures and fatal JS/TS parse or authoring failures are never cached, so
+  they are retried on the next run rather than remembered as broken. Structured
+  MDX diagnostics are a successful analysis result and are cached; extraction
+  still treats them as a failed source file, while lint reports their ranges.
 - Entries for files no longer in the extraction set are dropped, so a long-lived
   watch process does not grow without bound. Retention runs once over the union
   of every catalog's files; doing it per catalog would make each catalog evict
   the entries of its siblings, so a multi-catalog project would re-extract
   almost everything on every run.
 
-It can be turned off with `--no-cache` or `extract-cache: false`.
+It can be turned off with `--no-cache` on either command or with
+`extract-cache: false`.
 
 ## Benchmark Consequences
 
@@ -120,17 +128,18 @@ faster". The report states this in place.
   quotes, and it is recorded here rather than absorbed quietly. Reducing it
   means avoiding the record copy and using a more compact payload; neither is
   done here.
-- Catalog output is unaffected. Cold-with-cache, warm, and `--no-cache` runs
-  produce byte-identical catalogs.
+- Catalog and lint output are unaffected. Cold-with-cache, warm, and
+  `--no-cache` runs produce byte-identical results.
 - Writing catalogs now dominates the warm run at roughly 40 of 70 ms. The same
   reasoning applies there: if the message set is unchanged the rendered catalog
   is unchanged, and that could be established without re-rendering it. That is
   the next thing worth doing, and it is not done here.
 - The project gains an on-disk artifact. `.palamedes/` belongs in `.gitignore`.
-- The cache file is roughly the size of the extracted data — about 1.8 MB for
-  6,000 messages. Loading it is part of the 5 ms above, so JSON is fast enough
-  to read at this scale; writing it is the larger half of the cold cost above,
-  which is where a more compact format would pay off first.
+- The cache file is roughly the size of the extracted messages plus any emitted
+  source diagnostics — about 1.8 MB for the original 6,000-message benchmark.
+  Loading it is part of the 5 ms above, so JSON is fast enough to read at this
+  scale; writing it is the larger half of the cold cost above, which is where a
+  more compact format would pay off first.
 - Stale entries are impossible to observe through normal editing, but a tool
   that rewrites a file preserving both size and modification time would defeat
   the check. `--no-cache` exists for that case.

--- a/crates/palamedes-cli/src/cli.rs
+++ b/crates/palamedes-cli/src/cli.rs
@@ -10,6 +10,7 @@ use crate::command::{execute, Context};
 use crate::commands::audit::AuditOptions;
 use crate::commands::catalog::{CatalogCommand, CatalogSubcommand};
 use crate::commands::extract::ExtractOptions;
+use crate::commands::lint::LintOptions;
 use crate::commands::report::ReportOptions;
 use crate::commands::version::VersionCommand;
 use crate::error::CliError;
@@ -18,7 +19,7 @@ use crate::plugins;
 #[derive(Debug, Parser)]
 #[command(name = "pmds")]
 #[command(version)]
-#[command(about = "Palamedes CLI for extraction, audits, reports, and catalog workflows")]
+#[command(about = "Palamedes CLI for extraction, source lint, audits, reports, and catalogs")]
 pub struct Cli {
     #[command(subcommand)]
     command: Command,
@@ -28,6 +29,8 @@ pub struct Cli {
 enum Command {
     /// Extract messages from source files.
     Extract(ExtractOptions),
+    /// Check Palamedes source authoring without updating catalogs.
+    Lint(LintOptions),
     /// Audit catalogs for translation and ICU authoring issues.
     Audit(AuditOptions),
     /// Report per-locale catalog translation completeness.
@@ -47,6 +50,7 @@ impl Cli {
         let context = Context::from_env();
         match &self.command {
             Command::Extract(options) => execute(options, &context).map(|()| 0),
+            Command::Lint(options) => execute(options, &context).map(|()| 0),
             Command::Audit(options) => execute(options, &context).map(|()| 0),
             Command::Report(options) => execute(options, &context).map(|()| 0),
             Command::Catalog(catalog) => match &catalog.command {

--- a/crates/palamedes-cli/src/commands/extract/cache.rs
+++ b/crates/palamedes-cli/src/commands/extract/cache.rs
@@ -19,6 +19,7 @@ pub(super) fn load_extract_cache(config: &LoadedConfig, options: &ExtractOptions
         &palamedes::ExtractCatalogMessagesOptions {
             reference_scopes: config.reference_scopes,
             mdx: config.mdx.clone(),
+            rules: config.lint.rules.clone().into(),
         },
     )
 }

--- a/crates/palamedes-cli/src/commands/extract/mod.rs
+++ b/crates/palamedes-cli/src/commands/extract/mod.rs
@@ -246,6 +246,7 @@ fn extract_from_catalog(
         palamedes::ExtractCatalogMessagesOptions {
             reference_scopes: config.reference_scopes,
             mdx: config.mdx.clone(),
+            rules: config.lint.rules.clone().into(),
         },
         cache,
     )?;

--- a/crates/palamedes-cli/src/commands/extract/mod.rs
+++ b/crates/palamedes-cli/src/commands/extract/mod.rs
@@ -1,7 +1,7 @@
 //! `pmds extract` — read source files, update catalogs.
 
 mod cache;
-mod sources;
+pub(crate) mod sources;
 #[cfg(test)]
 mod test_support;
 mod watch;

--- a/crates/palamedes-cli/src/commands/extract/sources.rs
+++ b/crates/palamedes-cli/src/commands/extract/sources.rs
@@ -10,7 +10,7 @@ use ignore::WalkBuilder;
 use crate::config::{ConfigCatalog, LoadedConfig};
 use crate::error::CliError;
 
-pub(super) fn collect_source_files(
+pub(crate) fn collect_source_files(
     catalog: &ConfigCatalog,
     config: &LoadedConfig,
 ) -> Result<Vec<PathBuf>, CliError> {
@@ -57,7 +57,7 @@ pub(super) fn collect_source_files(
  * order and the resulting file order — and with it catalog origin order — is
  * unchanged. Other platforms keep Path's own ordering.
  */
-pub(super) fn sort_and_dedupe_paths<P: AsRef<Path> + Ord>(paths: &mut Vec<P>) {
+pub(crate) fn sort_and_dedupe_paths<P: AsRef<Path> + Ord>(paths: &mut Vec<P>) {
     #[cfg(unix)]
     {
         use std::os::unix::ffi::OsStrExt;

--- a/crates/palamedes-cli/src/commands/lint.rs
+++ b/crates/palamedes-cli/src/commands/lint.rs
@@ -1,25 +1,18 @@
 //! `pmds lint` — non-mutating Palamedes source-authoring diagnostics.
 
 use std::collections::BTreeSet;
-use std::fs;
 use std::path::{Path, PathBuf};
 
 use clap::{Args, ValueEnum};
 use palamedes::{
     analyze_source_file_cached, default_cache_path, ExtractCache, ExtractCatalogMessagesOptions,
-    SourceDiagnostic, SourceDiagnosticSeverity, SourceRange,
+    SourceDiagnostic, SourceDiagnosticSeverity, SourceRange, SOURCE_DIAGNOSTIC_CODES,
 };
 use serde::Serialize;
 
 use crate::command::{render_json, Command, Context};
 use crate::commands::extract::sources::{collect_source_files, sort_and_dedupe_paths};
 use crate::error::CliError;
-
-const KNOWN_DIAGNOSTIC_CODES: &[&str] = &[
-    "pmds/no-placeholder-only-message",
-    "pmds/no-empty-component-only-message",
-    "pmds/prefer-trans-in-jsx",
-];
 
 #[derive(Debug, Args)]
 pub struct LintOptions {
@@ -101,16 +94,6 @@ impl Command for LintOptions {
 
         for path in &files {
             let filename = display_source_path(path, &config.root_dir);
-            let source = match fs::read_to_string(path) {
-                Ok(source) => source,
-                Err(error) => {
-                    failed_files.push(LintFileFailure {
-                        file: filename,
-                        message: error.to_string(),
-                    });
-                    continue;
-                }
-            };
             match analyze_source_file_cached(
                 &path.to_string_lossy(),
                 &filename,
@@ -120,7 +103,7 @@ impl Command for LintOptions {
             ) {
                 Ok(result) => {
                     let (mut file_diagnostics, file_suppressed) =
-                        apply_suppressions(&source, &filename, result.diagnostics);
+                        apply_suppressions(&result.source, &filename, result.analysis.diagnostics);
                     diagnostics.append(&mut file_diagnostics);
                     suppressed += file_suppressed;
                 }
@@ -329,7 +312,7 @@ fn parse_suppressions(source: &str, filename: &str) -> (Vec<Suppression>, Vec<So
                 continue;
             }
             for code in codes {
-                if KNOWN_DIAGNOSTIC_CODES.contains(&code) {
+                if SOURCE_DIAGNOSTIC_CODES.contains(&code) {
                     suppressions.push(Suppression {
                         line: line_index + 1 + line_delta,
                         code: code.to_owned(),

--- a/crates/palamedes-cli/src/commands/lint.rs
+++ b/crates/palamedes-cli/src/commands/lint.rs
@@ -6,8 +6,8 @@ use std::path::{Path, PathBuf};
 
 use clap::{Args, ValueEnum};
 use palamedes::{
-    analyze_source_with_options, SourceAnalysisOptions, SourceDiagnostic, SourceDiagnosticSeverity,
-    SourceRange,
+    analyze_source_file_cached, default_cache_path, ExtractCache, ExtractCatalogMessagesOptions,
+    SourceDiagnostic, SourceDiagnosticSeverity, SourceRange,
 };
 use serde::Serialize;
 
@@ -32,6 +32,9 @@ pub struct LintOptions {
     /// Fail on error or warning diagnostics.
     #[arg(long, default_value = "error")]
     fail_on: LintFailOn,
+    /// Ignore and do not write the shared source-analysis cache.
+    #[arg(long)]
+    no_cache: bool,
 }
 
 #[derive(Clone, Copy, Debug, ValueEnum)]
@@ -40,7 +43,7 @@ enum LintFailOn {
     Warning,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct LintResult {
     diagnostics: Vec<SourceDiagnostic>,
@@ -48,14 +51,14 @@ pub struct LintResult {
     summary: LintSummary,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct LintFileFailure {
     file: String,
     message: String,
 }
 
-#[derive(Debug, Default, Serialize)]
+#[derive(Debug, Default, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct LintSummary {
     files: usize,
@@ -80,9 +83,20 @@ impl Command for LintOptions {
         let mut diagnostics = Vec::new();
         let mut failed_files = Vec::new();
         let mut suppressed = 0usize;
-        let analysis_options = SourceAnalysisOptions {
+        let analysis_options = ExtractCatalogMessagesOptions {
+            reference_scopes: config.reference_scopes,
             mdx: config.mdx.clone(),
             rules: config.lint.rules.clone().into(),
+        };
+        let cache_path = default_cache_path(&config.root_dir);
+        let mut cache = if self.no_cache || !config.extract_cache {
+            ExtractCache::disabled()
+        } else {
+            ExtractCache::load_with_options(
+                &cache_path,
+                &config.source_reference_root.to_string_lossy(),
+                &analysis_options,
+            )
         };
 
         for path in &files {
@@ -97,7 +111,13 @@ impl Command for LintOptions {
                     continue;
                 }
             };
-            match analyze_source_with_options(&source, &filename, &analysis_options) {
+            match analyze_source_file_cached(
+                &path.to_string_lossy(),
+                &filename,
+                &config.source_reference_root.to_string_lossy(),
+                &analysis_options,
+                &mut cache,
+            ) {
                 Ok(result) => {
                     let (mut file_diagnostics, file_suppressed) =
                         apply_suppressions(&source, &filename, result.diagnostics);
@@ -110,6 +130,13 @@ impl Command for LintOptions {
                 }),
             }
         }
+
+        let cache_keys = files
+            .iter()
+            .map(|path| path.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+        cache.retain_paths(&cache_keys.iter().map(String::as_str).collect());
+        let _ = cache.save(&cache_path);
 
         diagnostics.sort_by(|left, right| {
             (
@@ -222,6 +249,7 @@ fn severity_name(severity: SourceDiagnosticSeverity) -> &'static str {
 struct Suppression {
     line: usize,
     code: String,
+    primary: SourceRange,
 }
 
 fn apply_suppressions(
@@ -230,14 +258,27 @@ fn apply_suppressions(
     diagnostics: Vec<SourceDiagnostic>,
 ) -> (Vec<SourceDiagnostic>, usize) {
     let (suppressions, mut suppression_diagnostics) = parse_suppressions(source, filename);
+    let mut used = vec![false; suppressions.len()];
     let mut suppressed = 0usize;
     for diagnostic in diagnostics {
-        if suppressions.iter().any(|suppression| {
+        if let Some(index) = suppressions.iter().position(|suppression| {
             suppression.line == diagnostic.primary.line && suppression.code == diagnostic.code
         }) {
+            used[index] = true;
             suppressed += 1;
         } else {
             suppression_diagnostics.push(diagnostic);
+        }
+    }
+    for (suppression, used) in suppressions.into_iter().zip(used) {
+        if !used {
+            suppression_diagnostics.push(suppression_diagnostic(
+                filename,
+                suppression.primary,
+                "pmds/unused-suppression",
+                &format!("Unused suppression for `{}`.", suppression.code),
+                "Remove the directive or move it to the exact line that emits this diagnostic.",
+            ));
         }
     }
     (suppression_diagnostics, suppressed)
@@ -292,6 +333,7 @@ fn parse_suppressions(source: &str, filename: &str) -> (Vec<Suppression>, Vec<So
                     suppressions.push(Suppression {
                         line: line_index + 1 + line_delta,
                         code: code.to_owned(),
+                        primary: range.clone(),
                     });
                 } else {
                     diagnostics.push(suppression_diagnostic(
@@ -366,6 +408,7 @@ function View({ status }) {
             config: None,
             json: false,
             fail_on: LintFailOn::Error,
+            no_cache: true,
         }
         .run(&Context::with_cwd(&app))
         .expect("run lint");
@@ -387,6 +430,108 @@ function View({ status }) {
     }
 
     #[test]
+    fn lint_discovers_all_supported_source_extensions() {
+        let app = temp_dir("source-lint-extensions");
+        fs::create_dir_all(app.join("src")).expect("create source dir");
+        fs::write(
+            app.join("palamedes.yaml"),
+            r#"locales: [en]
+source-locale: en
+catalogs:
+  - path: locales/{locale}/app
+    include: [src]
+"#,
+        )
+        .expect("write config");
+        for extension in ["js", "ts", "jsx", "tsx"] {
+            fs::write(
+                app.join(format!("src/source.{extension}")),
+                "export const value = 1\n",
+            )
+            .expect("write source");
+        }
+        fs::write(app.join("src/guide.mdx"), "# Hello\n").expect("write MDX");
+
+        let output = LintOptions {
+            config: None,
+            json: false,
+            fail_on: LintFailOn::Error,
+            no_cache: true,
+        }
+        .run(&Context::with_cwd(&app))
+        .expect("run lint");
+
+        assert_eq!(output.summary.files, 5);
+        assert!(output.failed_files.is_empty());
+        fs::remove_dir_all(app).expect("cleanup");
+    }
+
+    #[test]
+    fn lint_reports_unused_suppressions() {
+        let source =
+            "// palamedes-lint-disable-next-line pmds/no-placeholder-only-message\nconst ok = 1\n";
+        let (diagnostics, suppressed) = super::apply_suppressions(source, "view.tsx", Vec::new());
+        assert_eq!(suppressed, 0);
+        assert_eq!(diagnostics[0].code, "pmds/unused-suppression");
+    }
+
+    #[test]
+    fn cached_and_uncached_json_results_are_byte_equivalent() {
+        let app = temp_dir("source-lint-cache");
+        fs::create_dir_all(app.join("src")).expect("create source dir");
+        fs::write(
+            app.join("palamedes.yaml"),
+            r#"locales: [en]
+source-locale: en
+catalogs:
+  - path: locales/{locale}/app
+    include: [src]
+"#,
+        )
+        .expect("write config");
+        let source = app.join("src/view.tsx");
+        fs::write(
+            &source,
+            r#"import { t } from "@palamedes/core/macro";
+function View({ status }) { return <p>{t`${status}`}</p>; }
+"#,
+        )
+        .expect("write source");
+        let aged = std::time::SystemTime::now() - std::time::Duration::from_secs(10);
+        fs::File::options()
+            .write(true)
+            .open(&source)
+            .expect("open source")
+            .set_modified(aged)
+            .expect("age source");
+
+        let context = Context::with_cwd(&app);
+        let cached = LintOptions {
+            config: None,
+            json: true,
+            fail_on: LintFailOn::Error,
+            no_cache: false,
+        }
+        .run(&context)
+        .expect("cached lint");
+        let cold = LintOptions {
+            config: None,
+            json: true,
+            fail_on: LintFailOn::Error,
+            no_cache: true,
+        }
+        .run(&context)
+        .expect("uncached lint");
+
+        assert_eq!(
+            serde_json::to_vec(&cached).expect("cached json"),
+            serde_json::to_vec(&cold).expect("uncached json")
+        );
+        assert!(app.join(".palamedes/extract-cache.json").exists());
+        fs::remove_dir_all(app).expect("cleanup");
+    }
+
+    #[test]
     fn warning_threshold_fails_after_building_the_result() {
         let mut result = super::LintResult {
             diagnostics: Vec::new(),
@@ -398,6 +543,7 @@ function View({ status }) {
             config: None,
             json: false,
             fail_on: LintFailOn::Warning,
+            no_cache: true,
         };
 
         assert!(options.verdict(&result).is_err());

--- a/crates/palamedes-cli/src/commands/lint.rs
+++ b/crates/palamedes-cli/src/commands/lint.rs
@@ -1,0 +1,405 @@
+//! `pmds lint` — non-mutating Palamedes source-authoring diagnostics.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use clap::{Args, ValueEnum};
+use palamedes::{
+    analyze_source_with_options, SourceAnalysisOptions, SourceDiagnostic, SourceDiagnosticSeverity,
+    SourceRange,
+};
+use serde::Serialize;
+
+use crate::command::{render_json, Command, Context};
+use crate::commands::extract::sources::{collect_source_files, sort_and_dedupe_paths};
+use crate::error::CliError;
+
+const KNOWN_DIAGNOSTIC_CODES: &[&str] = &[
+    "pmds/no-placeholder-only-message",
+    "pmds/no-empty-component-only-message",
+    "pmds/prefer-trans-in-jsx",
+];
+
+#[derive(Debug, Args)]
+pub struct LintOptions {
+    /// Path to a Palamedes config file.
+    #[arg(short, long)]
+    config: Option<PathBuf>,
+    /// Print one deterministic machine-readable JSON document.
+    #[arg(long)]
+    json: bool,
+    /// Fail on error or warning diagnostics.
+    #[arg(long, default_value = "error")]
+    fail_on: LintFailOn,
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+enum LintFailOn {
+    Error,
+    Warning,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LintResult {
+    diagnostics: Vec<SourceDiagnostic>,
+    failed_files: Vec<LintFileFailure>,
+    summary: LintSummary,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct LintFileFailure {
+    file: String,
+    message: String,
+}
+
+#[derive(Debug, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct LintSummary {
+    files: usize,
+    errors: usize,
+    warnings: usize,
+    infos: usize,
+    suppressed: usize,
+    failed_files: usize,
+}
+
+impl Command for LintOptions {
+    type Output = LintResult;
+
+    fn run(&self, context: &Context) -> Result<Self::Output, CliError> {
+        let config = context.load_config(self.config.as_deref())?;
+        let mut files = Vec::new();
+        for catalog in &config.catalogs {
+            files.extend(collect_source_files(catalog, &config)?);
+        }
+        sort_and_dedupe_paths(&mut files);
+
+        let mut diagnostics = Vec::new();
+        let mut failed_files = Vec::new();
+        let mut suppressed = 0usize;
+        let analysis_options = SourceAnalysisOptions {
+            mdx: config.mdx.clone(),
+            rules: config.lint.rules.clone().into(),
+        };
+
+        for path in &files {
+            let filename = display_source_path(path, &config.root_dir);
+            let source = match fs::read_to_string(path) {
+                Ok(source) => source,
+                Err(error) => {
+                    failed_files.push(LintFileFailure {
+                        file: filename,
+                        message: error.to_string(),
+                    });
+                    continue;
+                }
+            };
+            match analyze_source_with_options(&source, &filename, &analysis_options) {
+                Ok(result) => {
+                    let (mut file_diagnostics, file_suppressed) =
+                        apply_suppressions(&source, &filename, result.diagnostics);
+                    diagnostics.append(&mut file_diagnostics);
+                    suppressed += file_suppressed;
+                }
+                Err(error) => failed_files.push(LintFileFailure {
+                    file: filename,
+                    message: error.to_string(),
+                }),
+            }
+        }
+
+        diagnostics.sort_by(|left, right| {
+            (
+                left.file.as_str(),
+                left.primary.start,
+                left.primary.end,
+                left.code.as_str(),
+            )
+                .cmp(&(
+                    right.file.as_str(),
+                    right.primary.start,
+                    right.primary.end,
+                    right.code.as_str(),
+                ))
+        });
+        failed_files.sort_by(|left, right| left.file.cmp(&right.file));
+
+        let mut summary = LintSummary {
+            files: files.len(),
+            suppressed,
+            failed_files: failed_files.len(),
+            ..LintSummary::default()
+        };
+        for diagnostic in &diagnostics {
+            match diagnostic.severity {
+                SourceDiagnosticSeverity::Error => summary.errors += 1,
+                SourceDiagnosticSeverity::Warning => summary.warnings += 1,
+                SourceDiagnosticSeverity::Info => summary.infos += 1,
+            }
+        }
+
+        Ok(LintResult {
+            diagnostics,
+            failed_files,
+            summary,
+        })
+    }
+
+    fn render(&self, output: &Self::Output) -> Result<(), CliError> {
+        if self.json {
+            return render_json(output);
+        }
+
+        for diagnostic in &output.diagnostics {
+            println!(
+                "{}:{}:{}: {} {} {}",
+                diagnostic.file,
+                diagnostic.primary.line,
+                diagnostic.primary.column,
+                severity_name(diagnostic.severity),
+                diagnostic.code,
+                diagnostic.message
+            );
+            println!("  help: {}", diagnostic.help);
+        }
+        for failure in &output.failed_files {
+            println!(
+                "{}: error pmds/analysis-failed {}",
+                failure.file, failure.message
+            );
+        }
+        println!(
+            "Source lint: {} error(s), {} warning(s), {} info, {} suppressed across {} file(s)",
+            output.summary.errors,
+            output.summary.warnings,
+            output.summary.infos,
+            output.summary.suppressed,
+            output.summary.files
+        );
+        Ok(())
+    }
+
+    fn verdict(&self, output: &Self::Output) -> Result<(), CliError> {
+        if output.summary.failed_files > 0 {
+            return Err(CliError::LintAnalysisFailed {
+                failures: output.summary.failed_files,
+            });
+        }
+        match self.fail_on {
+            LintFailOn::Warning if output.summary.errors > 0 || output.summary.warnings > 0 => {
+                Err(CliError::LintFailedOnWarning {
+                    errors: output.summary.errors,
+                    warnings: output.summary.warnings,
+                })
+            }
+            LintFailOn::Error if output.summary.errors > 0 => Err(CliError::LintFailedOnError {
+                errors: output.summary.errors,
+            }),
+            _ => Ok(()),
+        }
+    }
+}
+
+fn display_source_path(path: &Path, root_dir: &Path) -> String {
+    path.strip_prefix(root_dir)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .into_owned()
+}
+
+fn severity_name(severity: SourceDiagnosticSeverity) -> &'static str {
+    match severity {
+        SourceDiagnosticSeverity::Error => "error",
+        SourceDiagnosticSeverity::Warning => "warning",
+        SourceDiagnosticSeverity::Info => "info",
+    }
+}
+
+#[derive(Debug)]
+struct Suppression {
+    line: usize,
+    code: String,
+}
+
+fn apply_suppressions(
+    source: &str,
+    filename: &str,
+    diagnostics: Vec<SourceDiagnostic>,
+) -> (Vec<SourceDiagnostic>, usize) {
+    let (suppressions, mut suppression_diagnostics) = parse_suppressions(source, filename);
+    let mut suppressed = 0usize;
+    for diagnostic in diagnostics {
+        if suppressions.iter().any(|suppression| {
+            suppression.line == diagnostic.primary.line && suppression.code == diagnostic.code
+        }) {
+            suppressed += 1;
+        } else {
+            suppression_diagnostics.push(diagnostic);
+        }
+    }
+    (suppression_diagnostics, suppressed)
+}
+
+fn parse_suppressions(source: &str, filename: &str) -> (Vec<Suppression>, Vec<SourceDiagnostic>) {
+    const DIRECTIVES: &[(&str, usize)] = &[
+        ("palamedes-lint-disable-next-line", 1),
+        ("palamedes-lint-disable-line", 0),
+    ];
+
+    let mut suppressions = Vec::new();
+    let mut diagnostics = Vec::new();
+    let mut line_start = 0usize;
+    for (line_index, line) in source.split_inclusive('\n').enumerate() {
+        for (directive, line_delta) in DIRECTIVES {
+            let Some(marker_index) = line.find(directive) else {
+                continue;
+            };
+            if !["//", "{/*", "<!--"]
+                .iter()
+                .any(|comment| line[..marker_index].contains(comment))
+            {
+                continue;
+            }
+            let rest = line[marker_index + directive.len()..]
+                .trim()
+                .trim_end_matches(['*', '/', '}', '-', '>'])
+                .trim();
+            let codes = rest
+                .split([',', ' ', '\t'])
+                .filter(|code| !code.is_empty())
+                .collect::<BTreeSet<_>>();
+            let range = SourceRange {
+                start: line_start + marker_index,
+                end: line_start + marker_index + directive.len(),
+                line: line_index + 1,
+                column: line[..marker_index].chars().count() + 1,
+            };
+            if codes.is_empty() {
+                diagnostics.push(suppression_diagnostic(
+                    filename,
+                    range,
+                    "pmds/invalid-suppression",
+                    "This suppression does not name a diagnostic code.",
+                    "Add one or more exact Palamedes diagnostic codes after the directive.",
+                ));
+                continue;
+            }
+            for code in codes {
+                if KNOWN_DIAGNOSTIC_CODES.contains(&code) {
+                    suppressions.push(Suppression {
+                        line: line_index + 1 + line_delta,
+                        code: code.to_owned(),
+                    });
+                } else {
+                    diagnostics.push(suppression_diagnostic(
+                        filename,
+                        range.clone(),
+                        "pmds/unknown-suppression-code",
+                        &format!("Unknown Palamedes suppression code `{code}`."),
+                        "Use a diagnostic code emitted by `pmds lint`; suppressions are code-specific.",
+                    ));
+                }
+            }
+        }
+        line_start += line.len();
+    }
+    (suppressions, diagnostics)
+}
+
+fn suppression_diagnostic(
+    filename: &str,
+    primary: SourceRange,
+    code: &str,
+    message: &str,
+    help: &str,
+) -> SourceDiagnostic {
+    SourceDiagnostic {
+        code: code.to_owned(),
+        severity: SourceDiagnosticSeverity::Warning,
+        file: filename.to_owned(),
+        primary,
+        message: message.to_owned(),
+        help: help.to_owned(),
+        related: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use super::{LintFailOn, LintOptions};
+    use crate::command::{Command, Context};
+    use crate::commands::test_support::temp_dir;
+
+    #[test]
+    fn lint_dedupes_catalog_files_and_applies_code_specific_suppressions() {
+        let app = temp_dir("source-lint");
+        fs::create_dir_all(app.join("src")).expect("create source dir");
+        fs::write(
+            app.join("palamedes.yaml"),
+            r#"locales: [en]
+source-locale: en
+catalogs:
+  - path: locales/{locale}/app
+    include: [src]
+  - path: locales/{locale}/shared
+    include: [src]
+"#,
+        )
+        .expect("write config");
+        fs::write(
+            app.join("src/view.tsx"),
+            r#"import { t } from "@palamedes/core/macro";
+function View({ status }) {
+  // palamedes-lint-disable-next-line pmds/no-placeholder-only-message
+  return <p>{t`${status}`}</p>;
+}
+"#,
+        )
+        .expect("write source");
+
+        let output = LintOptions {
+            config: None,
+            json: false,
+            fail_on: LintFailOn::Error,
+        }
+        .run(&Context::with_cwd(&app))
+        .expect("run lint");
+
+        assert_eq!(output.summary.files, 1);
+        assert_eq!(output.summary.suppressed, 1);
+        assert_eq!(output.summary.infos, 1);
+        assert_eq!(output.diagnostics[0].code, "pmds/prefer-trans-in-jsx");
+    }
+
+    #[test]
+    fn lint_reports_unknown_and_malformed_suppressions() {
+        let source =
+            "// palamedes-lint-disable-next-line\n// palamedes-lint-disable-line pmds/not-a-rule\n";
+        let (_, diagnostics) = super::parse_suppressions(source, "view.tsx");
+        assert_eq!(diagnostics.len(), 2);
+        assert_eq!(diagnostics[0].code, "pmds/invalid-suppression");
+        assert_eq!(diagnostics[1].code, "pmds/unknown-suppression-code");
+    }
+
+    #[test]
+    fn warning_threshold_fails_after_building_the_result() {
+        let mut result = super::LintResult {
+            diagnostics: Vec::new(),
+            failed_files: Vec::new(),
+            summary: super::LintSummary::default(),
+        };
+        result.summary.warnings = 1;
+        let options = LintOptions {
+            config: None,
+            json: false,
+            fail_on: LintFailOn::Warning,
+        };
+
+        assert!(options.verdict(&result).is_err());
+    }
+}

--- a/crates/palamedes-cli/src/commands/mod.rs
+++ b/crates/palamedes-cli/src/commands/mod.rs
@@ -5,6 +5,7 @@ use std::collections::BTreeSet;
 pub mod audit;
 pub mod catalog;
 pub mod extract;
+pub mod lint;
 pub mod report;
 #[cfg(test)]
 mod test_support;

--- a/crates/palamedes-cli/src/config.rs
+++ b/crates/palamedes-cli/src/config.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use ::config as config_rs;
 use palamedes::{
     CatalogArtifactConfig, CatalogConfig, FallbackLocales, MdxOptions, PalamedesCatalogFormat,
-    PoLineBreaks, PoOutputOptions,
+    PoLineBreaks, PoOutputOptions, SourceRuleLevel, SourceRuleOptions,
 };
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -59,6 +59,8 @@ pub struct LoadedConfig {
     pub catalogs: Vec<ConfigCatalog>,
     /// Shared MDX extraction and compilation semantics.
     pub mdx: MdxOptions,
+    /// Source-authoring lint rule configuration.
+    pub lint: ConfigLintOptions,
     /// Worker threads for the parallel extraction pass; `None` uses the
     /// measured default in the core.
     pub extract_threads: Option<usize>,
@@ -66,6 +68,49 @@ pub struct LoadedConfig {
     pub extract_cache: bool,
     /// Explicit binary plugins resolved only for external command namespaces.
     pub plugins: Vec<ConfigPluginDeclaration>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
+pub struct ConfigLintOptions {
+    pub rules: ConfigLintRules,
+}
+
+impl Default for ConfigLintOptions {
+    fn default() -> Self {
+        Self {
+            rules: ConfigLintRules::default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
+pub struct ConfigLintRules {
+    pub placeholder_only: SourceRuleLevel,
+    pub empty_component_only: SourceRuleLevel,
+    pub prefer_trans_in_jsx: SourceRuleLevel,
+}
+
+impl Default for ConfigLintRules {
+    fn default() -> Self {
+        let defaults = SourceRuleOptions::default();
+        Self {
+            placeholder_only: defaults.placeholder_only,
+            empty_component_only: defaults.empty_component_only,
+            prefer_trans_in_jsx: defaults.prefer_trans_in_jsx,
+        }
+    }
+}
+
+impl From<ConfigLintRules> for SourceRuleOptions {
+    fn from(value: ConfigLintRules) -> Self {
+        Self {
+            placeholder_only: value.placeholder_only,
+            empty_component_only: value.empty_component_only,
+            prefer_trans_in_jsx: value.prefer_trans_in_jsx,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -149,6 +194,8 @@ struct RawConfig {
     extract_cache: bool,
     #[serde(default)]
     mdx: MdxOptions,
+    #[serde(default)]
+    lint: ConfigLintOptions,
     catalogs: Vec<ConfigCatalog>,
     #[serde(default)]
     plugins: Vec<ConfigPluginDeclaration>,
@@ -245,6 +292,7 @@ fn unknown_top_level_keys(value: &serde_json::Value) -> Vec<String> {
         "extract-cache",
         "extract_cache",
         "mdx",
+        "lint",
         "catalogs",
         "plugins",
     ];
@@ -386,6 +434,7 @@ fn normalize_config(raw: RawConfig, config_path: PathBuf) -> Result<LoadedConfig
         pseudo_locale: raw.pseudo_locale,
         catalogs: raw.catalogs,
         mdx: raw.mdx,
+        lint: raw.lint,
         extract_threads: raw.extract_threads,
         extract_cache: raw.extract_cache,
         plugins: raw.plugins,
@@ -622,6 +671,42 @@ catalogs:
         let config = load_config(&app, None).expect("load config");
 
         assert!(!config.reference_scopes);
+    }
+
+    #[test]
+    fn loads_kebab_case_source_lint_rule_levels() {
+        let app = temp_dir("lint-rules");
+        fs::write(
+            app.join(CONFIG_FILENAME),
+            r#"
+locales: [en]
+source-locale: en
+lint:
+  rules:
+    placeholder-only: error
+    empty-component-only: warning
+    prefer-trans-in-jsx: off
+catalogs:
+  - path: src/locales/{locale}
+    include: [src]
+"#,
+        )
+        .expect("write config");
+
+        let config = load_config(&app, None).expect("load config");
+
+        assert_eq!(
+            config.lint.rules.placeholder_only,
+            palamedes::SourceRuleLevel::Error
+        );
+        assert_eq!(
+            config.lint.rules.empty_component_only,
+            palamedes::SourceRuleLevel::Warning
+        );
+        assert_eq!(
+            config.lint.rules.prefer_trans_in_jsx,
+            palamedes::SourceRuleLevel::Off
+        );
     }
 
     #[test]

--- a/crates/palamedes-cli/src/config.rs
+++ b/crates/palamedes-cli/src/config.rs
@@ -70,18 +70,10 @@ pub struct LoadedConfig {
     pub plugins: Vec<ConfigPluginDeclaration>,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
 #[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
 pub struct ConfigLintOptions {
     pub rules: ConfigLintRules,
-}
-
-impl Default for ConfigLintOptions {
-    fn default() -> Self {
-        Self {
-            rules: ConfigLintRules::default(),
-        }
-    }
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/crates/palamedes-cli/src/error.rs
+++ b/crates/palamedes-cli/src/error.rs
@@ -40,6 +40,12 @@ pub enum CliError {
     CompletenessBelowThreshold { threshold: String, locales: String },
     #[error("Extraction failed for {failures} source file(s); catalogs were not updated.")]
     ExtractionFailed { failures: usize },
+    #[error("Source lint failed with {errors} error diagnostic(s).")]
+    LintFailedOnError { errors: usize },
+    #[error("Source lint failed with {errors} error(s) and {warnings} warning(s).")]
+    LintFailedOnWarning { errors: usize, warnings: usize },
+    #[error("Source lint could not analyze {failures} source file(s).")]
+    LintAnalysisFailed { failures: usize },
     #[error("Could not build glob pattern {pattern}: {source}")]
     GlobPattern {
         pattern: String,

--- a/crates/palamedes-node/src/extract.rs
+++ b/crates/palamedes-node/src/extract.rs
@@ -140,6 +140,7 @@ pub fn extract_catalog_messages_from_files(
     let options = palamedes::ExtractCatalogMessagesOptions {
         reference_scopes: request.reference_scopes.unwrap_or(true),
         mdx: request.mdx.map(Into::into).unwrap_or_default(),
+        ..palamedes::ExtractCatalogMessagesOptions::default()
     };
     let request = palamedes::ExtractCatalogMessagesRequest {
         root_dir: request.root_dir,

--- a/crates/palamedes-node/src/lib.rs
+++ b/crates/palamedes-node/src/lib.rs
@@ -4,10 +4,12 @@ mod extract;
 mod mdx;
 mod po;
 mod shared;
+mod source;
 mod transform;
 
 pub use self::catalog::*;
 pub use self::extract::*;
 pub use self::mdx::*;
 pub use self::po::*;
+pub use self::source::*;
 pub use self::transform::*;

--- a/crates/palamedes-node/src/source.rs
+++ b/crates/palamedes-node/src/source.rs
@@ -1,0 +1,103 @@
+use napi::bindgen_prelude::Result;
+use napi_derive::napi;
+
+use crate::extract::NativeExtractedMessage;
+use crate::mdx::NativeMdxOptions;
+use crate::shared::{checked_u32, to_napi_error};
+
+#[napi(object)]
+pub struct NativeSourceRange {
+    pub start: u32,
+    pub end: u32,
+    pub line: u32,
+    pub column: u32,
+}
+
+#[napi(object)]
+pub struct NativeSourceDiagnostic {
+    pub code: String,
+    pub severity: String,
+    pub file: String,
+    pub primary: NativeSourceRange,
+    pub message: String,
+    pub help: String,
+    pub related: Option<NativeSourceRange>,
+}
+
+#[napi(object)]
+pub struct NativeSourceAnalysisResult {
+    pub messages: Vec<NativeExtractedMessage>,
+    pub diagnostics: Vec<NativeSourceDiagnostic>,
+}
+
+impl TryFrom<palamedes::SourceRange> for NativeSourceRange {
+    type Error = napi::Error;
+
+    fn try_from(value: palamedes::SourceRange) -> Result<Self> {
+        Ok(Self {
+            start: checked_u32(value.start, "sourceRange.start")?,
+            end: checked_u32(value.end, "sourceRange.end")?,
+            line: checked_u32(value.line, "sourceRange.line")?,
+            column: checked_u32(value.column, "sourceRange.column")?,
+        })
+    }
+}
+
+impl TryFrom<palamedes::SourceDiagnostic> for NativeSourceDiagnostic {
+    type Error = napi::Error;
+
+    fn try_from(value: palamedes::SourceDiagnostic) -> Result<Self> {
+        let severity = match value.severity {
+            palamedes::SourceDiagnosticSeverity::Error => "error",
+            palamedes::SourceDiagnosticSeverity::Warning => "warning",
+            palamedes::SourceDiagnosticSeverity::Info => "info",
+        };
+        Ok(Self {
+            code: value.code,
+            severity: severity.to_owned(),
+            file: value.file,
+            primary: NativeSourceRange::try_from(value.primary)?,
+            message: value.message,
+            help: value.help,
+            related: value.related.map(NativeSourceRange::try_from).transpose()?,
+        })
+    }
+}
+
+impl TryFrom<palamedes::SourceAnalysisResult> for NativeSourceAnalysisResult {
+    type Error = napi::Error;
+
+    fn try_from(value: palamedes::SourceAnalysisResult) -> Result<Self> {
+        Ok(Self {
+            messages: value
+                .messages
+                .into_iter()
+                .map(NativeExtractedMessage::try_from)
+                .collect::<Result<Vec<_>>>()?,
+            diagnostics: value
+                .diagnostics
+                .into_iter()
+                .map(NativeSourceDiagnostic::try_from)
+                .collect::<Result<Vec<_>>>()?,
+        })
+    }
+}
+
+#[napi]
+#[allow(clippy::needless_pass_by_value)]
+/// Analyze source-first messages and authoring diagnostics in one native pass.
+///
+/// # Errors
+///
+/// Returns an error for fatal parsing or authoring failures, or when source
+/// ranges exceed the Node binding range.
+pub fn analyze_source(
+    source: String,
+    filename: String,
+    mdx: Option<NativeMdxOptions>,
+) -> Result<NativeSourceAnalysisResult> {
+    let mdx = mdx.map(Into::into).unwrap_or_default();
+    palamedes::analyze_source_with_mdx_options(&source, &filename, &mdx)
+        .map_err(to_napi_error)
+        .and_then(NativeSourceAnalysisResult::try_from)
+}

--- a/crates/palamedes-node/src/source.rs
+++ b/crates/palamedes-node/src/source.rs
@@ -9,6 +9,7 @@ use crate::shared::{checked_u32, to_napi_error};
 pub struct NativeSourceRuleOptions {
     pub placeholder_only: Option<String>,
     pub empty_component_only: Option<String>,
+    pub prefer_trans_in_jsx: Option<String>,
 }
 
 #[napi(object)]
@@ -125,6 +126,11 @@ impl TryFrom<NativeSourceRuleOptions> for palamedes::SourceRuleOptions {
                 "rules.emptyComponentOnly",
             )?
             .unwrap_or(defaults.empty_component_only),
+            prefer_trans_in_jsx: source_rule_level(
+                value.prefer_trans_in_jsx,
+                "rules.preferTransInJsx",
+            )?
+            .unwrap_or(defaults.prefer_trans_in_jsx),
         })
     }
 }

--- a/crates/palamedes-node/src/source.rs
+++ b/crates/palamedes-node/src/source.rs
@@ -6,6 +6,18 @@ use crate::mdx::NativeMdxOptions;
 use crate::shared::{checked_u32, to_napi_error};
 
 #[napi(object)]
+pub struct NativeSourceRuleOptions {
+    pub placeholder_only: Option<String>,
+    pub empty_component_only: Option<String>,
+}
+
+#[napi(object)]
+pub struct NativeSourceAnalysisOptions {
+    pub mdx: Option<NativeMdxOptions>,
+    pub rules: Option<NativeSourceRuleOptions>,
+}
+
+#[napi(object)]
 pub struct NativeSourceRange {
     pub start: u32,
     pub end: u32,
@@ -83,6 +95,55 @@ impl TryFrom<palamedes::SourceAnalysisResult> for NativeSourceAnalysisResult {
     }
 }
 
+fn source_rule_level(
+    value: Option<String>,
+    field: &str,
+) -> Result<Option<palamedes::SourceRuleLevel>> {
+    value
+        .map(|value| match value.as_str() {
+            "off" => Ok(palamedes::SourceRuleLevel::Off),
+            "info" => Ok(palamedes::SourceRuleLevel::Info),
+            "warning" => Ok(palamedes::SourceRuleLevel::Warning),
+            "error" => Ok(palamedes::SourceRuleLevel::Error),
+            _ => Err(napi::Error::from_reason(format!(
+                "{field} must be one of: off, info, warning, error"
+            ))),
+        })
+        .transpose()
+}
+
+impl TryFrom<NativeSourceRuleOptions> for palamedes::SourceRuleOptions {
+    type Error = napi::Error;
+
+    fn try_from(value: NativeSourceRuleOptions) -> Result<Self> {
+        let defaults = Self::default();
+        Ok(Self {
+            placeholder_only: source_rule_level(value.placeholder_only, "rules.placeholderOnly")?
+                .unwrap_or(defaults.placeholder_only),
+            empty_component_only: source_rule_level(
+                value.empty_component_only,
+                "rules.emptyComponentOnly",
+            )?
+            .unwrap_or(defaults.empty_component_only),
+        })
+    }
+}
+
+impl TryFrom<NativeSourceAnalysisOptions> for palamedes::SourceAnalysisOptions {
+    type Error = napi::Error;
+
+    fn try_from(value: NativeSourceAnalysisOptions) -> Result<Self> {
+        Ok(Self {
+            mdx: value.mdx.map(Into::into).unwrap_or_default(),
+            rules: value
+                .rules
+                .map(TryInto::try_into)
+                .transpose()?
+                .unwrap_or_default(),
+        })
+    }
+}
+
 #[napi]
 #[allow(clippy::needless_pass_by_value)]
 /// Analyze source-first messages and authoring diagnostics in one native pass.
@@ -94,10 +155,13 @@ impl TryFrom<palamedes::SourceAnalysisResult> for NativeSourceAnalysisResult {
 pub fn analyze_source(
     source: String,
     filename: String,
-    mdx: Option<NativeMdxOptions>,
+    options: Option<NativeSourceAnalysisOptions>,
 ) -> Result<NativeSourceAnalysisResult> {
-    let mdx = mdx.map(Into::into).unwrap_or_default();
-    palamedes::analyze_source_with_mdx_options(&source, &filename, &mdx)
+    let options = options
+        .map(TryInto::try_into)
+        .transpose()?
+        .unwrap_or_default();
+    palamedes::analyze_source_with_options(&source, &filename, &options)
         .map_err(to_napi_error)
         .and_then(NativeSourceAnalysisResult::try_from)
 }

--- a/crates/palamedes/src/extract.rs
+++ b/crates/palamedes/src/extract.rs
@@ -21,7 +21,9 @@ use crate::mdx::{analyze_mdx, MdxOptions};
 use crate::placeholder_name::{expression_name, jsx_expression_name};
 use crate::source::{
     SourceAnalysisOptions, SourceAnalysisResult, SourceDiagnostic, SourceDiagnosticSeverity,
-    SourceLocator, SourceRange, SourceRuleOptions,
+    SourceFileAnalysisResult, SourceLocator, SourceRange, SourceRuleOptions,
+    SOURCE_DIAGNOSTIC_CODE_NO_EMPTY_COMPONENT_ONLY_MESSAGE,
+    SOURCE_DIAGNOSTIC_CODE_NO_PLACEHOLDER_ONLY_MESSAGE, SOURCE_DIAGNOSTIC_CODE_PREFER_TRANS_IN_JSX,
 };
 use crate::source_macros::{record_macro_import_declaration, ImportedMacro};
 use crate::translation_scope::validate_translation_macro_scopes;
@@ -230,7 +232,7 @@ struct ExtractionVisitor<'a> {
     diagnostics: Vec<SourceDiagnostic>,
     error: Option<PalamedesError>,
     scope_stack: Vec<String>,
-    jsx_parent_stack: Vec<String>,
+    jsx_parent_stack: Vec<&'a str>,
     renderable_t_spans: HashSet<(usize, usize)>,
     reference_scopes: bool,
 }
@@ -292,7 +294,7 @@ impl<'a> ExtractionVisitor<'a> {
         if !facts.has_literal_text() && facts.has_value_placeholder() {
             if let Some(severity) = self.rules.placeholder_only.severity() {
                 self.diagnostics.push(SourceDiagnostic {
-                    code: "pmds/no-placeholder-only-message".to_owned(),
+                    code: SOURCE_DIAGNOSTIC_CODE_NO_PLACEHOLDER_ONLY_MESSAGE.to_owned(),
                     severity,
                     file: self.filename.clone(),
                     primary: facts.range,
@@ -308,7 +310,7 @@ impl<'a> ExtractionVisitor<'a> {
         if facts.is_one_empty_component() {
             if let Some(severity) = self.rules.empty_component_only.severity() {
                 self.diagnostics.push(SourceDiagnostic {
-                    code: "pmds/no-empty-component-only-message".to_owned(),
+                    code: SOURCE_DIAGNOSTIC_CODE_NO_EMPTY_COMPONENT_ONLY_MESSAGE.to_owned(),
                     severity,
                     file: self.filename.clone(),
                     primary: facts.range,
@@ -334,7 +336,7 @@ impl<'a> ExtractionVisitor<'a> {
             _ => "the active UI framework",
         };
         self.diagnostics.push(SourceDiagnostic {
-            code: "pmds/prefer-trans-in-jsx".to_owned(),
+            code: SOURCE_DIAGNOSTIC_CODE_PREFER_TRANS_IN_JSX.to_owned(),
             severity,
             file: self.filename.clone(),
             primary: self.source_locator.range(start, end),
@@ -346,9 +348,9 @@ impl<'a> ExtractionVisitor<'a> {
         });
     }
 
-    fn walk_jsx_element_children(&mut self, element: &JSXElement<'a>, tag_name: Option<&str>) {
+    fn walk_jsx_element_children(&mut self, element: &JSXElement<'a>, tag_name: Option<&'a str>) {
         if let Some(tag_name) = tag_name {
-            self.jsx_parent_stack.push(tag_name.to_owned());
+            self.jsx_parent_stack.push(tag_name);
             walk::walk_jsx_element(self, element);
             self.jsx_parent_stack.pop();
         } else {
@@ -359,7 +361,7 @@ impl<'a> ExtractionVisitor<'a> {
     fn current_jsx_parent_allows_trans(&self) -> bool {
         !self.jsx_parent_stack.iter().any(|parent| {
             is_restricted_trans_parent(parent)
-                || self.imported_macros.get(parent).is_some_and(|macro_info| {
+                || self.imported_macros.get(*parent).is_some_and(|macro_info| {
                     matches!(
                         macro_info.imported_name.as_str(),
                         "Trans" | "Plural" | "Select" | "SelectOrdinal"
@@ -464,10 +466,10 @@ impl<'a> Visit<'a> for ExtractionVisitor<'a> {
             self.walk_jsx_element_children(it, None);
             return;
         };
-        let tag_name = tag_name.as_str().to_owned();
+        let tag_name = tag_name.as_str();
 
         if let Some(macro_name) = self
-            .imported_macro_name(&tag_name, &["Trans", "Plural", "Select", "SelectOrdinal"])
+            .imported_macro_name(tag_name, &["Trans", "Plural", "Select", "SelectOrdinal"])
             .map(str::to_string)
         {
             if let Some(nested_start) =
@@ -513,10 +515,14 @@ impl<'a> Visit<'a> for ExtractionVisitor<'a> {
             }
         }
 
-        self.walk_jsx_element_children(it, Some(&tag_name));
+        self.walk_jsx_element_children(it, Some(tag_name));
     }
 
     fn visit_jsx_child(&mut self, it: &JSXChild<'a>) {
+        if self.rules.prefer_trans_in_jsx.severity().is_none() {
+            walk::walk_jsx_child(self, it);
+            return;
+        }
         if let JSXChild::ExpressionContainer(container) = it {
             if self.current_jsx_parent_allows_trans() {
                 if let Some(expression) = container.expression.as_expression() {
@@ -1712,9 +1718,10 @@ pub fn analyze_source_with_options(
 
 /// Analyze one source file while reusing the cache shared with batch extraction.
 ///
-/// A compatible cache hit skips both reading and parsing. The stored messages
-/// retain the configured extraction semantics, while diagnostics are rewritten
-/// to `filename` on return so callers can choose project-relative display paths.
+/// The source is read exactly once so callers can apply suppressions to the same
+/// text that was analyzed. A compatible cache hit still skips parsing. Stored
+/// diagnostics are rewritten to `filename` on return so callers can choose
+/// project-relative display paths.
 ///
 /// # Errors
 ///
@@ -1727,23 +1734,26 @@ pub fn analyze_source_file_cached(
     root_dir: &str,
     options: &ExtractCatalogMessagesOptions,
     cache: &mut ExtractCache,
-) -> PalamedesResult<SourceAnalysisResult> {
+) -> PalamedesResult<SourceFileAnalysisResult> {
     cache.reset_if_request_differs(root_dir, options);
-    if let Some((_relative_file, messages, diagnostics)) = cache.get(path) {
-        return Ok(analysis_with_display_filename(
-            SourceAnalysisResult {
-                messages,
-                diagnostics,
-            },
-            filename,
-        ));
-    }
-
     let fingerprint = cache.fingerprint_before_read(path);
     let source = std::fs::read_to_string(path).map_err(|source| PalamedesError::ReadFile {
         path: PathBuf::from(path),
         source,
     })?;
+    if let Some((_relative_file, messages, diagnostics)) = cache.get_after_read(path, fingerprint) {
+        return Ok(SourceFileAnalysisResult {
+            source,
+            analysis: analysis_with_display_filename(
+                SourceAnalysisResult {
+                    messages,
+                    diagnostics,
+                },
+                filename,
+            ),
+        });
+    }
+
     let is_mdx = is_mdx_filename(path);
     let analysis = if !is_mdx && !source.contains("@palamedes") && !source.contains("i18n") {
         SourceAnalysisResult {
@@ -1773,7 +1783,10 @@ pub fn analyze_source_file_cached(
         &analysis.diagnostics,
         fingerprint,
     );
-    Ok(analysis_with_display_filename(analysis, filename))
+    Ok(SourceFileAnalysisResult {
+        source,
+        analysis: analysis_with_display_filename(analysis, filename),
+    })
 }
 
 fn analysis_with_display_filename(
@@ -4073,9 +4086,10 @@ const message = t({ message })
         )
         .expect("uncached analysis");
 
+        assert_eq!(cached.source, uncached.source);
         assert_eq!(
-            serde_json::to_vec(&cached).expect("serialize cached"),
-            serde_json::to_vec(&uncached).expect("serialize uncached"),
+            serde_json::to_vec(&cached.analysis).expect("serialize cached"),
+            serde_json::to_vec(&uncached.analysis).expect("serialize uncached"),
             "cached and uncached analysis must be byte-for-byte equivalent"
         );
         fs::remove_dir_all(root).expect("cleanup");

--- a/crates/palamedes/src/extract.rs
+++ b/crates/palamedes/src/extract.rs
@@ -17,15 +17,17 @@ use crate::jsx_entities::decode_jsx_entities;
 use crate::jsx_message::{
     clean_jsx_text, join_jsx_message_parts, JoinedJsxMessage, JsxMessagePart,
 };
-use crate::mdx::{extract_mdx_messages, MdxOptions};
+use crate::mdx::{analyze_mdx, MdxOptions};
 use crate::placeholder_name::{expression_name, jsx_expression_name};
+use crate::source::{SourceAnalysisResult, SourceDiagnostic, SourceDiagnosticSeverity};
+use crate::source_macros::{record_macro_import_declaration, ImportedMacro};
 use crate::translation_scope::validate_translation_macro_scopes;
 use oxc_allocator::Allocator;
 use oxc_ast::ast::{
     Argument, BindingPattern, CallExpression, Declaration, Expression, ImportDeclaration,
-    ImportDeclarationSpecifier, JSXAttributeValue, JSXChild, JSXElement, JSXExpression,
-    JSXOpeningElement, MemberExpression, ObjectExpression, ObjectPropertyKind,
-    TaggedTemplateExpression, TemplateLiteral, VariableDeclarator,
+    JSXAttributeValue, JSXChild, JSXElement, JSXExpression, JSXOpeningElement, MemberExpression,
+    ObjectExpression, ObjectPropertyKind, TaggedTemplateExpression, TemplateLiteral,
+    VariableDeclarator,
 };
 use oxc_ast_visit::{walk, Visit};
 use oxc_parser::Parser;
@@ -33,11 +35,6 @@ use oxc_span::{GetSpan, SourceType};
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 
-const PALAMEDES_MACRO_PACKAGES: [&str; 3] = [
-    "@palamedes/core/macro",
-    "@palamedes/react/macro",
-    "@palamedes/solid/macro",
-];
 type ChoiceOptions = Vec<(String, String)>;
 const CHOICE_VALUE_FALLBACK_NAME: &str = "value";
 
@@ -45,11 +42,6 @@ struct ExtractedChoiceOptions {
     options: ChoiceOptions,
     placeholders: BTreeMap<String, String>,
     offset: Option<String>,
-}
-
-#[derive(Debug, Clone)]
-struct ImportedMacro {
-    imported_name: String,
 }
 
 /// Extracted source-first message record emitted by the JS/TS/MDX extractor.
@@ -189,28 +181,12 @@ impl MacroCollector {
 
 impl<'a> Visit<'a> for MacroCollector {
     fn visit_import_declaration(&mut self, it: &ImportDeclaration<'a>) {
-        let source = it.source.value.as_str();
-        if !PALAMEDES_MACRO_PACKAGES.contains(&source) {
-            return;
-        }
-
-        if let Some(specifiers) = &it.specifiers {
-            for specifier in specifiers {
-                if let ImportDeclarationSpecifier::ImportSpecifier(specifier) = specifier {
-                    let imported_name = specifier.imported.name().to_string();
-                    if matches!(imported_name.as_str(), "msg" | "defineMessage")
-                        && self.removed_macro_import.is_none()
-                    {
-                        self.removed_macro_import =
-                            Some((imported_name.clone(), it.span.start as usize));
-                    }
-                    self.imported_macros.insert(
-                        specifier.local.name.to_string(),
-                        ImportedMacro { imported_name },
-                    );
-                }
-            }
-        }
+        record_macro_import_declaration(
+            it,
+            &mut self.imported_macros,
+            &mut self.removed_macro_import,
+            None,
+        );
     }
 }
 
@@ -1344,6 +1320,38 @@ pub fn extract_messages_with_mdx_options(
     extract_messages_in(&allocator, source, filename, true, mdx_options)
 }
 
+/// Analyze one JavaScript, TypeScript, JSX, TSX, or MDX source file.
+///
+/// Extraction and non-type-aware source diagnostics share one native parse and
+/// Palamedes macro classification. Parse failures and unsupported macro syntax
+/// remain fatal errors.
+///
+/// # Errors
+///
+/// Returns an error when JavaScript or TypeScript cannot be parsed, or when the
+/// source uses non-extractable Palamedes authoring syntax. MDX structural
+/// diagnostics are returned in the structured result to stay compatible with
+/// [`crate::analyze_mdx`].
+pub fn analyze_source(source: &str, filename: &str) -> PalamedesResult<SourceAnalysisResult> {
+    analyze_source_with_mdx_options(source, filename, &MdxOptions::default())
+}
+
+/// Analyze one source file with explicit MDX semantics.
+///
+/// JavaScript and TypeScript analysis is unaffected by `mdx_options`.
+///
+/// # Errors
+///
+/// Returns an error under the same conditions as [`analyze_source`].
+pub fn analyze_source_with_mdx_options(
+    source: &str,
+    filename: &str,
+    mdx_options: &MdxOptions,
+) -> PalamedesResult<SourceAnalysisResult> {
+    let allocator = Allocator::default();
+    analyze_source_in(&allocator, source, filename, true, mdx_options)
+}
+
 /*
  * Extraction against a caller-owned arena. A fresh Allocator per file means a
  * fresh set of bump chunks from the system allocator per file, and on a 1500
@@ -1358,16 +1366,64 @@ fn extract_messages_in(
     reference_scopes: bool,
     mdx_options: &MdxOptions,
 ) -> PalamedesResult<Vec<ExtractedMessageRecord>> {
-    if Path::new(filename)
+    let result = analyze_source_in(allocator, source, filename, reference_scopes, mdx_options)?;
+
+    if is_mdx_filename(filename) && !result.diagnostics.is_empty() {
+        let messages = result
+            .diagnostics
+            .iter()
+            .map(|diagnostic| {
+                format!(
+                    "{}:{}:{}: {} ({})",
+                    filename,
+                    diagnostic.primary.line,
+                    diagnostic.primary.column,
+                    diagnostic.message,
+                    diagnostic.code
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        return Err(PalamedesError::ParseModuleSource {
+            filename: filename.to_owned(),
+            messages,
+        });
+    }
+
+    Ok(result.messages)
+}
+
+fn is_mdx_filename(filename: &str) -> bool {
+    Path::new(filename)
         .extension()
         .and_then(|extension| extension.to_str())
         .is_some_and(|extension| extension.eq_ignore_ascii_case("mdx"))
-    {
-        return extract_mdx_messages(source, filename, mdx_options.clone()).map_err(|messages| {
-            PalamedesError::ParseModuleSource {
-                filename: filename.to_owned(),
-                messages,
-            }
+}
+
+fn analyze_source_in(
+    allocator: &Allocator,
+    source: &str,
+    filename: &str,
+    reference_scopes: bool,
+    mdx_options: &MdxOptions,
+) -> PalamedesResult<SourceAnalysisResult> {
+    if is_mdx_filename(filename) {
+        let result = analyze_mdx(source, filename, mdx_options.clone());
+        return Ok(SourceAnalysisResult {
+            messages: result.messages,
+            diagnostics: result
+                .diagnostics
+                .into_iter()
+                .map(|diagnostic| SourceDiagnostic {
+                    code: diagnostic.code,
+                    severity: SourceDiagnosticSeverity::Error,
+                    file: filename.to_owned(),
+                    primary: diagnostic.primary,
+                    message: diagnostic.message,
+                    help: "Fix the MDX syntax at the highlighted source range.".to_owned(),
+                    related: diagnostic.related,
+                })
+                .collect(),
         });
     }
 
@@ -1403,7 +1459,10 @@ fn extract_messages_in(
         && collector.removed_macro_import.is_none()
         && !source.contains("i18n")
     {
-        return Ok(Vec::new());
+        return Ok(SourceAnalysisResult {
+            messages: Vec::new(),
+            diagnostics: Vec::new(),
+        });
     }
 
     let line_locator = LineLocator::new(source);
@@ -1436,7 +1495,10 @@ fn extract_messages_in(
         return Err(error);
     }
 
-    Ok(extractor.messages)
+    Ok(SourceAnalysisResult {
+        messages: extractor.messages,
+        diagnostics: Vec::new(),
+    })
 }
 
 /// Extracts and aggregates source-first catalog update messages from files.
@@ -1898,13 +1960,16 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     use super::{
-        extract_catalog_messages_cached, extract_catalog_messages_from_files,
-        extract_catalog_messages_from_files_with_options, extract_messages as extract_messages_raw,
-        resolve_extract_threads, ExtractCatalogMessagesOptions, ExtractCatalogMessagesRequest,
-        ExtractedMessageRecord, DEFAULT_EXTRACT_THREADS,
+        analyze_source, analyze_source_with_mdx_options, extract_catalog_messages_cached,
+        extract_catalog_messages_from_files, extract_catalog_messages_from_files_with_options,
+        extract_messages as extract_messages_raw, resolve_extract_threads,
+        ExtractCatalogMessagesOptions, ExtractCatalogMessagesRequest, ExtractedMessageRecord,
+        DEFAULT_EXTRACT_THREADS,
     };
     use crate::error::PalamedesResult;
     use crate::extract_cache::ExtractCache;
+    use crate::mdx::MdxOptions;
+    use crate::source::SourceDiagnosticSeverity;
     use crate::test_support::scope_macro_test_source;
 
     static TEMP_COUNTER: AtomicUsize = AtomicUsize::new(0);
@@ -1914,6 +1979,45 @@ mod tests {
         filename: &str,
     ) -> PalamedesResult<Vec<ExtractedMessageRecord>> {
         extract_messages_raw(&scope_macro_test_source(source, filename), filename)
+    }
+
+    #[test]
+    fn shared_source_analysis_returns_extracted_messages_and_diagnostics() {
+        let source = scope_macro_test_source(
+            r#"import { t as translate } from "@palamedes/core/macro";
+function Greeting({ name }: { name: string }) {
+  return translate`Hello ${name}`;
+}
+"#,
+            "test.tsx",
+        );
+
+        let result = analyze_source(&source, "test.tsx").expect("analyze source");
+
+        assert_eq!(result.messages.len(), 1);
+        assert_eq!(result.messages[0].message, "Hello {name}");
+        assert!(result.diagnostics.is_empty());
+    }
+
+    #[test]
+    fn shared_source_analysis_maps_mdx_errors_to_the_common_diagnostic_shape() {
+        let result = analyze_source_with_mdx_options(
+            "# Intro\n\n<Component\n",
+            "guide.mdx",
+            &MdxOptions::default(),
+        )
+        .expect("MDX diagnostics are structured results");
+
+        assert!(result.messages.is_empty());
+        assert_eq!(result.diagnostics.len(), 1);
+        let diagnostic = &result.diagnostics[0];
+        assert_eq!(diagnostic.file, "guide.mdx");
+        assert_eq!(diagnostic.severity, SourceDiagnosticSeverity::Error);
+        assert!(!diagnostic.code.is_empty());
+        assert!(!diagnostic.message.is_empty());
+        assert!(!diagnostic.help.is_empty());
+        assert!(diagnostic.primary.line >= 1);
+        assert!(diagnostic.primary.column >= 1);
     }
 
     #[test]

--- a/crates/palamedes/src/extract.rs
+++ b/crates/palamedes/src/extract.rs
@@ -19,7 +19,10 @@ use crate::jsx_message::{
 };
 use crate::mdx::{analyze_mdx, MdxOptions};
 use crate::placeholder_name::{expression_name, jsx_expression_name};
-use crate::source::{SourceAnalysisResult, SourceDiagnostic, SourceDiagnosticSeverity};
+use crate::source::{
+    SourceAnalysisOptions, SourceAnalysisResult, SourceDiagnostic, SourceDiagnosticSeverity,
+    SourceLocator, SourceRange, SourceRuleOptions,
+};
 use crate::source_macros::{record_macro_import_declaration, ImportedMacro};
 use crate::translation_scope::validate_translation_macro_scopes;
 use oxc_allocator::Allocator;
@@ -129,42 +132,6 @@ struct AggregatedCatalogEntry {
     origins: Vec<CatalogUpdateOrigin>,
 }
 
-struct LineLocator {
-    line_starts: Vec<usize>,
-}
-
-impl LineLocator {
-    fn new(source: &str) -> Self {
-        let mut line_starts = vec![0];
-        // A byte scan: '\n' cannot occur inside a multi-byte UTF-8 sequence,
-        // and decoding every char just to find newlines showed up in profiles.
-        for (index, &byte) in source.as_bytes().iter().enumerate() {
-            if byte == b'\n' {
-                line_starts.push(index + 1);
-            }
-        }
-        Self { line_starts }
-    }
-
-    fn get_line(&self, offset: usize) -> usize {
-        match self.line_starts.binary_search(&offset) {
-            Ok(index) => index + 1,
-            Err(index) => index,
-        }
-    }
-
-    fn get_location(&self, offset: usize) -> (usize, usize) {
-        let line = self.get_line(offset);
-        let line_start = self
-            .line_starts
-            .get(line.saturating_sub(1))
-            .copied()
-            .unwrap_or(0);
-
-        (line, offset.saturating_sub(line_start) + 1)
-    }
-}
-
 struct MacroCollector {
     imported_macros: HashMap<String, ImportedMacro>,
     removed_macro_import: Option<(String, usize)>,
@@ -190,12 +157,68 @@ impl<'a> Visit<'a> for MacroCollector {
     }
 }
 
+#[derive(Clone, Copy)]
+enum SourceMessageSurface {
+    TaggedTemplate,
+    Descriptor,
+    Trans,
+    Runtime,
+    Choice,
+}
+
+enum AuthoredMessagePart {
+    Literal(String),
+    ValuePlaceholder,
+    Component { children: Vec<Self> },
+}
+
+struct AuthoredMessageFacts {
+    surface: SourceMessageSurface,
+    range: SourceRange,
+    parts: Vec<AuthoredMessagePart>,
+}
+
+impl AuthoredMessageFacts {
+    fn has_literal_text(&self) -> bool {
+        fn contains_literal(parts: &[AuthoredMessagePart]) -> bool {
+            parts.iter().any(|part| match part {
+                AuthoredMessagePart::Literal(value) => !value.trim().is_empty(),
+                AuthoredMessagePart::ValuePlaceholder => false,
+                AuthoredMessagePart::Component { children } => contains_literal(children),
+            })
+        }
+
+        contains_literal(&self.parts)
+    }
+
+    fn has_value_placeholder(&self) -> bool {
+        fn contains_value(parts: &[AuthoredMessagePart]) -> bool {
+            parts.iter().any(|part| match part {
+                AuthoredMessagePart::Literal(_) => false,
+                AuthoredMessagePart::ValuePlaceholder => true,
+                AuthoredMessagePart::Component { children } => contains_value(children),
+            })
+        }
+
+        contains_value(&self.parts)
+    }
+
+    fn is_one_empty_component(&self) -> bool {
+        matches!(
+            self.parts.as_slice(),
+            [AuthoredMessagePart::Component { children }] if children.is_empty()
+        )
+    }
+}
+
 struct ExtractionVisitor<'a> {
     filename: String,
     source: &'a str,
-    line_locator: &'a LineLocator,
+    source_locator: &'a SourceLocator<'a>,
     imported_macros: &'a HashMap<String, ImportedMacro>,
+    rules: &'a SourceRuleOptions,
     messages: Vec<ExtractedMessageRecord>,
+    diagnostics: Vec<SourceDiagnostic>,
     error: Option<PalamedesError>,
     scope_stack: Vec<String>,
     reference_scopes: bool,
@@ -205,24 +228,84 @@ impl<'a> ExtractionVisitor<'a> {
     fn new(
         filename: &str,
         source: &'a str,
-        line_locator: &'a LineLocator,
+        source_locator: &'a SourceLocator<'a>,
         imported_macros: &'a HashMap<String, ImportedMacro>,
+        rules: &'a SourceRuleOptions,
         reference_scopes: bool,
     ) -> Self {
         Self {
             filename: filename.to_string(),
             source,
-            line_locator,
+            source_locator,
             imported_macros,
+            rules,
             messages: Vec::new(),
+            diagnostics: Vec::new(),
             error: None,
             scope_stack: Vec::new(),
             reference_scopes,
         }
     }
 
-    fn push(&mut self, message: ExtractedMessageRecord) {
+    fn push(&mut self, message: ExtractedMessageRecord, facts: AuthoredMessageFacts) {
         self.messages.push(message);
+        self.diagnose(facts);
+    }
+
+    fn facts(
+        &self,
+        surface: SourceMessageSurface,
+        start: usize,
+        end: usize,
+        parts: Vec<AuthoredMessagePart>,
+    ) -> AuthoredMessageFacts {
+        AuthoredMessageFacts {
+            surface,
+            range: self.source_locator.range(start, end),
+            parts,
+        }
+    }
+
+    fn diagnose(&mut self, facts: AuthoredMessageFacts) {
+        if !matches!(
+            facts.surface,
+            SourceMessageSurface::TaggedTemplate
+                | SourceMessageSurface::Descriptor
+                | SourceMessageSurface::Trans
+        ) {
+            return;
+        }
+
+        if !facts.has_literal_text() && facts.has_value_placeholder() {
+            if let Some(severity) = self.rules.placeholder_only.severity() {
+                self.diagnostics.push(SourceDiagnostic {
+                    code: "pmds/no-placeholder-only-message".to_owned(),
+                    severity,
+                    file: self.filename.clone(),
+                    primary: facts.range,
+                    message: "This message contains placeholders but no translatable text."
+                        .to_owned(),
+                    help: "Move translation to the surrounding authored sentence, or remove the translation macro if this value should be rendered as-is.".to_owned(),
+                    related: None,
+                });
+            }
+            return;
+        }
+
+        if facts.is_one_empty_component() {
+            if let Some(severity) = self.rules.empty_component_only.severity() {
+                self.diagnostics.push(SourceDiagnostic {
+                    code: "pmds/no-empty-component-only-message".to_owned(),
+                    severity,
+                    file: self.filename.clone(),
+                    primary: facts.range,
+                    message: "This message contains only an empty component placeholder."
+                        .to_owned(),
+                    help: "Add translatable text around or inside the component, or render the component without a translation macro.".to_owned(),
+                    related: None,
+                });
+            }
+        }
     }
 
     fn fail(&mut self, message: PalamedesError) {
@@ -242,7 +325,7 @@ impl<'a> ExtractionVisitor<'a> {
     fn origin(&self, span_start: usize) -> (String, usize, Option<usize>) {
         (
             self.filename.clone(),
-            self.line_locator.get_line(span_start),
+            self.source_locator.line(span_start),
             None,
         )
     }
@@ -260,7 +343,7 @@ impl<'a> ExtractionVisitor<'a> {
     }
 
     fn location(&self, span_start: usize) -> String {
-        let (line, column) = self.line_locator.get_location(span_start);
+        let (line, column) = self.source_locator.location(span_start);
 
         format!("{}:{line}:{column}", self.filename)
     }
@@ -346,7 +429,21 @@ impl<'a> Visit<'a> for ExtractionVisitor<'a> {
                 self.source,
                 &self.location(it.span.start as usize),
             ) {
-                Ok(Some(message)) => self.push(message),
+                Ok(Some(message)) => {
+                    let surface = if macro_name == "Trans" {
+                        SourceMessageSurface::Trans
+                    } else {
+                        SourceMessageSurface::Choice
+                    };
+                    let parts = if macro_name == "Trans" {
+                        trans_authored_parts(it)
+                    } else {
+                        Vec::new()
+                    };
+                    let facts =
+                        self.facts(surface, it.span.start as usize, it.span.end as usize, parts);
+                    self.push(message, facts);
+                }
                 Ok(None) => {
                     self.fail_unsupported_macro(&macro_name, it.span.start as usize);
                     return;
@@ -377,7 +474,15 @@ impl<'a> Visit<'a> for ExtractionVisitor<'a> {
                     self.current_scope(),
                     self.source,
                 ) {
-                    Ok(Some(message)) => self.push(message),
+                    Ok(Some(message)) => {
+                        let facts = self.facts(
+                            SourceMessageSurface::TaggedTemplate,
+                            it.span.start as usize,
+                            it.span.end as usize,
+                            template_authored_parts(&it.quasi),
+                        );
+                        self.push(message, facts);
+                    }
                     Ok(None) => {
                         self.fail_unsupported_macro(&macro_name, it.span.start as usize);
                         return;
@@ -397,7 +502,15 @@ impl<'a> Visit<'a> for ExtractionVisitor<'a> {
                 self.current_scope(),
                 self.source,
             ) {
-                Ok(Some(message)) => self.push(message),
+                Ok(Some(message)) => {
+                    let facts = self.facts(
+                        SourceMessageSurface::Runtime,
+                        it.span.start as usize,
+                        it.span.end as usize,
+                        template_authored_parts(&it.quasi),
+                    );
+                    self.push(message, facts);
+                }
                 Ok(None) => {}
                 Err(error) => {
                     self.fail(error);
@@ -439,7 +552,23 @@ impl<'a> Visit<'a> for ExtractionVisitor<'a> {
                 };
 
                 match message {
-                    Ok(Some(message)) => self.push(message),
+                    Ok(Some(message)) => {
+                        let (surface, parts) = if macro_name == "t" {
+                            (
+                                SourceMessageSurface::Descriptor,
+                                descriptor_authored_parts(it),
+                            )
+                        } else {
+                            (SourceMessageSurface::Choice, Vec::new())
+                        };
+                        let facts = self.facts(
+                            surface,
+                            it.span.start as usize,
+                            it.span.end as usize,
+                            parts,
+                        );
+                        self.push(message, facts);
+                    }
                     Ok(None) => {
                         self.fail_unsupported_macro(&macro_name, it.span.start as usize);
                         return;
@@ -458,7 +587,15 @@ impl<'a> Visit<'a> for ExtractionVisitor<'a> {
                 self.origin(it.span.start as usize),
                 self.current_scope(),
             ) {
-                Ok(Some(message)) => self.push(message),
+                Ok(Some(message)) => {
+                    let facts = self.facts(
+                        SourceMessageSurface::Runtime,
+                        it.span.start as usize,
+                        it.span.end as usize,
+                        Vec::new(),
+                    );
+                    self.push(message, facts);
+                }
                 Ok(None) => {}
                 Err(error) => {
                     self.fail(error);
@@ -469,6 +606,75 @@ impl<'a> Visit<'a> for ExtractionVisitor<'a> {
 
         walk::walk_call_expression(self, it);
     }
+}
+
+fn template_authored_parts(template: &TemplateLiteral<'_>) -> Vec<AuthoredMessagePart> {
+    let mut parts = Vec::with_capacity(template.quasis.len() + template.expressions.len());
+    for (index, quasi) in template.quasis.iter().enumerate() {
+        let value = quasi
+            .value
+            .cooked
+            .map_or_else(|| quasi.value.raw.as_str(), |value| value.as_str());
+        parts.push(AuthoredMessagePart::Literal(value.to_owned()));
+        if template.expressions.get(index).is_some() {
+            parts.push(AuthoredMessagePart::ValuePlaceholder);
+        }
+    }
+    parts
+}
+
+fn descriptor_authored_parts(call: &CallExpression<'_>) -> Vec<AuthoredMessagePart> {
+    let Some(Argument::ObjectExpression(object)) = call.arguments.first() else {
+        return Vec::new();
+    };
+    let Some(message) = descriptor_property_value(object, "message") else {
+        return Vec::new();
+    };
+    match message.without_parentheses() {
+        Expression::StringLiteral(literal) => {
+            vec![AuthoredMessagePart::Literal(literal.value.to_string())]
+        }
+        Expression::TemplateLiteral(template) => template_authored_parts(template),
+        _ => Vec::new(),
+    }
+}
+
+fn trans_authored_parts(element: &JSXElement<'_>) -> Vec<AuthoredMessagePart> {
+    if let Some(message) = jsx_attributes(&element.opening_element).get("message") {
+        return vec![AuthoredMessagePart::Literal(message.clone())];
+    }
+    jsx_children_authored_parts(&element.children)
+}
+
+fn jsx_children_authored_parts(children: &[JSXChild<'_>]) -> Vec<AuthoredMessagePart> {
+    let mut parts = Vec::new();
+    for child in children {
+        match child {
+            JSXChild::Text(text) => {
+                let value = clean_jsx_text(text.value.as_str());
+                if !value.is_empty() {
+                    parts.push(AuthoredMessagePart::Literal(value));
+                }
+            }
+            JSXChild::ExpressionContainer(container) => match &container.expression {
+                JSXExpression::EmptyExpression(_) => {}
+                JSXExpression::StringLiteral(literal) => {
+                    parts.push(AuthoredMessagePart::Literal(literal.value.to_string()));
+                }
+                _ => parts.push(AuthoredMessagePart::ValuePlaceholder),
+            },
+            JSXChild::Element(element) => {
+                parts.push(AuthoredMessagePart::Component {
+                    children: jsx_children_authored_parts(&element.children),
+                });
+            }
+            JSXChild::Fragment(fragment) => {
+                parts.extend(jsx_children_authored_parts(&fragment.children));
+            }
+            JSXChild::Spread(_) => parts.push(AuthoredMessagePart::ValuePlaceholder),
+        }
+    }
+    parts
 }
 
 fn nested_message_macro_in_children<'a>(
@@ -1333,7 +1539,7 @@ pub fn extract_messages_with_mdx_options(
 /// diagnostics are returned in the structured result to stay compatible with
 /// [`crate::analyze_mdx`].
 pub fn analyze_source(source: &str, filename: &str) -> PalamedesResult<SourceAnalysisResult> {
-    analyze_source_with_mdx_options(source, filename, &MdxOptions::default())
+    analyze_source_with_options(source, filename, &SourceAnalysisOptions::default())
 }
 
 /// Analyze one source file with explicit MDX semantics.
@@ -1348,8 +1554,35 @@ pub fn analyze_source_with_mdx_options(
     filename: &str,
     mdx_options: &MdxOptions,
 ) -> PalamedesResult<SourceAnalysisResult> {
+    analyze_source_with_options(
+        source,
+        filename,
+        &SourceAnalysisOptions {
+            mdx: mdx_options.clone(),
+            ..SourceAnalysisOptions::default()
+        },
+    )
+}
+
+/// Analyze one source file with explicit MDX and rule options.
+///
+/// # Errors
+///
+/// Returns an error under the same conditions as [`analyze_source`].
+pub fn analyze_source_with_options(
+    source: &str,
+    filename: &str,
+    options: &SourceAnalysisOptions,
+) -> PalamedesResult<SourceAnalysisResult> {
     let allocator = Allocator::default();
-    analyze_source_in(&allocator, source, filename, true, mdx_options)
+    analyze_source_in(
+        &allocator,
+        source,
+        filename,
+        true,
+        &options.mdx,
+        &options.rules,
+    )
 }
 
 /*
@@ -1366,7 +1599,14 @@ fn extract_messages_in(
     reference_scopes: bool,
     mdx_options: &MdxOptions,
 ) -> PalamedesResult<Vec<ExtractedMessageRecord>> {
-    let result = analyze_source_in(allocator, source, filename, reference_scopes, mdx_options)?;
+    let result = analyze_source_in(
+        allocator,
+        source,
+        filename,
+        reference_scopes,
+        mdx_options,
+        &SourceRuleOptions::disabled(),
+    )?;
 
     if is_mdx_filename(filename) && !result.diagnostics.is_empty() {
         let messages = result
@@ -1406,6 +1646,7 @@ fn analyze_source_in(
     filename: &str,
     reference_scopes: bool,
     mdx_options: &MdxOptions,
+    rules: &SourceRuleOptions,
 ) -> PalamedesResult<SourceAnalysisResult> {
     if is_mdx_filename(filename) {
         let result = analyze_mdx(source, filename, mdx_options.clone());
@@ -1465,9 +1706,9 @@ fn analyze_source_in(
         });
     }
 
-    let line_locator = LineLocator::new(source);
+    let source_locator = SourceLocator::new(source);
     if let Some((macro_name, offset)) = collector.removed_macro_import.as_ref() {
-        let (line, column) = line_locator.get_location(*offset);
+        let (line, column) = source_locator.location(*offset);
         return Err(PalamedesError::UnsupportedMacroSyntax {
             macro_name: macro_name.clone(),
             location: format!("{filename}:{line}:{column}"),
@@ -1485,8 +1726,9 @@ fn analyze_source_in(
     let mut extractor = ExtractionVisitor::new(
         filename,
         source,
-        &line_locator,
+        &source_locator,
         &collector.imported_macros,
+        rules,
         reference_scopes,
     );
     extractor.visit_program(&parsed.program);
@@ -1497,7 +1739,7 @@ fn analyze_source_in(
 
     Ok(SourceAnalysisResult {
         messages: extractor.messages,
-        diagnostics: Vec::new(),
+        diagnostics: extractor.diagnostics,
     })
 }
 
@@ -1960,16 +2202,18 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     use super::{
-        analyze_source, analyze_source_with_mdx_options, extract_catalog_messages_cached,
-        extract_catalog_messages_from_files, extract_catalog_messages_from_files_with_options,
-        extract_messages as extract_messages_raw, resolve_extract_threads,
-        ExtractCatalogMessagesOptions, ExtractCatalogMessagesRequest, ExtractedMessageRecord,
-        DEFAULT_EXTRACT_THREADS,
+        analyze_source, analyze_source_with_mdx_options, analyze_source_with_options,
+        extract_catalog_messages_cached, extract_catalog_messages_from_files,
+        extract_catalog_messages_from_files_with_options, extract_messages as extract_messages_raw,
+        resolve_extract_threads, ExtractCatalogMessagesOptions, ExtractCatalogMessagesRequest,
+        ExtractedMessageRecord, DEFAULT_EXTRACT_THREADS,
     };
     use crate::error::PalamedesResult;
     use crate::extract_cache::ExtractCache;
     use crate::mdx::MdxOptions;
-    use crate::source::SourceDiagnosticSeverity;
+    use crate::source::{
+        SourceAnalysisOptions, SourceDiagnosticSeverity, SourceRuleLevel, SourceRuleOptions,
+    };
     use crate::test_support::scope_macro_test_source;
 
     static TEMP_COUNTER: AtomicUsize = AtomicUsize::new(0);
@@ -2018,6 +2262,106 @@ function Greeting({ name }: { name: string }) {
         assert!(!diagnostic.help.is_empty());
         assert!(diagnostic.primary.line >= 1);
         assert!(diagnostic.primary.column >= 1);
+    }
+
+    #[test]
+    fn diagnoses_placeholder_only_messages_from_semantic_source_parts() {
+        let source = r#"import { t as translate } from "@palamedes/core/macro";
+import { Trans as Translate } from "@palamedes/react/macro";
+function Greeting({ status, firstName, lastName }) {
+  const tagged = translate`${status}`;
+  const descriptor = translate({ message: `${firstName}${lastName}` });
+  return <Translate>{firstName}{lastName}</Translate>;
+}
+"#;
+
+        let result = analyze_source(source, "test.tsx").expect("analyze placeholder-only source");
+
+        assert_eq!(result.messages.len(), 3);
+        assert_eq!(result.diagnostics.len(), 3);
+        for diagnostic in &result.diagnostics {
+            assert_eq!(diagnostic.code, "pmds/no-placeholder-only-message");
+            assert_eq!(diagnostic.severity, SourceDiagnosticSeverity::Warning);
+            let highlighted = &source[diagnostic.primary.start..diagnostic.primary.end];
+            assert!(highlighted.starts_with("translate") || highlighted.starts_with("<Translate>"));
+        }
+    }
+
+    #[test]
+    fn placeholder_only_classification_handles_solid_aliases_and_literal_braces() {
+        let placeholder_source = r#"import { Trans as Translate } from "@palamedes/solid/macro";
+const message = <Translate>{status}</Translate>;
+"#;
+        let placeholder =
+            analyze_source(placeholder_source, "test.tsx").expect("analyze Solid Trans alias");
+        assert_eq!(placeholder.diagnostics.len(), 1);
+
+        let literal_source = r#"import { t } from "@palamedes/core/macro";
+import { Trans } from "@palamedes/react/macro";
+function Greeting({ status }) {
+  const tagged = t`Status: ${status}`;
+  const descriptor = t({ message: "{name}" });
+  return <Trans>{"{name}"}</Trans>;
+}
+"#;
+        let literal = analyze_source(literal_source, "test.tsx").expect("analyze literal text");
+        assert_eq!(literal.messages.len(), 3);
+        assert!(literal.diagnostics.is_empty());
+    }
+
+    #[test]
+    fn empty_component_only_is_opt_in_and_preserves_nested_jsx_semantics() {
+        let source = r#"import { Trans } from "@palamedes/react/macro";
+const icon = <Trans>{/* formatting */}<><Button /></></Trans>;
+const rich = <Trans><strong>Delete project</strong></Trans>;
+"#;
+
+        let recommended = analyze_source(source, "test.tsx").expect("analyze recommended rules");
+        assert!(recommended.diagnostics.is_empty());
+
+        let configured = analyze_source_with_options(
+            source,
+            "test.tsx",
+            &SourceAnalysisOptions {
+                rules: SourceRuleOptions {
+                    empty_component_only: SourceRuleLevel::Warning,
+                    ..SourceRuleOptions::default()
+                },
+                ..SourceAnalysisOptions::default()
+            },
+        )
+        .expect("analyze opt-in component rule");
+
+        assert_eq!(configured.diagnostics.len(), 1);
+        let diagnostic = &configured.diagnostics[0];
+        assert_eq!(diagnostic.code, "pmds/no-empty-component-only-message");
+        assert_eq!(
+            &source[diagnostic.primary.start..diagnostic.primary.end],
+            "<Trans>{/* formatting */}<><Button /></></Trans>"
+        );
+    }
+
+    #[test]
+    fn mdx_rich_text_corpus_keeps_component_only_diagnostics_disabled() {
+        let result = analyze_source(
+            "Delete **project**.\n\nClick <Button /> to continue.",
+            "guide.mdx",
+        )
+        .expect("analyze valid MDX rich text");
+
+        assert!(!result.messages.is_empty());
+        assert!(result.diagnostics.is_empty());
+    }
+
+    #[test]
+    fn extraction_ignores_non_fatal_source_authoring_diagnostics() {
+        let source = r#"import { t } from "@palamedes/core/macro";
+function Greeting({ status }) { return t`${status}`; }
+"#;
+
+        let messages = extract_messages_raw(source, "test.ts").expect("extract messages");
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].message, "{status}");
     }
 
     #[test]

--- a/crates/palamedes/src/extract.rs
+++ b/crates/palamedes/src/extract.rs
@@ -90,6 +90,12 @@ pub struct ExtractCatalogMessagesOptions {
     pub reference_scopes: bool,
     /// MDX translation-unit and configured-field behavior.
     pub mdx: MdxOptions,
+    /// Source-authoring rules evaluated while the shared analysis is cached.
+    ///
+    /// Extraction output never depends on these diagnostics. Keeping them in
+    /// the same pass lets `pmds extract` warm the cache consumed by
+    /// `pmds lint` without parsing an unchanged file twice.
+    pub rules: SourceRuleOptions,
 }
 
 impl Default for ExtractCatalogMessagesOptions {
@@ -97,6 +103,7 @@ impl Default for ExtractCatalogMessagesOptions {
         Self {
             reference_scopes: true,
             mdx: MdxOptions::default(),
+            rules: SourceRuleOptions::disabled(),
         }
     }
 }
@@ -121,6 +128,8 @@ pub struct ExtractCatalogMessagesResult {
     pub file_count: usize,
     /// Non-fatal file failures skipped during extraction.
     pub failed_files: Vec<ExtractCatalogFileFailure>,
+    /// Source-authoring diagnostics collected by the shared analysis pass.
+    pub diagnostics: Vec<SourceDiagnostic>,
 }
 
 #[derive(Debug)]
@@ -1701,6 +1710,82 @@ pub fn analyze_source_with_options(
     )
 }
 
+/// Analyze one source file while reusing the cache shared with batch extraction.
+///
+/// A compatible cache hit skips both reading and parsing. The stored messages
+/// retain the configured extraction semantics, while diagnostics are rewritten
+/// to `filename` on return so callers can choose project-relative display paths.
+///
+/// # Errors
+///
+/// Returns an error when the file cannot be read or has the same fatal source
+/// authoring problem as [`analyze_source_with_options`]. Cache failures remain
+/// advisory and degrade to a normal analysis.
+pub fn analyze_source_file_cached(
+    path: &str,
+    filename: &str,
+    root_dir: &str,
+    options: &ExtractCatalogMessagesOptions,
+    cache: &mut ExtractCache,
+) -> PalamedesResult<SourceAnalysisResult> {
+    cache.reset_if_request_differs(root_dir, options);
+    if let Some((_relative_file, messages, diagnostics)) = cache.get(path) {
+        return Ok(analysis_with_display_filename(
+            SourceAnalysisResult {
+                messages,
+                diagnostics,
+            },
+            filename,
+        ));
+    }
+
+    let fingerprint = cache.fingerprint_before_read(path);
+    let source = std::fs::read_to_string(path).map_err(|source| PalamedesError::ReadFile {
+        path: PathBuf::from(path),
+        source,
+    })?;
+    let is_mdx = is_mdx_filename(path);
+    let analysis = if !is_mdx && !source.contains("@palamedes") && !source.contains("i18n") {
+        SourceAnalysisResult {
+            messages: Vec::new(),
+            diagnostics: Vec::new(),
+        }
+    } else {
+        EXTRACT_ARENA.with(|arena| {
+            let mut arena = arena.borrow_mut();
+            let analysis = analyze_source_in(
+                &arena,
+                &source,
+                path,
+                options.reference_scopes,
+                &options.mdx,
+                &options.rules,
+            );
+            arena.reset();
+            analysis
+        })?
+    };
+
+    cache.insert(
+        path.to_owned(),
+        relative_origin_file(Path::new(root_dir), path),
+        &analysis.messages,
+        &analysis.diagnostics,
+        fingerprint,
+    );
+    Ok(analysis_with_display_filename(analysis, filename))
+}
+
+fn analysis_with_display_filename(
+    mut analysis: SourceAnalysisResult,
+    filename: &str,
+) -> SourceAnalysisResult {
+    for diagnostic in &mut analysis.diagnostics {
+        diagnostic.file = filename.to_owned();
+    }
+    analysis
+}
+
 /*
  * Extraction against a caller-owned arena. A fresh Allocator per file means a
  * fresh set of bump chunks from the system allocator per file, and on a 1500
@@ -1725,25 +1810,7 @@ fn extract_messages_in(
     )?;
 
     if is_mdx_filename(filename) && !result.diagnostics.is_empty() {
-        let messages = result
-            .diagnostics
-            .iter()
-            .map(|diagnostic| {
-                format!(
-                    "{}:{}:{}: {} ({})",
-                    filename,
-                    diagnostic.primary.line,
-                    diagnostic.primary.column,
-                    diagnostic.message,
-                    diagnostic.code
-                )
-            })
-            .collect::<Vec<_>>()
-            .join("\n");
-        return Err(PalamedesError::ParseModuleSource {
-            filename: filename.to_owned(),
-            messages,
-        });
+        return Err(mdx_diagnostics_error(&result.diagnostics));
     }
 
     Ok(result.messages)
@@ -1754,6 +1821,27 @@ fn is_mdx_filename(filename: &str) -> bool {
         .extension()
         .and_then(|extension| extension.to_str())
         .is_some_and(|extension| extension.eq_ignore_ascii_case("mdx"))
+}
+
+fn mdx_diagnostics_error(diagnostics: &[SourceDiagnostic]) -> PalamedesError {
+    let filename = diagnostics
+        .first()
+        .map_or_else(String::new, |diagnostic| diagnostic.file.clone());
+    let messages = diagnostics
+        .iter()
+        .map(|diagnostic| {
+            format!(
+                "{}:{}:{}: {} ({})",
+                diagnostic.file,
+                diagnostic.primary.line,
+                diagnostic.primary.column,
+                diagnostic.message,
+                diagnostic.code
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    PalamedesError::ParseModuleSource { filename, messages }
 }
 
 fn analyze_source_in(
@@ -1916,9 +2004,11 @@ pub fn extract_catalog_messages_cached(
     let root_dir = PathBuf::from(&request.root_dir);
     let mut catalog = BTreeMap::<String, AggregatedCatalogEntry>::new();
     let mut failed_files = Vec::new();
+    let mut diagnostics = Vec::new();
     let file_count = request.files.len();
     let reference_scopes = options.reference_scopes;
     let mdx_options = options.mdx;
+    let rules = options.rules;
 
     /*
      * A cache handed to us may have been loaded for a different request — watch
@@ -1931,6 +2021,7 @@ pub fn extract_catalog_messages_cached(
         &ExtractCatalogMessagesOptions {
             reference_scopes,
             mdx: mdx_options.clone(),
+            rules: rules.clone(),
         },
     );
 
@@ -1952,7 +2043,16 @@ pub fn extract_catalog_messages_cached(
         request
             .files
             .iter()
-            .map(|file| extract_one_file(file, &root_dir, reference_scopes, &mdx_options, cache))
+            .map(|file| {
+                extract_one_file(
+                    file,
+                    &root_dir,
+                    reference_scopes,
+                    &mdx_options,
+                    &rules,
+                    cache,
+                )
+            })
             .collect()
     } else {
         rayon::ThreadPoolBuilder::new()
@@ -1966,7 +2066,14 @@ pub fn extract_catalog_messages_cached(
                     .files
                     .par_iter()
                     .map(|file| {
-                        extract_one_file(file, &root_dir, reference_scopes, &mdx_options, cache)
+                        extract_one_file(
+                            file,
+                            &root_dir,
+                            reference_scopes,
+                            &mdx_options,
+                            &rules,
+                            cache,
+                        )
                     })
                     .collect()
             })
@@ -1998,12 +2105,28 @@ pub fn extract_catalog_messages_cached(
                 path,
                 relative_file,
                 messages,
+                diagnostics: file_diagnostics,
                 fresh,
                 fingerprint,
             } => {
                 if fresh {
-                    cache.insert(path, relative_file.clone(), &messages, fingerprint);
+                    cache.insert(
+                        path.clone(),
+                        relative_file.clone(),
+                        &messages,
+                        &file_diagnostics,
+                        fingerprint,
+                    );
                 }
+                if is_mdx_filename(&path) && !file_diagnostics.is_empty() {
+                    failed_files.push(ExtractCatalogFileFailure {
+                        path,
+                        message: mdx_diagnostics_error(&file_diagnostics).to_string(),
+                    });
+                    diagnostics.extend(file_diagnostics);
+                    continue;
+                }
+                diagnostics.extend(file_diagnostics);
                 for message in messages {
                     add_extracted_message(&mut catalog, message, &relative_file);
                 }
@@ -2021,6 +2144,7 @@ pub fn extract_catalog_messages_cached(
             .collect(),
         file_count,
         failed_files,
+        diagnostics,
     })
 }
 
@@ -2039,13 +2163,15 @@ fn extract_one_file(
     root_dir: &Path,
     reference_scopes: bool,
     mdx_options: &MdxOptions,
+    rules: &SourceRuleOptions,
     cache: &ExtractCache,
 ) -> FileExtraction {
-    if let Some((relative_file, messages)) = cache.get(file) {
+    if let Some((relative_file, messages, diagnostics)) = cache.get(file) {
         return FileExtraction::Extracted {
             path: file.clone(),
             relative_file,
             messages,
+            diagnostics,
             fresh: false,
             fingerprint: None,
         };
@@ -2091,27 +2217,30 @@ fn extract_one_file(
             path: file.clone(),
             relative_file: relative_origin_file(root_dir, file),
             messages: Vec::new(),
+            diagnostics: Vec::new(),
             fresh: true,
             fingerprint,
         };
     }
 
-    let extracted = EXTRACT_ARENA.with(|arena| {
+    let analyzed = EXTRACT_ARENA.with(|arena| {
         let mut arena = arena.borrow_mut();
-        let extracted = extract_messages_in(&arena, &source, file, reference_scopes, mdx_options);
+        let analyzed =
+            analyze_source_in(&arena, &source, file, reference_scopes, mdx_options, rules);
         /*
          * Safe to reset here: ExtractedMessageRecord owns its strings, so
          * nothing returned above borrows from the arena.
          */
         arena.reset();
-        extracted
+        analyzed
     });
 
-    match extracted {
-        Ok(messages) => FileExtraction::Extracted {
+    match analyzed {
+        Ok(analysis) => FileExtraction::Extracted {
             path: file.clone(),
             relative_file: relative_origin_file(root_dir, file),
-            messages,
+            messages: analysis.messages,
+            diagnostics: analysis.diagnostics,
             fresh: true,
             fingerprint,
         },
@@ -2159,6 +2288,7 @@ enum FileExtraction {
         path: String,
         relative_file: String,
         messages: Vec<ExtractedMessageRecord>,
+        diagnostics: Vec<SourceDiagnostic>,
         /// False when the result came from the cache and need not be stored again.
         fresh: bool,
         /// File identity observed before reading, used to reject mid-run edits.
@@ -2326,11 +2456,12 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     use super::{
-        analyze_source, analyze_source_with_mdx_options, analyze_source_with_options,
-        extract_catalog_messages_cached, extract_catalog_messages_from_files,
-        extract_catalog_messages_from_files_with_options, extract_messages as extract_messages_raw,
-        resolve_extract_threads, ExtractCatalogMessagesOptions, ExtractCatalogMessagesRequest,
-        ExtractedMessageRecord, DEFAULT_EXTRACT_THREADS,
+        analyze_source, analyze_source_file_cached, analyze_source_with_mdx_options,
+        analyze_source_with_options, extract_catalog_messages_cached,
+        extract_catalog_messages_from_files, extract_catalog_messages_from_files_with_options,
+        extract_messages as extract_messages_raw, resolve_extract_threads,
+        ExtractCatalogMessagesOptions, ExtractCatalogMessagesRequest, ExtractedMessageRecord,
+        DEFAULT_EXTRACT_THREADS,
     };
     use crate::error::PalamedesResult;
     use crate::extract_cache::ExtractCache;
@@ -3882,6 +4013,71 @@ const message = t({ message })
         .expect("third extraction");
         assert_eq!(third.messages[0].origins[0].file, "App.tsx");
 
+        fs::remove_dir_all(root).expect("cleanup");
+    }
+
+    #[test]
+    fn extraction_warms_byte_equivalent_cached_source_analysis() {
+        let root = temp_root("shared-analysis-cache");
+        let src = root.join("src");
+        fs::create_dir_all(&src).expect("src dir");
+        let view = src.join("View.tsx");
+        fs::write(
+            &view,
+            r#"
+              import { t } from "@palamedes/react/macro"
+              function View({ status }) {
+                return <p>{t`${status}`}</p>
+              }
+            "#,
+        )
+        .expect("source");
+        let aged = std::time::SystemTime::now() - std::time::Duration::from_secs(10);
+        fs::File::options()
+            .write(true)
+            .open(&view)
+            .expect("open source")
+            .set_modified(aged)
+            .expect("age source");
+
+        let path = view.to_string_lossy().into_owned();
+        let root_dir = root.to_string_lossy().into_owned();
+        let options = ExtractCatalogMessagesOptions {
+            rules: SourceRuleOptions::default(),
+            ..ExtractCatalogMessagesOptions::default()
+        };
+        let mut cache =
+            ExtractCache::load_with_options(&root.join("cache.json"), &root_dir, &options);
+        let extracted = extract_catalog_messages_cached(
+            ExtractCatalogMessagesRequest {
+                root_dir: root_dir.clone(),
+                files: vec![path.clone()],
+                max_threads: Some(1),
+            },
+            options.clone(),
+            &mut cache,
+        )
+        .expect("extract and warm cache");
+        assert_eq!(extracted.diagnostics.len(), 2);
+        assert_eq!(cache.len(), 1);
+
+        let cached =
+            analyze_source_file_cached(&path, "src/View.tsx", &root_dir, &options, &mut cache)
+                .expect("cached analysis");
+        let uncached = analyze_source_file_cached(
+            &path,
+            "src/View.tsx",
+            &root_dir,
+            &options,
+            &mut ExtractCache::disabled(),
+        )
+        .expect("uncached analysis");
+
+        assert_eq!(
+            serde_json::to_vec(&cached).expect("serialize cached"),
+            serde_json::to_vec(&uncached).expect("serialize uncached"),
+            "cached and uncached analysis must be byte-for-byte equivalent"
+        );
         fs::remove_dir_all(root).expect("cleanup");
     }
 

--- a/crates/palamedes/src/extract.rs
+++ b/crates/palamedes/src/extract.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 
@@ -28,9 +28,9 @@ use crate::translation_scope::validate_translation_macro_scopes;
 use oxc_allocator::Allocator;
 use oxc_ast::ast::{
     Argument, BindingPattern, CallExpression, Declaration, Expression, ImportDeclaration,
-    JSXAttributeValue, JSXChild, JSXElement, JSXExpression, JSXOpeningElement, MemberExpression,
-    ObjectExpression, ObjectPropertyKind, TaggedTemplateExpression, TemplateLiteral,
-    VariableDeclarator,
+    JSXAttributeValue, JSXChild, JSXElement, JSXExpression, JSXOpeningElement, LogicalOperator,
+    MemberExpression, ObjectExpression, ObjectPropertyKind, TaggedTemplateExpression,
+    TemplateLiteral, VariableDeclarator,
 };
 use oxc_ast_visit::{walk, Visit};
 use oxc_parser::Parser;
@@ -221,6 +221,8 @@ struct ExtractionVisitor<'a> {
     diagnostics: Vec<SourceDiagnostic>,
     error: Option<PalamedesError>,
     scope_stack: Vec<String>,
+    jsx_parent_stack: Vec<String>,
+    renderable_t_spans: HashSet<(usize, usize)>,
     reference_scopes: bool,
 }
 
@@ -243,6 +245,8 @@ impl<'a> ExtractionVisitor<'a> {
             diagnostics: Vec::new(),
             error: None,
             scope_stack: Vec::new(),
+            jsx_parent_stack: Vec::new(),
+            renderable_t_spans: HashSet::new(),
             reference_scopes,
         }
     }
@@ -306,6 +310,53 @@ impl<'a> ExtractionVisitor<'a> {
                 });
             }
         }
+    }
+
+    fn diagnose_prefer_trans(&mut self, start: usize, end: usize, macro_source: &str) {
+        if !self.renderable_t_spans.contains(&(start, end)) {
+            return;
+        }
+        let Some(severity) = self.rules.prefer_trans_in_jsx.severity() else {
+            return;
+        };
+        let framework = match macro_source {
+            "@palamedes/react/macro" => "React",
+            "@palamedes/solid/macro" => "Solid",
+            _ => "the active UI framework",
+        };
+        self.diagnostics.push(SourceDiagnostic {
+            code: "pmds/prefer-trans-in-jsx".to_owned(),
+            severity,
+            file: self.filename.clone(),
+            primary: self.source_locator.range(start, end),
+            message: "This `t` message is rendered directly as a JSX child; `<Trans>` is often easier to read here, while `t` remains supported.".to_owned(),
+            help: format!(
+                "Consider {framework}'s `<Trans>` macro for JSX-native readability. `t` remains supported; preserve any comment or context metadata when converting."
+            ),
+            related: None,
+        });
+    }
+
+    fn walk_jsx_element_children(&mut self, element: &JSXElement<'a>, tag_name: Option<&str>) {
+        if let Some(tag_name) = tag_name {
+            self.jsx_parent_stack.push(tag_name.to_owned());
+            walk::walk_jsx_element(self, element);
+            self.jsx_parent_stack.pop();
+        } else {
+            walk::walk_jsx_element(self, element);
+        }
+    }
+
+    fn current_jsx_parent_allows_trans(&self) -> bool {
+        !self.jsx_parent_stack.iter().any(|parent| {
+            is_restricted_trans_parent(parent)
+                || self.imported_macros.get(parent).is_some_and(|macro_info| {
+                    matches!(
+                        macro_info.imported_name.as_str(),
+                        "Trans" | "Plural" | "Select" | "SelectOrdinal"
+                    )
+                })
+        })
     }
 
     fn fail(&mut self, message: PalamedesError) {
@@ -401,15 +452,13 @@ impl<'a> Visit<'a> for ExtractionVisitor<'a> {
         }
 
         let Some(tag_name) = it.opening_element.name.get_identifier_name() else {
-            walk::walk_jsx_element(self, it);
+            self.walk_jsx_element_children(it, None);
             return;
         };
+        let tag_name = tag_name.as_str().to_owned();
 
         if let Some(macro_name) = self
-            .imported_macro_name(
-                tag_name.as_str(),
-                &["Trans", "Plural", "Select", "SelectOrdinal"],
-            )
+            .imported_macro_name(&tag_name, &["Trans", "Plural", "Select", "SelectOrdinal"])
             .map(str::to_string)
         {
             if let Some(nested_start) =
@@ -455,7 +504,21 @@ impl<'a> Visit<'a> for ExtractionVisitor<'a> {
             }
         }
 
-        walk::walk_jsx_element(self, it);
+        self.walk_jsx_element_children(it, Some(&tag_name));
+    }
+
+    fn visit_jsx_child(&mut self, it: &JSXChild<'a>) {
+        if let JSXChild::ExpressionContainer(container) = it {
+            if self.current_jsx_parent_allows_trans() {
+                if let Some(expression) = container.expression.as_expression() {
+                    collect_direct_render_expression_spans(
+                        expression,
+                        &mut self.renderable_t_spans,
+                    );
+                }
+            }
+        }
+        walk::walk_jsx_child(self, it);
     }
 
     fn visit_tagged_template_expression(&mut self, it: &TaggedTemplateExpression<'a>) {
@@ -468,6 +531,11 @@ impl<'a> Visit<'a> for ExtractionVisitor<'a> {
                 .imported_macro_name(tag_name, &["t"])
                 .map(str::to_string)
             {
+                let macro_source = self
+                    .imported_macros
+                    .get(tag_name)
+                    .map(|macro_info| macro_info.source.clone())
+                    .unwrap_or_default();
                 match extract_from_tagged_template(
                     &it.quasi,
                     self.origin(it.span.start as usize),
@@ -482,6 +550,11 @@ impl<'a> Visit<'a> for ExtractionVisitor<'a> {
                             template_authored_parts(&it.quasi),
                         );
                         self.push(message, facts);
+                        self.diagnose_prefer_trans(
+                            it.span.start as usize,
+                            it.span.end as usize,
+                            &macro_source,
+                        );
                     }
                     Ok(None) => {
                         self.fail_unsupported_macro(&macro_name, it.span.start as usize);
@@ -532,6 +605,11 @@ impl<'a> Visit<'a> for ExtractionVisitor<'a> {
                 .imported_macro_name(callee_name, &["t", "plural", "select", "selectOrdinal"])
                 .map(str::to_string)
             {
+                let macro_source = self
+                    .imported_macros
+                    .get(callee_name)
+                    .map(|macro_info| macro_info.source.clone())
+                    .unwrap_or_default();
                 let message = match macro_name.as_str() {
                     "plural" | "select" | "selectOrdinal" => extract_from_choice_call(
                         it,
@@ -568,6 +646,13 @@ impl<'a> Visit<'a> for ExtractionVisitor<'a> {
                             parts,
                         );
                         self.push(message, facts);
+                        if macro_name == "t" {
+                            self.diagnose_prefer_trans(
+                                it.span.start as usize,
+                                it.span.end as usize,
+                                &macro_source,
+                            );
+                        }
                     }
                     Ok(None) => {
                         self.fail_unsupported_macro(&macro_name, it.span.start as usize);
@@ -605,6 +690,37 @@ impl<'a> Visit<'a> for ExtractionVisitor<'a> {
         }
 
         walk::walk_call_expression(self, it);
+    }
+}
+
+fn is_restricted_trans_parent(parent: &str) -> bool {
+    matches!(
+        parent,
+        "option" | "textarea" | "title" | "desc" | "script" | "style"
+    )
+}
+
+fn collect_direct_render_expression_spans(
+    expression: &Expression<'_>,
+    spans: &mut HashSet<(usize, usize)>,
+) {
+    match expression.without_parentheses() {
+        Expression::TaggedTemplateExpression(expression) => {
+            spans.insert((expression.span.start as usize, expression.span.end as usize));
+        }
+        Expression::CallExpression(expression) => {
+            spans.insert((expression.span.start as usize, expression.span.end as usize));
+        }
+        Expression::ConditionalExpression(expression) => {
+            collect_direct_render_expression_spans(&expression.consequent, spans);
+            collect_direct_render_expression_spans(&expression.alternate, spans);
+        }
+        Expression::LogicalExpression(expression)
+            if expression.operator == LogicalOperator::And =>
+        {
+            collect_direct_render_expression_spans(&expression.right, spans);
+        }
+        _ => {}
     }
 }
 
@@ -1737,6 +1853,14 @@ fn analyze_source_in(
         return Err(error);
     }
 
+    extractor.diagnostics.sort_by(|left, right| {
+        (left.primary.start, left.primary.end, left.code.as_str()).cmp(&(
+            right.primary.start,
+            right.primary.end,
+            right.code.as_str(),
+        ))
+    });
+
     Ok(SourceAnalysisResult {
         messages: extractor.messages,
         diagnostics: extractor.diagnostics,
@@ -2362,6 +2486,93 @@ function Greeting({ status }) { return t`${status}`; }
         let messages = extract_messages_raw(source, "test.ts").expect("extract messages");
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].message, "{status}");
+    }
+
+    #[test]
+    fn suggests_trans_for_direct_conditional_and_logical_jsx_render_positions() {
+        let source = r#"import { t as translate } from "@palamedes/react/macro";
+function Greeting({ name, ready }) {
+  return <section>
+    {translate`Welcome ${name}`}
+    {ready ? translate({ message: "Ready", comment: "Visible state", context: "status" }) : translate`Waiting`}
+    {ready && translate`Done`}
+  </section>;
+}
+"#;
+
+        let result = analyze_source(source, "test.tsx").expect("analyze render positions");
+        let diagnostics = result
+            .diagnostics
+            .iter()
+            .filter(|diagnostic| diagnostic.code == "pmds/prefer-trans-in-jsx")
+            .collect::<Vec<_>>();
+
+        assert_eq!(diagnostics.len(), 4);
+        for diagnostic in diagnostics {
+            assert_eq!(diagnostic.severity, SourceDiagnosticSeverity::Info);
+            assert!(diagnostic.message.contains("`t` remains supported"));
+            assert!(diagnostic.help.contains("React's `<Trans>`"));
+            assert!(diagnostic.help.contains("`t` remains supported"));
+            assert!(
+                source[diagnostic.primary.start..diagnostic.primary.end].starts_with("translate")
+            );
+        }
+    }
+
+    #[test]
+    fn prefer_trans_resolves_solid_and_core_macro_sources_without_guessing_a_fix() {
+        let solid_source = r#"import { t as translate } from "@palamedes/solid/macro";
+function Greeting() { return <p>{translate`Hello`}</p>; }
+"#;
+        let solid = analyze_source(solid_source, "solid.tsx").expect("analyze Solid render");
+        assert!(solid.diagnostics[0].help.contains("Solid's `<Trans>`"));
+
+        let core_source = r#"import { t as translate } from "@palamedes/core/macro";
+function Greeting() { return <p>{translate`Hello`}</p>; }
+"#;
+        let core = analyze_source(core_source, "core.tsx").expect("analyze core render");
+        assert!(core.diagnostics[0]
+            .help
+            .contains("the active UI framework's `<Trans>`"));
+    }
+
+    #[test]
+    fn prefer_trans_excludes_non_render_and_structurally_restricted_positions() {
+        let source = r#"import { t as translate } from "@palamedes/react/macro";
+function Greeting({ ready }) {
+  const render = (value) => value;
+  return <>
+    <Card title={translate`Attribute`} />
+    <div>{render(translate`Argument`)}</div>
+    <div>{[translate`Array`]}</div>
+    <div>{({ label: translate`Object` }).label}</div>
+    <option>{translate`Option`}</option>
+    <textarea>{translate`Textarea`}</textarea>
+    <svg><title>{translate`Title`}</title><desc>{translate`Description`}</desc></svg>
+    <div>{translate`Left side` && <span />}</div>
+    <div>{translate`Fallback` || "fallback"}</div>
+    <div>{translate`Fallback` ?? "fallback"}</div>
+  </>;
+}
+"#;
+
+        let result = analyze_source(source, "test.tsx").expect("analyze excluded positions");
+        assert_eq!(result.messages.len(), 11);
+        assert!(result
+            .diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.code != "pmds/prefer-trans-in-jsx"));
+    }
+
+    #[test]
+    fn prefer_trans_ignores_unrelated_local_t_functions() {
+        let source = r#"function t(strings) { return strings[0]; }
+function Greeting() { return <p>{t`Hello`}</p>; }
+"#;
+
+        let result = analyze_source(source, "test.tsx").expect("analyze unrelated t");
+        assert!(result.messages.is_empty());
+        assert!(result.diagnostics.is_empty());
     }
 
     #[test]

--- a/crates/palamedes/src/extract_cache.rs
+++ b/crates/palamedes/src/extract_cache.rs
@@ -213,6 +213,31 @@ impl ExtractCache {
         ))
     }
 
+    /// Returns an entry only when `path` stayed unchanged across a caller-owned read.
+    pub(crate) fn get_after_read(
+        &self,
+        path: &str,
+        before: Option<ReadStartFingerprint>,
+    ) -> Option<(String, Vec<ExtractedMessageRecord>, Vec<SourceDiagnostic>)>
+    where
+        ExtractedMessageRecord: Clone,
+    {
+        if !self.enabled {
+            return None;
+        }
+        let before = before?;
+        let entry = self.entries.get(path)?;
+        let current = FileFingerprint::read(Path::new(path))?;
+        if current != before.fingerprint || current != entry.fingerprint {
+            return None;
+        }
+        Some((
+            entry.relative_file.clone(),
+            entry.messages.clone(),
+            entry.diagnostics.clone(),
+        ))
+    }
+
     /// Identity of `path` before its contents are read, or `None` when the cache
     /// is disabled and the `stat` would be wasted.
     pub(crate) fn fingerprint_before_read(&self, path: &str) -> Option<ReadStartFingerprint> {
@@ -445,6 +470,33 @@ mod tests {
         write_aged(&source, "const a = 22222\n");
         assert!(cache.get(&key).is_none());
 
+        std::fs::remove_dir_all(root).expect("cleanup");
+    }
+
+    #[test]
+    fn misses_when_a_file_changes_during_a_caller_owned_read() {
+        let root = temp_root("changed-during-read");
+        std::fs::create_dir_all(&root).expect("root");
+        let source = root.join("a.tsx");
+        write_aged(&source, "const a = 1\n");
+        let key = source.to_string_lossy().into_owned();
+
+        let mut cache = ExtractCache::load(&root.join("cache.json"), "root", true);
+        let cached_read = cache.fingerprint_before_read(&key);
+        cache.insert(
+            key.clone(),
+            "a.tsx".to_owned(),
+            &[record("Hello")],
+            &[],
+            cached_read,
+        );
+
+        let before = cache.fingerprint_before_read(&key);
+        let read_source = std::fs::read_to_string(&source).expect("read source");
+        assert_eq!(read_source, "const a = 1\n");
+        write_aged(&source, "const a = 22222\n");
+
+        assert!(cache.get_after_read(&key, before).is_none());
         std::fs::remove_dir_all(root).expect("cleanup");
     }
 

--- a/crates/palamedes/src/extract_cache.rs
+++ b/crates/palamedes/src/extract_cache.rs
@@ -1,11 +1,11 @@
-//! Per-file extraction cache.
+//! Per-file extraction and source-analysis cache.
 //!
 //! Extraction is dominated by reading and parsing source. On a repeat run most
 //! files are untouched, so their result is still valid and the work is pure
-//! waste. This caches the extracted messages per file and validates entries
-//! with a `stat` instead of a read: on the realistic benchmark corpus, reading
-//! all 1500 files costs ~25 ms and parsing them ~94 ms, against ~2.7 ms to stat
-//! them.
+//! waste. This caches extracted messages and source diagnostics per file and
+//! validates entries with a `stat` instead of a parse: on the realistic
+//! benchmark corpus, reading all 1500 files costs ~25 ms and parsing them ~94
+//! ms, against ~2.7 ms to stat them.
 //!
 //! The cache is advisory. Anything unexpected — missing file, unreadable
 //! directory, corrupt or stale payload, schema change — degrades to a miss and
@@ -18,10 +18,11 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use serde::{Deserialize, Serialize};
 
 use crate::extract::{ExtractCatalogMessagesOptions, ExtractedMessageRecord};
+use crate::source::{SourceDiagnostic, SourceRuleOptions};
 
 /// Bumped whenever the cached payload shape or the extractor's output changes
 /// in a way that makes previously stored entries wrong.
-const CACHE_SCHEMA: u32 = 2;
+const CACHE_SCHEMA: u32 = 3;
 
 /*
  * A file modified in the same instant it was cached cannot be distinguished
@@ -78,6 +79,7 @@ struct CacheEntry {
     /// Origin path as stored in catalogs, which depends on the reference root.
     relative_file: String,
     messages: Vec<ExtractedMessageRecord>,
+    diagnostics: Vec<SourceDiagnostic>,
 }
 
 /*
@@ -95,6 +97,8 @@ struct CacheStamp {
     reference_scopes: bool,
     /// Configured MDX fields and opt-out semantics also change records.
     mdx_stamp: String,
+    /// Rule levels affect diagnostics but never extracted messages.
+    rules: SourceRuleOptions,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -103,11 +107,11 @@ struct CachePayload {
     entries: HashMap<String, CacheEntry>,
 }
 
-/// Extraction cache for one project root.
+/// Extraction and source-analysis cache for one project root.
 ///
 /// Load once per process and keep it alive: a single `pmds extract` saves the
-/// read and parse of every unchanged file, and watch mode reuses the same
-/// instance across rebuilds so later runs never touch disk for them.
+/// read and parse of every unchanged file, `pmds lint` reuses its diagnostics,
+/// and watch mode reuses the same instance across rebuilds.
 #[derive(Debug)]
 pub struct ExtractCache {
     stamp: CacheStamp,
@@ -127,6 +131,7 @@ impl ExtractCache {
                 root_dir: String::new(),
                 reference_scopes: false,
                 mdx_stamp: String::new(),
+                rules: SourceRuleOptions::disabled(),
             },
             entries: HashMap::new(),
             dirty: false,
@@ -167,6 +172,7 @@ impl ExtractCache {
             root_dir: root_dir.to_owned(),
             reference_scopes: options.reference_scopes,
             mdx_stamp: options.mdx.extraction_stamp(),
+            rules: options.rules.clone(),
         };
 
         let entries = std::fs::read(path)
@@ -185,7 +191,10 @@ impl ExtractCache {
     }
 
     /// Cached result for `path`, if the file still looks exactly as it did.
-    pub(crate) fn get(&self, path: &str) -> Option<(String, Vec<ExtractedMessageRecord>)>
+    pub(crate) fn get(
+        &self,
+        path: &str,
+    ) -> Option<(String, Vec<ExtractedMessageRecord>, Vec<SourceDiagnostic>)>
     where
         ExtractedMessageRecord: Clone,
     {
@@ -197,7 +206,11 @@ impl ExtractCache {
         if current != entry.fingerprint {
             return None;
         }
-        Some((entry.relative_file.clone(), entry.messages.clone()))
+        Some((
+            entry.relative_file.clone(),
+            entry.messages.clone(),
+            entry.diagnostics.clone(),
+        ))
     }
 
     /// Identity of `path` before its contents are read, or `None` when the cache
@@ -229,7 +242,8 @@ impl ExtractCache {
         if !self.enabled
             || (self.stamp.root_dir == root_dir
                 && self.stamp.reference_scopes == options.reference_scopes
-                && self.stamp.mdx_stamp == mdx_stamp)
+                && self.stamp.mdx_stamp == mdx_stamp
+                && self.stamp.rules == options.rules)
         {
             return;
         }
@@ -237,6 +251,7 @@ impl ExtractCache {
         self.stamp.root_dir = root_dir.to_owned();
         self.stamp.reference_scopes = options.reference_scopes;
         self.stamp.mdx_stamp = mdx_stamp;
+        self.stamp.rules = options.rules.clone();
         if !self.entries.is_empty() {
             self.entries.clear();
             self.dirty = true;
@@ -256,6 +271,7 @@ impl ExtractCache {
         path: String,
         relative_file: String,
         messages: &[ExtractedMessageRecord],
+        diagnostics: &[SourceDiagnostic],
         before: Option<ReadStartFingerprint>,
     ) where
         ExtractedMessageRecord: Clone,
@@ -282,6 +298,7 @@ impl ExtractCache {
                 fingerprint,
                 relative_file,
                 messages: messages.to_vec(),
+                diagnostics: diagnostics.to_vec(),
             },
         );
         self.dirty = true;
@@ -412,7 +429,13 @@ mod tests {
 
         let mut cache = ExtractCache::load(&root.join("cache.json"), "root", true);
         let before = cache.fingerprint_before_read(&key);
-        cache.insert(key.clone(), "a.tsx".to_owned(), &[record("Hello")], before);
+        cache.insert(
+            key.clone(),
+            "a.tsx".to_owned(),
+            &[record("Hello")],
+            &[],
+            before,
+        );
 
         let hit = cache.get(&key).expect("cache hit");
         assert_eq!(hit.0, "a.tsx");
@@ -436,7 +459,13 @@ mod tests {
 
         let mut cache = ExtractCache::load(&cache_path, "root-one", true);
         let before = cache.fingerprint_before_read(&key);
-        cache.insert(key.clone(), "a.tsx".to_owned(), &[record("Hello")], before);
+        cache.insert(
+            key.clone(),
+            "a.tsx".to_owned(),
+            &[record("Hello")],
+            &[],
+            before,
+        );
         cache.save(&cache_path).expect("save");
 
         // Same file, different reference root: origins would differ, so the
@@ -461,11 +490,28 @@ mod tests {
                     translatable_attributes: vec!["alt".to_owned(), "title".to_owned()],
                     ..crate::MdxOptions::default()
                 },
+                ..ExtractCatalogMessagesOptions::default()
             },
         );
         assert!(
             mdx_changed.is_empty(),
             "changed MDX extraction semantics must discard entries"
+        );
+
+        let rules_changed = ExtractCache::load_with_options(
+            &cache_path,
+            "root-one",
+            &ExtractCatalogMessagesOptions {
+                rules: SourceRuleOptions {
+                    placeholder_only: crate::SourceRuleLevel::Error,
+                    ..SourceRuleOptions::default()
+                },
+                ..ExtractCatalogMessagesOptions::default()
+            },
+        );
+        assert!(
+            rules_changed.is_empty(),
+            "changed source rule levels must discard cached diagnostics"
         );
 
         std::fs::remove_dir_all(root).expect("cleanup");
@@ -483,7 +529,13 @@ mod tests {
 
         let mut cache = ExtractCache::load(&root.join("cache.json"), "root", true);
         let before = cache.fingerprint_before_read(&key);
-        cache.insert(key.clone(), "a.tsx".to_owned(), &[record("Hello")], before);
+        cache.insert(
+            key.clone(),
+            "a.tsx".to_owned(),
+            &[record("Hello")],
+            &[],
+            before,
+        );
         assert!(cache.is_empty(), "young files must not be cached");
         assert!(cache.get(&key).is_none());
 
@@ -511,7 +563,13 @@ mod tests {
         // guard alone would not catch it.
         write_aged(&source, "const a = 999999\n");
 
-        cache.insert(key.clone(), "a.tsx".to_owned(), &[record("Stale")], before);
+        cache.insert(
+            key.clone(),
+            "a.tsx".to_owned(),
+            &[record("Stale")],
+            &[],
+            before,
+        );
         assert!(
             cache.is_empty(),
             "a file edited between read and insert must not be cached"
@@ -543,7 +601,13 @@ mod tests {
         // Extraction takes long enough for the window to pass before the insert.
         std::thread::sleep(RACY_WINDOW + Duration::from_millis(100));
 
-        cache.insert(key.clone(), "a.tsx".to_owned(), &[record("Hello")], before);
+        cache.insert(
+            key.clone(),
+            "a.tsx".to_owned(),
+            &[record("Hello")],
+            &[],
+            before,
+        );
         assert!(
             cache.is_empty(),
             "a file that was young when it was read must not be cached"
@@ -562,7 +626,13 @@ mod tests {
 
         let mut cache = ExtractCache::load(&root.join("cache.json"), "root-one", true);
         let before = cache.fingerprint_before_read(&key);
-        cache.insert(key.clone(), "a.tsx".to_owned(), &[record("Hello")], before);
+        cache.insert(
+            key.clone(),
+            "a.tsx".to_owned(),
+            &[record("Hello")],
+            &[],
+            before,
+        );
         assert_eq!(cache.len(), 1);
 
         // Same stamp: entries survive.
@@ -576,7 +646,13 @@ mod tests {
         assert!(cache.get(&key).is_none());
 
         let before = cache.fingerprint_before_read(&key);
-        cache.insert(key.clone(), "a.tsx".to_owned(), &[record("Hello")], before);
+        cache.insert(
+            key.clone(),
+            "a.tsx".to_owned(),
+            &[record("Hello")],
+            &[],
+            before,
+        );
         cache.reset_if_request_differs("root-two", &options(true));
         assert_eq!(cache.len(), 1, "matching requests keep their entries");
         cache.reset_if_request_differs("root-two", &options(false));
@@ -605,7 +681,7 @@ mod tests {
         for path in [&first, &second, &dropped] {
             let key = path.to_string_lossy().into_owned();
             let before = cache.fingerprint_before_read(&key);
-            cache.insert(key, "file.tsx".to_owned(), &[record("Hello")], before);
+            cache.insert(key, "file.tsx".to_owned(), &[record("Hello")], &[], before);
         }
         assert_eq!(cache.len(), 3);
 
@@ -657,7 +733,13 @@ mod tests {
 
         let mut cache = ExtractCache::disabled();
         let before = cache.fingerprint_before_read(&key);
-        cache.insert(key.clone(), "a.tsx".to_owned(), &[record("Hello")], before);
+        cache.insert(
+            key.clone(),
+            "a.tsx".to_owned(),
+            &[record("Hello")],
+            &[],
+            before,
+        );
         assert!(cache.get(&key).is_none());
         assert!(!cache.is_dirty());
 

--- a/crates/palamedes/src/lib.rs
+++ b/crates/palamedes/src/lib.rs
@@ -78,11 +78,12 @@ pub use catalog_update::{
 pub use diagnostic::{CatalogDiagnostic, CatalogDiagnosticSeverity, CatalogDiagnosticSourceKey};
 pub use error::{PalamedesError, PalamedesResult};
 pub use extract::{
-    analyze_source, analyze_source_with_mdx_options, analyze_source_with_options,
-    extract_catalog_messages_cached, extract_catalog_messages_from_files,
-    extract_catalog_messages_from_files_with_options, extract_messages,
-    extract_messages_with_mdx_options, ExtractCatalogFileFailure, ExtractCatalogMessagesOptions,
-    ExtractCatalogMessagesRequest, ExtractCatalogMessagesResult, ExtractedMessageRecord,
+    analyze_source, analyze_source_file_cached, analyze_source_with_mdx_options,
+    analyze_source_with_options, extract_catalog_messages_cached,
+    extract_catalog_messages_from_files, extract_catalog_messages_from_files_with_options,
+    extract_messages, extract_messages_with_mdx_options, ExtractCatalogFileFailure,
+    ExtractCatalogMessagesOptions, ExtractCatalogMessagesRequest, ExtractCatalogMessagesResult,
+    ExtractedMessageRecord,
 };
 pub use extract_cache::{default_cache_path, ExtractCache};
 pub use mdx::{

--- a/crates/palamedes/src/lib.rs
+++ b/crates/palamedes/src/lib.rs
@@ -103,7 +103,9 @@ pub use runtime_message::{
 };
 pub use source::{
     SourceAnalysisOptions, SourceAnalysisResult, SourceDiagnostic, SourceDiagnosticSeverity,
-    SourceRange, SourceRuleLevel, SourceRuleOptions,
+    SourceFileAnalysisResult, SourceRange, SourceRuleLevel, SourceRuleOptions,
+    SOURCE_DIAGNOSTIC_CODES, SOURCE_DIAGNOSTIC_CODE_NO_EMPTY_COMPONENT_ONLY_MESSAGE,
+    SOURCE_DIAGNOSTIC_CODE_NO_PLACEHOLDER_ONLY_MESSAGE, SOURCE_DIAGNOSTIC_CODE_PREFER_TRANS_IN_JSX,
 };
 pub use transform::{
     transform_macros, NativeTransformEdit, NativeTransformOptions, NativeTransformResult,

--- a/crates/palamedes/src/lib.rs
+++ b/crates/palamedes/src/lib.rs
@@ -37,6 +37,8 @@ mod mdx;
 mod message_metadata;
 mod placeholder_name;
 mod runtime_message;
+mod source;
+mod source_macros;
 #[cfg(test)]
 mod test_support;
 mod transform;
@@ -76,10 +78,11 @@ pub use catalog_update::{
 pub use diagnostic::{CatalogDiagnostic, CatalogDiagnosticSeverity, CatalogDiagnosticSourceKey};
 pub use error::{PalamedesError, PalamedesResult};
 pub use extract::{
-    extract_catalog_messages_cached, extract_catalog_messages_from_files,
-    extract_catalog_messages_from_files_with_options, extract_messages,
-    extract_messages_with_mdx_options, ExtractCatalogFileFailure, ExtractCatalogMessagesOptions,
-    ExtractCatalogMessagesRequest, ExtractCatalogMessagesResult, ExtractedMessageRecord,
+    analyze_source, analyze_source_with_mdx_options, extract_catalog_messages_cached,
+    extract_catalog_messages_from_files, extract_catalog_messages_from_files_with_options,
+    extract_messages, extract_messages_with_mdx_options, ExtractCatalogFileFailure,
+    ExtractCatalogMessagesOptions, ExtractCatalogMessagesRequest, ExtractCatalogMessagesResult,
+    ExtractedMessageRecord,
 };
 pub use extract_cache::{default_cache_path, ExtractCache};
 pub use mdx::{
@@ -97,6 +100,7 @@ pub use runtime_message::{
     compile_runtime_catalog_messages, RuntimeCompiledMessage, RuntimeCompiledMessages,
     RuntimeMessageChoiceKind, RuntimeMessageFormat, RuntimeMessageNode,
 };
+pub use source::{SourceAnalysisResult, SourceDiagnostic, SourceDiagnosticSeverity, SourceRange};
 pub use transform::{
     transform_macros, NativeTransformEdit, NativeTransformOptions, NativeTransformResult,
     NativeTransformSourceMap,

--- a/crates/palamedes/src/lib.rs
+++ b/crates/palamedes/src/lib.rs
@@ -78,11 +78,11 @@ pub use catalog_update::{
 pub use diagnostic::{CatalogDiagnostic, CatalogDiagnosticSeverity, CatalogDiagnosticSourceKey};
 pub use error::{PalamedesError, PalamedesResult};
 pub use extract::{
-    analyze_source, analyze_source_with_mdx_options, extract_catalog_messages_cached,
-    extract_catalog_messages_from_files, extract_catalog_messages_from_files_with_options,
-    extract_messages, extract_messages_with_mdx_options, ExtractCatalogFileFailure,
-    ExtractCatalogMessagesOptions, ExtractCatalogMessagesRequest, ExtractCatalogMessagesResult,
-    ExtractedMessageRecord,
+    analyze_source, analyze_source_with_mdx_options, analyze_source_with_options,
+    extract_catalog_messages_cached, extract_catalog_messages_from_files,
+    extract_catalog_messages_from_files_with_options, extract_messages,
+    extract_messages_with_mdx_options, ExtractCatalogFileFailure, ExtractCatalogMessagesOptions,
+    ExtractCatalogMessagesRequest, ExtractCatalogMessagesResult, ExtractedMessageRecord,
 };
 pub use extract_cache::{default_cache_path, ExtractCache};
 pub use mdx::{
@@ -100,7 +100,10 @@ pub use runtime_message::{
     compile_runtime_catalog_messages, RuntimeCompiledMessage, RuntimeCompiledMessages,
     RuntimeMessageChoiceKind, RuntimeMessageFormat, RuntimeMessageNode,
 };
-pub use source::{SourceAnalysisResult, SourceDiagnostic, SourceDiagnosticSeverity, SourceRange};
+pub use source::{
+    SourceAnalysisOptions, SourceAnalysisResult, SourceDiagnostic, SourceDiagnosticSeverity,
+    SourceRange, SourceRuleLevel, SourceRuleOptions,
+};
 pub use transform::{
     transform_macros, NativeTransformEdit, NativeTransformOptions, NativeTransformResult,
     NativeTransformSourceMap,

--- a/crates/palamedes/src/mdx.rs
+++ b/crates/palamedes/src/mdx.rs
@@ -15,6 +15,7 @@ use crate::extract::ExtractedMessageRecord;
 use crate::icu_text::{compiled_message_key, escape_icu_literal, escape_icu_source_literal};
 use crate::jsx_entities::decode_jsx_entities;
 use crate::jsx_message::{clean_jsx_text, join_jsx_message_parts, JsxMessagePart};
+use crate::source::{SourceLocator, SourceRange};
 use crate::transform::NativeTransformSourceMap;
 
 const DEFAULT_IGNORE_DIRECTIVE: &str = "palamedes-ignore";
@@ -110,19 +111,8 @@ impl MdxOptions {
     }
 }
 
-/// Source range with an exact UTF-8 byte span and one-based start location.
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct MdxSourceRange {
-    /// Inclusive start byte.
-    pub start: usize,
-    /// Exclusive end byte.
-    pub end: usize,
-    /// One-based source line.
-    pub line: usize,
-    /// One-based Unicode scalar column.
-    pub column: usize,
-}
+/// Backward-compatible name for the shared source diagnostic range.
+pub type MdxSourceRange = SourceRange;
 
 /// Structured source-ranged MDX diagnostic.
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -240,13 +230,7 @@ fn diagnostic_record(locator: &SourceLocator, diagnostic: MdxDiagnostic) -> MdxD
 }
 
 fn source_range(locator: &SourceLocator, range: Range) -> MdxSourceRange {
-    let (line, column) = locator.location(range.start_usize());
-    MdxSourceRange {
-        start: range.start_usize(),
-        end: range.end_usize(),
-        line,
-        column,
-    }
+    locator.range(range.start_usize(), range.end_usize())
 }
 
 #[derive(Debug)]
@@ -272,7 +256,7 @@ struct MdxCompiler<'a> {
     filename: &'a str,
     options: MdxOptions,
     link_references: &'a [ferromark::LinkRefDef],
-    locator: SourceLocator,
+    locator: SourceLocator<'a>,
     body: ModuleWriter,
     esm: Vec<(usize, String)>,
     messages: Vec<ExtractedMessageRecord>,
@@ -1794,33 +1778,6 @@ fn generated_position(source: &str) -> (usize, usize) {
     let line = source.bytes().filter(|byte| *byte == b'\n').count();
     let column_source = source.rsplit_once('\n').map_or(source, |(_, tail)| tail);
     (line, column_source.encode_utf16().count())
-}
-
-struct SourceLocator {
-    line_starts: Vec<usize>,
-}
-
-impl SourceLocator {
-    fn new(source: &str) -> Self {
-        let mut line_starts = vec![0];
-        for (index, byte) in source.bytes().enumerate() {
-            if byte == b'\n' {
-                line_starts.push(index + 1);
-            }
-        }
-        Self { line_starts }
-    }
-
-    fn location(&self, offset: usize) -> (usize, usize) {
-        let line_index = match self.line_starts.binary_search(&offset) {
-            Ok(index) => index,
-            Err(index) => index.saturating_sub(1),
-        };
-        (
-            line_index + 1,
-            offset.saturating_sub(self.line_starts[line_index]) + 1,
-        )
-    }
 }
 
 fn source_position_utf16(source: &str, offset: usize) -> (usize, usize) {

--- a/crates/palamedes/src/source.rs
+++ b/crates/palamedes/src/source.rs
@@ -1,0 +1,114 @@
+use serde::{Deserialize, Serialize};
+
+use crate::extract::ExtractedMessageRecord;
+
+/// Source range with an exact UTF-8 byte span and one-based start location.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SourceRange {
+    /// Inclusive start byte.
+    pub start: usize,
+    /// Exclusive end byte.
+    pub end: usize,
+    /// One-based source line.
+    pub line: usize,
+    /// One-based Unicode scalar column.
+    pub column: usize,
+}
+
+/// Severity assigned to a source-authoring diagnostic.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SourceDiagnosticSeverity {
+    /// Authoring error that should normally fail CI.
+    Error,
+    /// Suspicious authoring that should normally be reviewed.
+    Warning,
+    /// Informational authoring guidance.
+    Info,
+}
+
+/// Structured diagnostic produced while analyzing an authored source file.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SourceDiagnostic {
+    /// Stable machine-readable diagnostic code.
+    pub code: String,
+    /// Configured diagnostic severity.
+    pub severity: SourceDiagnosticSeverity,
+    /// Source filename supplied to the analyzer.
+    pub file: String,
+    /// Primary source location.
+    pub primary: SourceRange,
+    /// Human-readable explanation of the finding.
+    pub message: String,
+    /// Actionable guidance for resolving the finding.
+    pub help: String,
+    /// Related source location, such as the opening side of a mismatch.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub related: Option<SourceRange>,
+}
+
+/// Messages and non-fatal diagnostics produced by one source analysis.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SourceAnalysisResult {
+    /// Source-first messages extracted from the analyzed file.
+    pub messages: Vec<ExtractedMessageRecord>,
+    /// Source-authoring diagnostics in deterministic source order.
+    pub diagnostics: Vec<SourceDiagnostic>,
+}
+
+/// Byte-offset to source-location index shared by source analyzers.
+pub(crate) struct SourceLocator<'a> {
+    source: &'a str,
+    line_starts: Vec<usize>,
+}
+
+impl<'a> SourceLocator<'a> {
+    pub(crate) fn new(source: &'a str) -> Self {
+        let mut line_starts = vec![0];
+        for (index, &byte) in source.as_bytes().iter().enumerate() {
+            if byte == b'\n' {
+                line_starts.push(index + 1);
+            }
+        }
+        Self {
+            source,
+            line_starts,
+        }
+    }
+
+    pub(crate) fn location(&self, offset: usize) -> (usize, usize) {
+        let offset = offset.min(self.source.len());
+        let line_index = match self.line_starts.binary_search(&offset) {
+            Ok(index) => index,
+            Err(index) => index.saturating_sub(1),
+        };
+        let line_start = self.line_starts[line_index];
+        let column = self.source[line_start..offset].chars().count() + 1;
+        (line_index + 1, column)
+    }
+
+    pub(crate) fn range(&self, start: usize, end: usize) -> SourceRange {
+        let (line, column) = self.location(start);
+        SourceRange {
+            start,
+            end,
+            line,
+            column,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SourceLocator;
+
+    #[test]
+    fn source_locations_use_unicode_scalar_columns() {
+        let locator = SourceLocator::new("a😀b\nc");
+        assert_eq!(locator.location("a😀".len()), (1, 3));
+        assert_eq!(locator.location("a😀b\n".len()), (2, 1));
+    }
+}

--- a/crates/palamedes/src/source.rs
+++ b/crates/palamedes/src/source.rs
@@ -62,6 +62,8 @@ pub struct SourceRuleOptions {
     pub placeholder_only: SourceRuleLevel,
     /// Diagnose messages containing only one empty component placeholder.
     pub empty_component_only: SourceRuleLevel,
+    /// Suggest JSX-native `<Trans>` authoring in directly renderable positions.
+    pub prefer_trans_in_jsx: SourceRuleLevel,
 }
 
 impl Default for SourceRuleOptions {
@@ -69,6 +71,7 @@ impl Default for SourceRuleOptions {
         Self {
             placeholder_only: SourceRuleLevel::Warning,
             empty_component_only: SourceRuleLevel::Off,
+            prefer_trans_in_jsx: SourceRuleLevel::Info,
         }
     }
 }
@@ -78,6 +81,7 @@ impl SourceRuleOptions {
         Self {
             placeholder_only: SourceRuleLevel::Off,
             empty_component_only: SourceRuleLevel::Off,
+            prefer_trans_in_jsx: SourceRuleLevel::Off,
         }
     }
 }

--- a/crates/palamedes/src/source.rs
+++ b/crates/palamedes/src/source.rs
@@ -3,6 +3,21 @@ use serde::{Deserialize, Serialize};
 use crate::extract::ExtractedMessageRecord;
 use crate::mdx::MdxOptions;
 
+/// Diagnostic code for messages made only of runtime placeholders.
+pub const SOURCE_DIAGNOSTIC_CODE_NO_PLACEHOLDER_ONLY_MESSAGE: &str =
+    "pmds/no-placeholder-only-message";
+/// Diagnostic code for messages made only of one empty component placeholder.
+pub const SOURCE_DIAGNOSTIC_CODE_NO_EMPTY_COMPONENT_ONLY_MESSAGE: &str =
+    "pmds/no-empty-component-only-message";
+/// Diagnostic code for JSX render positions where `<Trans>` may be clearer.
+pub const SOURCE_DIAGNOSTIC_CODE_PREFER_TRANS_IN_JSX: &str = "pmds/prefer-trans-in-jsx";
+/// All diagnostic codes emitted by built-in source-authoring rules.
+pub const SOURCE_DIAGNOSTIC_CODES: &[&str] = &[
+    SOURCE_DIAGNOSTIC_CODE_NO_PLACEHOLDER_ONLY_MESSAGE,
+    SOURCE_DIAGNOSTIC_CODE_NO_EMPTY_COMPONENT_ONLY_MESSAGE,
+    SOURCE_DIAGNOSTIC_CODE_PREFER_TRANS_IN_JSX,
+];
+
 /// Source range with an exact UTF-8 byte span and one-based start location.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -125,6 +140,15 @@ pub struct SourceAnalysisResult {
     pub messages: Vec<ExtractedMessageRecord>,
     /// Source-authoring diagnostics in deterministic source order.
     pub diagnostics: Vec<SourceDiagnostic>,
+}
+
+/// Source text and structured result produced by one cached file analysis.
+#[derive(Debug)]
+pub struct SourceFileAnalysisResult {
+    /// Exact source text used for both analysis and caller-side suppressions.
+    pub source: String,
+    /// Messages and diagnostics derived from `source`.
+    pub analysis: SourceAnalysisResult,
 }
 
 /// Byte-offset to source-location index shared by source analyzers.

--- a/crates/palamedes/src/source.rs
+++ b/crates/palamedes/src/source.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::extract::ExtractedMessageRecord;
+use crate::mdx::MdxOptions;
 
 /// Source range with an exact UTF-8 byte span and one-based start location.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -26,6 +27,69 @@ pub enum SourceDiagnosticSeverity {
     Warning,
     /// Informational authoring guidance.
     Info,
+}
+
+/// Configurable level for one source-authoring rule.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SourceRuleLevel {
+    /// Do not run the rule.
+    Off,
+    /// Emit an informational diagnostic.
+    Info,
+    /// Emit a warning diagnostic.
+    Warning,
+    /// Emit an error diagnostic.
+    Error,
+}
+
+impl SourceRuleLevel {
+    pub(crate) fn severity(self) -> Option<SourceDiagnosticSeverity> {
+        match self {
+            Self::Off => None,
+            Self::Info => Some(SourceDiagnosticSeverity::Info),
+            Self::Warning => Some(SourceDiagnosticSeverity::Warning),
+            Self::Error => Some(SourceDiagnosticSeverity::Error),
+        }
+    }
+}
+
+/// Levels for the built-in source-authoring rules.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(default, rename_all = "camelCase")]
+pub struct SourceRuleOptions {
+    /// Diagnose messages whose authored content consists only of values.
+    pub placeholder_only: SourceRuleLevel,
+    /// Diagnose messages containing only one empty component placeholder.
+    pub empty_component_only: SourceRuleLevel,
+}
+
+impl Default for SourceRuleOptions {
+    fn default() -> Self {
+        Self {
+            placeholder_only: SourceRuleLevel::Warning,
+            empty_component_only: SourceRuleLevel::Off,
+        }
+    }
+}
+
+impl SourceRuleOptions {
+    pub(crate) fn disabled() -> Self {
+        Self {
+            placeholder_only: SourceRuleLevel::Off,
+            empty_component_only: SourceRuleLevel::Off,
+        }
+    }
+}
+
+/// Options controlling source analysis and built-in diagnostics.
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(default, rename_all = "camelCase")]
+pub struct SourceAnalysisOptions {
+    /// MDX extraction and compilation semantics.
+    pub mdx: MdxOptions,
+    /// Built-in source-authoring rule levels.
+    pub rules: SourceRuleOptions,
 }
 
 /// Structured diagnostic produced while analyzing an authored source file.
@@ -88,6 +152,10 @@ impl<'a> SourceLocator<'a> {
         let line_start = self.line_starts[line_index];
         let column = self.source[line_start..offset].chars().count() + 1;
         (line_index + 1, column)
+    }
+
+    pub(crate) fn line(&self, offset: usize) -> usize {
+        self.location(offset).0
     }
 
     pub(crate) fn range(&self, start: usize, end: usize) -> SourceRange {

--- a/crates/palamedes/src/source_macros.rs
+++ b/crates/palamedes/src/source_macros.rs
@@ -1,0 +1,57 @@
+use std::collections::HashMap;
+
+use oxc_ast::ast::{ImportDeclaration, ImportDeclarationSpecifier};
+
+pub(crate) const PALAMEDES_MACRO_PACKAGES: [&str; 3] = [
+    "@palamedes/core/macro",
+    "@palamedes/react/macro",
+    "@palamedes/solid/macro",
+];
+
+#[derive(Clone, Debug)]
+pub(crate) struct ImportedMacro {
+    pub(crate) imported_name: String,
+    pub(crate) source: String,
+}
+
+pub(crate) fn record_macro_import_declaration(
+    declaration: &ImportDeclaration<'_>,
+    macro_imports: &mut HashMap<String, ImportedMacro>,
+    removed_macro_import: &mut Option<(String, usize)>,
+    macro_import_ranges: Option<&mut Vec<(usize, usize)>>,
+) -> bool {
+    let source = declaration.source.value.as_str();
+    if !PALAMEDES_MACRO_PACKAGES.contains(&source) {
+        return false;
+    }
+
+    if let Some(ranges) = macro_import_ranges {
+        ranges.push((
+            declaration.span.start as usize,
+            declaration.span.end as usize,
+        ));
+    }
+
+    if let Some(specifiers) = &declaration.specifiers {
+        for specifier in specifiers {
+            if let ImportDeclarationSpecifier::ImportSpecifier(specifier) = specifier {
+                let imported_name = specifier.imported.name().to_string();
+                if matches!(imported_name.as_str(), "msg" | "defineMessage")
+                    && removed_macro_import.is_none()
+                {
+                    *removed_macro_import =
+                        Some((imported_name.clone(), declaration.span.start as usize));
+                }
+                macro_imports.insert(
+                    specifier.local.name.to_string(),
+                    ImportedMacro {
+                        imported_name,
+                        source: source.to_string(),
+                    },
+                );
+            }
+        }
+    }
+
+    true
+}

--- a/crates/palamedes/src/transform/imports.rs
+++ b/crates/palamedes/src/transform/imports.rs
@@ -1,22 +1,12 @@
 use std::collections::{HashMap, HashSet};
 
+use crate::source_macros::record_macro_import_declaration;
+pub(super) use crate::source_macros::ImportedMacro;
 use oxc_ast::ast::{
     BindingIdentifier, IdentifierReference, ImportDeclaration, ImportDeclarationSpecifier,
     ImportOrExportKind, JSXIdentifier,
 };
 use oxc_ast_visit::{walk, Visit};
-
-pub(super) const PALAMEDES_MACRO_PACKAGES: [&str; 3] = [
-    "@palamedes/core/macro",
-    "@palamedes/react/macro",
-    "@palamedes/solid/macro",
-];
-
-#[derive(Debug, Clone)]
-pub(super) struct ImportedMacro {
-    pub imported_name: String,
-    pub source: String,
-}
 
 pub(super) struct ImportCollector {
     runtime_module: String,
@@ -71,31 +61,12 @@ impl<'a> Visit<'a> for ImportCollector {
     fn visit_import_declaration(&mut self, it: &ImportDeclaration<'a>) {
         let source = it.source.value.as_str();
 
-        if PALAMEDES_MACRO_PACKAGES.contains(&source) {
-            self.macro_import_ranges
-                .push((it.span.start as usize, it.span.end as usize));
-
-            if let Some(specifiers) = &it.specifiers {
-                for specifier in specifiers {
-                    if let ImportDeclarationSpecifier::ImportSpecifier(specifier) = specifier {
-                        let imported_name = specifier.imported.name().to_string();
-                        if matches!(imported_name.as_str(), "msg" | "defineMessage")
-                            && self.removed_macro_import.is_none()
-                        {
-                            self.removed_macro_import =
-                                Some((imported_name.clone(), it.span.start as usize));
-                        }
-                        self.macro_imports.insert(
-                            specifier.local.name.to_string(),
-                            ImportedMacro {
-                                imported_name,
-                                source: source.to_string(),
-                            },
-                        );
-                    }
-                }
-            }
-        }
+        record_macro_import_declaration(
+            it,
+            &mut self.macro_imports,
+            &mut self.removed_macro_import,
+            Some(&mut self.macro_import_ranges),
+        );
 
         if source == self.runtime_module && it.import_kind == ImportOrExportKind::Value {
             if let Some(specifiers) = &it.specifiers {

--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -7,6 +7,7 @@ commands.
 ## Commands
 
 - `pmds extract`
+- `pmds lint`
 - `pmds audit`
 - `pmds report`
 - `pmds catalog merge`

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -62,15 +62,43 @@ pmds lint --fail-on warning
 
 Options:
 
-| Option                | Description                                                     |
-| --------------------- | --------------------------------------------------------------- |
-| `-c, --config <path>` | Use a specific config file.                                     |
-| `--json`              | Print one deterministic result document.                        |
-| `--fail-on <level>`   | Fail on `error` or `warning`. Default: `error`.                  |
+| Option                | Description                                               |
+| --------------------- | --------------------------------------------------------- |
+| `-c, --config <path>` | Use a specific config file.                               |
+| `--json`              | Print one deterministic result document.                  |
+| `--fail-on <level>`   | Fail on `error` or `warning`. Default: `error`.           |
+| `--no-cache`          | Ignore and do not write the shared source-analysis cache. |
 
 Human diagnostics contain file, line, column, severity, stable code, message,
 and actionable help. JSON contains `diagnostics`, `failedFiles`, and a
 `summary` with file and severity counts plus the number of suppressed findings.
+Diagnostics are ordered by file, byte range, and code; failed files are ordered
+by file. The document shape is stable:
+
+```json
+{
+  "diagnostics": [
+    {
+      "code": "pmds/no-placeholder-only-message",
+      "severity": "warning",
+      "file": "src/view.tsx",
+      "primary": { "start": 91, "end": 103, "line": 3, "column": 14 },
+      "message": "This message contains placeholders but no translatable text.",
+      "help": "Move translation to the surrounding authored sentence, or remove the translation macro if this value should be rendered as-is."
+    }
+  ],
+  "failedFiles": [],
+  "summary": {
+    "files": 1,
+    "errors": 0,
+    "warnings": 1,
+    "infos": 0,
+    "suppressed": 0,
+    "failedFiles": 0
+  }
+}
+```
+
 Exit code `0` means the configured threshold passed, `1` means diagnostics met
 the threshold or a file could not be analyzed, and `2` is reserved by Clap for
 invalid command-line usage.
@@ -84,7 +112,10 @@ const label = t`${status}`
 const inline = t`${status}` // palamedes-lint-disable-line pmds/no-placeholder-only-message
 ```
 
-Unknown codes and directives without a code are reported by `pmds lint`.
+Unknown codes, directives without a code, and valid suppressions that no longer
+match a finding are reported by `pmds lint`.
+The default `.palamedes/extract-cache.json` stores compatible messages and
+diagnostics together, so `extract` and `lint` can reuse the same native parse.
 
 ## `pmds audit`
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -48,6 +48,44 @@ Options:
 | `--no-cache`          | Ignore and do not write the extraction cache in `.palamedes/`. Use for a cold run; the cache is on by default.                                               |
 | `-v, --verbose`       | Print verbose extraction details.                                                                                                                            |
 
+## `pmds lint`
+
+Checks Palamedes source authoring without creating or updating catalogs. It
+uses the union of the configured `catalogs[].include` and `exclude` file sets,
+deduplicates overlapping catalogs, and supports JS, TS, JSX, TSX, and MDX.
+
+```bash
+pmds lint
+pmds lint --json
+pmds lint --fail-on warning
+```
+
+Options:
+
+| Option                | Description                                                     |
+| --------------------- | --------------------------------------------------------------- |
+| `-c, --config <path>` | Use a specific config file.                                     |
+| `--json`              | Print one deterministic result document.                        |
+| `--fail-on <level>`   | Fail on `error` or `warning`. Default: `error`.                  |
+
+Human diagnostics contain file, line, column, severity, stable code, message,
+and actionable help. JSON contains `diagnostics`, `failedFiles`, and a
+`summary` with file and severity counts plus the number of suppressed findings.
+Exit code `0` means the configured threshold passed, `1` means diagnostics met
+the threshold or a file could not be analyzed, and `2` is reserved by Clap for
+invalid command-line usage.
+
+Suppressions are deliberately code-specific and line-scoped:
+
+```tsx
+// palamedes-lint-disable-next-line pmds/no-placeholder-only-message
+const label = t`${status}`
+
+const inline = t`${status}` // palamedes-lint-disable-line pmds/no-placeholder-only-message
+```
+
+Unknown codes and directives without a code are reported by `pmds lint`.
+
 ## `pmds audit`
 
 Audits catalogs for missing translations, fuzzy review markers, and ICU

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -41,6 +41,7 @@ catalogs:
 | `source-reference-root` | No       | `git \| config \| lingui \| path`      | Root used for catalog source references. Defaults to nearest Git root, then config. |
 | `reference-scopes`      | No       | `boolean`                              | Adds stable source scopes to catalog references. Defaults to `true`.                |
 | `mdx`                   | No       | MDX options                            | Shared native MDX extraction and Vite compilation behavior.                         |
+| `lint`                  | No       | source lint options                    | Source-authoring rule levels used by `pmds lint`.                                   |
 | `plugins`               | No       | `(string \| [string, options])[]`      | Explicit CLI plugin packages. Never auto-discovered.                                |
 | `extract-threads`       | No       | `number`                               | Worker threads for the parallel extraction pass. Defaults to `4`; `1` runs serial.  |
 | `extract-cache`         | No       | `boolean`                              | Reuse the on-disk extraction cache. Defaults to `true`.                             |
@@ -72,6 +73,26 @@ reference root, or extraction-relevant MDX options change. Use `--no-cache` for 
 this to `false` if a tool in your pipeline rewrites files without changing their
 size or modification time. See
 [ADR-019](https://github.com/sebastian-software/palamedes/blob/main/adr/019-extraction-cache.md).
+
+## Source Lint
+
+`pmds lint` scans the same configured source files as extraction without
+writing catalogs. Rule levels use `off`, `info`, `warning`, or `error`:
+
+```yaml
+lint:
+  rules:
+    placeholder-only: warning
+    empty-component-only: off
+    prefer-trans-in-jsx: info
+```
+
+Those are also the defaults. `placeholder-only` catches messages made only of
+runtime values. `empty-component-only` is opt-in because component-only
+authoring needs more project context. `prefer-trans-in-jsx` is an informational
+readability suggestion for safe direct render positions; `t` remains fully
+supported. Advanced dictionary and ambiguity policies are not part of this
+open-source config surface.
 
 ## Catalogs
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,7 +44,7 @@ catalogs:
 | `lint`                  | No       | source lint options                    | Source-authoring rule levels used by `pmds lint`.                                   |
 | `plugins`               | No       | `(string \| [string, options])[]`      | Explicit CLI plugin packages. Never auto-discovered.                                |
 | `extract-threads`       | No       | `number`                               | Worker threads for the parallel extraction pass. Defaults to `4`; `1` runs serial.  |
-| `extract-cache`         | No       | `boolean`                              | Reuse the on-disk extraction cache. Defaults to `true`.                             |
+| `extract-cache`         | No       | `boolean`                              | Reuse the shared extraction/source-analysis cache. Defaults to `true`.              |
 
 The native CLI and JS config loader both accept snake_case aliases for these
 hyphenated config keys: `source_locale`, `fallback_locales`, `pseudo_locale`,
@@ -63,15 +63,16 @@ hardware; see
 [ADR-013](https://github.com/sebastian-software/palamedes/blob/main/adr/013-bounded-parallel-extraction.md)
 for the numbers. `--threads` on the command line overrides this value.
 
-`extract-cache` controls whether extraction reuses its own results for files
-that have not changed. The cache lives at `.palamedes/extract-cache.json` under
-the project root — add `.palamedes/` to your `.gitignore`. Entries are validated
-with a `stat` (size and modification time), so a repeat run skips both reading
-and parsing unchanged files; watch mode holds the cache for the life of the
-process. It is discarded automatically whenever the extractor version, source
-reference root, or extraction-relevant MDX options change. Use `--no-cache` for a one-off cold run, or set
-this to `false` if a tool in your pipeline rewrites files without changing their
-size or modification time. See
+`extract-cache` controls whether extraction and source lint reuse their shared
+analysis for files that have not changed. The cache lives at
+`.palamedes/extract-cache.json` under the project root — add `.palamedes/` to
+your `.gitignore`. Entries are validated with a `stat` (size and modification
+time), so a repeat run skips parsing unchanged files; watch mode holds the cache
+for the life of the process. It is discarded automatically whenever the
+extractor version, source reference root, reference-scope behavior, MDX options,
+or lint rule levels change. Use `--no-cache` on `pmds extract` or `pmds lint` for
+a one-off cold run, or set this to `false` if a tool in your pipeline rewrites
+files without changing their size or modification time. See
 [ADR-019](https://github.com/sebastian-software/palamedes/blob/main/adr/019-extraction-cache.md).
 
 ## Source Lint

--- a/docs/proof-and-benchmarks.md
+++ b/docs/proof-and-benchmarks.md
@@ -14,7 +14,7 @@ This repo can credibly prove five things:
 - Palamedes is browser-verified across Next.js, TanStack Start, SolidStart, Waku, and React Router, with server-first Remix v3 smoke-verified
 - the runtime model stays centered on `getI18n()`
 - the message identity model stays centered on `message + context`
-- transform, extract, catalog update, and catalog compile steps are measured locally and reproducibly
+- transform, extract, source analysis, catalog update, and catalog compile steps are measured locally and reproducibly
 - nested ICU semantics survive source, extraction, macro transformation, PO catalog update, catalog compile, and runtime rendering
 
 This page is not here to manufacture headline numbers. It is here to make the
@@ -51,6 +51,7 @@ The benchmark flow here focuses on the operations Palamedes claims to improve:
 
 - transform
 - extract
+- source analysis, including the incremental cost of semantic authoring facts and diagnostics
 - catalog update
 - catalog artifact compile
 - end-to-end extract and catalog update workflows

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -77,6 +77,9 @@ pnpm exec pmds extract --config ./palamedes.yaml
 pnpm exec pmds extract --threads 1
 pnpm exec pmds extract --no-cache
 pnpm exec pmds extract --verbose
+pnpm exec pmds lint
+pnpm exec pmds lint --json
+pnpm exec pmds lint --fail-on warning
 pnpm exec pmds audit
 pnpm exec pmds audit --json
 pnpm exec pmds audit --fail-on warning
@@ -90,6 +93,10 @@ pnpm exec pmds catalog convert src/locales/de.po --to fcl --output src/locales/d
 `pmds audit` reports missing translations, extra catalog entries, obsolete
 messages, fuzzy review markers, and ICU compatibility issues through the same `ferrocat`
 catalog engine that powers Palamedes builds.
+
+`pmds lint` is non-mutating and checks Palamedes authoring across the same
+configured sources as extraction. It supports stable human and JSON output,
+configured rule levels, code-specific line suppressions, and CI thresholds.
 
 `pmds catalog convert` preserves translator comments, obsolete state, and
 review markers such as `fuzzy` when converting PO catalogs to FCL.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -80,6 +80,7 @@ pnpm exec pmds extract --verbose
 pnpm exec pmds lint
 pnpm exec pmds lint --json
 pnpm exec pmds lint --fail-on warning
+pnpm exec pmds lint --no-cache
 pnpm exec pmds audit
 pnpm exec pmds audit --json
 pnpm exec pmds audit --fail-on warning
@@ -103,8 +104,9 @@ review markers such as `fuzzy` when converting PO catalogs to FCL.
 
 `--threads <COUNT>` sets the worker threads for the parallel extraction pass,
 overriding `extract-threads` in the config; it defaults to `4` and `1` runs
-serial. `--no-cache` ignores and does not write the extraction cache in
-`.palamedes/` — use it for a cold run; the cache is on by default.
+serial. `--no-cache` on `extract` or `lint` ignores and does not write their
+shared source-analysis cache in `.palamedes/` — use it for a cold run; the cache
+is on by default.
 
 For local performance checks, set `PALAMEDES_TIMING_JSON=1` on `pmds extract`.
 The command prints a machine-readable timing line with total, glob, extract,

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -41,6 +41,16 @@ export type PalamedesMdxConfig = {
   ignoreDirective?: string
 }
 
+export type PalamedesSourceRuleLevel = "off" | "info" | "warning" | "error"
+
+export type PalamedesLintConfig = {
+  rules?: {
+    placeholderOnly?: PalamedesSourceRuleLevel
+    emptyComponentOnly?: PalamedesSourceRuleLevel
+    preferTransInJsx?: PalamedesSourceRuleLevel
+  }
+}
+
 export type PalamedesPluginDeclaration = string | readonly [specifier: string, options: unknown]
 
 export type PalamedesConfig = {
@@ -51,6 +61,7 @@ export type PalamedesConfig = {
   sourceReferenceRoot?: PalamedesSourceReferenceRoot
   referenceScopes?: boolean
   mdx?: PalamedesMdxConfig
+  lint?: PalamedesLintConfig
   catalogs: PalamedesCatalogConfig[]
   plugins?: PalamedesPluginDeclaration[]
 }
@@ -68,6 +79,7 @@ type PalamedesDataConfig = {
   "reference-scopes"?: unknown
   reference_scopes?: unknown
   mdx?: unknown
+  lint?: unknown
   catalogs?: unknown
   plugins?: unknown
 }
@@ -208,6 +220,8 @@ function normalizeDataConfig(config: PalamedesDataConfig, configPath: string): P
   )
   const referenceScopes = getConfigValue(config, "reference-scopes", "reference_scopes")
   const mdx = config.mdx === undefined ? undefined : normalizeMdxDataConfig(config.mdx, configPath)
+  const lint =
+    config.lint === undefined ? undefined : normalizeLintDataConfig(config.lint, configPath)
 
   return {
     locales: config.locales as string[],
@@ -221,6 +235,7 @@ function normalizeDataConfig(config: PalamedesDataConfig, configPath: string): P
       : {}),
     ...(referenceScopes !== undefined ? { referenceScopes: referenceScopes as boolean } : {}),
     ...(mdx !== undefined ? { mdx } : {}),
+    ...(lint !== undefined ? { lint } : {}),
     catalogs: normalizeDataCatalogs(config.catalogs, configPath) as PalamedesCatalogConfig[],
     ...(config.plugins !== undefined
       ? { plugins: config.plugins as PalamedesPluginDeclaration[] }
@@ -326,6 +341,47 @@ function normalizeMdxDataConfig(value: unknown, configPath: string): PalamedesMd
     ...(transModule !== undefined ? { transModule: transModule as string } : {}),
     ...(runtimeModule !== undefined ? { runtimeModule: runtimeModule as string } : {}),
     ...(ignoreDirective !== undefined ? { ignoreDirective: ignoreDirective as string } : {}),
+  }
+}
+
+function normalizeLintDataConfig(value: unknown, configPath: string): PalamedesLintConfig {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new TypeError(`Invalid Palamedes config in ${configPath}: "lint" must be an object.`)
+  }
+  const lint = value as Record<string, unknown>
+  const rules = lint.rules
+  if (rules === undefined) {
+    return {}
+  }
+  if (!rules || typeof rules !== "object" || Array.isArray(rules)) {
+    throw new TypeError(
+      `Invalid Palamedes config in ${configPath}: "lint.rules" must be an object.`
+    )
+  }
+  const record = rules as Record<string, unknown>
+  for (const [camel, kebab] of [
+    ["placeholderOnly", "placeholder-only"],
+    ["emptyComponentOnly", "empty-component-only"],
+    ["preferTransInJsx", "prefer-trans-in-jsx"],
+  ]) {
+    if (camel in record) {
+      throw new Error(
+        `Invalid Palamedes config in ${configPath}: unknown key "lint.rules.${camel}". Data configs use kebab-case: "lint.rules.${kebab}".`
+      )
+    }
+  }
+  return {
+    rules: {
+      ...(record["placeholder-only"] !== undefined
+        ? { placeholderOnly: record["placeholder-only"] as PalamedesSourceRuleLevel }
+        : {}),
+      ...(record["empty-component-only"] !== undefined
+        ? { emptyComponentOnly: record["empty-component-only"] as PalamedesSourceRuleLevel }
+        : {}),
+      ...(record["prefer-trans-in-jsx"] !== undefined
+        ? { preferTransInJsx: record["prefer-trans-in-jsx"] as PalamedesSourceRuleLevel }
+        : {}),
+    },
   }
 }
 
@@ -464,6 +520,7 @@ async function normalizeConfig(
     sourceReferenceRoot: await resolveSourceReferenceRoot(config.sourceReferenceRoot, rootDir),
     referenceScopes: config.referenceScopes ?? true,
     ...(config.mdx ? { mdx: cloneMdxConfig(config.mdx) } : {}),
+    ...(config.lint ? { lint: cloneLintConfig(config.lint) } : {}),
     catalogs: config.catalogs.map((catalog) => ({
       path: catalog.path,
       ...(catalog.format !== undefined ? { format: catalog.format } : {}),
@@ -487,6 +544,7 @@ function normalizeConfigSync(config: PalamedesConfig, configPath: string): Loade
     sourceReferenceRoot: resolveSourceReferenceRootSync(config.sourceReferenceRoot, rootDir),
     referenceScopes: config.referenceScopes ?? true,
     ...(config.mdx ? { mdx: cloneMdxConfig(config.mdx) } : {}),
+    ...(config.lint ? { lint: cloneLintConfig(config.lint) } : {}),
     catalogs: config.catalogs.map((catalog) => ({
       path: catalog.path,
       ...(catalog.format !== undefined ? { format: catalog.format } : {}),
@@ -505,6 +563,13 @@ function cloneMdxConfig(config: PalamedesMdxConfig): PalamedesMdxConfig {
       ? { translatableAttributes: [...config.translatableAttributes] }
       : {}),
     ...(config.frontMatterFields ? { frontMatterFields: [...config.frontMatterFields] } : {}),
+  }
+}
+
+function cloneLintConfig(config: PalamedesLintConfig): PalamedesLintConfig {
+  return {
+    ...config,
+    ...(config.rules ? { rules: { ...config.rules } } : {}),
   }
 }
 
@@ -638,6 +703,7 @@ function validateConfig(config: unknown, configPath: string): asserts config is 
   }
 
   validateMdx(record.mdx, configPath)
+  validateLint(record.lint, configPath)
   validateFallbackLocales(record.fallbackLocales, configPath, record.locales as string[])
   validatePlugins(record.plugins, configPath)
 
@@ -683,6 +749,33 @@ function validateMdx(value: unknown, configPath: string): void {
     ) {
       throw new TypeError(
         `Invalid Palamedes config in ${configPath}: "mdx.${field}" must be a non-empty string.`
+      )
+    }
+  }
+}
+
+function validateLint(value: unknown, configPath: string): void {
+  if (value === undefined) {
+    return
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new TypeError(`Invalid Palamedes config in ${configPath}: "lint" must be an object.`)
+  }
+  const rules = (value as Record<string, unknown>).rules
+  if (rules === undefined) {
+    return
+  }
+  if (!rules || typeof rules !== "object" || Array.isArray(rules)) {
+    throw new TypeError(
+      `Invalid Palamedes config in ${configPath}: "lint.rules" must be an object.`
+    )
+  }
+  const record = rules as Record<string, unknown>
+  for (const field of ["placeholderOnly", "emptyComponentOnly", "preferTransInJsx"] as const) {
+    const level = record[field]
+    if (level !== undefined && !["off", "info", "warning", "error"].includes(level as string)) {
+      throw new TypeError(
+        `Invalid Palamedes config in ${configPath}: "lint.rules.${field}" must be "off", "info", "warning", or "error".`
       )
     }
   }

--- a/packages/config/src/loadConfig.test.ts
+++ b/packages/config/src/loadConfig.test.ts
@@ -86,6 +86,35 @@ describe("loadPalamedesConfig", () => {
     ])
   })
 
+  it("normalizes source lint rules from data configs", async () => {
+    const fixtureDir = await createTempDir()
+    await writeFile(
+      path.join(fixtureDir, "palamedes.yaml"),
+      `
+        locales: [en]
+        source-locale: en
+        lint:
+          rules:
+            placeholder-only: error
+            empty-component-only: warning
+            prefer-trans-in-jsx: off
+        catalogs:
+          - path: src/locales/{locale}
+            include: [src]
+      `
+    )
+
+    const config = await loadPalamedesConfig({ cwd: fixtureDir })
+
+    expect(config.lint).toStrictEqual({
+      rules: {
+        placeholderOnly: "error",
+        emptyComponentOnly: "warning",
+        preferTransInJsx: "off",
+      },
+    })
+  })
+
   it("loads PO output options from JavaScript and data configs", async () => {
     const jsDir = await createTempDir()
     await writeFile(

--- a/packages/core-node/README.md
+++ b/packages/core-node/README.md
@@ -105,7 +105,7 @@ console.log(po.headers.Language)
 - `compileCatalogModule(config, resourcePath, options)`
 - `renderCatalogModule(messages)`
 - `extractMessagesNative(source, filename, mdxOptions?)`
-- `analyzeSourceNative(source, filename, mdxOptions?)`
+- `analyzeSourceNative(source, filename, options?)`
 - `analyzeMdxNative(source, filename, options?)`
 - `extractCatalogMessagesFromFiles(request)`
 - `transformMacrosNative(source, filename, options?)`
@@ -137,6 +137,9 @@ diagnostics, React or Solid JSX, compiled message IDs, and a source map.
 point. It returns extracted messages plus deterministic diagnostics with a
 stable code, lowercase severity, filename, exact UTF-8 byte range, one-based
 line and Unicode-scalar column, actionable help, and an optional related range.
+The recommended `placeholderOnly` rule defaults to `"warning"`; the narrower
+`emptyComponentOnly` rule defaults to `"off"`. Both accept `"off"`, `"info"`,
+`"warning"`, or `"error"` through `options.rules`.
 
 `compileCatalogModule(config, resourcePath, options)` is the direct module
 rendering API used by the first-party Vite, Next, and Remix `.po` loaders. Pass

--- a/packages/core-node/README.md
+++ b/packages/core-node/README.md
@@ -138,8 +138,11 @@ point. It returns extracted messages plus deterministic diagnostics with a
 stable code, lowercase severity, filename, exact UTF-8 byte range, one-based
 line and Unicode-scalar column, actionable help, and an optional related range.
 The recommended `placeholderOnly` rule defaults to `"warning"`; the narrower
-`emptyComponentOnly` rule defaults to `"off"`. Both accept `"off"`, `"info"`,
-`"warning"`, or `"error"` through `options.rules`.
+`emptyComponentOnly` rule defaults to `"off"`; and the readability-oriented
+`preferTransInJsx` suggestion defaults to `"info"`. All three accept `"off"`,
+`"info"`, `"warning"`, or `"error"` through `options.rules`. The JSX rule never
+treats `t` as invalid and the initial diagnostic does not auto-fix imports or
+unsafe attribute, restricted-element, or non-render rewrites.
 
 `compileCatalogModule(config, resourcePath, options)` is the direct module
 rendering API used by the first-party Vite, Next, and Remix `.po` loaders. Pass

--- a/packages/core-node/README.md
+++ b/packages/core-node/README.md
@@ -105,6 +105,7 @@ console.log(po.headers.Language)
 - `compileCatalogModule(config, resourcePath, options)`
 - `renderCatalogModule(messages)`
 - `extractMessagesNative(source, filename, mdxOptions?)`
+- `analyzeSourceNative(source, filename, mdxOptions?)`
 - `analyzeMdxNative(source, filename, options?)`
 - `extractCatalogMessagesFromFiles(request)`
 - `transformMacrosNative(source, filename, options?)`
@@ -131,6 +132,11 @@ mapping to the native Ferrocat-backed API internally.
 `analyzeMdxNative` uses the same FerroMark-backed semantic workflow as native
 catalog extraction. It returns extracted messages, structured source-ranged
 diagnostics, React or Solid JSX, compiled message IDs, and a source map.
+
+`analyzeSourceNative` is the shared JS, TS, JSX, TSX, and MDX authoring entry
+point. It returns extracted messages plus deterministic diagnostics with a
+stable code, lowercase severity, filename, exact UTF-8 byte range, one-based
+line and Unicode-scalar column, actionable help, and an optional related range.
 
 `compileCatalogModule(config, resourcePath, options)` is the direct module
 rendering API used by the first-party Vite, Next, and Remix `.po` loaders. Pass

--- a/packages/core-node/src/generated/palamedes-node-types.ts
+++ b/packages/core-node/src/generated/palamedes-node-types.ts
@@ -373,6 +373,14 @@ export interface ParsedPoFile {
   headerOrder: Array<string>;
   items: Array<ParsedPoItem>;
 }
+export interface NativeSourceRuleOptions {
+  placeholderOnly?: string;
+  emptyComponentOnly?: string;
+}
+export interface NativeSourceAnalysisOptions {
+  mdx?: NativeMdxOptions;
+  rules?: NativeSourceRuleOptions;
+}
 export interface NativeSourceRange {
   start: number;
   end: number;
@@ -441,6 +449,6 @@ export interface NativeBindings {
   analyzeMdx(source: string, filename: string, options?: NativeMdxOptions | undefined | null): NativeMdxAnalysisResult;
   getNativeInfo(): NativeInfo;
   parsePo(source: string): ParsedPoFile;
-  analyzeSource(source: string, filename: string, mdx?: NativeMdxOptions | undefined | null): NativeSourceAnalysisResult;
+  analyzeSource(source: string, filename: string, options?: NativeSourceAnalysisOptions | undefined | null): NativeSourceAnalysisResult;
   transformMacros(source: string, filename: string, options?: NativeTransformOptions | undefined | null): NativeTransformResult;
 }

--- a/packages/core-node/src/generated/palamedes-node-types.ts
+++ b/packages/core-node/src/generated/palamedes-node-types.ts
@@ -376,6 +376,7 @@ export interface ParsedPoFile {
 export interface NativeSourceRuleOptions {
   placeholderOnly?: string;
   emptyComponentOnly?: string;
+  preferTransInJsx?: string;
 }
 export interface NativeSourceAnalysisOptions {
   mdx?: NativeMdxOptions;

--- a/packages/core-node/src/generated/palamedes-node-types.ts
+++ b/packages/core-node/src/generated/palamedes-node-types.ts
@@ -373,6 +373,25 @@ export interface ParsedPoFile {
   headerOrder: Array<string>;
   items: Array<ParsedPoItem>;
 }
+export interface NativeSourceRange {
+  start: number;
+  end: number;
+  line: number;
+  column: number;
+}
+export interface NativeSourceDiagnostic {
+  code: string;
+  severity: string;
+  file: string;
+  primary: NativeSourceRange;
+  message: string;
+  help: string;
+  related?: NativeSourceRange;
+}
+export interface NativeSourceAnalysisResult {
+  messages: Array<NativeExtractedMessage>;
+  diagnostics: Array<NativeSourceDiagnostic>;
+}
 export interface NativeTransformOptions {
   runtimeModule?: string;
   runtimeImportName?: string;
@@ -422,5 +441,6 @@ export interface NativeBindings {
   analyzeMdx(source: string, filename: string, options?: NativeMdxOptions | undefined | null): NativeMdxAnalysisResult;
   getNativeInfo(): NativeInfo;
   parsePo(source: string): ParsedPoFile;
+  analyzeSource(source: string, filename: string, mdx?: NativeMdxOptions | undefined | null): NativeSourceAnalysisResult;
   transformMacros(source: string, filename: string, options?: NativeTransformOptions | undefined | null): NativeTransformResult;
 }

--- a/packages/core-node/src/index.test.ts
+++ b/packages/core-node/src/index.test.ts
@@ -82,6 +82,21 @@ const message = <Trans><Button /></Trans>;`
     ])
   })
 
+  it("suggests Trans for a directly rendered t message", () => {
+    const source = `import { t as translate } from "@palamedes/solid/macro";
+function Greeting({ name }) { return <p>{translate\`Hello \${name}\`}</p>; }`
+    const result = analyzeSourceNative(source, "greeting.tsx")
+
+    expect(result.diagnostics).toMatchObject([
+      {
+        code: "pmds/prefer-trans-in-jsx",
+        severity: "info",
+      },
+    ])
+    expect(result.diagnostics[0]?.message).toContain("`t` remains supported")
+    expect(result.diagnostics[0]?.help).toContain("Solid's `<Trans>`")
+  })
+
   it("renders executable catalog modules from in-memory messages", () => {
     const code = renderCatalogModule({
       greeting: "Hallo {name}",

--- a/packages/core-node/src/index.test.ts
+++ b/packages/core-node/src/index.test.ts
@@ -65,6 +65,23 @@ function Greeting({ name }: { name: string }) {
     })
   })
 
+  it("configures source rule levels without changing extraction", () => {
+    const source = `import { Trans } from "@palamedes/react/macro";
+const message = <Trans><Button /></Trans>;`
+    const defaultResult = analyzeSourceNative(source, "component.tsx")
+    const configuredResult = analyzeSourceNative(source, "component.tsx", {
+      rules: { emptyComponentOnly: "error" },
+    })
+
+    expect(defaultResult.diagnostics).toStrictEqual([])
+    expect(configuredResult.diagnostics).toMatchObject([
+      {
+        code: "pmds/no-empty-component-only-message",
+        severity: "error",
+      },
+    ])
+  })
+
   it("renders executable catalog modules from in-memory messages", () => {
     const code = renderCatalogModule({
       greeting: "Hallo {name}",

--- a/packages/core-node/src/index.test.ts
+++ b/packages/core-node/src/index.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it } from "vitest"
 
 import {
   analyzeMdxNative,
+  analyzeSourceNative,
   compileCatalogArtifact,
   compileCatalogModule,
   extractMessagesNative,
@@ -39,6 +40,29 @@ describe("@palamedes/core-node", () => {
 
     expect(info.palamedesVersion).toMatch(/^\d+\.\d+\.\d+/)
     expect(info.ferrocatVersion).toMatch(/^\d+\.\d+\.\d+/)
+  })
+
+  it("analyzes extracted messages and source diagnostics through one native contract", () => {
+    const source = `import { t as translate } from "@palamedes/core/macro";
+function Greeting({ name }: { name: string }) {
+  return translate\`Hello \${name}\`;
+}`
+    const result = analyzeSourceNative(source, "greeting.tsx")
+
+    expect(result.messages).toHaveLength(1)
+    expect(result.messages[0]?.message).toBe("Hello {name}")
+    expect(result.diagnostics).toStrictEqual([])
+  })
+
+  it("maps MDX structural failures to the shared source diagnostic schema", () => {
+    const result = analyzeSourceNative("# Good\n\n<Component\n", "broken.mdx")
+
+    expect(result.messages).toStrictEqual([])
+    expect(result.diagnostics[0]).toMatchObject({
+      severity: "error",
+      file: "broken.mdx",
+      primary: { line: 3, column: 1 },
+    })
   })
 
   it("renders executable catalog modules from in-memory messages", () => {

--- a/packages/core-node/src/index.ts
+++ b/packages/core-node/src/index.ts
@@ -52,6 +52,9 @@ import type {
   NativeMdxFramework as GeneratedNativeMdxFramework,
   NativeMdxOptions as GeneratedNativeMdxOptions,
   NativeMdxSourceRange as GeneratedNativeMdxSourceRange,
+  NativeSourceAnalysisResult as GeneratedNativeSourceAnalysisResult,
+  NativeSourceDiagnostic as GeneratedNativeSourceDiagnostic,
+  NativeSourceRange as GeneratedNativeSourceRange,
   NativeTransformEdit as GeneratedNativeTransformEdit,
   NativeTransformOptions as GeneratedNativeTransformOptions,
   NativeTransformResult as GeneratedNativeTransformResult,
@@ -178,6 +181,19 @@ export type MdxSourceRange = GeneratedNativeMdxSourceRange
 export type MdxDiagnostic = GeneratedNativeMdxDiagnostic
 export type MdxAnalysisResult = Omit<GeneratedNativeMdxAnalysisResult, "messages"> & {
   messages: NativeExtractedMessage[]
+}
+
+export type SourceRange = GeneratedNativeSourceRange
+export type SourceDiagnosticSeverity = "error" | "warning" | "info"
+export type SourceDiagnostic = Omit<GeneratedNativeSourceDiagnostic, "severity"> & {
+  severity: SourceDiagnosticSeverity
+}
+export type SourceAnalysisResult = Omit<
+  GeneratedNativeSourceAnalysisResult,
+  "messages" | "diagnostics"
+> & {
+  messages: NativeExtractedMessage[]
+  diagnostics: SourceDiagnostic[]
 }
 
 export type NativeTransformOptions = GeneratedNativeTransformOptions
@@ -647,6 +663,19 @@ export function extractMessagesNative(
   options?: MdxOptions
 ): NativeExtractedMessage[] {
   return mapExtractedMessages(native.extractMessages(source, filename, toNativeMdxOptions(options)))
+}
+
+export function analyzeSourceNative(
+  source: string,
+  filename: string,
+  options?: MdxOptions
+): SourceAnalysisResult {
+  const result = native.analyzeSource(source, filename, toNativeMdxOptions(options))
+  return {
+    ...result,
+    messages: mapExtractedMessages(result.messages),
+    diagnostics: result.diagnostics as SourceDiagnostic[],
+  }
 }
 
 export function analyzeMdxNative(

--- a/packages/core-node/src/index.ts
+++ b/packages/core-node/src/index.ts
@@ -200,10 +200,11 @@ export type SourceAnalysisResult = Omit<
 export type SourceRuleLevel = "off" | "info" | "warning" | "error"
 export type SourceRuleOptions = Omit<
   GeneratedNativeSourceRuleOptions,
-  "placeholderOnly" | "emptyComponentOnly"
+  "placeholderOnly" | "emptyComponentOnly" | "preferTransInJsx"
 > & {
   placeholderOnly?: SourceRuleLevel
   emptyComponentOnly?: SourceRuleLevel
+  preferTransInJsx?: SourceRuleLevel
 }
 export type SourceAnalysisOptions = Omit<GeneratedNativeSourceAnalysisOptions, "mdx" | "rules"> & {
   mdx?: MdxOptions

--- a/packages/core-node/src/index.ts
+++ b/packages/core-node/src/index.ts
@@ -53,8 +53,10 @@ import type {
   NativeMdxOptions as GeneratedNativeMdxOptions,
   NativeMdxSourceRange as GeneratedNativeMdxSourceRange,
   NativeSourceAnalysisResult as GeneratedNativeSourceAnalysisResult,
+  NativeSourceAnalysisOptions as GeneratedNativeSourceAnalysisOptions,
   NativeSourceDiagnostic as GeneratedNativeSourceDiagnostic,
   NativeSourceRange as GeneratedNativeSourceRange,
+  NativeSourceRuleOptions as GeneratedNativeSourceRuleOptions,
   NativeTransformEdit as GeneratedNativeTransformEdit,
   NativeTransformOptions as GeneratedNativeTransformOptions,
   NativeTransformResult as GeneratedNativeTransformResult,
@@ -194,6 +196,18 @@ export type SourceAnalysisResult = Omit<
 > & {
   messages: NativeExtractedMessage[]
   diagnostics: SourceDiagnostic[]
+}
+export type SourceRuleLevel = "off" | "info" | "warning" | "error"
+export type SourceRuleOptions = Omit<
+  GeneratedNativeSourceRuleOptions,
+  "placeholderOnly" | "emptyComponentOnly"
+> & {
+  placeholderOnly?: SourceRuleLevel
+  emptyComponentOnly?: SourceRuleLevel
+}
+export type SourceAnalysisOptions = Omit<GeneratedNativeSourceAnalysisOptions, "mdx" | "rules"> & {
+  mdx?: MdxOptions
+  rules?: SourceRuleOptions
 }
 
 export type NativeTransformOptions = GeneratedNativeTransformOptions
@@ -668,9 +682,15 @@ export function extractMessagesNative(
 export function analyzeSourceNative(
   source: string,
   filename: string,
-  options?: MdxOptions
+  options?: SourceAnalysisOptions
 ): SourceAnalysisResult {
-  const result = native.analyzeSource(source, filename, toNativeMdxOptions(options))
+  const nativeOptions: GeneratedNativeSourceAnalysisOptions | undefined = options
+    ? {
+        ...options,
+        mdx: toNativeMdxOptions(options.mdx),
+      }
+    : undefined
+  const result = native.analyzeSource(source, filename, nativeOptions)
   return {
     ...result,
     messages: mapExtractedMessages(result.messages),

--- a/scripts/benchmark-proof.mjs
+++ b/scripts/benchmark-proof.mjs
@@ -33,6 +33,7 @@ const coreNode = await import(
 )
 
 const {
+  analyzeSourceNative,
   compileCatalogArtifact,
   extractMessagesNative,
   getNativeInfo,
@@ -189,6 +190,17 @@ async function runLargeCatalogBenchmark({ messageCount, sourceFileCount, warmup,
     runs
   )
 
+  const analyzeResult = await benchmark(
+    "large-source-analysis",
+    () => {
+      for (const fixture of largeFixture.fixtures) {
+        analyzeSourceNative(fixture.source, fixture.filename)
+      }
+    },
+    warmup,
+    runs
+  )
+
   const updateResult = await benchmark(
     "large-catalog-update",
     async () => {
@@ -222,7 +234,7 @@ async function runLargeCatalogBenchmark({ messageCount, sourceFileCount, warmup,
   )
   console.log("Fixture generator: benchmarks/large-catalog/fixture.mjs")
   console.log("")
-  printResults([transformResult, extractResult, updateResult, artifactResult])
+  printResults([transformResult, extractResult, analyzeResult, updateResult, artifactResult])
 }
 
 async function main() {
@@ -275,6 +287,17 @@ async function main() {
       runs
     )
 
+    const analyzeResult = await benchmark(
+      "source-analysis",
+      () => {
+        for (const fixture of fixtures) {
+          analyzeSourceNative(fixture.source, fixture.filename)
+        }
+      },
+      warmup,
+      runs
+    )
+
     const updateResult = await benchmark(
       "catalog-update",
       async () => {
@@ -316,7 +339,7 @@ async function main() {
     console.log(`Runs: ${runs}`)
     console.log("")
 
-    printResults([transformResult, extractResult, updateResult, artifactResult])
+    printResults([transformResult, extractResult, analyzeResult, updateResult, artifactResult])
 
     await runLargeCatalogBenchmark({
       messageCount: largeMessages,


### PR DESCRIPTION
## Summary

This implements the open-source source-authoring diagnostics discussed in #510. It:

- adds one native Rust analysis result for extracted messages and structured diagnostics
- preserves literal, value-placeholder, component-tree, source-surface, and exact macro-range facts until diagnostics run
- aligns MDX diagnostics with the shared source-range schema while preserving existing extract failures
- shares Palamedes macro import and alias classification between extraction and transformation
- exposes the analysis contract and configurable rule levels through `analyzeSourceNative`
- diagnoses placeholder-only messages by default and empty-component-only messages when opted in
- suggests `<Trans>` in conservative, directly renderable JSX positions while keeping `t` fully supported
- adds non-mutating `pmds lint` with human and deterministic JSON output, configured severities, `--fail-on`, and code-specific line suppressions
- reports malformed, unknown, and unused suppressions
- extends the extraction cache with compatible diagnostics so `extract` and `lint` reuse the same native parse
- records extract-versus-analysis cost in the normal and large proof benchmarks

## Increments

- [x] Complete the shared analysis, semantic source-fact, and benchmark work in #515
- [x] Diagnose messages without translatable content (#514)
- [x] Suggest `<Trans>` in safe, directly renderable JSX positions (#517)
- [x] Add the non-mutating `pmds lint` workflow (#518)

Each increment is preserved as a separate commit. The Oxlint/ESLint adapter work in #516 remains separate because it has a different packaging and compatibility risk.

## Verification

- `cargo test --workspace --locked` (Rust 1.97.1)
- `cargo clippy -p palamedes -p palamedes-cli -p palamedes-node --all-targets --locked -- -D warnings` (Rust 1.97.1)
- `pnpm build`
- `pnpm test`
- `pnpm check-types`
- `pnpm lint`
- `pnpm format:check`
- generated native type declarations checked against napi-rs output
- proof benchmark with normal and 10,000-message extract/source-analysis lanes
- cached and uncached lint JSON verified byte-for-byte equivalent

Closes #515
Closes #514
Closes #517
Closes #518
