### PR TITLE
fix(next): preserve i18n scope across RSC suspension

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,9 +61,13 @@ jobs:
       - name: Build packages
         run: pnpm build
 
-      - name: Verify Next.js RSC request scope in production
+      - name: Verify Next.js RSC request scope with Turbopack
         if: matrix.os == 'ubuntu-24.04' && matrix.node == 24
         run: pnpm --filter @palamedes/example-nextjs-cookie test:rsc-scope
+
+      - name: Verify Next.js RSC request scope with Webpack
+        if: matrix.os == 'ubuntu-24.04' && matrix.node == 24
+        run: pnpm --filter @palamedes/example-nextjs-cookie test:rsc-scope:webpack
 
       - name: Test ESLint and Oxlint adapter
         run: pnpm --filter @palamedes/eslint-plugin test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,10 @@ jobs:
       - name: Build packages
         run: pnpm build
 
+      - name: Verify Next.js RSC request scope in production
+        if: matrix.os == 'ubuntu-24.04' && matrix.node == 24
+        run: pnpm --filter @palamedes/example-nextjs-cookie test:rsc-scope
+
       - name: Test ESLint and Oxlint adapter
         run: pnpm --filter @palamedes/eslint-plugin test
 

--- a/docs/api/next-plugin.md
+++ b/docs/api/next-plugin.md
@@ -12,6 +12,7 @@ storage/import boundary.
 - `withPalamedes(baseConfig?, options?)`
 - default export `withPalamedes`
 - `WithPalamedesOptions`
+- `createNextServerI18nScope<T>()` from `@palamedes/next-plugin/server`
 - internal loader subpaths used by plugin wiring:
   `@palamedes/next-plugin/palamedes-loader` and
   `@palamedes/next-plugin/palamedes-po-loader`
@@ -51,6 +52,27 @@ module.exports = withPalamedes({})
 ```
 
 ## App Router Client Catalog Boundary
+
+Create the request scope once in a server-only module. Unlike the generic Node
+scope, this adapter keys the instance to Next's complete render lifetime, so it
+survives suspension and the handoff from the RSC pass to Client Component
+server rendering:
+
+```ts
+import "server-only"
+
+import { createNextServerI18nScope } from "@palamedes/next-plugin/server"
+import type { PalamedesI18n } from "@palamedes/core"
+
+export const serverI18n = createNextServerI18nScope<PalamedesI18n>()
+```
+
+Activate a fresh instance during each request's initialization. The adapter
+stores it under a weak Next render key, never as a process-global last request.
+Its server-storage integration supports the declared Next 16 peer range and is
+verified against Next 16.2. If a later Next 16 build removes that internal
+module, the application build fails with a module-resolution error; upgrade
+Palamedes before adopting that Next release.
 
 After resolving and activating the request-local server i18n instance, wrap
 translated Client Components in a boundary created by the shared React runtime:

--- a/docs/api/runtime.md
+++ b/docs/api/runtime.md
@@ -15,6 +15,7 @@ macro output.
 The server subpath `@palamedes/runtime/server` exports:
 
 - `createServerI18nScope<T>()`
+- `CreateServerI18nScopeOptions`
 - `ServerI18nScope`
 
 ## Client Runtime
@@ -59,7 +60,17 @@ serverI18n.activate(i18n)
 ```
 
 `createServerI18nScope()` uses Node `AsyncLocalStorage`, so keep it out of
-client bundles and Edge-only runtime paths.
+client bundles and Edge-only runtime paths. `scope.activate()` lasts for the
+current inherited async context; `scope.run()` lasts for its callback. A host
+adapter can supply `requestKeyProvider` when the framework exposes a stable
+render identity across context changes. Provider IDs replace earlier
+registrations from the same adapter, so repeated dev/HMR scope creation stays
+bounded, and instances are stored against weak request keys.
+
+Next.js App Router rendering has separate RSC and Client Component server
+passes and can resume work from a context captured before activation. Use
+`createNextServerI18nScope()` from `@palamedes/next-plugin/server` there rather
+than configuring `requestKeyProvider` in application code.
 
 Isomorphic SSR client-component bundles can call `activateServerI18n(i18n)` to
 enter that existing request scope without importing the Node-only server

--- a/docs/migrate-from-lingui.md
+++ b/docs/migrate-from-lingui.md
@@ -183,17 +183,17 @@ setServerI18nGetter(() => getRequestScopedI18n())
 ```
 
 For Next.js App Router Server Components on the Node runtime, prefer the
-server-only helper:
+Next render-lifetime helper:
 
 ```ts
 // src/lib/i18n.server.ts
 import "server-only"
 
 import { cache } from "react"
-import { createServerI18nScope } from "@palamedes/runtime/server"
+import { createNextServerI18nScope } from "@palamedes/next-plugin/server"
 import type { PalamedesI18n } from "@palamedes/core"
 
