### PR TITLE
fix(solid): type compiled runtime renderer

### DIFF
--- a/packages/solid/src/transShared.tsx
+++ b/packages/solid/src/transShared.tsx
@@ -94,32 +94,32 @@ export function createSolidMessageRuntime(
   const runtime: CompiledMessageRuntime<JSX.Element[]> = createCompiledMessageRuntime<
     JSX.Element[]
   >(locale, {
-    pattern(pattern, values) {
+    pattern(pattern: string, values: Record<string, unknown>) {
       const nodes = parsePattern(i18n, pattern, fallbackParser)
       return renderNodes(nodes, values, runtime, locale)
     },
-    join(...parts) {
+    join(...parts: Array<string | JSX.Element[]>) {
       return parts.flatMap((part) => (typeof part === "string" ? [part] : part))
     },
-    value(value) {
+    value(value: unknown) {
       return [renderVariable(value)]
     },
-    number(value, style) {
+    number(value: unknown, style?: string) {
       return [formatMessageArgument("number", value, style, locale)]
     },
-    date(value, style) {
+    date(value: unknown, style?: string) {
       return [formatMessageArgument("date", value, style, locale)]
     },
-    time(value, style) {
+    time(value: unknown, style?: string) {
       return [formatMessageArgument("time", value, style, locale)]
     },
-    pound(value) {
+    pound(value: number) {
       return [replacePoundPlaceholders("#", value, locale)]
     },
-    literal(value) {
+    literal(value: string) {
       return [value]
     },
-    tag(name, children) {
+    tag(name: string, children: JSX.Element[]) {
       const component = components[name]
       if (typeof component === "function") {
         return [component(children as unknown as JSX.Element)]
@@ -190,6 +190,8 @@ function renderNode(
       return renderNodes(resolved.nodes, values, runtime, locale, nextPluralValue)
     }
   }
+
+  return []
 }
 
 function renderVariable(value: unknown): JSX.Element {


### PR DESCRIPTION
## What this fixes

The Palamedes Deploy Site workflow is currently failing during the Ardo/TypeDoc prebuild step because `packages/solid/src/transShared.tsx` is compiled under strict TypeScript settings and the shared compiled-runtime renderer leaves several callback parameters implicit.

This adds the missing host-renderer parameter types and gives `renderNode` an explicit fallback return so TypeDoc can convert the Solid package API again.

## Validation

- `corepack pnpm --filter @palamedes/solid build`
- `corepack pnpm --filter @palamedes/core build`
- `corepack pnpm --filter @palamedes/runtime build`
- `corepack pnpm build:site`
- `corepack pnpm --filter @palamedes/solid exec tsc --noEmit -p tsconfig.json`
- `corepack pnpm format:check -- packages/solid/src/transShared.tsx`

Note: full `corepack pnpm check-types` still fails locally before this package on the existing Darwin checkout because `@palamedes/core-node` native package types are not resolvable for `packages/extractor`; the targeted Solid typecheck and the failing site build path both pass.
