### PR TITLE
Add Preview ESLint and Oxlint adapter for native diagnostics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,9 @@ jobs:
       - name: Build packages
         run: pnpm build
 
+      - name: Test ESLint and Oxlint adapter
+        run: pnpm --filter @palamedes/eslint-plugin test
+
       - name: Check parser-free browser runtime
         if: ${{ matrix.full }}
         run: pnpm --filter @palamedes/example-vite-mdx build && node ./scripts/check-runtime-browser-bundle.mjs

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -283,6 +283,7 @@ jobs:
           --filter @palamedes/core-node
           --filter @palamedes/transform
           --filter @palamedes/extractor
+          --filter @palamedes/eslint-plugin
           --filter @palamedes/react
           --filter @palamedes/remix
           --filter @palamedes/solid
@@ -301,6 +302,7 @@ jobs:
           node ./scripts/publish-package-if-needed.mjs @palamedes/core-node
           node ./scripts/publish-package-if-needed.mjs @palamedes/transform
           node ./scripts/publish-package-if-needed.mjs @palamedes/extractor
+          node ./scripts/publish-package-if-needed.mjs @palamedes/eslint-plugin
           node ./scripts/publish-package-if-needed.mjs @palamedes/react
           node ./scripts/publish-package-if-needed.mjs @palamedes/remix
           node ./scripts/publish-package-if-needed.mjs @palamedes/solid

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -182,6 +182,11 @@
         },
         {
           "type": "json",
+          "path": "packages/eslint-plugin/package.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
           "path": "packages/extractor/package.json",
           "jsonpath": "$.version"
         },