-export const serverI18n = createServerI18nScope<PalamedesI18n>()
+export const serverI18n = createNextServerI18nScope<PalamedesI18n>()
 
 const loadActiveServerI18n = cache(async () => {
   const locale = await resolveLocaleFromCookiesOrHeaders()
@@ -224,10 +224,11 @@ export default async function Page() {
 ```
 
 This follows the official RSC model: server-only modules prevent accidental
-client imports, React `cache()` memoizes work within the current request, and
-the runtime scope is activated before downstream Server Components call direct
-macros. Do not register a new global server getter from every Server Component
-render.
+client imports, React `cache()` memoizes setup work within the current request,
+and the Next adapter keeps the active instance bound through the RSC and Client
+Component server-render passes, including suspension and resumption. Create one
+scope at module level, activate a fresh instance per request, and do not register
+a global server getter from every Server Component render.
 
 For backend servers outside React frameworks, use the same runtime getter with
 request-local storage. The Hono/Express pattern is documented here:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -74,12 +74,12 @@ available.
 Fix:
 
 - For Next.js App Router Server Components, use a server-only module with
-  `@palamedes/runtime/server`.
+  `createNextServerI18nScope()` from `@palamedes/next-plugin/server`.
 - Create the server scope once at module level.
 - Activate the request-local i18n instance before downstream Server Components
   render translated code.
-- Keep `@palamedes/runtime/server` out of Client Components and Edge runtime
-  code because it uses Node server APIs.
+- Keep both Next and generic server scope subpaths out of Client Components and
+  Edge runtime code because they use Node server APIs.
 
 Direct server runtimes can register the getter explicitly:
 

--- a/examples/nextjs-cookie/package.json
+++ b/examples/nextjs-cookie/package.json
@@ -6,11 +6,13 @@
     "dev": "next dev --port 4010",
     "build": "next build && node ../../scripts/normalize-next-required-server-files.mjs",
     "start": "next start --port 4010",
-    "extract": "pmds extract"
+    "extract": "pmds extract",
+    "test:rsc-scope": "next build --webpack && node ./scripts/rsc-scope-production.test.mjs"
   },
   "dependencies": {
     "@palamedes/core": "workspace:^",
     "@palamedes/example-ui": "workspace:^",
+    "@palamedes/next-plugin": "workspace:^",
     "@palamedes/react": "workspace:^",
     "@palamedes/runtime": "workspace:^",
     "next": "^16.2.12",
@@ -21,7 +23,6 @@
   "devDependencies": {
     "@palamedes/cli": "workspace:^",
     "@palamedes/config": "workspace:^",
-    "@palamedes/next-plugin": "workspace:^",
     "@types/node": "^24.0.0",
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.4",

--- a/examples/nextjs-cookie/package.json
+++ b/examples/nextjs-cookie/package.json
@@ -7,7 +7,8 @@
     "build": "next build && node ../../scripts/normalize-next-required-server-files.mjs",
     "start": "next start --port 4010",
     "extract": "pmds extract",
-    "test:rsc-scope": "next build --webpack && node ./scripts/rsc-scope-production.test.mjs"
+    "test:rsc-scope": "next build && node ./scripts/rsc-scope-production.test.mjs",
+    "test:rsc-scope:webpack": "next build --webpack && node ./scripts/rsc-scope-production.test.mjs"
   },
   "dependencies": {
     "@palamedes/core": "workspace:^",

--- a/examples/nextjs-cookie/scripts/rsc-scope-production.test.mjs
+++ b/examples/nextjs-cookie/scripts/rsc-scope-production.test.mjs
@@ -1,7 +1,10 @@
 import { spawn } from "node:child_process"
+import { createRequire } from "node:module"
 
 const port = 4198
 const baseUrl = `http://127.0.0.1:${port}`
+const require = createRequire(import.meta.url)
+const nextCli = require.resolve("next/dist/bin/next")
 let serverOutput = ""
 
 function waitForExit(child) {
@@ -50,7 +53,7 @@ async function assertLocale(locale, expected) {
   }
 }
 
-const server = spawn("pnpm", ["exec", "next", "start", "--port", String(port)], {
+const server = spawn(process.execPath, [nextCli, "start", "--port", String(port)], {
   cwd: new URL("..", import.meta.url),
   env: { ...process.env, NODE_ENV: "production" },
   stdio: ["ignore", "pipe", "pipe"],

--- a/examples/nextjs-cookie/scripts/rsc-scope-production.test.mjs
+++ b/examples/nextjs-cookie/scripts/rsc-scope-production.test.mjs
@@ -1,0 +1,79 @@
+import { spawn } from "node:child_process"
+
+const port = 4198
+const baseUrl = `http://127.0.0.1:${port}`
+let serverOutput = ""
+
+function waitForExit(child) {
+  return new Promise((resolve) => child.once("exit", resolve))
+}
+
+async function stopServer(child) {
+  if (child.exitCode !== null || child.signalCode !== null) return
+
+  child.kill("SIGTERM")
+  await Promise.race([waitForExit(child), new Promise((resolve) => setTimeout(resolve, 2000))])
+
+  if (child.exitCode === null && child.signalCode === null) {
+    child.kill("SIGKILL")
+    await waitForExit(child)
+  }
+}
+
+async function waitForServer() {
+  const deadline = Date.now() + 30_000
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(`${baseUrl}/rsc-scope-probe`, {
+        headers: { "accept-language": "en" },
+      })
+      if (response.status >= 200) return
+    } catch {}
+    await new Promise((resolve) => setTimeout(resolve, 250))
+  }
+  throw new Error(`Timed out waiting for Next.js on port ${port}`)
+}
+
+async function assertLocale(locale, expected) {
+  const response = await fetch(`${baseUrl}/rsc-scope-probe`, {
+    headers: { "accept-language": locale },
+  })
+  const body = await response.text()
+
+  if (response.status !== 200 || !body.includes(`data-probe-locale="${locale}"`)) {
+    throw new Error(
+      `Expected ${locale} request to return 200 with its request locale, got ${response.status}`
+    )
+  }
+  if (!body.includes(`>${expected}</output>`)) {
+    throw new Error(`Expected ${locale} response to contain ${JSON.stringify(expected)}`)
+  }
+}
+
+const server = spawn("pnpm", ["exec", "next", "start", "--port", String(port)], {
+  cwd: new URL("..", import.meta.url),
+  env: { ...process.env, NODE_ENV: "production" },
+  stdio: ["ignore", "pipe", "pipe"],
+})
+
+for (const stream of [server.stdout, server.stderr]) {
+  stream.setEncoding("utf8")
+  stream.on("data", (chunk) => {
+    serverOutput += chunk
+  })
+}
+
+try {
+  await waitForServer()
+  await Promise.all(
+    Array.from({ length: 12 }, (_, index) =>
+      index % 2 === 0 ? assertLocale("en", "More tickets") : assertLocale("de", "Mehr Tickets")
+    )
+  )
+  console.log("Next.js production RSC scope remained request-local across suspension")
+} catch (error) {
+  console.error(serverOutput)
+  throw error
+} finally {
+  await stopServer(server)
+}

--- a/examples/nextjs-cookie/src/app/rsc-scope-probe/ScopeSuspensionProbe.tsx
+++ b/examples/nextjs-cookie/src/app/rsc-scope-probe/ScopeSuspensionProbe.tsx
@@ -1,0 +1,30 @@
+"use client"
+
+import { use } from "react"
+import { t } from "@palamedes/core/macro"
+import type { Locale } from "@/lib/i18n"
+
+const browserReady = Promise.resolve()
+const serverResources = new WeakMap<object, Promise<void>>()
+
+function getSuspensionResource(token: object): Promise<void> {
+  if (typeof window !== "undefined") return browserReady
+
+  let resource = serverResources.get(token)
+  if (!resource) {
+    resource = new Promise((resolve) => setTimeout(resolve, 25))
+    serverResources.set(token, resource)
+  }
+  return resource
+}
+
+export function ScopeSuspensionProbe({
+  locale,
+  suspensionToken,
+}: {
+  locale: Locale
+  suspensionToken: object
+}) {
+  use(getSuspensionResource(suspensionToken))
+  return <output data-probe-locale={locale}>{t`More tickets`}</output>
+}

--- a/examples/nextjs-cookie/src/app/rsc-scope-probe/page.tsx
+++ b/examples/nextjs-cookie/src/app/rsc-scope-probe/page.tsx
@@ -1,0 +1,13 @@
+import { ScopeSuspensionProbe } from "./ScopeSuspensionProbe"
+import { ClientLocaleBoundary } from "@/components/ClientLocaleBoundary"
+import { createActiveServerI18n } from "@/lib/i18n.server"
+
+export default async function RscScopeProbePage() {
+  const { locale } = await createActiveServerI18n()
+
+  return (
+    <ClientLocaleBoundary locale={locale}>
+      <ScopeSuspensionProbe locale={locale} suspensionToken={{}} />
+    </ClientLocaleBoundary>
+  )
+}

--- a/examples/nextjs-cookie/src/lib/i18n.server.ts
+++ b/examples/nextjs-cookie/src/lib/i18n.server.ts
@@ -3,12 +3,12 @@ import "server-only"
 import { cache } from "react"
 import { cookies } from "next/headers"
 import { headers } from "next/headers"
-import { createServerI18nScope } from "@palamedes/runtime/server"
+import { createNextServerI18nScope } from "@palamedes/next-plugin/server"
 import type { PalamedesI18n } from "@palamedes/core"
 import type { LocaleSource } from "@palamedes/core/locale"
 import { createExampleI18n, type Locale, loadMessages, locales } from "./i18n"
 
-export const serverI18nScope = createServerI18nScope<PalamedesI18n>()
+export const serverI18nScope = createNextServerI18nScope<PalamedesI18n>()
 
 /**
  * Get the current locale from cookies (server-side only)

--- a/examples/nextjs-route/package.json
+++ b/examples/nextjs-route/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@palamedes/core": "workspace:^",
     "@palamedes/example-ui": "workspace:^",
+    "@palamedes/next-plugin": "workspace:^",
     "@palamedes/react": "workspace:^",
     "@palamedes/runtime": "workspace:^",
     "next": "^16.2.12",
@@ -21,7 +22,6 @@
   "devDependencies": {
     "@palamedes/cli": "workspace:^",
     "@palamedes/config": "workspace:^",
-    "@palamedes/next-plugin": "workspace:^",
     "@types/node": "^24.0.0",
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.4",

--- a/examples/nextjs-route/src/lib/i18n.server.ts
+++ b/examples/nextjs-route/src/lib/i18n.server.ts
@@ -1,12 +1,12 @@
 import "server-only"
 
 import { headers } from "next/headers"
-import { createServerI18nScope } from "@palamedes/runtime/server"
+import { createNextServerI18nScope } from "@palamedes/next-plugin/server"
 import type { PalamedesI18n } from "@palamedes/core"
 import type { LocaleSource, LocaleSuggestion } from "@palamedes/core/locale"
 import { createExampleI18n, type Locale, loadMessages, locales } from "./i18n"
 
-export const serverI18nScope = createServerI18nScope<PalamedesI18n>()
+export const serverI18nScope = createNextServerI18nScope<PalamedesI18n>()
 
 export function runWithServerI18n<Result>(i18n: PalamedesI18n, callback: () => Result): Result {
   return serverI18nScope.run(i18n, callback)

--- a/examples/nextjs-subdomain/package.json
+++ b/examples/nextjs-subdomain/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@palamedes/core": "workspace:^",
     "@palamedes/example-ui": "workspace:^",
+    "@palamedes/next-plugin": "workspace:^",
     "@palamedes/react": "workspace:^",
     "@palamedes/runtime": "workspace:^",
     "next": "^16.2.12",
@@ -21,7 +22,6 @@
   "devDependencies": {
     "@palamedes/cli": "workspace:^",
     "@palamedes/config": "workspace:^",
-    "@palamedes/next-plugin": "workspace:^",
     "@types/node": "^24.0.0",
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.4",

--- a/examples/nextjs-subdomain/src/lib/i18n.server.ts
+++ b/examples/nextjs-subdomain/src/lib/i18n.server.ts
@@ -1,12 +1,12 @@
 import "server-only"
 
 import { headers } from "next/headers"
-import { createServerI18nScope } from "@palamedes/runtime/server"
+import { createNextServerI18nScope } from "@palamedes/next-plugin/server"
 import type { PalamedesI18n } from "@palamedes/core"
 import type { LocaleSource, LocaleSuggestion } from "@palamedes/core/locale"
 import { createExampleI18n, type Locale, loadMessages, locales } from "./i18n"
 
-export const serverI18nScope = createServerI18nScope<PalamedesI18n>()
+export const serverI18nScope = createNextServerI18nScope<PalamedesI18n>()
 
 export function runWithServerI18n<Result>(i18n: PalamedesI18n, callback: () => Result): Result {
   return serverI18nScope.run(i18n, callback)

--- a/examples/nextjs-tld/package.json
+++ b/examples/nextjs-tld/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@palamedes/core": "workspace:^",
     "@palamedes/example-ui": "workspace:^",
+    "@palamedes/next-plugin": "workspace:^",
     "@palamedes/react": "workspace:^",
     "@palamedes/runtime": "workspace:^",
     "next": "^16.2.12",
@@ -21,7 +22,6 @@
   "devDependencies": {
     "@palamedes/cli": "workspace:^",
     "@palamedes/config": "workspace:^",
-    "@palamedes/next-plugin": "workspace:^",
     "@types/node": "^24.0.0",
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.4",

--- a/examples/nextjs-tld/src/lib/i18n.server.ts
+++ b/examples/nextjs-tld/src/lib/i18n.server.ts
@@ -1,12 +1,12 @@
 import "server-only"
 
 import { headers } from "next/headers"
-import { createServerI18nScope } from "@palamedes/runtime/server"
+import { createNextServerI18nScope } from "@palamedes/next-plugin/server"
 import type { PalamedesI18n } from "@palamedes/core"
 import type { LocaleSource, LocaleSuggestion } from "@palamedes/core/locale"
 import { createExampleI18n, type Locale, loadMessages, locales } from "./i18n"
 
-export const serverI18nScope = createServerI18nScope<PalamedesI18n>()
+export const serverI18nScope = createNextServerI18nScope<PalamedesI18n>()
 
 export function runWithServerI18n<Result>(i18n: PalamedesI18n, callback: () => Result): Result {
   return serverI18nScope.run(i18n, callback)

--- a/packages/next-plugin/README.md
+++ b/packages/next-plugin/README.md
@@ -66,19 +66,19 @@ loader is still a `.po` import loader. Keep direct app imports on `.po` unless a
 future adapter release explicitly documents `.fcl` imports.
 
 For App Router Server Components on the Node runtime, use a server-only module
-with `@palamedes/runtime/server`. This follows the official RSC shape: keep
+with `@palamedes/next-plugin/server`. This follows the official RSC shape: keep
 server code behind `server-only`, memoize request work with React `cache()`, and
-bind direct macro calls to the active request scope while rendering.
+bind direct macro calls to the complete Next render lifetime.
 
 ```ts
 // src/lib/i18n.server.ts
 import "server-only"
 
 import { cache } from "react"
-import { createServerI18nScope } from "@palamedes/runtime/server"
+import { createNextServerI18nScope } from "@palamedes/next-plugin/server"
 import type { PalamedesI18n } from "@palamedes/core"
 
-export const serverI18n = createServerI18nScope<PalamedesI18n>()
+export const serverI18n = createNextServerI18nScope<PalamedesI18n>()
 
 const loadActiveServerI18n = cache(async () => {
   const locale = await resolveLocaleFromCookiesOrHeaders()
@@ -136,12 +136,25 @@ module code in its own chunk, which preserves the parser-free runtime and lets
 Turbopack omit inactive locale catalogs from the initial client bundle. Locale
 changes require a document navigation.
 
-Do not call `setServerI18nGetter()` inside every Server Component render. Create
-one server scope at module level, activate it during request-local server
-initialization, and let downstream Server Components call macros normally. Use
-`serverI18n.run(i18n, callback)` for tightly scoped helper callbacks or classic
-Node request handlers. The `@palamedes/runtime/server` subpath imports Node
-`async_hooks`, so keep it out of Client Components and Edge runtime code.
+Create one Next server scope at module level and activate a fresh i18n instance
+during request-local server initialization. Its lifetime is the complete App
+Router render, including the RSC pass, Client Component server prerender, and
+React suspension/resumption. Next render objects are held as weak request keys;
+there is no process-global "last request" instance to leak another locale.
+
+Do not call `setServerI18nGetter()` inside every Server Component render. Use
+`serverI18n.run(i18n, callback)` only for tightly scoped helper callbacks. Use
+the generic `createServerI18nScope()` from `@palamedes/runtime/server` for
+classic Node request handlers outside Next. Both server subpaths are Node-only,
+so keep them out of Client Components and Edge runtime code.
+
+The Next render-lifetime adapter supports the package's declared Next 16 peer
+range and is verified against Next 16.2. It intentionally binds to Next's
+server render storage because public React async context does not span both
+App Router render passes. If a future Next 16 release removes that server
+storage module, the import fails during the application build instead of
+silently falling back to stale or cross-request i18n state; upgrade Palamedes
+before adopting that Next release.
 
 References: [Next.js Server and Client Components](https://nextjs.org/docs/app/getting-started/server-and-client-components), [Next.js data fetching and request-scoped React cache](https://nextjs.org/docs/app/getting-started/fetching-data), and [React `cache`](https://react.dev/reference/react/cache).
 

--- a/packages/next-plugin/build.config.ts
+++ b/packages/next-plugin/build.config.ts
@@ -1,7 +1,7 @@
 import { defineBuildConfig } from "unbuild"
 
 export default defineBuildConfig({
-  entries: ["./src/index"],
+  entries: ["./src/index", "./src/server"],
   declaration: true,
   failOnWarn: false,
   rollup: {

--- a/packages/next-plugin/package.json
+++ b/packages/next-plugin/package.json
@@ -53,6 +53,16 @@
         "default": "./dist/index.cjs"
       }
     },
+    "./server": {
+      "import": {
+        "types": "./dist/server.d.mts",
+        "default": "./dist/server.mjs"
+      },
+      "require": {
+        "types": "./dist/server.d.cts",
+        "default": "./dist/server.cjs"
+      }
+    },
     "./palamedes-loader": "./palamedes-loader.cjs",
     "./palamedes-po-loader": "./palamedes-po-loader.cjs"
   },

--- a/packages/next-plugin/src/server.test.ts
+++ b/packages/next-plugin/src/server.test.ts
@@ -1,0 +1,30 @@
+import { AsyncLocalStorage } from "node:async_hooks"
+
+import { afterEach, describe, expect, it } from "vitest"
+import "next/dist/server/node-environment.js"
+import { workAsyncStorage } from "next/dist/server/app-render/work-async-storage.external.js"
+import { getI18n, resetI18nRuntime, type I18nInstance } from "@palamedes/runtime"
+
+import { createNextServerI18nScope } from "./server"
+
+describe("@palamedes/next-plugin/server", () => {
+  afterEach(() => resetI18nRuntime())
+
+  it("uses the Next render store when React resumes an earlier async context", () => {
+    const scope = createNextServerI18nScope<I18nInstance>()
+    const i18n: I18nInstance = {
+      locale: "de",
+      _: (message: string) => message,
+    }
+
+    workAsyncStorage.run({} as never, () => {
+      const resumeFromBeforeActivation = AsyncLocalStorage.snapshot()
+      scope.activate(i18n)
+
+      resumeFromBeforeActivation(() => {
+        expect(scope.get()).toBe(i18n)
+        expect(getI18n()).toBe(i18n)
+      })
+    })
+  })
+})

--- a/packages/next-plugin/src/server.ts
+++ b/packages/next-plugin/src/server.ts
@@ -1,0 +1,25 @@
+import { workAsyncStorage } from "next/dist/server/app-render/work-async-storage.external.js"
+import { createServerI18nScope, type ServerI18nScope } from "@palamedes/runtime/server"
+import type { I18nInstance } from "@palamedes/runtime"
+
+const NEXT_RENDER_REQUEST_KEY_PROVIDER = Symbol.for("palamedes.nextPlugin.renderRequestKeyProvider")
+
+/**
+ * Create an i18n scope keyed to Next.js' complete App Router render lifetime.
+ * The render key remains stable when React suspends and resumes work in a
+ * different async execution context.
+ */
+export function createNextServerI18nScope<
+  T extends I18nInstance = I18nInstance,
+>(): ServerI18nScope<T> {
+  return createServerI18nScope<T>({
+    requestKeyProvider: {
+      get: () => workAsyncStorage.getStore(),
+      // A stable ID lets runtime registration replace this closure during HMR
+      // instead of retaining one provider for every module evaluation.
+      id: NEXT_RENDER_REQUEST_KEY_PROVIDER,
+    },
+  })
+}
+
+export type { ServerI18nScope }

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -121,7 +121,8 @@ export const ClientCatalogBoundary = createClientCatalogBoundary<Locale>({
 ```
 
 Then render it from the Server Component after activating the same request
-locale through `@palamedes/runtime/server`:
+locale. In Next.js, use the render-lifetime scope from
+`@palamedes/next-plugin/server`:
 
 ```tsx
 const { locale } = await createActiveServerI18n()

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -122,6 +122,12 @@ For a fuller walkthrough, including Hono and Express examples, see:
   - `requestKeyProvider` is an adapter-only escape hatch for a stable host render
     identity; its symbol ID makes repeat registration bounded during dev HMR
 
+When a request key is available, `scope.activate()` updates the instance stored
+for that key. Multiple activations under the same key are last-write-wins, which
+matches hosts such as Next where one render has one active instance.
+`scope.run()` remains isolated to its callback and takes precedence over that
+request-key fallback.
+
 The `@palamedes/runtime/server` implementation imports Node `async_hooks`. In
 non-Node bundles, the subpath resolves to a small fallback module that throws an
 actionable Node-only error when called.

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -72,7 +72,15 @@ await serverI18n.run(i18n, async () => {
 
 All scopes created by this helper share the same runtime getter, so independently
 created scopes do not disconnect transformed `getI18n()` calls from the scope
-that was activated for the current async context.
+that was activated for the current async context. Framework adapters can also
+provide a stable request key for hosts that resume rendering from an earlier
+async context; application code should use the framework adapter rather than
+constructing that provider itself.
+
+Next.js App Router applications must use
+`createNextServerI18nScope()` from `@palamedes/next-plugin/server`. A plain
+`AsyncLocalStorage.enterWith()` lifetime does not cover Next's separate RSC and
+Client Component server-render passes after suspension.
 
 ## Backend Servers
 
@@ -90,9 +98,11 @@ const serverI18n = createServerI18nScope<ReturnType<typeof createI18n>>()
 ```
 
 Per request, resolve the locale from `Accept-Language`, cookies, session data,
-or the user profile. Use `serverI18n.activate(i18n)` when framework rendering
-continues after the initializer returns, as in React Server Components. Use
-`serverI18n.run(i18n, ...)` for tightly scoped request-handler callbacks.
+or the user profile. Use `serverI18n.activate(i18n)` only when the host preserves
+the current Node async context after the initializer returns. Use
+`serverI18n.run(i18n, ...)` for tightly scoped request-handler callbacks. Hosts
+with multi-pass rendering or suspension need a framework adapter with a stable
+request key; Next applications use `@palamedes/next-plugin/server`.
 
 For a fuller walkthrough, including Hono and Express examples, see:
 
@@ -109,6 +119,8 @@ For a fuller walkthrough, including Hono and Express examples, see:
   - `scope.activate(i18n)` binds an i18n instance to the current async context
   - `scope.run(i18n, callback)` runs a callback inside a scoped async context
   - `scope.get()` returns the current scoped i18n instance, if one is active
+  - `requestKeyProvider` is an adapter-only escape hatch for a stable host render
+    identity; its symbol ID makes repeat registration bounded during dev HMR
 
 The `@palamedes/runtime/server` implementation imports Node `async_hooks`. In
 non-Node bundles, the subpath resolves to a small fallback module that throws an

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -22,6 +22,17 @@ export type ServerI18nScope<T extends I18nInstance = I18nInstance> = {
   get(): T | undefined
 }
 
+export type CreateServerI18nScopeOptions = {
+  /**
+   * A framework adapter's stable request/render identity. The provider ID
+   * replaces an earlier registration from the same adapter during dev HMR.
+   */
+  requestKeyProvider?: {
+    get(): object | undefined
+    id: symbol
+  }
+}
+
 type GlobalRuntimeState = typeof globalThis & {
   [CLIENT_I18N_KEY]?: I18nInstance
   [SERVER_I18N_GETTER_KEY]?: ServerI18nGetter
@@ -30,6 +41,8 @@ type GlobalRuntimeState = typeof globalThis & {
       enterWith(i18n: I18nInstance): void
       getStore(): I18nInstance | undefined
     }
+    activate(i18n: I18nInstance): void
+    get(): I18nInstance | undefined
   }
   [REGISTERED_MESSAGES_KEY]?: Map<string, Record<string, unknown>[]>
 }
@@ -122,12 +135,12 @@ export function activateServerI18n<T extends I18nInstance>(i18n: T): T {
       "No server i18n scope is configured. Create one with createServerI18nScope() from @palamedes/runtime/server before activating SSR client components."
     )
   }
-  state[SERVER_I18N_GETTER_KEY] ??= () => scopeState.active.getStore()
-  const activeI18n = scopeState.active.getStore()
+  state[SERVER_I18N_GETTER_KEY] ??= () => scopeState.get()
+  const activeI18n = scopeState.get()
   if (activeI18n === i18n) {
     return i18n
   }
-  scopeState.active.enterWith(i18n)
+  scopeState.activate(i18n)
   return i18n
 }
 

--- a/packages/runtime/src/server-unavailable.ts
+++ b/packages/runtime/src/server-unavailable.ts
@@ -1,10 +1,12 @@
-import type { I18nInstance, ServerI18nScope } from "./index"
+import type { CreateServerI18nScopeOptions, I18nInstance, ServerI18nScope } from "./index"
 
-export type { ServerI18nScope } from "./index"
+export type { CreateServerI18nScopeOptions, ServerI18nScope } from "./index"
 
 const SERVER_RUNTIME_UNAVAILABLE_MESSAGE =
   "@palamedes/runtime/server is only available in Node.js server runtimes. Import it from server-only Node code, not Client Components or Edge runtime code."
 
-export function createServerI18nScope<T extends I18nInstance = I18nInstance>(): ServerI18nScope<T> {
+export function createServerI18nScope<T extends I18nInstance = I18nInstance>(
+  _options: CreateServerI18nScopeOptions = {}
+): ServerI18nScope<T> {
   throw new Error(SERVER_RUNTIME_UNAVAILABLE_MESSAGE)
 }

--- a/packages/runtime/src/server.test.ts
+++ b/packages/runtime/src/server.test.ts
@@ -164,4 +164,155 @@ describe("@palamedes/runtime/server", () => {
       }),
     ])
   })
+
+  it("restores the request instance through a host render key after context resumption", () => {
+    const requestStorage = new AsyncLocalStorage<object>()
+    const scope = createServerI18nScope<I18nInstance>({
+      requestKeyProvider: {
+        get: () => requestStorage.getStore(),
+        id: Symbol("test-request"),
+      },
+    })
+    const requestKey = {}
+    const i18n = createTestI18n("de")
+
+    requestStorage.run(requestKey, () => {
+      const resumeFromBeforeActivation = AsyncLocalStorage.snapshot()
+      scope.activate(i18n)
+
+      resumeFromBeforeActivation(() => {
+        expect(scope.get()).toBe(i18n)
+        expect(getI18n()).toBe(i18n)
+      })
+    })
+  })
+
+  it("prefers a nested run scope over the host render fallback", () => {
+    const requestStorage = new AsyncLocalStorage<object>()
+    const scope = createServerI18nScope<I18nInstance>({
+      requestKeyProvider: {
+        get: () => requestStorage.getStore(),
+        id: Symbol("test-nested-run"),
+      },
+    })
+    const requestI18n = createTestI18n("de")
+    const nestedI18n = createTestI18n("en")
+
+    requestStorage.run({}, () => {
+      scope.activate(requestI18n)
+
+      scope.run(nestedI18n, () => {
+        expect(scope.get()).toBe(nestedI18n)
+        expect(getI18n()).toBe(nestedI18n)
+      })
+
+      expect(scope.get()).toBe(requestI18n)
+      expect(getI18n()).toBe(requestI18n)
+    })
+  })
+
+  it("keeps sibling run branches isolated when one branch activates another instance", async () => {
+    const scope = createServerI18nScope<I18nInstance>()
+    const outerI18n = createTestI18n("en")
+    const nestedI18n = createTestI18n("de")
+
+    await scope.run(outerI18n, async () => {
+      let markActivated: () => void = () => {}
+      const activated = new Promise<void>((resolve) => {
+        markActivated = resolve
+      })
+
+      const activatingBranch = (async () => {
+        await Promise.resolve()
+        scope.activate(nestedI18n)
+        markActivated()
+        await Promise.resolve()
+        expect(scope.get()).toBe(nestedI18n)
+        expect(getI18n()).toBe(nestedI18n)
+      })()
+      const siblingBranch = (async () => {
+        await activated
+        expect(scope.get()).toBe(outerI18n)
+        expect(getI18n()).toBe(outerI18n)
+      })()
+
+      await Promise.all([activatingBranch, siblingBranch])
+    })
+  })
+
+  it("keeps host render keys isolated when requests resume concurrently", async () => {
+    const requestStorage = new AsyncLocalStorage<object>()
+    const scope = createServerI18nScope<I18nInstance>({
+      requestKeyProvider: {
+        get: () => requestStorage.getStore(),
+        id: Symbol("test-concurrent-requests"),
+      },
+    })
+    const deI18n = createTestI18n("de")
+    const enI18n = createTestI18n("en")
+
+    async function render(i18n: I18nInstance) {
+      return requestStorage.run({}, async () => {
+        const resumeFromBeforeActivation = AsyncLocalStorage.snapshot()
+        scope.activate(i18n)
+        await new Promise((resolve) => setTimeout(resolve, 0))
+        return resumeFromBeforeActivation(() => getI18n())
+      })
+    }
+
+    await expect(Promise.all([render(deI18n), render(enI18n)])).resolves.toEqual([deI18n, enI18n])
+  })
+
+  it("replaces a framework request-key provider with the same stable id", () => {
+    const providerId = Symbol("test-hmr-provider")
+    const staleRequestStorage = new AsyncLocalStorage<object>()
+    const currentRequestStorage = new AsyncLocalStorage<object>()
+    let staleProviderCalls = 0
+    createServerI18nScope<I18nInstance>({
+      requestKeyProvider: {
+        get() {
+          staleProviderCalls += 1
+          return staleRequestStorage.getStore()
+        },
+        id: providerId,
+      },
+    })
+    const scope = createServerI18nScope<I18nInstance>({
+      requestKeyProvider: {
+        get: () => currentRequestStorage.getStore(),
+        id: providerId,
+      },
+    })
+
+    scope.activate(createTestI18n())
+    expect(staleProviderCalls).toBe(0)
+  })
+
+  it("shares external request activation with an isolated SSR module graph", async () => {
+    const requestStorage = new AsyncLocalStorage<object>()
+    const scope = createServerI18nScope<I18nInstance>({
+      requestKeyProvider: {
+        get: () => requestStorage.getStore(),
+        id: Symbol("test-isolated-ssr-request"),
+      },
+    })
+    const serverI18n = createTestI18n("en")
+    const clientComponentI18n = createTestI18n("de")
+    vi.resetModules()
+    const isolatedRuntime = await import("./index")
+
+    requestStorage.run({}, () => {
+      const resumeFromBeforeActivation = AsyncLocalStorage.snapshot()
+      scope.activate(serverI18n)
+      isolatedRuntime.activateServerI18n(clientComponentI18n)
+
+      resumeFromBeforeActivation(() => {
+        expect(scope.get()).toBe(clientComponentI18n)
+        expect(isolatedRuntime.getI18n()).toBe(clientComponentI18n)
+        expect(getI18n()).toBe(clientComponentI18n)
+      })
+    })
+
+    isolatedRuntime.resetI18nRuntime()
+  })
 })

--- a/packages/runtime/src/server.test.ts
+++ b/packages/runtime/src/server.test.ts
@@ -44,6 +44,34 @@ describe("@palamedes/runtime/server", () => {
     isolatedRuntime.resetI18nRuntime()
   })
 
+  it("upgrades shared state from an older runtime copy without disconnecting it", () => {
+    const stateKey = Symbol.for("palamedes.runtime.serverI18nScopeState")
+    const globalState = globalThis as typeof globalThis & Record<symbol, unknown>
+    const previousState = globalState[stateKey]
+    const legacyActive = new AsyncLocalStorage<I18nInstance>()
+    globalState[stateKey] = { active: legacyActive }
+
+    try {
+      const scope = createServerI18nScope<I18nInstance>()
+      const i18n = createTestI18n("de")
+
+      scope.run(i18n, () => {
+        expect(legacyActive.getStore()).toBe(i18n)
+        expect(scope.get()).toBe(i18n)
+        expect(getI18n()).toBe(i18n)
+      })
+
+      expect(globalState[stateKey]).toMatchObject({
+        active: legacyActive,
+        activate: expect.any(Function),
+        get: expect.any(Function),
+        run: expect.any(Function),
+      })
+    } finally {
+      globalState[stateKey] = previousState
+    }
+  })
+
   it("activates an i18n instance for the current async server context", async () => {
     const scope = createServerI18nScope<I18nInstance>()
     const i18n = createTestI18n()

--- a/packages/runtime/src/server.ts
+++ b/packages/runtime/src/server.ts
@@ -1,13 +1,24 @@
 import { AsyncLocalStorage } from "node:async_hooks"
 
-import { type I18nInstance, type ServerI18nScope, setServerI18nGetter } from "./index"
+import {
+  type CreateServerI18nScopeOptions,
+  type I18nInstance,
+  type ServerI18nScope,
+  setServerI18nGetter,
+} from "./index"
 
-export type { ServerI18nScope } from "./index"
+export type { CreateServerI18nScopeOptions, ServerI18nScope } from "./index"
 
 const SERVER_SCOPE_STATE_KEY = Symbol.for("palamedes.runtime.serverI18nScopeState")
 
 type ServerScopeState = {
   active: AsyncLocalStorage<I18nInstance>
+  activate(i18n: I18nInstance): void
+  get(): I18nInstance | undefined
+  getRun(): I18nInstance | undefined
+  requestI18n: WeakMap<object, I18nInstance>
+  requestKeyProviders: Map<symbol, () => object | undefined>
+  run<Result>(i18n: I18nInstance, callback: () => Result): Result
 }
 
 function getServerScopeState(): ServerScopeState {
@@ -17,35 +28,76 @@ function getServerScopeState(): ServerScopeState {
     return existing
   }
 
+  const active = new AsyncLocalStorage<I18nInstance>()
+  const running = new AsyncLocalStorage<I18nInstance>()
+  const requestI18n = new WeakMap<object, I18nInstance>()
+  const requestKeyProviders = new Map<symbol, () => object | undefined>()
   const state: ServerScopeState = {
-    active: new AsyncLocalStorage<I18nInstance>(),
+    active,
+    activate(i18n) {
+      if (running.getStore()) running.enterWith(i18n)
+      active.enterWith(i18n)
+      for (const getRequestKey of requestKeyProviders.values()) {
+        const requestKey = getRequestKey()
+        if (requestKey) requestI18n.set(requestKey, i18n)
+      }
+    },
+    get() {
+      const runI18n = running.getStore()
+      if (runI18n) return runI18n
+      for (const getRequestKey of requestKeyProviders.values()) {
+        const requestKey = getRequestKey()
+        if (!requestKey) continue
+        const requestScopedI18n = requestI18n.get(requestKey)
+        if (requestScopedI18n) return requestScopedI18n
+      }
+      return active.getStore()
+    },
+    getRun: () => running.getStore(),
+    requestI18n,
+    requestKeyProviders,
+    run: (i18n, callback) => running.run(i18n, () => active.run(i18n, callback)),
   }
   globalState[SERVER_SCOPE_STATE_KEY] = state
   return state
 }
 
-export function createServerI18nScope<T extends I18nInstance = I18nInstance>(): ServerI18nScope<T> {
+export function createServerI18nScope<T extends I18nInstance = I18nInstance>(
+  options: CreateServerI18nScopeOptions = {}
+): ServerI18nScope<T> {
   const sharedState = getServerScopeState()
   const storage = new AsyncLocalStorage<T>()
+  const requestKeyProvider = options.requestKeyProvider
+  const getRequestKey = requestKeyProvider?.get
+  if (requestKeyProvider) {
+    sharedState.requestKeyProviders.set(requestKeyProvider.id, requestKeyProvider.get)
+  }
 
   const scope: ServerI18nScope<T> = {
     run(i18n, callback) {
-      return sharedState.active.run(i18n, () => storage.run(i18n, callback))
+      return sharedState.run(i18n, () => storage.run(i18n, callback))
     },
     activate(i18n) {
       // enterWith() binds to the CURRENT async context: call this inside a
       // per-request context (middleware, loader, handler). Calling it at
       // module scope leaks one request's i18n into every later request.
-      sharedState.active.enterWith(i18n)
+      sharedState.activate(i18n)
       storage.enterWith(i18n)
       return i18n
     },
     get() {
+      const runI18n = sharedState.getRun()
+      if (runI18n) return runI18n as T
+      const requestKey = getRequestKey?.()
+      if (requestKey) {
+        const requestScopedI18n = sharedState.requestI18n.get(requestKey)
+        if (requestScopedI18n) return requestScopedI18n as T
+      }
       return storage.getStore()
     },
   }
 
-  setServerI18nGetter(() => sharedState.active.getStore())
+  setServerI18nGetter(() => sharedState.get())
 
   return scope
 }

--- a/packages/runtime/src/server.ts
+++ b/packages/runtime/src/server.ts
@@ -21,18 +21,26 @@ type ServerScopeState = {
   run<Result>(i18n: I18nInstance, callback: () => Result): Result
 }
 
-function getServerScopeState(): ServerScopeState {
-  const globalState = globalThis as typeof globalThis & Record<symbol, ServerScopeState | undefined>
-  const existing = globalState[SERVER_SCOPE_STATE_KEY]
-  if (existing) {
-    return existing
-  }
+type LegacyServerScopeState = Pick<ServerScopeState, "active">
 
-  const active = new AsyncLocalStorage<I18nInstance>()
+function isCurrentServerScopeState(
+  state: LegacyServerScopeState | ServerScopeState
+): state is ServerScopeState {
+  return (
+    typeof (state as ServerScopeState).activate === "function" &&
+    typeof (state as ServerScopeState).get === "function" &&
+    typeof (state as ServerScopeState).getRun === "function" &&
+    typeof (state as ServerScopeState).run === "function" &&
+    (state as ServerScopeState).requestI18n instanceof WeakMap &&
+    (state as ServerScopeState).requestKeyProviders instanceof Map
+  )
+}
+
+function createServerScopeState(active: AsyncLocalStorage<I18nInstance>): ServerScopeState {
   const running = new AsyncLocalStorage<I18nInstance>()
   const requestI18n = new WeakMap<object, I18nInstance>()
   const requestKeyProviders = new Map<symbol, () => object | undefined>()
-  const state: ServerScopeState = {
+  return {
     active,
     activate(i18n) {
       if (running.getStore()) running.enterWith(i18n)
@@ -58,6 +66,19 @@ function getServerScopeState(): ServerScopeState {
     requestKeyProviders,
     run: (i18n, callback) => running.run(i18n, () => active.run(i18n, callback)),
   }
+}
+
+function getServerScopeState(): ServerScopeState {
+  const globalState = globalThis as typeof globalThis &
+    Record<symbol, LegacyServerScopeState | ServerScopeState | undefined>
+  const existing = globalState[SERVER_SCOPE_STATE_KEY]
+  if (existing && isCurrentServerScopeState(existing)) {
+    return existing
+  }
+
+  // Runtime copies share this symbol across module graphs and versions. Reuse
+  // an older state's storage so scopes created before this upgrade stay linked.
+  const state = createServerScopeState(existing?.active ?? new AsyncLocalStorage<I18nInstance>())
   globalState[SERVER_SCOPE_STATE_KEY] = state
   return state
 }
@@ -90,6 +111,8 @@ export function createServerI18nScope<T extends I18nInstance = I18nInstance>(
       if (runI18n) return runI18n as T
       const requestKey = getRequestKey?.()
       if (requestKey) {
+        // A host render key is more precise than an AsyncLocalStorage context,
+        // which may have been captured before activation or reused after it.
         const requestScopedI18n = sharedState.requestI18n.get(requestKey)
         if (requestScopedI18n) return requestScopedI18n as T
       }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,6 +99,9 @@ importers:
       '@palamedes/example-ui':
         specifier: workspace:^
         version: link:../../packages/example-ui
+      '@palamedes/next-plugin':
+        specifier: workspace:^
+        version: link:../../packages/next-plugin
       '@palamedes/react':
         specifier: workspace:^
         version: link:../../packages/react
@@ -124,9 +127,6 @@ importers:
       '@palamedes/config':
         specifier: workspace:^
         version: link:../../packages/config
-      '@palamedes/next-plugin':
-        specifier: workspace:^
-        version: link:../../packages/next-plugin
       '@types/node':
         specifier: ^24.0.0
         version: 24.13.3
@@ -148,6 +148,9 @@ importers:
       '@palamedes/example-ui':
         specifier: workspace:^
         version: link:../../packages/example-ui
+      '@palamedes/next-plugin':
+        specifier: workspace:^
+        version: link:../../packages/next-plugin
       '@palamedes/react':
         specifier: workspace:^
         version: link:../../packages/react
@@ -173,9 +176,6 @@ importers:
       '@palamedes/config':
         specifier: workspace:^
         version: link:../../packages/config
-      '@palamedes/next-plugin':
-        specifier: workspace:^
-        version: link:../../packages/next-plugin
       '@types/node':
         specifier: ^24.0.0
         version: 24.13.3
@@ -197,6 +197,9 @@ importers:
       '@palamedes/example-ui':
         specifier: workspace:^
         version: link:../../packages/example-ui
+      '@palamedes/next-plugin':
+        specifier: workspace:^
+        version: link:../../packages/next-plugin
       '@palamedes/react':
         specifier: workspace:^
         version: link:../../packages/react
@@ -222,9 +225,6 @@ importers:
       '@palamedes/config':
         specifier: workspace:^
         version: link:../../packages/config
-      '@palamedes/next-plugin':
-        specifier: workspace:^
-        version: link:../../packages/next-plugin
       '@types/node':
         specifier: ^24.0.0
         version: 24.13.3
@@ -246,6 +246,9 @@ importers:
       '@palamedes/example-ui':
         specifier: workspace:^
         version: link:../../packages/example-ui
+      '@palamedes/next-plugin':
+        specifier: workspace:^
+        version: link:../../packages/next-plugin
       '@palamedes/react':
         specifier: workspace:^
         version: link:../../packages/react
@@ -271,9 +274,6 @@ importers:
       '@palamedes/config':
         specifier: workspace:^
         version: link:../../packages/config
-      '@palamedes/next-plugin':
-        specifier: workspace:^
-        version: link:../../packages/next-plugin
       '@types/node':
         specifier: ^24.0.0
         version: 24.13.3

--- a/site/app/data/steps.ts
+++ b/site/app/data/steps.ts
@@ -183,9 +183,9 @@ export default withPalamedes({})
 // src/lib/i18n.server.ts
 import "server-only"
 import { createI18n } from "@palamedes/core"
-import { createServerI18nScope } from "@palamedes/runtime/server"
+import { createNextServerI18nScope } from "@palamedes/next-plugin/server"
 
-export const serverI18n = createServerI18nScope<ReturnType<typeof createI18n>>()`,
+export const serverI18n = createNextServerI18nScope<ReturnType<typeof createI18n>>()`,
     },
     {
       title: "Write & extract",

--- a/site/app/routes/frameworks/nextjs.tsx
+++ b/site/app/routes/frameworks/nextjs.tsx
@@ -119,7 +119,7 @@ export default async function Page() {
   },
   boundary: {
     title: "Current boundary: the request scope targets the Node runtime.",
-    body: "The @palamedes/runtime/server entry uses Node async hooks and must stay out of Edge and Client Components. Direct catalog imports currently use PO files even when FCL is configured for other catalog workflows.",
+    body: "The @palamedes/next-plugin/server entry binds i18n to the complete Node render lifetime and must stay out of Edge and Client Components. Direct catalog imports currently use PO files even when FCL is configured for other catalog workflows.",
     link: {
       label: "Read the Next.js integration notes",
       href: docsHref("api/next-plugin"),


### PR DESCRIPTION
## Summary

Next can resume Client Component server rendering in an async context captured before `scope.activate()`. The plain `AsyncLocalStorage` scope is missing there, which made translated Client Components fail during production prerendering.

This PR:

- adds `createNextServerI18nScope()` under `@palamedes/next-plugin/server`, keyed to Next's stable App Router render store
- keeps render instances in a `WeakMap`, with no process-global "last request" fallback
- preserves nested `run()` overrides and sibling async-branch isolation
- moves the Next examples to the adapter and documents its Node/Next 16 lifecycle and compatibility boundary
- adds a real production-build regression that suspends a Client Component and checks concurrent English/German requests

## Issue

Closes #538.

## Validation

- `pnpm --filter @palamedes/runtime test` (28 tests)
- `pnpm --filter @palamedes/next-plugin test` (19 tests)
- focused Runtime and Next adapter TypeScript checks and builds
- `pnpm check:published-types`
- `pnpm format:check`
- `pnpm lint`
- `pnpm --filter @palamedes/example-nextjs-cookie test:rsc-scope` (optimized Next 16.2 production build plus 12 concurrent alternating `en`/`de` requests)

## Follow-up

None planned. Next doesn't expose a public request identity that spans both App Router server-render passes, so the adapter uses Next 16's internal render storage. The compatibility boundary and build-time failure mode are documented.
