### PR TITLE
fix(site): resolve compiled core entry in TypeDoc

### DIFF
--- a/site/tsconfig.typedoc.json
+++ b/site/tsconfig.typedoc.json
@@ -14,6 +14,7 @@
       "@palamedes/cli": ["packages/cli/src/index.ts"],
       "@palamedes/config": ["packages/config/src/index.ts"],
       "@palamedes/core": ["packages/core/src/index.ts"],
+      "@palamedes/core/compiled": ["packages/core/src/compiled.ts"],
       "@palamedes/core/locale": ["packages/core/src/locale.ts"],
       "@palamedes/core/macro": ["packages/core/src/macro.ts"],
       "@palamedes/core-node": ["packages/core-node/src/index.ts"],


### PR DESCRIPTION
## What changed

- map `@palamedes/core/compiled` to `packages/core/src/compiled.ts` in the site TypeDoc configuration

## Why

The release site build failed during TypeDoc conversion because the React and Solid sources import the compiled Core entrypoint, but the site-specific TypeScript path map only covered the other Core subpaths.

## Impact

The generated API reference can resolve the compiled runtime types again, allowing the GitHub Pages release build to complete.

## Validation

- `pnpm build:site`
- `pnpm exec oxfmt --check site/tsconfig.typedoc.json`
- `git diff --check`

The full site build completed TypeDoc generation, client and SSR bundles, and prerendered all 151 routes on the exact failed release commit.