--- a/README.md
+++ b/README.md
@@ -144,21 +144,23 @@ Evidence:
 - [`@palamedes/vite-plugin`](https://www.npmjs.com/package/@palamedes/vite-plugin) for Vite projects
 - [`@palamedes/next-plugin`](https://www.npmjs.com/package/@palamedes/next-plugin) for Next.js projects
 - [`@palamedes/cli`](https://www.npmjs.com/package/@palamedes/cli) for extraction workflows and CI
+- [`@palamedes/eslint-plugin`](https://www.npmjs.com/package/@palamedes/eslint-plugin) for preview ESLint/Oxlint editor diagnostics
 
 There is no top-level `palamedes` install path yet. If you are trying
 Palamedes today, start with the scoped packages above.
 
 ## Recommended Packages
 
-| Package                                                                          | Role                                | Typical audience |
-| -------------------------------------------------------------------------------- | ----------------------------------- | ---------------- |
-| [`@palamedes/vite-plugin`](https://www.npmjs.com/package/@palamedes/vite-plugin) | Recommended Vite entry point        | App teams        |
-| [`@palamedes/next-plugin`](https://www.npmjs.com/package/@palamedes/next-plugin) | Recommended Next.js entry point     | App teams        |
-| [`@palamedes/cli`](https://www.npmjs.com/package/@palamedes/cli)                 | Extraction CLI                      | App teams, CI    |
-| [`@palamedes/core`](https://www.npmjs.com/package/@palamedes/core)               | App-facing i18n instance            | App teams        |
-| [`@palamedes/react`](https://www.npmjs.com/package/@palamedes/react)             | React translation components        | React app teams  |
-| [`@palamedes/solid`](https://www.npmjs.com/package/@palamedes/solid)             | Solid translation components        | Solid app teams  |
-| [`@palamedes/runtime`](https://www.npmjs.com/package/@palamedes/runtime)         | Runtime bridge for transformed code | App teams        |
+| Package                                                                              | Role                                | Typical audience |
+| ------------------------------------------------------------------------------------ | ----------------------------------- | ---------------- |
+| [`@palamedes/vite-plugin`](https://www.npmjs.com/package/@palamedes/vite-plugin)     | Recommended Vite entry point        | App teams        |
+| [`@palamedes/next-plugin`](https://www.npmjs.com/package/@palamedes/next-plugin)     | Recommended Next.js entry point     | App teams        |
+| [`@palamedes/cli`](https://www.npmjs.com/package/@palamedes/cli)                     | Extraction CLI                      | App teams, CI    |
+| [`@palamedes/eslint-plugin`](https://www.npmjs.com/package/@palamedes/eslint-plugin) | Preview lint/editor adapter         | App teams        |
+| [`@palamedes/core`](https://www.npmjs.com/package/@palamedes/core)                   | App-facing i18n instance            | App teams        |
+| [`@palamedes/react`](https://www.npmjs.com/package/@palamedes/react)                 | React translation components        | React app teams  |
+| [`@palamedes/solid`](https://www.npmjs.com/package/@palamedes/solid)                 | Solid translation components        | Solid app teams  |
+| [`@palamedes/runtime`](https://www.npmjs.com/package/@palamedes/runtime)             | Runtime bridge for transformed code | App teams        |
 
 Both UI packages also expose headless frontend helpers for locale sync and
 locale-switch modelling. The example matrix uses those public helpers directly

--- a/docs/research/oxlint-eslint-adapter.md
+++ b/docs/research/oxlint-eslint-adapter.md
@@ -1,0 +1,167 @@
+# Native Diagnostics Through ESLint And Oxlint
+
+Research and implementation snapshot: 2026-08-04.
+
+## Decision
+
+Publish `@palamedes/eslint-plugin` as a Preview package, but keep `pmds lint` as
+the stable CI and full-file-format interface.
+
+The package is deliberately an adapter, not a second implementation. Macro
+recognition, React/Solid alias handling, message semantics, diagnostic wording,
+and source ranges remain in the Rust core. ESLint and Oxlint only provide rule
+names, host severity, host suppressions, and editor presentation.
+
+This gives teams normal lint integration without allowing rule semantics to
+drift between extraction, `pmds lint`, ESLint, and Oxlint. It also preserves the
+product boundary: deterministic authoring defects are open source, while
+dictionary, terminology, ambiguity, and AI-assisted review remain outside this
+rule surface.
+
+## Why One Compatible Adapter
+
+Oxlint documents its JavaScript plugin API as ESLint v9+ compatible and supports
+source APIs, fixes, options, inline directives, and language-server diagnostics.
+The API is still alpha and does not support custom parsers/file formats or
+type-aware JavaScript rules. See the official
+[JavaScript plugin status and support matrix](https://oxc.rs/docs/guide/usage/linter/js-plugins.html).
+
+The adapter therefore uses `@oxlint/plugins`' `eslintCompatPlugin` and
+`createOnce` API. Oxlint calls `createOnce` once and can skip a file when the
+`before` hook returns `false`; the compatibility wrapper supplies regular
+`create` rules to ESLint. This is the path recommended by Oxlint for packages
+published to npm. See
+[Writing JavaScript plugins](https://oxc.rs/docs/guide/usage/linter/writing-js-plugins.html).
+The ESLint integration test exercises the generated `create` path, while the
+Oxlint worker test exercises `createOnce`; both report the same native result.
+
+Each facade listens only for `Program`:
+
+1. `before` rejects files that cannot contain Palamedes imports.
+2. `Program` asks a shared coordinator for the native analysis.
+3. The coordinator enables all native rules once and caches by filename plus a
+   SHA-256 source fingerprint.
+4. Each facade reports only the native diagnostic code it owns.
+
+This means enabling two or three public rules still performs one native parse
+per unchanged file. A source edit changes the fingerprint and invalidates the
+entry. Tests exercise the coordinator with distinct source objects to cover
+hosts that create a separate context for each enabled rule.
+
+## Rule Mapping
+
+| Native code                            | ESLint/Oxlint rule                          | Recommended                                          |
+| -------------------------------------- | ------------------------------------------- | ---------------------------------------------------- |
+| `pmds/no-placeholder-only-message`     | `palamedes/no-placeholder-only-message`     | warning                                              |
+| `pmds/no-empty-component-only-message` | `palamedes/no-empty-component-only-message` | off                                                  |
+| `pmds/prefer-trans-in-jsx`             | `palamedes/prefer-trans-in-jsx`             | warning in the adapter; informational in `pmds lint` |
+
+`prefer-trans-in-jsx` remains a readability suggestion. Tagged `t` calls are
+supported and appropriate outside direct JSX render positions.
+
+The host owns each rule's severity. The facades intentionally accept no custom
+options (`meta.schema` is empty): adding parallel JS options would duplicate the
+native policy surface and create configuration drift.
+
+Rust reports UTF-8 byte offsets. JavaScript linters use UTF-16 string indices,
+so the adapter converts every boundary before calling ESLint's
+`SourceCode#getLocFromIndex`. Tests cover ASCII and non-ASCII source, including
+an emoji before an aliased macro call, for both React and Solid imports.
+
+## Suppressions And Fixes
+
+The host owns suppression syntax and severity:
+
+```tsx
+// eslint-disable-next-line palamedes/no-placeholder-only-message
+const eslintValue = t`${status}`
+
+// oxlint-disable-next-line palamedes/no-placeholder-only-message
+const oxlintValue = t`${status}`
+```
+
+`pmds lint` suppressions stay separate because the native CLI also supports
+MDX and can run without either JavaScript linter. There are no adapter fixes in
+this version: the diagnostics explain intent, but the native result does not
+yet carry a safe edit. In particular, replacing `t` with `Trans` must preserve
+metadata and imports and should not be guessed by the facade.
+
+## Performance
+
+Run the checked harness from the repository root:
+
+```bash
+pnpm --filter @palamedes/eslint-plugin benchmark
+```
+
+The harness generates 250 JSX files with eight placeholder-only messages per
+file, runs every path in a fresh process, and reports the first run plus the
+median of five subsequent runs. `pmds lint` additionally gets its normal
+persistent source-analysis cache on warm runs. Peak RSS comes from the platform
+`time` utility when available.
+
+Measured on 2026-08-04 with Node 24.18.0 on macOS arm64:
+
+| Path                               | Cold wall time | Warm median |  Peak RSS |
+| ---------------------------------- | -------------: | ----------: | --------: |
+| `pmds lint`                        |       127.8 ms |    119.8 ms |  20.3 MiB |
+| ESLint adapter                     |       478.2 ms |    482.4 ms | 206.0 MiB |
+| Oxlint adapter                     |       312.1 ms |    304.7 ms | 108.1 MiB |
+| Parser-free JavaScript lower bound |        91.9 ms |     95.6 ms |  51.6 MiB |
+
+The JavaScript lower bound only reads files and matches tagged templates. It is
+not correctness-equivalent; it shows the irreducible Node process and file-I/O
+cost. The result supports the intended split: Oxlint is materially lighter than
+ESLint for editor integration, while the native CLI remains the fastest and
+lowest-memory project scanner.
+
+## Editor/LSP Verification
+
+Oxlint's official extensions launch the project-local `oxlint --lsp`, so the
+project must install Oxlint locally. The VS Code/Cursor extension is
+`oxc.oxc-vscode`; other supported editor instructions are in the official
+[editor setup](https://oxc.rs/docs/guide/usage/linter/editors.html).
+
+Reproduce the adapter path without relying on a screenshot:
+
+1. Install `oxlint` and `@palamedes/eslint-plugin` locally.
+2. Add the `jsPlugins` and `rules` configuration shown in the package README.
+3. Run `pnpm exec oxlint --config .oxlintrc.json src` and confirm the expected
+   `palamedes(...)` diagnostics.
+4. Install/enable the Oxc editor extension and open the same JSX/TSX file.
+5. Confirm the underline matches the macro call and that an
+   `oxlint-disable-next-line` directive removes only the named rule.
+
+The integration test runs the built package inside an actual Oxlint worker and
+checks both the diagnostic ID and exact source position. The manual step only
+verifies editor transport and rendering.
+
+## Packaging And Failure Modes
+
+- `@oxlint/plugins` is a runtime dependency, as required by the compatibility
+  wrapper; ESLint and Oxlint are optional peers so teams install only their
+  chosen host.
+- `@palamedes/core-node` resolves its platform-specific optional dependency
+  relative to itself. This works with hoisted installs and pnpm's isolated
+  layout and has been tested inside Oxlint's worker process.
+- Supported native targets currently match `@palamedes/core-node`: macOS arm64,
+  Linux x64 glibc/musl, Linux arm64 glibc, and Windows x64 MSVC. Missing or
+  pruned optional dependencies produce the core binding's actionable load
+  error.
+- All Palamedes packages publish in lockstep. A mixed older `core-node` version
+  may lack the source-analysis binding, so lockfiles should resolve one
+  Palamedes release.
+- The adapter skips irrelevant files before native analysis, but the host still
+  pays its own parsing and process cost.
+- Oxlint JavaScript plugins cannot currently supply custom parsers or formats,
+  so MDX remains a `pmds lint` responsibility.
+- Oxlint's plugin API is alpha. The package remains Preview until that API and
+  its editor behavior settle; `pmds lint` is the compatibility fallback.
+
+## Follow-Up Gate
+
+Promote the adapter from Preview only after Oxlint's JavaScript plugin API is no
+longer alpha, CI covers the supported OS matrix through the published native
+packages, and at least one real project has validated editor restart, monorepo
+resolution, and dependency-upgrade behavior. No rule logic should move into
+the adapter during that promotion.

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -41,6 +41,7 @@ may change faster than Stable surfaces.
 | `@palamedes/vite-plugin` and `@palamedes/next-plugin` | Stable   | Plugin options and `.po` loading behavior are public integration APIs.                                                        |
 | `@palamedes/config`                                   | Stable   | Config file names, `defineConfig`, and the config schema are public.                                                          |
 | `@palamedes/cli`                                      | Stable   | Documented commands and flags are public. New commands may appear in minors.                                                  |
+| `@palamedes/eslint-plugin`                            | Preview  | Thin ESLint/Oxlint facades over native diagnostics; Oxlint's JavaScript plugin API is still alpha.                            |
 | `pmds` binary plugin protocol                         | Preview  | Protocol v1 is version-negotiated; native package resolution and capabilities may evolve before promotion.                    |
 | Source-string-first PO catalogs                       | Stable   | Message identity is `message + context`. Catalog files remain user-owned.                                                     |
 | FCL catalog storage                                   | Preview  | Supported through config, CLI, and native catalog APIs; app-facing framework imports remain PO-loader based for now.          |

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -1,0 +1,91 @@
+# @palamedes/eslint-plugin
+
+Thin ESLint/Oxlint rule facades over Palamedes' native source analysis. The
+plugin does not recognize macros or implement authoring rules in JavaScript.
+
+This package is Preview. Oxlint's JavaScript plugin API is still alpha, so
+`pmds lint` remains the stable CI and MDX interface.
+
+## Installation
+
+Install the adapter with the host you already use:
+
+```bash
+pnpm add -D @palamedes/eslint-plugin eslint
+# or
+pnpm add -D @palamedes/eslint-plugin oxlint
+```
+
+Keep optional dependencies enabled so `@palamedes/core-node` can install the
+native package for the current platform.
+
+## ESLint flat config
+
+```js
+import palamedes from "@palamedes/eslint-plugin"
+
+export default [
+  {
+    files: ["**/*.{js,jsx,ts,tsx}"],
+    plugins: { palamedes },
+    rules: {
+      "palamedes/no-placeholder-only-message": "warn",
+      "palamedes/prefer-trans-in-jsx": "warn",
+    },
+  },
+]
+```
+
+The exported `configs.recommended` enables
+`no-placeholder-only-message` and `prefer-trans-in-jsx` as warnings.
+
+## Oxlint
+
+```json
+{
+  "jsPlugins": [
+    {
+      "name": "palamedes",
+      "specifier": "@palamedes/eslint-plugin"
+    }
+  ],
+  "rules": {
+    "palamedes/no-placeholder-only-message": "warn",
+    "palamedes/prefer-trans-in-jsx": "warn"
+  }
+}
+```
+
+## Rules
+
+| Rule                                        | Default in `configs.recommended` | Purpose                                                                                |
+| ------------------------------------------- | -------------------------------- | -------------------------------------------------------------------------------------- |
+| `palamedes/no-placeholder-only-message`     | warning                          | Reject messages made only of runtime values.                                           |
+| `palamedes/no-empty-component-only-message` | off                              | Reject a single empty component placeholder; opt in when that policy fits the project. |
+| `palamedes/prefer-trans-in-jsx`             | warning                          | Suggest `Trans` for safe direct JSX render positions; `t` remains supported.           |
+
+Each host owns rule severity and its normal inline directives:
+
+```tsx
+// eslint-disable-next-line palamedes/no-placeholder-only-message
+const eslintLabel = t`${status}`
+
+// oxlint-disable-next-line palamedes/no-placeholder-only-message
+const oxlintLabel = t`${status}`
+```
+
+The adapter enables every native Core diagnostic in one analysis and caches the
+result by filename and source fingerprint. Multiple enabled rule facades do not
+repeat native parsing. UTF-8 byte ranges from Rust are converted to the UTF-16
+indices expected by JavaScript linters before `SourceCode#getLocFromIndex` maps
+them to editor locations.
+
+There are no fixes in this version. `pmds lint` suppressions are intentionally
+separate from ESLint/Oxlint directives and are only consumed by the CLI.
+
+MDX is not supported through the adapter because Oxlint JavaScript plugins do
+not currently support custom parsers or file formats. Use `pmds lint` for MDX.
+
+The implementation rationale, benchmark, packaging risks, and reproducible LSP
+verification are documented in
+[Native diagnostics through ESLint and Oxlint](../../docs/research/oxlint-eslint-adapter.md).

--- a/packages/eslint-plugin/build.config.ts
+++ b/packages/eslint-plugin/build.config.ts
@@ -1,0 +1,10 @@
+import { defineBuildConfig } from "unbuild"
+
+export default defineBuildConfig({
+  entries: ["./src/index"],
+  declaration: true,
+  failOnWarn: false,
+  rollup: {
+    emitCJS: true,
+  },
+})

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,0 +1,78 @@
+{
+  "name": "@palamedes/eslint-plugin",
+  "version": "1.11.0",
+  "description": "ESLint and Oxlint adapter for native Palamedes source diagnostics",
+  "keywords": [
+    "palamedes",
+    "i18n",
+    "eslint",
+    "oxlint",
+    "lint"
+  ],
+  "homepage": "https://github.com/sebastian-software/palamedes",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sebastian-software/palamedes.git",
+    "directory": "packages/eslint-plugin"
+  },
+  "bugs": "https://github.com/sebastian-software/palamedes/issues",
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "sideEffects": false,
+  "files": [
+    "LICENSE",
+    "README.md",
+    "dist/"
+  ],
+  "scripts": {
+    "build": "unbuild",
+    "test": "unbuild && vitest run --globals src/index.test.ts",
+    "benchmark": "unbuild && node ./scripts/benchmark.mjs",
+    "stub": "unbuild --stub"
+  },
+  "engines": {
+    "node": ">=22.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@oxlint/plugins": "^1.76.0",
+    "@palamedes/core-node": "workspace:^"
+  },
+  "peerDependencies": {
+    "eslint": ">=9 <11",
+    "oxlint": ">=1.76.0"
+  },
+  "peerDependenciesMeta": {
+    "eslint": {
+      "optional": true
+    },
+    "oxlint": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@types/node": "^24.0.0",
+    "eslint": "^10.8.0",
+    "oxlint": "^1.76.0",
+    "typescript": "^6.0.3",
+    "unbuild": "^3.6.1",
+    "vitest": "^4.1.10"
+  }
+}

--- a/packages/eslint-plugin/scripts/benchmark.mjs
+++ b/packages/eslint-plugin/scripts/benchmark.mjs
@@ -1,0 +1,257 @@
+import { spawnSync } from "node:child_process"
+import { createRequire } from "node:module"
+import { mkdtempSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import { fileURLToPath, pathToFileURL } from "node:url"
+import { performance } from "node:perf_hooks"
+
+const packageRoot = fileURLToPath(new URL("..", import.meta.url))
+const repoRoot = path.resolve(packageRoot, "../..")
+
+if (process.argv[2] === "--control-worker") {
+  const sourceRoot = process.argv[3]
+  let findings = 0
+  for (const filename of sourceFiles(sourceRoot)) {
+    const source = readFileSync(filename, "utf8")
+    findings += source.match(/\b(?:t|translate)`[^`]*\$\{[^}]+\}[^`]*`/g)?.length ?? 0
+  }
+  console.log(findings)
+  process.exit(0)
+}
+
+const options = parseOptions(process.argv.slice(2))
+const directory = mkdtempSync(path.join(tmpdir(), "palamedes-lint-adapter-benchmark-"))
+
+try {
+  const sourceRoot = path.join(directory, "src")
+  mkdirSync(sourceRoot)
+  generateCorpus(sourceRoot, options.files, options.messagesPerFile)
+
+  const pluginPath = path.join(packageRoot, "dist", "index.mjs")
+  const eslintConfig = path.join(directory, "eslint.config.mjs")
+  const oxlintConfig = path.join(directory, ".oxlintrc.json")
+  const palamedesConfig = path.join(directory, "palamedes.yaml")
+
+  writeFileSync(
+    palamedesConfig,
+    `locales: [en, de]\nsource-locale: en\ncatalogs:\n  - path: locales/{locale}\n    include: [src]\n`
+  )
+  writeFileSync(
+    eslintConfig,
+    `import palamedes from ${JSON.stringify(pathToFileURL(pluginPath).href)}\n\nexport default [{\n  files: ["src/**/*.jsx"],\n  languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } },\n  plugins: { palamedes },\n  rules: {\n    "palamedes/no-placeholder-only-message": "warn",\n    "palamedes/prefer-trans-in-jsx": "warn",\n  },\n}]\n`
+  )
+  writeFileSync(
+    oxlintConfig,
+    JSON.stringify({
+      categories: { correctness: "off" },
+      plugins: [],
+      jsPlugins: [{ name: "palamedes", specifier: pluginPath }],
+      rules: {
+        "palamedes/no-placeholder-only-message": "warn",
+        "palamedes/prefer-trans-in-jsx": "warn",
+      },
+    })
+  )
+
+  const require = createRequire(import.meta.url)
+  const eslintEntry = require.resolve("eslint")
+  const eslintBin = path.resolve(path.dirname(eslintEntry), "../bin/eslint.js")
+  const oxlintEntry = require.resolve("oxlint")
+  const oxlintBin = path.resolve(path.dirname(oxlintEntry), "../bin/oxlint")
+  const pmds = resolvePmds(options.pmds)
+
+  const cases = [
+    {
+      name: "pmds lint",
+      command: pmds,
+      coldArgs: ["lint", "--config", palamedesConfig, "--json", "--fail-on", "error", "--no-cache"],
+      warmArgs: ["lint", "--config", palamedesConfig, "--json", "--fail-on", "error"],
+      seedWarmCache: true,
+    },
+    {
+      name: "ESLint adapter",
+      command: process.execPath,
+      coldArgs: [eslintBin, "--config", eslintConfig, "--format", "json", "src/**/*.jsx"],
+    },
+    {
+      name: "Oxlint adapter",
+      command: process.execPath,
+      coldArgs: [
+        oxlintBin,
+        "--config",
+        oxlintConfig,
+        "--format",
+        "json",
+        "--threads",
+        "1",
+        sourceRoot,
+      ],
+    },
+    {
+      name: "parser-free JS lower bound",
+      command: process.execPath,
+      coldArgs: [fileURLToPath(import.meta.url), "--control-worker", sourceRoot],
+    },
+  ]
+
+  const rows = []
+  for (const benchmarkCase of cases) {
+    const cold = runMeasured(benchmarkCase.command, benchmarkCase.coldArgs, directory)
+    const warmArgs = benchmarkCase.warmArgs ?? benchmarkCase.coldArgs
+    if (benchmarkCase.seedWarmCache) {
+      runMeasured(benchmarkCase.command, warmArgs, directory)
+    }
+    const warm = Array.from({ length: options.runs }, () =>
+      runMeasured(benchmarkCase.command, warmArgs, directory)
+    )
+    rows.push({
+      name: benchmarkCase.name,
+      coldMs: cold.elapsedMs,
+      warmMs: median(warm.map((sample) => sample.elapsedMs)),
+      maxRssMb: Math.max(cold.maxRssMb ?? 0, ...warm.map((sample) => sample.maxRssMb ?? 0)),
+    })
+  }
+
+  console.log(
+    `Corpus: ${options.files} JSX files, ${options.messagesPerFile} placeholder-only messages/file (${options.files * options.messagesPerFile} messages)`
+  )
+  console.log(`Runtime: ${process.version}, ${process.platform}/${process.arch}`)
+  console.log(`Warm result: median of ${options.runs} fresh-process runs`)
+  console.log("")
+  console.log("| Path | Cold wall time | Warm median | Peak RSS |")
+  console.log("| --- | ---: | ---: | ---: |")
+  for (const row of rows) {
+    const rss = row.maxRssMb > 0 ? `${row.maxRssMb.toFixed(1)} MiB` : "n/a"
+    console.log(
+      `| ${row.name} | ${row.coldMs.toFixed(1)} ms | ${row.warmMs.toFixed(1)} ms | ${rss} |`
+    )
+  }
+  console.log("")
+  console.log(
+    "Cold is the first process after fixture generation. Warm retains process startup for realistic CLI usage; pmds additionally uses its persistent source-analysis cache."
+  )
+  console.log(
+    "The parser-free JS row only reads files and matches tagged templates. It is a lower bound, not a correctness-equivalent implementation."
+  )
+} finally {
+  rmSync(directory, { recursive: true, force: true })
+}
+
+function parseOptions(args) {
+  const options = { files: 250, messagesPerFile: 8, runs: 5, pmds: undefined }
+  for (let index = 0; index < args.length; index += 1) {
+    const value = args[index]
+    if (value === "--") continue
+    if (value === "--files") options.files = positiveInteger(args[++index], value)
+    else if (value === "--messages-per-file") {
+      options.messagesPerFile = positiveInteger(args[++index], value)
+    } else if (value === "--runs") options.runs = positiveInteger(args[++index], value)
+    else if (value === "--pmds") options.pmds = path.resolve(args[++index])
+    else throw new Error(`Unknown argument: ${value}`)
+  }
+  return options
+}
+
+function positiveInteger(value, option) {
+  const number = Number.parseInt(value ?? "", 10)
+  if (!Number.isSafeInteger(number) || number < 1) {
+    throw new Error(`${option} expects a positive integer`)
+  }
+  return number
+}
+
+function generateCorpus(sourceRoot, fileCount, messagesPerFile) {
+  for (let fileIndex = 0; fileIndex < fileCount; fileIndex += 1) {
+    const valueNames = Array.from({ length: messagesPerFile }, (_, index) => `value${index}`)
+    const messages = Array.from(
+      { length: messagesPerFile },
+      (_, messageIndex) => `      <p>{translate\`\${value${messageIndex}}\`}</p>`
+    ).join("\n")
+    writeFileSync(
+      path.join(sourceRoot, `view-${fileIndex}.jsx`),
+      `import { t as translate } from "@palamedes/react/macro"\n\nexport function View${fileIndex}({ ${valueNames.join(", ")} }) {\n  return (\n    <section>\n${messages}\n    </section>\n  )\n}\n`
+    )
+  }
+}
+
+function resolvePmds(explicitPath) {
+  const candidates = [
+    explicitPath,
+    process.env.PALAMEDES_CLI,
+    path.join(repoRoot, "target", "release", executableName("pmds")),
+    path.join(repoRoot, "target", "debug", executableName("pmds")),
+  ].filter(Boolean)
+  for (const candidate of candidates) {
+    try {
+      readFileSync(candidate)
+      return candidate
+    } catch {
+      // Try the next local binary candidate.
+    }
+  }
+  throw new Error("No pmds binary found; build it or pass --pmds /absolute/path/to/pmds")
+}
+
+function executableName(name) {
+  return process.platform === "win32" ? `${name}.exe` : name
+}
+
+function runMeasured(command, args, cwd) {
+  const timer = memoryTimer(command, args)
+  const startedAt = performance.now()
+  let result = spawnSync(timer.command, timer.args, {
+    cwd,
+    encoding: "utf8",
+    maxBuffer: 128 * 1024 * 1024,
+  })
+  let elapsedMs = performance.now() - startedAt
+  let maxRssMb = parseMaxRss(result.stderr)
+  if (result.status !== 0 && timer.command !== command && maxRssMb === undefined) {
+    const fallbackStartedAt = performance.now()
+    result = spawnSync(command, args, {
+      cwd,
+      encoding: "utf8",
+      maxBuffer: 128 * 1024 * 1024,
+    })
+    elapsedMs = performance.now() - fallbackStartedAt
+    maxRssMb = undefined
+  }
+  if (result.status !== 0) {
+    throw new Error(
+      `${path.basename(command)} failed (${result.status ?? result.signal}):\n${result.stdout}\n${result.stderr}`
+    )
+  }
+  return { elapsedMs, maxRssMb }
+}
+
+function memoryTimer(command, args) {
+  if (process.platform === "darwin") {
+    return { command: "/usr/bin/time", args: ["-l", command, ...args] }
+  }
+  if (process.platform === "linux") {
+    return { command: "/usr/bin/time", args: ["-v", command, ...args] }
+  }
+  return { command, args }
+}
+
+function parseMaxRss(stderr) {
+  const mac = stderr.match(/(\d+)\s+maximum resident set size/)
+  if (mac) return Number(mac[1]) / 1024 / 1024
+  const linux = stderr.match(/Maximum resident set size \(kbytes\):\s+(\d+)/)
+  if (linux) return Number(linux[1]) / 1024
+  return
+}
+
+function median(values) {
+  const sorted = [...values].sort((left, right) => left - right)
+  const middle = Math.floor(sorted.length / 2)
+  return sorted.length % 2 === 0 ? (sorted[middle - 1] + sorted[middle]) / 2 : sorted[middle]
+}
+
+function sourceFiles(directory) {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const filename = path.join(directory, entry.name)
+    return entry.isDirectory() ? sourceFiles(filename) : filename.endsWith(".jsx") ? [filename] : []
+  })
+}

--- a/packages/eslint-plugin/src/analysis.ts
+++ b/packages/eslint-plugin/src/analysis.ts
@@ -1,0 +1,112 @@
+import { createHash } from "node:crypto"
+
+import {
+  analyzeSourceNative,
+  type SourceAnalysisOptions,
+  type SourceDiagnostic,
+} from "@palamedes/core-node"
+
+export type SourceCodeLike = {
+  text: string
+}
+
+export type AnalysisContext = {
+  filename: string
+  sourceCode: SourceCodeLike
+}
+
+export type AnalyzeSource = (
+  source: string,
+  filename: string,
+  options?: SourceAnalysisOptions
+) => { diagnostics: SourceDiagnostic[] }
+
+type CachedAnalysis = {
+  fingerprint: string
+  diagnostics: SourceDiagnostic[]
+  failure?: string
+}
+
+const ALL_RULES: SourceAnalysisOptions = {
+  rules: {
+    placeholderOnly: "warning",
+    emptyComponentOnly: "warning",
+    preferTransInJsx: "warning",
+  },
+}
+
+export function mightContainPalamedesSource(source: string): boolean {
+  return source.includes("@palamedes") || source.includes("i18n")
+}
+
+export function createAnalysisCoordinator(analyze: AnalyzeSource = analyzeSourceNative) {
+  const bySourceCode = new WeakMap<SourceCodeLike, CachedAnalysis>()
+  const byFilename = new Map<string, CachedAnalysis>()
+  let nativeCalls = 0
+
+  function analyzeContext(context: AnalysisContext): CachedAnalysis {
+    const weakHit = bySourceCode.get(context.sourceCode)
+    if (weakHit) {
+      return weakHit
+    }
+
+    const source = context.sourceCode.text
+    const fingerprint = sourceFingerprint(source)
+    const fileHit = byFilename.get(context.filename)
+    if (fileHit?.fingerprint === fingerprint) {
+      bySourceCode.set(context.sourceCode, fileHit)
+      return fileHit
+    }
+
+    nativeCalls += 1
+    let cached: CachedAnalysis
+    try {
+      cached = {
+        fingerprint,
+        diagnostics: analyze(source, context.filename, ALL_RULES).diagnostics,
+      }
+    } catch (error) {
+      cached = {
+        fingerprint,
+        diagnostics: [],
+        failure: error instanceof Error ? error.message : String(error),
+      }
+    }
+    bySourceCode.set(context.sourceCode, cached)
+    byFilename.set(context.filename, cached)
+    return cached
+  }
+
+  return {
+    analyzeContext,
+    nativeCallCount: () => nativeCalls,
+  }
+}
+
+function sourceFingerprint(source: string): string {
+  return createHash("sha256").update(source).digest("base64url")
+}
+
+export function utf8ByteOffsetToUtf16Index(source: string, requestedOffset: number): number {
+  const target = Math.max(0, requestedOffset)
+  let bytes = 0
+  let utf16Index = 0
+
+  for (const character of source) {
+    if (bytes >= target) {
+      break
+    }
+    const codePoint = character.codePointAt(0) ?? 0
+    bytes += utf8Length(codePoint)
+    utf16Index += character.length
+  }
+
+  return Math.min(utf16Index, source.length)
+}
+
+function utf8Length(codePoint: number): number {
+  if (codePoint <= 0x7f) return 1
+  if (codePoint <= 0x07_ff) return 2
+  if (codePoint <= 0xff_ff) return 3
+  return 4
+}

--- a/packages/eslint-plugin/src/index.test.ts
+++ b/packages/eslint-plugin/src/index.test.ts
@@ -1,0 +1,161 @@
+import { createRequire } from "node:module"
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import { spawnSync } from "node:child_process"
+import { fileURLToPath } from "node:url"
+
+import { ESLint } from "eslint"
+
+import plugin from "./index"
+import { createAnalysisCoordinator, utf8ByteOffsetToUtf16Index } from "./analysis"
+
+function eslintFor(rules: Record<string, "warn" | "error">): ESLint {
+  return new ESLint({
+    overrideConfigFile: true,
+    overrideConfig: [
+      {
+        files: ["**/*.{js,jsx}"],
+        languageOptions: {
+          ecmaVersion: "latest",
+          sourceType: "module",
+          parserOptions: { ecmaFeatures: { jsx: true } },
+        },
+        plugins: { palamedes: plugin },
+        rules,
+      },
+    ],
+  })
+}
+
+describe("native Palamedes lint adapter", () => {
+  it("maps UTF-8 byte offsets to JavaScript UTF-16 indices", () => {
+    const source = "😀éa"
+    expect(utf8ByteOffsetToUtf16Index(source, 0)).toBe(0)
+    expect(utf8ByteOffsetToUtf16Index(source, 4)).toBe(2)
+    expect(utf8ByteOffsetToUtf16Index(source, 6)).toBe(3)
+    expect(utf8ByteOffsetToUtf16Index(source, 7)).toBe(4)
+  })
+
+  it("shares one native analysis across rule facades and invalidates on edits", () => {
+    const analyze = vi.fn(() => ({ diagnostics: [] }))
+    const coordinator = createAnalysisCoordinator(analyze)
+    const source = "import { t } from '@palamedes/core/macro'"
+
+    coordinator.analyzeContext({ filename: "view.tsx", sourceCode: { text: source } })
+    coordinator.analyzeContext({ filename: "view.tsx", sourceCode: { text: source } })
+    expect(analyze).toHaveBeenCalledTimes(1)
+    expect(coordinator.nativeCallCount()).toBe(1)
+
+    coordinator.analyzeContext({
+      filename: "view.tsx",
+      sourceCode: { text: `${source}\nexport const edited = true` },
+    })
+    expect(analyze).toHaveBeenCalledTimes(2)
+  })
+
+  it.each(["react", "solid"])(
+    "reports aliased %s macros through separate ESLint rule names at the exact Unicode range",
+    async (framework) => {
+      const source = `import { t as translate } from "@palamedes/${framework}/macro"
+function View({ status }) {
+  return <p>🙂{translate\`${"${status}"}\`}</p>
+}`
+      const [result] = await eslintFor({
+        "palamedes/no-placeholder-only-message": "warn",
+        "palamedes/prefer-trans-in-jsx": "warn",
+      }).lintText(source, { filePath: `view-${framework}.jsx` })
+
+      expect(result.errorCount).toBe(0)
+      expect(result.warningCount).toBe(2)
+      expect(result.messages.map((message) => message.ruleId).sort()).toStrictEqual([
+        "palamedes/no-placeholder-only-message",
+        "palamedes/prefer-trans-in-jsx",
+      ])
+      const line = source.split("\n")[2]
+      const expectedColumn = line.indexOf("translate") + 1
+      for (const message of result.messages) {
+        expect(message.line).toBe(3)
+        expect(message.column).toBe(expectedColumn)
+      }
+    }
+  )
+
+  it("uses ESLint's own code-specific inline directives", async () => {
+    const source = `import { t } from "@palamedes/core/macro"
+function View({ status }) {
+  // eslint-disable-next-line palamedes/no-placeholder-only-message
+  return <p>{t\`${"${status}"}\`}</p>
+}`
+    const [result] = await eslintFor({
+      "palamedes/no-placeholder-only-message": "warn",
+      "palamedes/prefer-trans-in-jsx": "warn",
+    }).lintText(source, { filePath: "view.jsx" })
+
+    expect(result.messages.map((message) => message.ruleId)).toStrictEqual([
+      "palamedes/prefer-trans-in-jsx",
+    ])
+  })
+
+  it("runs the built plugin through Oxlint with native diagnostics and suppressions", () => {
+    const directory = mkdtempSync(path.join(tmpdir(), "palamedes-oxlint-adapter-"))
+    try {
+      const pluginPath = fileURLToPath(new URL("../dist/index.mjs", import.meta.url))
+      const sourcePath = path.join(directory, "view.tsx")
+      const configPath = path.join(directory, ".oxlintrc.json")
+      writeFileSync(
+        sourcePath,
+        `import { t } from "@palamedes/react/macro"
+function View({ status }: { status: string }) {
+  // oxlint-disable-next-line palamedes/no-placeholder-only-message
+  return <p>{t\`${"${status}"}\`}</p>
+}`
+      )
+      writeFileSync(
+        configPath,
+        JSON.stringify({
+          categories: { correctness: "off" },
+          plugins: [],
+          jsPlugins: [{ name: "palamedes", specifier: pluginPath }],
+          rules: {
+            "palamedes/no-placeholder-only-message": "warn",
+            "palamedes/prefer-trans-in-jsx": "warn",
+          },
+        })
+      )
+
+      const require = createRequire(import.meta.url)
+      const oxlintEntry = require.resolve("oxlint")
+      const oxlintBin = path.resolve(path.dirname(oxlintEntry), "../bin/oxlint")
+      const run = spawnSync(
+        process.execPath,
+        [oxlintBin, "--config", configPath, "--format", "json", "--threads", "1", sourcePath],
+        { cwd: directory, encoding: "utf8" }
+      )
+
+      expect(run).toMatchObject({ status: 0 })
+      const output = JSON.parse(run.stdout) as {
+        diagnostics: Array<{
+          code: string
+          labels: Array<{ span: { line: number; column: number } }>
+        }>
+      }
+      expect(output.diagnostics).toHaveLength(1)
+      expect(output.diagnostics[0].code).toBe("palamedes(prefer-trans-in-jsx)")
+      expect(output.diagnostics[0].labels[0].span).toMatchObject({ line: 4, column: 14 })
+    } finally {
+      rmSync(directory, { recursive: true, force: true })
+    }
+  })
+
+  it("loads the CommonJS build and emits both module formats", () => {
+    const packageRoot = fileURLToPath(new URL("..", import.meta.url))
+    const commonJs = createRequire(import.meta.url)(path.join(packageRoot, "dist/index.cjs")) as {
+      rules: Record<string, unknown>
+    }
+    expect(Object.keys(commonJs.rules)).toContain("prefer-trans-in-jsx")
+    expect(readFileSync(path.join(packageRoot, "dist/index.mjs"), "utf8")).toContain(
+      "prefer-trans-in-jsx"
+    )
+  })
+})

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -1,0 +1,116 @@
+import { eslintCompatPlugin, type Context, type Rule } from "@oxlint/plugins"
+import type { ESLint } from "eslint"
+
+import {
+  createAnalysisCoordinator,
+  mightContainPalamedesSource,
+  utf8ByteOffsetToUtf16Index,
+} from "./analysis"
+
+type DiagnosticCode =
+  | "pmds/no-placeholder-only-message"
+  | "pmds/no-empty-component-only-message"
+  | "pmds/prefer-trans-in-jsx"
+
+type CompatibleContext = Context & {
+  filename?: string
+  getFilename?: () => string
+  sourceCode: Context["sourceCode"] & {
+    getLocFromIndex(index: number): { line: number; column: number }
+  }
+}
+
+const analysis = createAnalysisCoordinator()
+
+function createFacade(code: DiagnosticCode, description: string): Rule {
+  return {
+    meta: {
+      type: "suggestion",
+      docs: { description },
+      schema: [],
+    },
+    createOnce(rawContext) {
+      const context = rawContext as CompatibleContext
+      return {
+        before() {
+          return mightContainPalamedesSource(context.sourceCode.text) ? undefined : false
+        },
+        Program() {
+          const filename = context.filename ?? context.getFilename?.() ?? "<input>"
+          const result = analysis.analyzeContext({
+            filename,
+            sourceCode: context.sourceCode,
+          })
+          if (result.failure) {
+            context.report({
+              loc: {
+                start: { line: 1, column: 0 },
+                end: { line: 1, column: Math.min(1, context.sourceCode.text.length) },
+              },
+              message: `Palamedes native analysis failed: ${result.failure}`,
+            })
+            return
+          }
+
+          for (const diagnostic of result.diagnostics) {
+            if (diagnostic.code !== code) continue
+            const start = utf8ByteOffsetToUtf16Index(
+              context.sourceCode.text,
+              diagnostic.primary.start
+            )
+            const end = utf8ByteOffsetToUtf16Index(context.sourceCode.text, diagnostic.primary.end)
+            context.report({
+              loc: {
+                start: context.sourceCode.getLocFromIndex(start),
+                end: context.sourceCode.getLocFromIndex(Math.max(start, end)),
+              },
+              message: `${diagnostic.message} ${diagnostic.help}`,
+            })
+          }
+        },
+      }
+    },
+  }
+}
+
+const rules = {
+  "no-placeholder-only-message": createFacade(
+    "pmds/no-placeholder-only-message",
+    "Disallow Palamedes messages that contain placeholders but no translatable text."
+  ),
+  "no-empty-component-only-message": createFacade(
+    "pmds/no-empty-component-only-message",
+    "Disallow Palamedes messages that consist only of one empty component placeholder."
+  ),
+  "prefer-trans-in-jsx": createFacade(
+    "pmds/prefer-trans-in-jsx",
+    "Suggest Trans for translation calls in safe, directly renderable JSX positions."
+  ),
+}
+
+const plugin = eslintCompatPlugin({
+  meta: {
+    name: "@palamedes/eslint-plugin",
+  },
+  rules,
+}) as unknown as ESLint.Plugin
+
+type PalamedesFlatConfig = {
+  plugins: Record<string, ESLint.Plugin>
+  rules: Record<string, "warn">
+}
+
+export const configs: Record<"recommended", PalamedesFlatConfig> = {
+  recommended: {
+    plugins: { palamedes: plugin },
+    rules: {
+      "palamedes/no-placeholder-only-message": "warn",
+      "palamedes/prefer-trans-in-jsx": "warn",
+    },
+  },
+}
+
+Object.assign(plugin, { configs })
+
+export { rules }
+export default plugin

--- a/packages/eslint-plugin/tsconfig.json
+++ b/packages/eslint-plugin/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1428,6 +1428,34 @@ importers:
 
   packages/create-palamedes: {}
 
+  packages/eslint-plugin:
+    dependencies:
+      '@oxlint/plugins':
+        specifier: ^1.76.0
+        version: 1.76.0
+      '@palamedes/core-node':
+        specifier: workspace:^
+        version: link:../core-node
+    devDependencies:
+      '@types/node':
+        specifier: ^24.0.0
+        version: 24.13.3
+      eslint:
+        specifier: ^10.8.0
+        version: 10.8.0(jiti@2.7.0)(supports-color@10.2.2)
+      oxlint:
+        specifier: ^1.76.0
+        version: 1.76.0
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      unbuild:
+        specifier: ^3.6.1
+        version: 3.6.1(typescript@6.0.3)
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@edge-runtime/vm@3.2.0)(@types/node@24.13.3)(jsdom@29.1.1)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
+
   packages/example-ui:
     devDependencies:
       typescript:
@@ -4385,6 +4413,10 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
+
+  '@oxlint/plugins@1.76.0':
+    resolution: {integrity: sha512-twmbsVrYAjkaOw6I2pDiYSAxVLNOV8kcqMzajJ599SpqXzea+GjDCZVad1VUqNR/4thWjM4PER5n+3/TQtTkZQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
   '@parcel/watcher-android-arm64@2.5.6':
     resolution: {integrity: sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==}
@@ -13827,6 +13859,8 @@ snapshots:
 
   '@oxlint/binding-win32-x64-msvc@1.76.0':
     optional: true
+
+  '@oxlint/plugins@1.76.0': {}
 
   '@parcel/watcher-android-arm64@2.5.6':
     optional: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1454,7 +1454,7 @@ importers:
         version: 3.6.1(typescript@6.0.3)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@edge-runtime/vm@3.2.0)(@types/node@24.13.3)(jsdom@29.1.1)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.10(@edge-runtime/vm@3.2.0)(@types/node@24.13.3)(jsdom@29.1.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/example-ui:
     devDependencies:

--- a/scripts/check-published-types.mjs
+++ b/scripts/check-published-types.mjs
@@ -40,6 +40,7 @@ function checkProgram(fileName, compilerOptions) {
 try {
   mkdirSync(scopeDirectory, { recursive: true })
   linkPackage("core")
+  linkPackage("eslint-plugin")
   linkPackage("next-plugin")
   linkPackage("vite-plugin")
 
@@ -47,6 +48,7 @@ try {
   writeFileSync(
     esmFixture,
     `import { plural, select, selectOrdinal, t } from "@palamedes/core/macro"
+import palamedesLint, { configs as palamedesLintConfigs } from "@palamedes/eslint-plugin"
 import withPalamedes from "@palamedes/next-plugin"
 import vitePalamedes, { palamedes } from "@palamedes/vite-plugin"
 
@@ -59,6 +61,8 @@ export const lengths = [
 
 export default withPalamedes({})
 export const vitePlugins = [vitePalamedes(), palamedes()]
+export const lintPlugin = palamedesLint
+export const lintConfig = palamedesLintConfigs.recommended
 `
   )
   checkProgram(esmFixture, {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,7 @@
     { "path": "packages/remix" },
     { "path": "packages/vite-plugin" },
     { "path": "packages/next-plugin" },
-    { "path": "packages/cli" }
+    { "path": "packages/cli" },
+    { "path": "packages/eslint-plugin" }
   ]
 }


### PR DESCRIPTION
## Stack

This PR is stacked on #520 because the adapter consumes the native source-analysis API introduced there. Review only commit `03c9f74` for the adapter-specific delta.

## Summary

- publish `@palamedes/eslint-plugin` as a Preview package with three thin native-diagnostic facades
- use Oxlint `createOnce` plus `eslintCompatPlugin`, skipping irrelevant files before native analysis
- share one native analysis by filename and source fingerprint across enabled rule facades
- map Rust UTF-8 byte spans to exact ESLint/Oxlint UTF-16 source locations
- verify React and Solid aliases, Unicode, ESLint/Oxlint suppressions, ESM/CJS packaging, and actual Oxlint worker loading
- wire the package into release, publish, type-consumer, and cross-platform CI workflows
- document LSP verification, packaging failures, OSS/Plus boundaries, and the publish recommendation

## Recommendation

Publish the adapter as Preview for ESLint/Oxlint editor UX. Keep `pmds lint` as the stable CI and MDX interface while the Oxlint JavaScript plugin API remains alpha. All rule semantics stay native; the adapter contains no second recognizer or policy implementation.

## Benchmark

Generated corpus: 250 JSX files and 2,000 placeholder-only messages; Node 24.18.0 on macOS arm64; warm result is the median of five fresh-process runs.

| Path | Cold | Warm median | Peak RSS |
| --- | ---: | ---: | ---: |
| `pmds lint` | 127.8 ms | 119.8 ms | 20.3 MiB |
| ESLint adapter | 478.2 ms | 482.4 ms | 206.0 MiB |
| Oxlint adapter | 312.1 ms | 304.7 ms | 108.1 MiB |
| Parser-free JS lower bound | 91.9 ms | 95.6 ms | 51.6 MiB |

Reproduce with `pnpm --filter @palamedes/eslint-plugin benchmark`.

## Verification

- [x] `pnpm build`
- [x] `pnpm test`
- [x] `pnpm check-types`
- [x] `pnpm lint`
- [x] `pnpm format:check`
- [x] `pnpm check:release-set`
- [x] `pnpm check:published-types`
- [x] adapter benchmark with wall time and peak RSS

Closes #516