### PR TITLE
feat(benchmark): add a General Translation lane to the e2e workflow benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ The current proof:
 every cache cleared, every tool doing the same work — and that is the lane the
 comparison numbers come from. But it is not the run you actually make. You edit
 a few files and extract again. On the realistic corpus (1,500 files, 6,000
-messages) a cold extract and catalog update takes `82.14 ms`; touching `5`
-source files and re-running takes `33.11 ms`, because extraction is cached per
+messages) a cold extract and catalog update takes `83.89 ms`; touching `5`
+source files and re-running takes `33.08 ms`, because extraction is cached per
 file and validated by a `stat` — unchanged files are neither read nor parsed
 ([ADR-019](https://palamedes.dev/decisions/019-extraction-cache)). In watch
 mode that cache is held in memory for the life of the process.

--- a/benchmarks/e2e-workflow/README.md
+++ b/benchmarks/e2e-workflow/README.md
@@ -7,13 +7,22 @@ would run to update catalogs:
 - Lingui: `lingui extract`
 - React Intl: `formatjs extract`
 - i18next-cli: `i18next-cli extract`
+- General Translation: `gtx-cli generate`
 
 The harness generates the same logical source inventory for each tool, renders
 it into each tool's idiomatic source shape, resets catalogs before every timed
-run, then measures scan, extract, and output writes together. Palamedes,
-Lingui, and i18next-cli update `en` and `de` catalogs. The React Intl lane uses
-`@formatjs/cli` to write one aggregated extracted-message JSON artifact instead;
-the generated report records that narrower scope explicitly.
+run, then measures scan, extract, and output writes together. Palamedes, Lingui,
+i18next-cli, and General Translation update `en` and `de` catalogs. The React
+Intl lane uses `@formatjs/cli` to write one aggregated extracted-message JSON
+artifact instead; the generated report records that narrower scope explicitly.
+
+The General Translation lane runs `gtx-cli generate`, GT's path for teams
+handling their own translations: it extracts and merges catalogs entirely
+locally, with no API key and no network access. GT's default workflow
+(`gtx-cli translate`) sends content to the GT API and is out of scope here.
+Because GT keys catalogs by a content hash it computes itself, the baseline
+catalogs for that lane are derived from a real `gtx-cli generate` run rather
+than from a reimplementation of its hashing.
 
 The timed median does not include runtime catalog/artifact compilation, linting,
 type-checking, bundling, or the post-run semantic validation. The validation is

--- a/benchmarks/e2e-workflow/package.json
+++ b/benchmarks/e2e-workflow/package.json
@@ -2,7 +2,7 @@
   "name": "@palamedes/benchmark-e2e-workflow",
   "private": true,
   "type": "module",
-  "description": "End-to-end extraction workflow benchmark for Palamedes, Lingui, React Intl, and i18next-cli",
+  "description": "End-to-end extraction workflow benchmark for Palamedes, Lingui, React Intl, i18next-cli, and General Translation",
   "engines": {
     "node": ">=22.22.0"
   },
@@ -17,6 +17,8 @@
     "@lingui/cli": "6.6.0",
     "@lingui/conf": "6.6.0",
     "@lingui/format-po": "6.6.0",
+    "gt-react": "11.1.4",
+    "gtx-cli": "2.16.0",
     "i18next-cli": "1.67.3"
   }
 }

--- a/benchmarks/e2e-workflow/results/latest.json
+++ b/benchmarks/e2e-workflow/results/latest.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "benchmark": "palamedes-e2e-extract-update-workflow",
-  "generatedAt": "2026-07-31T08:33:20.786Z",
+  "generatedAt": "2026-08-05T09:07:39.077Z",
   "machineLocal": true,
   "seed": 20260703,
   "warmup": 3,
@@ -11,21 +11,25 @@
     "nodeVersion": "v24.18.0",
     "platform": "darwin",
     "arch": "arm64",
-    "generatedAt": "2026-07-31T08:33:20.786Z"
+    "generatedAt": "2026-08-05T09:07:39.077Z"
   },
   "versions": {
     "benchmarkPackage": "@palamedes/benchmark-e2e-workflow",
     "palamedes": {
-      "cli": "pmds (Palamedes) v1.9.0"
+      "cli": "pmds (Palamedes) v1.12.0"
     },
     "lingui": {
       "cli": "6.6.0"
     },
     "formatjs": {
-      "cli": "6.16.14"
+      "cli": "6.16.16"
     },
     "i18nextCli": {
       "cli": "1.67.3"
+    },
+    "gt": {
+      "cli": "2.16.0",
+      "react": "11.1.4"
     }
   },
   "methodology": {
@@ -34,7 +38,8 @@
     "reset": "catalog files and tool caches are reset to the same baseline state before every cold warmup and measured run",
     "semanticCheck": "active catalog messages are normalized after each tool run and compared with the generated current inventory",
     "toolScopes": {
-      "formatjs": "source scan, extraction, content-hash ID generation, and one aggregated extracted-message JSON write; the React Intl extraction workflow does not update locale translation catalogs",
+      "formatjs": "source scan, extraction, content-hash ID generation, and one aggregated extracted-message JSON write; the React Intl extraction workflow does not update locale translation catalogs, so this lane covers less work than every other lane in the table",
+      "gt": "source scan, extraction, content-hash keying, and merge/update of existing en/de catalogs; gtx-cli generate runs fully locally, seeds new entries with the source text, and drops removed entries immediately instead of marking them obsolete",
       "otherTools": "source scan, extraction, merge/update of existing en/de catalogs, and catalog writes"
     }
   },
@@ -76,13 +81,20 @@
               "en": 640,
               "de": 640
             }
+          },
+          "gt": {
+            "activeMessagesByTarget": {
+              "en": 640,
+              "de": 640
+            },
+            "preservedTranslations": 528
           }
         }
       },
       "results": [
         {
           "tool": "palamedes",
-          "version": "pmds (Palamedes) v1.9.0",
+          "version": "pmds (Palamedes) v1.12.0",
           "profile": "small",
           "fileCount": 80,
           "sourceMessageCount": 640,
@@ -93,20 +105,20 @@
           "sourceBytes": 23590,
           "warmup": 3,
           "runs": 7,
-          "medianMs": 12.816542,
+          "medianMs": 14.113583,
           "rawSamplesMs": [
-            12.184375,
-            12.318917,
-            12.751167,
-            12.816542,
-            12.959917,
-            13.222375,
-            13.317125
+            13.606625,
+            13.887,
+            13.966834,
+            14.113583,
+            14.23625,
+            14.32675,
+            14.854875
           ],
           "stdoutBytes": 175,
           "stderrBytes": 0,
           "palamedesTiming": {
-            "totalMs": 5,
+            "totalMs": 6,
             "globMs": 0,
             "extractMs": 3,
             "writeMs": 1,
@@ -114,15 +126,15 @@
             "totalFiles": 80
           },
           "warm": {
-            "medianMs": 10.265375,
+            "medianMs": 10.76375,
             "samplesMs": [
-              9.428625,
-              9.814042,
-              10.078,
-              10.265375,
-              10.410667,
-              10.588292,
-              11.157084
+              10.121459,
+              10.2065,
+              10.584583,
+              10.76375,
+              10.975,
+              10.983083,
+              11.471917
             ],
             "touchedFiles": 5,
             "palamedesTiming": {
@@ -149,28 +161,28 @@
           "sourceBytes": 23590,
           "warmup": 3,
           "runs": 7,
-          "medianMs": 690.974042,
+          "medianMs": 747.176625,
           "rawSamplesMs": [
-            683.987,
-            684.016334,
-            687.69325,
-            690.974042,
-            695.483,
-            703.010291,
-            704.654542
+            732.131375,
+            734.159083,
+            742.392,
+            747.176625,
+            759.621833,
+            793.186709,
+            795.973292
           ],
-          "stdoutBytes": 757,
+          "stdoutBytes": 755,
           "stderrBytes": 18,
           "warm": {
-            "medianMs": 687.763417,
+            "medianMs": 944.157709,
             "samplesMs": [
-              674.540375,
-              678.100458,
-              684.4095,
-              687.763417,
-              688.996709,
-              731.565458,
-              735.847083
+              689.073667,
+              716.492417,
+              937.278792,
+              944.157709,
+              1027.130833,
+              1173.490375,
+              1383.133042
             ],
             "touchedFiles": 5,
             "palamedesTiming": null
@@ -178,7 +190,7 @@
         },
         {
           "tool": "formatjs",
-          "version": "6.16.14",
+          "version": "6.16.16",
           "profile": "small",
           "fileCount": 80,
           "sourceMessageCount": 640,
@@ -189,28 +201,28 @@
           "sourceBytes": 23590,
           "warmup": 3,
           "runs": 7,
-          "medianMs": 282.843375,
+          "medianMs": 288.59175,
           "rawSamplesMs": [
-            279.484916,
-            282.53775,
-            282.640042,
-            282.843375,
-            283.56225,
-            289.24275,
-            289.667958
+            280.049792,
+            282.137208,
+            286.901291,
+            288.59175,
+            291.93675,
+            294.560125,
+            304.478333
           ],
           "stdoutBytes": 0,
           "stderrBytes": 0,
           "warm": {
-            "medianMs": 283.896291,
+            "medianMs": 290.938083,
             "samplesMs": [
-              279.130125,
-              280.607209,
-              282.756417,
-              283.896291,
-              284.355542,
-              286.434958,
-              286.504416
+              282.950333,
+              284.655417,
+              287.564792,
+              290.938083,
+              292.836834,
+              294.129208,
+              296.325458
             ],
             "touchedFiles": 5,
             "palamedesTiming": null
@@ -229,28 +241,68 @@
           "sourceBytes": 23590,
           "warmup": 3,
           "runs": 7,
-          "medianMs": 404.92525,
+          "medianMs": 625.871083,
           "rawSamplesMs": [
-            396.930209,
-            400.530916,
-            404.599416,
-            404.92525,
-            405.70775,
-            407.441208,
-            413.188125
+            454.758583,
+            483.264667,
+            594.898125,
+            625.871083,
+            980.497209,
+            980.886667,
+            1032.254417
           ],
           "stdoutBytes": 292,
           "stderrBytes": 0,
           "warm": {
-            "medianMs": 412.250625,
+            "medianMs": 436.590958,
             "samplesMs": [
-              401.211625,
-              404.8285,
-              409.36725,
-              412.250625,
-              415.810333,
-              418.292417,
-              422.7095
+              430.963667,
+              434.614083,
+              435.696417,
+              436.590958,
+              439.631208,
+              446.252375,
+              452.348
+            ],
+            "touchedFiles": 5,
+            "palamedesTiming": null
+          }
+        },
+        {
+          "tool": "gt",
+          "version": "2.16.0",
+          "profile": "small",
+          "fileCount": 80,
+          "sourceMessageCount": 640,
+          "baselineMessageCount": 624,
+          "changedCount": 48,
+          "newCount": 64,
+          "removedCount": 48,
+          "sourceBytes": 23590,
+          "warmup": 3,
+          "runs": 7,
+          "medianMs": 577.891208,
+          "rawSamplesMs": [
+            554.212,
+            564.579541,
+            571.4815,
+            577.891208,
+            630.929166,
+            652.015542,
+            813.980958
+          ],
+          "stdoutBytes": 0,
+          "stderrBytes": 0,
+          "warm": {
+            "medianMs": 593.569292,
+            "samplesMs": [
+              569.963041,
+              591.972458,
+              593.223042,
+              593.569292,
+              605.725708,
+              607.053,
+              623.816875
             ],
             "touchedFiles": 5,
             "palamedesTiming": null
@@ -295,13 +347,20 @@
               "en": 1920,
               "de": 1920
             }
+          },
+          "gt": {
+            "activeMessagesByTarget": {
+              "en": 1920,
+              "de": 1920
+            },
+            "preservedTranslations": 1584
           }
         }
       },
       "results": [
         {
           "tool": "palamedes",
-          "version": "pmds (Palamedes) v1.9.0",
+          "version": "pmds (Palamedes) v1.12.0",
           "profile": "medium",
           "fileCount": 240,
           "sourceMessageCount": 1920,
@@ -312,15 +371,15 @@
           "sourceBytes": 70681,
           "warmup": 3,
           "runs": 7,
-          "medianMs": 22.224,
+          "medianMs": 23.800583,
           "rawSamplesMs": [
-            18.527042,
-            20.357917,
-            20.901625,
-            22.224,
-            22.942375,
-            23.582709,
-            25.639042
+            22.100416,
+            22.537792,
+            23.658666,
+            23.800583,
+            24.253834,
+            24.62525,
+            25.560917
           ],
           "stdoutBytes": 181,
           "stderrBytes": 0,
@@ -333,20 +392,20 @@
             "totalFiles": 240
           },
           "warm": {
-            "medianMs": 14.054042,
+            "medianMs": 15.162792,
             "samplesMs": [
-              13.540541,
-              13.753917,
-              13.89075,
-              14.054042,
-              14.297542,
-              14.322875,
-              14.831625
+              14.62275,
+              14.688375,
+              14.865542,
+              15.162792,
+              15.315625,
+              15.599125,
+              15.874083
             ],
             "touchedFiles": 5,
             "palamedesTiming": {
               "engine": "ferrocat",
-              "totalMs": 5,
+              "totalMs": 6,
               "globMs": 1,
               "extractMs": 1,
               "writeMs": 3,
@@ -368,28 +427,28 @@
           "sourceBytes": 70681,
           "warmup": 3,
           "runs": 7,
-          "medianMs": 761.691375,
+          "medianMs": 836.691125,
           "rawSamplesMs": [
-            742.1285,
-            745.153417,
-            758.432291,
-            761.691375,
-            762.642208,
-            772.6385,
-            782.778
+            780.122042,
+            780.143834,
+            794.750958,
+            836.691125,
+            906.325583,
+            962.967292,
+            1360.123167
           ],
-          "stdoutBytes": 757,
+          "stdoutBytes": 755,
           "stderrBytes": 18,
           "warm": {
-            "medianMs": 768.431125,
+            "medianMs": 791.67175,
             "samplesMs": [
-              763.817416,
-              765.395584,
-              768.020333,
-              768.431125,
-              771.311833,
-              779.397875,
-              785.041833
+              783.116667,
+              788.942208,
+              790.532709,
+              791.67175,
+              810.851875,
+              817.332875,
+              828.661542
             ],
             "touchedFiles": 5,
             "palamedesTiming": null
@@ -397,7 +456,7 @@
         },
         {
           "tool": "formatjs",
-          "version": "6.16.14",
+          "version": "6.16.16",
           "profile": "medium",
           "fileCount": 240,
           "sourceMessageCount": 1920,
@@ -408,28 +467,28 @@
           "sourceBytes": 70681,
           "warmup": 3,
           "runs": 7,
-          "medianMs": 305.90325,
+          "medianMs": 344.091833,
           "rawSamplesMs": [
-            302.760375,
-            305.115125,
-            305.778083,
-            305.90325,
-            307.132875,
-            308.528125,
-            309.269
+            312.582875,
+            316.733083,
+            318.448083,
+            344.091833,
+            366.439,
+            387.450375,
+            406.68675
           ],
           "stdoutBytes": 0,
           "stderrBytes": 0,
           "warm": {
-            "medianMs": 306.131959,
+            "medianMs": 318.124417,
             "samplesMs": [
-              304.756334,
-              305.482833,
-              305.658292,
-              306.131959,
-              309.543334,
-              312.540333,
-              313.04775
+              310.953208,
+              312.095959,
+              315.6375,
+              318.124417,
+              319.380542,
+              319.506625,
+              326.24325
             ],
             "touchedFiles": 5,
             "palamedesTiming": null
@@ -448,28 +507,68 @@
           "sourceBytes": 70681,
           "warmup": 3,
           "runs": 7,
-          "medianMs": 618.691834,
+          "medianMs": 658.399083,
           "rawSamplesMs": [
-            610.339417,
-            615.609417,
-            618.393208,
-            618.691834,
-            623.626125,
-            632.091583,
-            636.472333
+            644.070125,
+            653.173417,
+            657.99,
+            658.399083,
+            659.378958,
+            668.0275,
+            671.154834
           ],
           "stdoutBytes": 294,
           "stderrBytes": 0,
           "warm": {
-            "medianMs": 620.6525,
+            "medianMs": 663.52275,
             "samplesMs": [
-              613.589791,
-              615.85,
-              615.950875,
-              620.6525,
-              621.764375,
-              626.55175,
-              633.14825
+              647.226334,
+              648.365458,
+              653.620875,
+              663.52275,
+              683.437,
+              684.355542,
+              687.229083
+            ],
+            "touchedFiles": 5,
+            "palamedesTiming": null
+          }
+        },
+        {
+          "tool": "gt",
+          "version": "2.16.0",
+          "profile": "medium",
+          "fileCount": 240,
+          "sourceMessageCount": 1920,
+          "baselineMessageCount": 1872,
+          "changedCount": 144,
+          "newCount": 192,
+          "removedCount": 144,
+          "sourceBytes": 70681,
+          "warmup": 3,
+          "runs": 7,
+          "medianMs": 669.269,
+          "rawSamplesMs": [
+            649.284958,
+            655.838834,
+            667.244583,
+            669.269,
+            670.920583,
+            727.254916,
+            732.787166
+          ],
+          "stdoutBytes": 0,
+          "stderrBytes": 0,
+          "warm": {
+            "medianMs": 654.03125,
+            "samplesMs": [
+              636.799959,
+              638.079625,
+              645.573334,
+              654.03125,
+              655.651417,
+              656.182,
+              682.18775
             ],
             "touchedFiles": 5,
             "palamedesTiming": null
@@ -514,13 +613,20 @@
               "en": 6000,
               "de": 6000
             }
+          },
+          "gt": {
+            "activeMessagesByTarget": {
+              "en": 6000,
+              "de": 6000
+            },
+            "preservedTranslations": 4950
           }
         }
       },
       "results": [
         {
           "tool": "palamedes",
-          "version": "pmds (Palamedes) v1.9.0",
+          "version": "pmds (Palamedes) v1.12.0",
           "profile": "realistic",
           "fileCount": 1500,
           "sourceMessageCount": 6000,
@@ -531,42 +637,42 @@
           "sourceBytes": 220653,
           "warmup": 3,
           "runs": 7,
-          "medianMs": 82.13825,
+          "medianMs": 83.886917,
           "rawSamplesMs": [
-            80.220583,
-            81.125083,
-            81.72775,
-            82.13825,
-            83.231042,
-            89.974292,
-            90.664875
+            78.998208,
+            80.994375,
+            81.174667,
+            83.886917,
+            84.540958,
+            90.733541,
+            93.564667
           ],
           "stdoutBytes": 184,
           "stderrBytes": 0,
           "palamedesTiming": {
-            "totalMs": 70,
+            "totalMs": 71,
             "globMs": 5,
-            "extractMs": 54,
+            "extractMs": 55,
             "writeMs": 9,
             "totalMessages": 6000,
             "totalFiles": 1500
           },
           "warm": {
-            "medianMs": 33.107291,
+            "medianMs": 33.076208,
             "samplesMs": [
-              31.926375,
-              32.253833,
-              32.994416,
-              33.107291,
-              33.277708,
-              33.35525,
-              33.66275
+              32.158833,
+              32.219958,
+              33.038583,
+              33.076208,
+              33.33725,
+              33.535167,
+              34.096833
             ],
             "touchedFiles": 5,
             "palamedesTiming": {
               "engine": "ferrocat",
               "totalMs": 21,
-              "globMs": 5,
+              "globMs": 6,
               "extractMs": 5,
               "writeMs": 9,
               "totalMessages": 6000,
@@ -587,28 +693,28 @@
           "sourceBytes": 220653,
           "warmup": 3,
           "runs": 7,
-          "medianMs": 2405.519042,
+          "medianMs": 2480.238791,
           "rawSamplesMs": [
-            2303.802,
-            2330.530166,
-            2404.753708,
-            2405.519042,
-            2429.401292,
-            2440.329834,
-            2463.156208
+            2368.226833,
+            2398.626042,
+            2446.920333,
+            2480.238791,
+            2484.396584,
+            2513.979292,
+            2676.587792
           ],
-          "stdoutBytes": 757,
+          "stdoutBytes": 755,
           "stderrBytes": 15,
           "warm": {
-            "medianMs": 2339.329125,
+            "medianMs": 2459.890584,
             "samplesMs": [
-              2305.382916,
-              2313.4585,
-              2318.154333,
-              2339.329125,
-              2348.535916,
-              2374.383709,
-              2442.501417
+              2374.141959,
+              2390.504417,
+              2430.440542,
+              2459.890584,
+              2474.552,
+              2509.835125,
+              2527.666542
             ],
             "touchedFiles": 5,
             "palamedesTiming": null
@@ -616,7 +722,7 @@
         },
         {
           "tool": "formatjs",
-          "version": "6.16.14",
+          "version": "6.16.16",
           "profile": "realistic",
           "fileCount": 1500,
           "sourceMessageCount": 6000,
@@ -627,28 +733,28 @@
           "sourceBytes": 220653,
           "warmup": 3,
           "runs": 7,
-          "medianMs": 470.805208,
+          "medianMs": 475.85125,
           "rawSamplesMs": [
-            465.90875,
-            467.564667,
-            470.098042,
-            470.805208,
-            474.769459,
-            479.674958,
-            486.343125
+            470.59775,
+            474.339416,
+            474.887333,
+            475.85125,
+            478.501,
+            479.725583,
+            485.533667
           ],
           "stdoutBytes": 0,
           "stderrBytes": 0,
           "warm": {
-            "medianMs": 470.600625,
+            "medianMs": 481.165542,
             "samplesMs": [
-              464.395667,
-              466.127042,
-              468.495333,
-              470.600625,
-              472.442125,
-              472.512208,
-              475.56025
+              473.743125,
+              476.05825,
+              479.112875,
+              481.165542,
+              484.291666,
+              486.008666,
+              486.351709
             ],
             "touchedFiles": 5,
             "palamedesTiming": null
@@ -667,28 +773,68 @@
           "sourceBytes": 220653,
           "warmup": 3,
           "runs": 7,
-          "medianMs": 6256.981666,
+          "medianMs": 6644.626958,
           "rawSamplesMs": [
-            6196.349167,
-            6241.401833,
-            6248.174375,
-            6256.981666,
-            6258.779792,
-            6277.703416,
-            6305.53925
+            6533.403833,
+            6550.073875,
+            6567.712084,
+            6644.626958,
+            6650.116625,
+            6653.462,
+            6665.600792
           ],
           "stdoutBytes": 300,
           "stderrBytes": 0,
           "warm": {
-            "medianMs": 6196.057208,
+            "medianMs": 6708.1685,
             "samplesMs": [
-              6174.098167,
-              6175.226125,
-              6176.94825,
-              6196.057208,
-              6196.54325,
-              6309.892958,
-              6336.03225
+              6583.161375,
+              6615.682584,
+              6632.902,
+              6708.1685,
+              6709.2955,
+              6854.991042,
+              7118.938834
+            ],
+            "touchedFiles": 5,
+            "palamedesTiming": null
+          }
+        },
+        {
+          "tool": "gt",
+          "version": "2.16.0",
+          "profile": "realistic",
+          "fileCount": 1500,
+          "sourceMessageCount": 6000,
+          "baselineMessageCount": 5850,
+          "changedCount": 450,
+          "newCount": 600,
+          "removedCount": 450,
+          "sourceBytes": 220653,
+          "warmup": 3,
+          "runs": 7,
+          "medianMs": 6116.434167,
+          "rawSamplesMs": [
+            5837.311708,
+            5947.811125,
+            6069.096167,
+            6116.434167,
+            6182.588584,
+            6403.362292,
+            6897.715292
+          ],
+          "stdoutBytes": 0,
+          "stderrBytes": 0,
+          "warm": {
+            "medianMs": 5877.809625,
+            "samplesMs": [
+              5692.909542,
+              5749.60475,
+              5844.953291,
+              5877.809625,
+              5969.788958,
+              6100.264833,
+              7004.541833
             ],
             "touchedFiles": 5,
             "palamedesTiming": null
@@ -700,7 +846,7 @@
   "results": [
     {
       "tool": "palamedes",
-      "version": "pmds (Palamedes) v1.9.0",
+      "version": "pmds (Palamedes) v1.12.0",
       "profile": "small",
       "fileCount": 80,
       "sourceMessageCount": 640,
@@ -711,20 +857,20 @@
       "sourceBytes": 23590,
       "warmup": 3,
       "runs": 7,
-      "medianMs": 12.816542,
+      "medianMs": 14.113583,
       "rawSamplesMs": [
-        12.184375,
-        12.318917,
-        12.751167,
-        12.816542,
-        12.959917,
-        13.222375,
-        13.317125
+        13.606625,
+        13.887,
+        13.966834,
+        14.113583,
+        14.23625,
+        14.32675,
+        14.854875
       ],
       "stdoutBytes": 175,
       "stderrBytes": 0,
       "palamedesTiming": {
-        "totalMs": 5,
+        "totalMs": 6,
         "globMs": 0,
         "extractMs": 3,
         "writeMs": 1,
@@ -732,15 +878,15 @@
         "totalFiles": 80
       },
       "warm": {
-        "medianMs": 10.265375,
+        "medianMs": 10.76375,
         "samplesMs": [
-          9.428625,
-          9.814042,
-          10.078,
-          10.265375,
-          10.410667,
-          10.588292,
-          11.157084
+          10.121459,
+          10.2065,
+          10.584583,
+          10.76375,
+          10.975,
+          10.983083,
+          11.471917
         ],
         "touchedFiles": 5,
         "palamedesTiming": {
@@ -767,28 +913,28 @@
       "sourceBytes": 23590,
       "warmup": 3,
       "runs": 7,
-      "medianMs": 690.974042,
+      "medianMs": 747.176625,
       "rawSamplesMs": [
-        683.987,
-        684.016334,
-        687.69325,
-        690.974042,
-        695.483,
-        703.010291,
-        704.654542
+        732.131375,
+        734.159083,
+        742.392,
+        747.176625,
+        759.621833,
+        793.186709,
+        795.973292
       ],
-      "stdoutBytes": 757,
+      "stdoutBytes": 755,
       "stderrBytes": 18,
       "warm": {
-        "medianMs": 687.763417,
+        "medianMs": 944.157709,
         "samplesMs": [
-          674.540375,
-          678.100458,
-          684.4095,
-          687.763417,
-          688.996709,
-          731.565458,
-          735.847083
+          689.073667,
+          716.492417,
+          937.278792,
+          944.157709,
+          1027.130833,
+          1173.490375,
+          1383.133042
         ],
         "touchedFiles": 5,
         "palamedesTiming": null
@@ -796,7 +942,7 @@
     },
     {
       "tool": "formatjs",
-      "version": "6.16.14",
+      "version": "6.16.16",
       "profile": "small",
       "fileCount": 80,
       "sourceMessageCount": 640,
@@ -807,28 +953,28 @@
       "sourceBytes": 23590,
       "warmup": 3,
       "runs": 7,
-      "medianMs": 282.843375,
+      "medianMs": 288.59175,
       "rawSamplesMs": [
-        279.484916,
-        282.53775,
-        282.640042,
-        282.843375,
-        283.56225,
-        289.24275,
-        289.667958
+        280.049792,
+        282.137208,
+        286.901291,
+        288.59175,
+        291.93675,
+        294.560125,
+        304.478333
       ],
       "stdoutBytes": 0,
       "stderrBytes": 0,
       "warm": {
-        "medianMs": 283.896291,
+        "medianMs": 290.938083,
         "samplesMs": [
-          279.130125,
-          280.607209,
-          282.756417,
-          283.896291,
-          284.355542,
-          286.434958,
-          286.504416
+          282.950333,
+          284.655417,
+          287.564792,
+          290.938083,
+          292.836834,
+          294.129208,
+          296.325458
         ],
         "touchedFiles": 5,
         "palamedesTiming": null
@@ -847,28 +993,68 @@
       "sourceBytes": 23590,
       "warmup": 3,
       "runs": 7,
-      "medianMs": 404.92525,
+      "medianMs": 625.871083,
       "rawSamplesMs": [
-        396.930209,
-        400.530916,
-        404.599416,
-        404.92525,
-        405.70775,
-        407.441208,
-        413.188125
+        454.758583,
+        483.264667,
+        594.898125,
+        625.871083,
+        980.497209,
+        980.886667,
+        1032.254417
       ],
       "stdoutBytes": 292,
       "stderrBytes": 0,
       "warm": {
-        "medianMs": 412.250625,
+        "medianMs": 436.590958,
         "samplesMs": [
-          401.211625,
-          404.8285,
-          409.36725,
-          412.250625,
-          415.810333,
-          418.292417,
-          422.7095
+          430.963667,
+          434.614083,
+          435.696417,
+          436.590958,
+          439.631208,
+          446.252375,
+          452.348
+        ],
+        "touchedFiles": 5,
+        "palamedesTiming": null
+      }
+    },
+    {
+      "tool": "gt",
+      "version": "2.16.0",
+      "profile": "small",
+      "fileCount": 80,
+      "sourceMessageCount": 640,
+      "baselineMessageCount": 624,
+      "changedCount": 48,
+      "newCount": 64,
+      "removedCount": 48,
+      "sourceBytes": 23590,
+      "warmup": 3,
+      "runs": 7,
+      "medianMs": 577.891208,
+      "rawSamplesMs": [
+        554.212,
+        564.579541,
+        571.4815,
+        577.891208,
+        630.929166,
+        652.015542,
+        813.980958
+      ],
+      "stdoutBytes": 0,
+      "stderrBytes": 0,
+      "warm": {
+        "medianMs": 593.569292,
+        "samplesMs": [
+          569.963041,
+          591.972458,
+          593.223042,
+          593.569292,
+          605.725708,
+          607.053,
+          623.816875
         ],
         "touchedFiles": 5,
         "palamedesTiming": null
@@ -876,7 +1062,7 @@
     },
     {
       "tool": "palamedes",
-      "version": "pmds (Palamedes) v1.9.0",
+      "version": "pmds (Palamedes) v1.12.0",
       "profile": "medium",
       "fileCount": 240,
       "sourceMessageCount": 1920,
@@ -887,15 +1073,15 @@
       "sourceBytes": 70681,
       "warmup": 3,
       "runs": 7,
-      "medianMs": 22.224,
+      "medianMs": 23.800583,
       "rawSamplesMs": [
-        18.527042,
-        20.357917,
-        20.901625,
-        22.224,
-        22.942375,
-        23.582709,
-        25.639042
+        22.100416,
+        22.537792,
+        23.658666,
+        23.800583,
+        24.253834,
+        24.62525,
+        25.560917
       ],
       "stdoutBytes": 181,
       "stderrBytes": 0,
@@ -908,20 +1094,20 @@
         "totalFiles": 240
       },
       "warm": {
-        "medianMs": 14.054042,
+        "medianMs": 15.162792,
         "samplesMs": [
-          13.540541,
-          13.753917,
-          13.89075,
-          14.054042,
-          14.297542,
-          14.322875,
-          14.831625
+          14.62275,
+          14.688375,
+          14.865542,
+          15.162792,
+          15.315625,
+          15.599125,
+          15.874083
         ],
         "touchedFiles": 5,
         "palamedesTiming": {
           "engine": "ferrocat",
-          "totalMs": 5,
+          "totalMs": 6,
           "globMs": 1,
           "extractMs": 1,
           "writeMs": 3,
@@ -943,28 +1129,28 @@
       "sourceBytes": 70681,
       "warmup": 3,
       "runs": 7,
-      "medianMs": 761.691375,
+      "medianMs": 836.691125,
       "rawSamplesMs": [
-        742.1285,
-        745.153417,
-        758.432291,
-        761.691375,
-        762.642208,
-        772.6385,
-        782.778
+        780.122042,
+        780.143834,
+        794.750958,
+        836.691125,
+        906.325583,
+        962.967292,
+        1360.123167
       ],
-      "stdoutBytes": 757,
+      "stdoutBytes": 755,
       "stderrBytes": 18,
       "warm": {
-        "medianMs": 768.431125,
+        "medianMs": 791.67175,
         "samplesMs": [
-          763.817416,
-          765.395584,
-          768.020333,
-          768.431125,
-          771.311833,
-          779.397875,
-          785.041833
+          783.116667,
+          788.942208,
+          790.532709,
+          791.67175,
+          810.851875,
+          817.332875,
+          828.661542
         ],
         "touchedFiles": 5,
         "palamedesTiming": null
@@ -972,7 +1158,7 @@
     },
     {
       "tool": "formatjs",
-      "version": "6.16.14",
+      "version": "6.16.16",
       "profile": "medium",
       "fileCount": 240,
       "sourceMessageCount": 1920,
@@ -983,28 +1169,28 @@
       "sourceBytes": 70681,
       "warmup": 3,
       "runs": 7,
-      "medianMs": 305.90325,
+      "medianMs": 344.091833,
       "rawSamplesMs": [
-        302.760375,
-        305.115125,
-        305.778083,
-        305.90325,
-        307.132875,
-        308.528125,
-        309.269
+        312.582875,
+        316.733083,
+        318.448083,
+        344.091833,
+        366.439,
+        387.450375,
+        406.68675
       ],
       "stdoutBytes": 0,
       "stderrBytes": 0,
       "warm": {
-        "medianMs": 306.131959,
+        "medianMs": 318.124417,
         "samplesMs": [
-          304.756334,
-          305.482833,
-          305.658292,
-          306.131959,
-          309.543334,
-          312.540333,
-          313.04775
+          310.953208,
+          312.095959,
+          315.6375,
+          318.124417,
+          319.380542,
+          319.506625,
+          326.24325
         ],
         "touchedFiles": 5,
         "palamedesTiming": null
@@ -1023,28 +1209,68 @@
       "sourceBytes": 70681,
       "warmup": 3,
       "runs": 7,
-      "medianMs": 618.691834,
+      "medianMs": 658.399083,
       "rawSamplesMs": [
-        610.339417,
-        615.609417,
-        618.393208,
-        618.691834,
-        623.626125,
-        632.091583,
-        636.472333
+        644.070125,
+        653.173417,
+        657.99,
+        658.399083,
+        659.378958,
+        668.0275,
+        671.154834
       ],
       "stdoutBytes": 294,
       "stderrBytes": 0,
       "warm": {
-        "medianMs": 620.6525,
+        "medianMs": 663.52275,
         "samplesMs": [
-          613.589791,
-          615.85,
-          615.950875,
-          620.6525,
-          621.764375,
-          626.55175,
-          633.14825
+          647.226334,
+          648.365458,
+          653.620875,
+          663.52275,
+          683.437,
+          684.355542,
+          687.229083
+        ],
+        "touchedFiles": 5,
+        "palamedesTiming": null
+      }
+    },
+    {
+      "tool": "gt",
+      "version": "2.16.0",
+      "profile": "medium",
+      "fileCount": 240,
+      "sourceMessageCount": 1920,
+      "baselineMessageCount": 1872,
+      "changedCount": 144,
+      "newCount": 192,
+      "removedCount": 144,
+      "sourceBytes": 70681,
+      "warmup": 3,
+      "runs": 7,
+      "medianMs": 669.269,
+      "rawSamplesMs": [
+        649.284958,
+        655.838834,
+        667.244583,
+        669.269,
+        670.920583,
+        727.254916,
+        732.787166
+      ],
+      "stdoutBytes": 0,
+      "stderrBytes": 0,
+      "warm": {
+        "medianMs": 654.03125,
+        "samplesMs": [
+          636.799959,
+          638.079625,
+          645.573334,
+          654.03125,
+          655.651417,
+          656.182,
+          682.18775
         ],
         "touchedFiles": 5,
         "palamedesTiming": null
@@ -1052,7 +1278,7 @@
     },
     {
       "tool": "palamedes",
-      "version": "pmds (Palamedes) v1.9.0",
+      "version": "pmds (Palamedes) v1.12.0",
       "profile": "realistic",
       "fileCount": 1500,
       "sourceMessageCount": 6000,
@@ -1063,42 +1289,42 @@
       "sourceBytes": 220653,
       "warmup": 3,
       "runs": 7,
-      "medianMs": 82.13825,
+      "medianMs": 83.886917,
       "rawSamplesMs": [
-        80.220583,
-        81.125083,
-        81.72775,
-        82.13825,
-        83.231042,
-        89.974292,
-        90.664875
+        78.998208,
+        80.994375,
+        81.174667,
+        83.886917,
+        84.540958,
+        90.733541,
+        93.564667
       ],
       "stdoutBytes": 184,
       "stderrBytes": 0,
       "palamedesTiming": {
-        "totalMs": 70,
+        "totalMs": 71,
         "globMs": 5,
-        "extractMs": 54,
+        "extractMs": 55,
         "writeMs": 9,
         "totalMessages": 6000,
         "totalFiles": 1500
       },
       "warm": {
-        "medianMs": 33.107291,
+        "medianMs": 33.076208,
         "samplesMs": [
-          31.926375,
-          32.253833,
-          32.994416,
-          33.107291,
-          33.277708,
-          33.35525,
-          33.66275
+          32.158833,
+          32.219958,
+          33.038583,
+          33.076208,
+          33.33725,
+          33.535167,
+          34.096833
         ],
         "touchedFiles": 5,
         "palamedesTiming": {
           "engine": "ferrocat",
           "totalMs": 21,
-          "globMs": 5,
+          "globMs": 6,
           "extractMs": 5,
           "writeMs": 9,
           "totalMessages": 6000,
@@ -1119,28 +1345,28 @@
       "sourceBytes": 220653,
       "warmup": 3,
       "runs": 7,
-      "medianMs": 2405.519042,
+      "medianMs": 2480.238791,
       "rawSamplesMs": [
-        2303.802,
-        2330.530166,
-        2404.753708,
-        2405.519042,
-        2429.401292,
-        2440.329834,
-        2463.156208
+        2368.226833,
+        2398.626042,
+        2446.920333,
+        2480.238791,
+        2484.396584,
+        2513.979292,
+        2676.587792
       ],
-      "stdoutBytes": 757,
+      "stdoutBytes": 755,
       "stderrBytes": 15,
       "warm": {
-        "medianMs": 2339.329125,
+        "medianMs": 2459.890584,
         "samplesMs": [
-          2305.382916,
-          2313.4585,
-          2318.154333,
-          2339.329125,
-          2348.535916,
-          2374.383709,
-          2442.501417
+          2374.141959,
+          2390.504417,
+          2430.440542,
+          2459.890584,
+          2474.552,
+          2509.835125,
+          2527.666542
         ],
         "touchedFiles": 5,
         "palamedesTiming": null
@@ -1148,7 +1374,7 @@
     },
     {
       "tool": "formatjs",
-      "version": "6.16.14",
+      "version": "6.16.16",
       "profile": "realistic",
       "fileCount": 1500,
       "sourceMessageCount": 6000,
@@ -1159,28 +1385,28 @@
       "sourceBytes": 220653,
       "warmup": 3,
       "runs": 7,
-      "medianMs": 470.805208,
+      "medianMs": 475.85125,
       "rawSamplesMs": [
-        465.90875,
-        467.564667,
-        470.098042,
-        470.805208,
-        474.769459,
-        479.674958,
-        486.343125
+        470.59775,
+        474.339416,
+        474.887333,
+        475.85125,
+        478.501,
+        479.725583,
+        485.533667
       ],
       "stdoutBytes": 0,
       "stderrBytes": 0,
       "warm": {
-        "medianMs": 470.600625,
+        "medianMs": 481.165542,
         "samplesMs": [
-          464.395667,
-          466.127042,
-          468.495333,
-          470.600625,
-          472.442125,
-          472.512208,
-          475.56025
+          473.743125,
+          476.05825,
+          479.112875,
+          481.165542,
+          484.291666,
+          486.008666,
+          486.351709
         ],
         "touchedFiles": 5,
         "palamedesTiming": null
@@ -1199,28 +1425,68 @@
       "sourceBytes": 220653,
       "warmup": 3,
       "runs": 7,
-      "medianMs": 6256.981666,
+      "medianMs": 6644.626958,
       "rawSamplesMs": [
-        6196.349167,
-        6241.401833,
-        6248.174375,
-        6256.981666,
-        6258.779792,
-        6277.703416,
-        6305.53925
+        6533.403833,
+        6550.073875,
+        6567.712084,
+        6644.626958,
+        6650.116625,
+        6653.462,
+        6665.600792
       ],
       "stdoutBytes": 300,
       "stderrBytes": 0,
       "warm": {
-        "medianMs": 6196.057208,
+        "medianMs": 6708.1685,
         "samplesMs": [
-          6174.098167,
-          6175.226125,
-          6176.94825,
-          6196.057208,
-          6196.54325,
-          6309.892958,
-          6336.03225
+          6583.161375,
+          6615.682584,
+          6632.902,
+          6708.1685,
+          6709.2955,
+          6854.991042,
+          7118.938834
+        ],
+        "touchedFiles": 5,
+        "palamedesTiming": null
+      }
+    },
+    {
+      "tool": "gt",
+      "version": "2.16.0",
+      "profile": "realistic",
+      "fileCount": 1500,
+      "sourceMessageCount": 6000,
+      "baselineMessageCount": 5850,
+      "changedCount": 450,
+      "newCount": 600,
+      "removedCount": 450,
+      "sourceBytes": 220653,
+      "warmup": 3,
+      "runs": 7,
+      "medianMs": 6116.434167,
+      "rawSamplesMs": [
+        5837.311708,
+        5947.811125,
+        6069.096167,
+        6116.434167,
+        6182.588584,
+        6403.362292,
+        6897.715292
+      ],
+      "stdoutBytes": 0,
+      "stderrBytes": 0,
+      "warm": {
+        "medianMs": 5877.809625,
+        "samplesMs": [
+          5692.909542,
+          5749.60475,
+          5844.953291,
+          5877.809625,
+          5969.788958,
+          6100.264833,
+          7004.541833
         ],
         "touchedFiles": 5,
         "palamedesTiming": null
@@ -1233,81 +1499,108 @@
       "baselineTool": "palamedes",
       "comparedTool": "lingui",
       "fasterTool": "palamedes",
-      "palamedesMedianMs": 12.816542,
-      "comparedMedianMs": 690.974042,
-      "speedupFactor": 53.912673324832866
+      "palamedesMedianMs": 14.113583,
+      "comparedMedianMs": 747.176625,
+      "speedupFactor": 52.94025089164105
     },
     {
       "profile": "small",
       "baselineTool": "palamedes",
       "comparedTool": "formatjs",
       "fasterTool": "palamedes",
-      "palamedesMedianMs": 12.816542,
-      "comparedMedianMs": 282.843375,
-      "speedupFactor": 22.06861843077485
+      "palamedesMedianMs": 14.113583,
+      "comparedMedianMs": 288.59175,
+      "speedupFactor": 20.447801950787408
     },
     {
       "profile": "small",
       "baselineTool": "palamedes",
       "comparedTool": "i18nextCli",
       "fasterTool": "palamedes",
-      "palamedesMedianMs": 12.816542,
-      "comparedMedianMs": 404.92525,
-      "speedupFactor": 31.593954906089333
+      "palamedesMedianMs": 14.113583,
+      "comparedMedianMs": 625.871083,
+      "speedupFactor": 44.34530076451883
+    },
+    {
+      "profile": "small",
+      "baselineTool": "palamedes",
+      "comparedTool": "gt",
+      "fasterTool": "palamedes",
+      "palamedesMedianMs": 14.113583,
+      "comparedMedianMs": 577.891208,
+      "speedupFactor": 40.94574765316504
     },
     {
       "profile": "medium",
       "baselineTool": "palamedes",
       "comparedTool": "lingui",
       "fasterTool": "palamedes",
-      "palamedesMedianMs": 22.224,
-      "comparedMedianMs": 761.691375,
-      "speedupFactor": 34.27337000539957
+      "palamedesMedianMs": 23.800583,
+      "comparedMedianMs": 836.691125,
+      "speedupFactor": 35.15422815483134
     },
     {
       "profile": "medium",
       "baselineTool": "palamedes",
       "comparedTool": "formatjs",
       "fasterTool": "palamedes",
-      "palamedesMedianMs": 22.224,
-      "comparedMedianMs": 305.90325,
-      "speedupFactor": 13.764545086393088
+      "palamedesMedianMs": 23.800583,
+      "comparedMedianMs": 344.091833,
+      "speedupFactor": 14.457285899257174
     },
     {
       "profile": "medium",
       "baselineTool": "palamedes",
       "comparedTool": "i18nextCli",
       "fasterTool": "palamedes",
-      "palamedesMedianMs": 22.224,
-      "comparedMedianMs": 618.691834,
-      "speedupFactor": 27.838905417566593
+      "palamedesMedianMs": 23.800583,
+      "comparedMedianMs": 658.399083,
+      "speedupFactor": 27.66314938587849
+    },
+    {
+      "profile": "medium",
+      "baselineTool": "palamedes",
+      "comparedTool": "gt",
+      "fasterTool": "palamedes",
+      "palamedesMedianMs": 23.800583,
+      "comparedMedianMs": 669.269,
+      "speedupFactor": 28.119857400131753
     },
     {
       "profile": "realistic",
       "baselineTool": "palamedes",
       "comparedTool": "lingui",
       "fasterTool": "palamedes",
-      "palamedesMedianMs": 82.13825,
-      "comparedMedianMs": 2405.519042,
-      "speedupFactor": 29.28622221681129
+      "palamedesMedianMs": 83.886917,
+      "comparedMedianMs": 2480.238791,
+      "speedupFactor": 29.56645541044261
     },
     {
       "profile": "realistic",
       "baselineTool": "palamedes",
       "comparedTool": "formatjs",
       "fasterTool": "palamedes",
-      "palamedesMedianMs": 82.13825,
-      "comparedMedianMs": 470.805208,
-      "speedupFactor": 5.7318631453677185
+      "palamedesMedianMs": 83.886917,
+      "comparedMedianMs": 475.85125,
+      "speedupFactor": 5.672532344942418
     },
     {
       "profile": "realistic",
       "baselineTool": "palamedes",
       "comparedTool": "i18nextCli",
       "fasterTool": "palamedes",
-      "palamedesMedianMs": 82.13825,
-      "comparedMedianMs": 6256.981666,
-      "speedupFactor": 76.17622320904086
+      "palamedesMedianMs": 83.886917,
+      "comparedMedianMs": 6644.626958,
+      "speedupFactor": 79.20933556301753
+    },
+    {
+      "profile": "realistic",
+      "baselineTool": "palamedes",
+      "comparedTool": "gt",
+      "fasterTool": "palamedes",
+      "palamedesMedianMs": 83.886917,
+      "comparedMedianMs": 6116.434167,
+      "speedupFactor": 72.91284965210964
     }
   ]
 }

--- a/benchmarks/e2e-workflow/results/latest.md
+++ b/benchmarks/e2e-workflow/results/latest.md
@@ -1,6 +1,6 @@
 # End-to-End Extraction Workflow Benchmark
 
-Generated: 2026-07-31T08:33:20.786Z
+Generated: 2026-08-05T09:07:39.077Z
 Node: v24.18.0
 Platform: darwin/arm64
 Seed: 20260703
@@ -10,10 +10,11 @@ Machine-local: yes
 
 ## Versions
 
-- Palamedes CLI: pmds (Palamedes) v1.9.0
+- Palamedes CLI: pmds (Palamedes) v1.12.0
 - Lingui CLI: 6.6.0
-- React Intl extraction CLI (@formatjs/cli): 6.16.14
+- React Intl extraction CLI (@formatjs/cli): 6.16.16
 - i18next-cli: 1.67.3
+- General Translation CLI (gtx-cli): 2.16.0 (corpus authored against gt-react 11.1.4)
 
 ## Methodology
 
@@ -21,7 +22,8 @@ Machine-local: yes
 - Corpus: same generated logical message inventory rendered into each tool's idiomatic source shape
 - Reset: catalog files and tool caches are reset to the same baseline state before every cold warmup and measured run
 - Semantic check: active catalog messages are normalized after each tool run and compared with the generated current inventory
-- React Intl scope: source scan, extraction, content-hash ID generation, and one aggregated extracted-message JSON write; the React Intl extraction workflow does not update locale translation catalogs
+- React Intl scope: source scan, extraction, content-hash ID generation, and one aggregated extracted-message JSON write; the React Intl extraction workflow does not update locale translation catalogs, so this lane covers less work than every other lane in the table
+- General Translation scope: source scan, extraction, content-hash keying, and merge/update of existing en/de catalogs; gtx-cli generate runs fully locally, seeds new entries with the source text, and drops removed entries immediately instead of marking them obsolete
 - Other tool scope: source scan, extraction, merge/update of existing en/de catalogs, and catalog writes
 
 ## Small
@@ -34,16 +36,18 @@ Machine-local: yes
 
 | Tool | Median | Samples |
 | --- | ---: | --- |
-| Palamedes | 12.82 ms | 12.18 ms, 12.32 ms, 12.75 ms, 12.82 ms, 12.96 ms, 13.22 ms, 13.32 ms |
-| Lingui | 690.97 ms | 683.99 ms, 684.02 ms, 687.69 ms, 690.97 ms, 695.48 ms, 703.01 ms, 704.65 ms |
-| React Intl | 282.84 ms | 279.48 ms, 282.54 ms, 282.64 ms, 282.84 ms, 283.56 ms, 289.24 ms, 289.67 ms |
-| i18next-cli | 404.93 ms | 396.93 ms, 400.53 ms, 404.60 ms, 404.93 ms, 405.71 ms, 407.44 ms, 413.19 ms |
+| Palamedes | 14.11 ms | 13.61 ms, 13.89 ms, 13.97 ms, 14.11 ms, 14.24 ms, 14.33 ms, 14.85 ms |
+| Lingui | 747.18 ms | 732.13 ms, 734.16 ms, 742.39 ms, 747.18 ms, 759.62 ms, 793.19 ms, 795.97 ms |
+| React Intl | 288.59 ms | 280.05 ms, 282.14 ms, 286.90 ms, 288.59 ms, 291.94 ms, 294.56 ms, 304.48 ms |
+| i18next-cli | 625.87 ms | 454.76 ms, 483.26 ms, 594.90 ms, 625.87 ms, 980.50 ms, 980.89 ms, 1032.25 ms |
+| General Translation | 577.89 ms | 554.21 ms, 564.58 ms, 571.48 ms, 577.89 ms, 630.93 ms, 652.02 ms, 813.98 ms |
 
 | Comparison | Faster | Speedup |
 | --- | --- | ---: |
-| Palamedes vs Lingui | Palamedes | 53.91x |
-| Palamedes vs React Intl | Palamedes | 22.07x |
-| Palamedes vs i18next-cli | Palamedes | 31.59x |
+| Palamedes vs Lingui | Palamedes | 52.94x |
+| Palamedes vs React Intl | Palamedes | 20.45x |
+| Palamedes vs i18next-cli | Palamedes | 44.35x |
+| Palamedes vs General Translation | Palamedes | 40.95x |
 
 ### Warm
 
@@ -53,10 +57,11 @@ This lane is **not** a like-for-like speed comparison and is deliberately exclud
 
 | Tool | Median | Samples |
 | --- | ---: | --- |
-| Palamedes | 10.27 ms | 9.43 ms, 9.81 ms, 10.08 ms, 10.27 ms, 10.41 ms, 10.59 ms, 11.16 ms |
-| Lingui | 687.76 ms | 674.54 ms, 678.10 ms, 684.41 ms, 687.76 ms, 689.00 ms, 731.57 ms, 735.85 ms |
-| React Intl | 283.90 ms | 279.13 ms, 280.61 ms, 282.76 ms, 283.90 ms, 284.36 ms, 286.43 ms, 286.50 ms |
-| i18next-cli | 412.25 ms | 401.21 ms, 404.83 ms, 409.37 ms, 412.25 ms, 415.81 ms, 418.29 ms, 422.71 ms |
+| Palamedes | 10.76 ms | 10.12 ms, 10.21 ms, 10.58 ms, 10.76 ms, 10.97 ms, 10.98 ms, 11.47 ms |
+| Lingui | 944.16 ms | 689.07 ms, 716.49 ms, 937.28 ms, 944.16 ms, 1027.13 ms, 1173.49 ms, 1383.13 ms |
+| React Intl | 290.94 ms | 282.95 ms, 284.66 ms, 287.56 ms, 290.94 ms, 292.84 ms, 294.13 ms, 296.33 ms |
+| i18next-cli | 436.59 ms | 430.96 ms, 434.61 ms, 435.70 ms, 436.59 ms, 439.63 ms, 446.25 ms, 452.35 ms |
+| General Translation | 593.57 ms | 569.96 ms, 591.97 ms, 593.22 ms, 593.57 ms, 605.73 ms, 607.05 ms, 623.82 ms |
 
 ## Medium
 
@@ -68,16 +73,18 @@ This lane is **not** a like-for-like speed comparison and is deliberately exclud
 
 | Tool | Median | Samples |
 | --- | ---: | --- |
-| Palamedes | 22.22 ms | 18.53 ms, 20.36 ms, 20.90 ms, 22.22 ms, 22.94 ms, 23.58 ms, 25.64 ms |
-| Lingui | 761.69 ms | 742.13 ms, 745.15 ms, 758.43 ms, 761.69 ms, 762.64 ms, 772.64 ms, 782.78 ms |
-| React Intl | 305.90 ms | 302.76 ms, 305.12 ms, 305.78 ms, 305.90 ms, 307.13 ms, 308.53 ms, 309.27 ms |
-| i18next-cli | 618.69 ms | 610.34 ms, 615.61 ms, 618.39 ms, 618.69 ms, 623.63 ms, 632.09 ms, 636.47 ms |
+| Palamedes | 23.80 ms | 22.10 ms, 22.54 ms, 23.66 ms, 23.80 ms, 24.25 ms, 24.63 ms, 25.56 ms |
+| Lingui | 836.69 ms | 780.12 ms, 780.14 ms, 794.75 ms, 836.69 ms, 906.33 ms, 962.97 ms, 1360.12 ms |
+| React Intl | 344.09 ms | 312.58 ms, 316.73 ms, 318.45 ms, 344.09 ms, 366.44 ms, 387.45 ms, 406.69 ms |
+| i18next-cli | 658.40 ms | 644.07 ms, 653.17 ms, 657.99 ms, 658.40 ms, 659.38 ms, 668.03 ms, 671.15 ms |
+| General Translation | 669.27 ms | 649.28 ms, 655.84 ms, 667.24 ms, 669.27 ms, 670.92 ms, 727.25 ms, 732.79 ms |
 
 | Comparison | Faster | Speedup |
 | --- | --- | ---: |
-| Palamedes vs Lingui | Palamedes | 34.27x |
-| Palamedes vs React Intl | Palamedes | 13.76x |
-| Palamedes vs i18next-cli | Palamedes | 27.84x |
+| Palamedes vs Lingui | Palamedes | 35.15x |
+| Palamedes vs React Intl | Palamedes | 14.46x |
+| Palamedes vs i18next-cli | Palamedes | 27.66x |
+| Palamedes vs General Translation | Palamedes | 28.12x |
 
 ### Warm
 
@@ -87,10 +94,11 @@ This lane is **not** a like-for-like speed comparison and is deliberately exclud
 
 | Tool | Median | Samples |
 | --- | ---: | --- |
-| Palamedes | 14.05 ms | 13.54 ms, 13.75 ms, 13.89 ms, 14.05 ms, 14.30 ms, 14.32 ms, 14.83 ms |
-| Lingui | 768.43 ms | 763.82 ms, 765.40 ms, 768.02 ms, 768.43 ms, 771.31 ms, 779.40 ms, 785.04 ms |
-| React Intl | 306.13 ms | 304.76 ms, 305.48 ms, 305.66 ms, 306.13 ms, 309.54 ms, 312.54 ms, 313.05 ms |
-| i18next-cli | 620.65 ms | 613.59 ms, 615.85 ms, 615.95 ms, 620.65 ms, 621.76 ms, 626.55 ms, 633.15 ms |
+| Palamedes | 15.16 ms | 14.62 ms, 14.69 ms, 14.87 ms, 15.16 ms, 15.32 ms, 15.60 ms, 15.87 ms |
+| Lingui | 791.67 ms | 783.12 ms, 788.94 ms, 790.53 ms, 791.67 ms, 810.85 ms, 817.33 ms, 828.66 ms |
+| React Intl | 318.12 ms | 310.95 ms, 312.10 ms, 315.64 ms, 318.12 ms, 319.38 ms, 319.51 ms, 326.24 ms |
+| i18next-cli | 663.52 ms | 647.23 ms, 648.37 ms, 653.62 ms, 663.52 ms, 683.44 ms, 684.36 ms, 687.23 ms |
+| General Translation | 654.03 ms | 636.80 ms, 638.08 ms, 645.57 ms, 654.03 ms, 655.65 ms, 656.18 ms, 682.19 ms |
 
 ## Realistic
 
@@ -102,16 +110,18 @@ This lane is **not** a like-for-like speed comparison and is deliberately exclud
 
 | Tool | Median | Samples |
 | --- | ---: | --- |
-| Palamedes | 82.14 ms | 80.22 ms, 81.13 ms, 81.73 ms, 82.14 ms, 83.23 ms, 89.97 ms, 90.66 ms |
-| Lingui | 2405.52 ms | 2303.80 ms, 2330.53 ms, 2404.75 ms, 2405.52 ms, 2429.40 ms, 2440.33 ms, 2463.16 ms |
-| React Intl | 470.81 ms | 465.91 ms, 467.56 ms, 470.10 ms, 470.81 ms, 474.77 ms, 479.67 ms, 486.34 ms |
-| i18next-cli | 6256.98 ms | 6196.35 ms, 6241.40 ms, 6248.17 ms, 6256.98 ms, 6258.78 ms, 6277.70 ms, 6305.54 ms |
+| Palamedes | 83.89 ms | 79.00 ms, 80.99 ms, 81.17 ms, 83.89 ms, 84.54 ms, 90.73 ms, 93.56 ms |
+| Lingui | 2480.24 ms | 2368.23 ms, 2398.63 ms, 2446.92 ms, 2480.24 ms, 2484.40 ms, 2513.98 ms, 2676.59 ms |
+| React Intl | 475.85 ms | 470.60 ms, 474.34 ms, 474.89 ms, 475.85 ms, 478.50 ms, 479.73 ms, 485.53 ms |
+| i18next-cli | 6644.63 ms | 6533.40 ms, 6550.07 ms, 6567.71 ms, 6644.63 ms, 6650.12 ms, 6653.46 ms, 6665.60 ms |
+| General Translation | 6116.43 ms | 5837.31 ms, 5947.81 ms, 6069.10 ms, 6116.43 ms, 6182.59 ms, 6403.36 ms, 6897.72 ms |
 
 | Comparison | Faster | Speedup |
 | --- | --- | ---: |
-| Palamedes vs Lingui | Palamedes | 29.29x |
-| Palamedes vs React Intl | Palamedes | 5.73x |
-| Palamedes vs i18next-cli | Palamedes | 76.18x |
+| Palamedes vs Lingui | Palamedes | 29.57x |
+| Palamedes vs React Intl | Palamedes | 5.67x |
+| Palamedes vs i18next-cli | Palamedes | 79.21x |
+| Palamedes vs General Translation | Palamedes | 72.91x |
 
 ### Warm
 
@@ -121,16 +131,18 @@ This lane is **not** a like-for-like speed comparison and is deliberately exclud
 
 | Tool | Median | Samples |
 | --- | ---: | --- |
-| Palamedes | 33.11 ms | 31.93 ms, 32.25 ms, 32.99 ms, 33.11 ms, 33.28 ms, 33.36 ms, 33.66 ms |
-| Lingui | 2339.33 ms | 2305.38 ms, 2313.46 ms, 2318.15 ms, 2339.33 ms, 2348.54 ms, 2374.38 ms, 2442.50 ms |
-| React Intl | 470.60 ms | 464.40 ms, 466.13 ms, 468.50 ms, 470.60 ms, 472.44 ms, 472.51 ms, 475.56 ms |
-| i18next-cli | 6196.06 ms | 6174.10 ms, 6175.23 ms, 6176.95 ms, 6196.06 ms, 6196.54 ms, 6309.89 ms, 6336.03 ms |
+| Palamedes | 33.08 ms | 32.16 ms, 32.22 ms, 33.04 ms, 33.08 ms, 33.34 ms, 33.54 ms, 34.10 ms |
+| Lingui | 2459.89 ms | 2374.14 ms, 2390.50 ms, 2430.44 ms, 2459.89 ms, 2474.55 ms, 2509.84 ms, 2527.67 ms |
+| React Intl | 481.17 ms | 473.74 ms, 476.06 ms, 479.11 ms, 481.17 ms, 484.29 ms, 486.01 ms, 486.35 ms |
+| i18next-cli | 6708.17 ms | 6583.16 ms, 6615.68 ms, 6632.90 ms, 6708.17 ms, 6709.30 ms, 6854.99 ms, 7118.94 ms |
+| General Translation | 5877.81 ms | 5692.91 ms, 5749.60 ms, 5844.95 ms, 5877.81 ms, 5969.79 ms, 6100.26 ms, 7004.54 ms |
 
 ## Notes
 
 - These are machine-local CLI workflow timings, not universal cross-machine claims.
 - Cold runs clear every tool cache alongside the catalogs. The source corpus is generated once per profile and never changes, so a retained cache would be hit by every run after the first and would silently turn the cold medians into warm ones.
 - The i18next-cli corpus uses natural-language keys so semantic comparison can normalize active messages; key-based application architectures may have different catalog shapes.
-- The React Intl extraction workflow writes one extracted-message JSON artifact and does not update locale translation catalogs; its result is reported with that narrower scope instead of being presented as a catalog-merge equivalent.
+- **React Intl covers less work than every other lane.** `formatjs extract` writes one aggregated extracted-message JSON artifact and never reads or merges a locale catalog, so its median is not comparable to the catalog-update medians around it and must not be read as one.
+- The General Translation lane runs `gtx-cli generate`, which extracts and merges en/de catalogs entirely locally with no API key and no network access. It is GT's path for teams handling their own translations; GT's default workflow (`gtx-cli translate`) sends content to the GT API and is deliberately out of scope here.
 - The harness reports source-message equivalence after each run instead of assuming every parser extracts the same result.
 - Raw samples and Palamedes timing breakdowns are stored in the accompanying JSON output.

--- a/benchmarks/e2e-workflow/src/corpus.mjs
+++ b/benchmarks/e2e-workflow/src/corpus.mjs
@@ -1,6 +1,8 @@
-import { cp, mkdir, writeFile } from "node:fs/promises"
+import { cp, mkdir, readFile, rm, writeFile } from "node:fs/promises"
 import { createHash } from "node:crypto"
 import path from "node:path"
+
+import { runCommand } from "./exec.mjs"
 
 export const DEFAULT_SEED = 20_260_703
 
@@ -51,7 +53,12 @@ const ACTIONS = ["approve", "publish", "archive", "sync", "route", "stage", "ass
 const SURFACES = ["toolbar", "panel", "modal", "summary", "sidebar", "header", "detail", "overview"]
 const linguiFormatPoImport = JSON.stringify(import.meta.resolve("@lingui/format-po"))
 
-export async function createWorkflowCorpus({ profileName, rootDir, seed = DEFAULT_SEED }) {
+export async function createWorkflowCorpus({
+  profileName,
+  rootDir,
+  seed = DEFAULT_SEED,
+  toolPaths,
+}) {
   const profile = PROFILE_DEFINITIONS[profileName]
 
   if (!profile) {
@@ -66,6 +73,7 @@ export async function createWorkflowCorpus({ profileName, rootDir, seed = DEFAUL
     lingui: path.join(profileRoot, "lingui"),
     formatjs: path.join(profileRoot, "formatjs"),
     i18nextCli: path.join(profileRoot, "i18next-cli"),
+    gt: path.join(profileRoot, "gt"),
   }
 
   await Promise.all(
@@ -79,6 +87,7 @@ export async function createWorkflowCorpus({ profileName, rootDir, seed = DEFAUL
     writeLinguiWorkspace(toolRoots.lingui, generated, profile),
     writeFormatJsWorkspace(toolRoots.formatjs, generated, profile),
     writeI18nextCliWorkspace(toolRoots.i18nextCli, generated, profile),
+    writeGtWorkspace(toolRoots.gt, generated, profile, toolPaths?.gt),
   ])
 
   const fileCount =
@@ -206,6 +215,129 @@ async function writeI18nextCliWorkspace(rootDir, inventory, profile) {
   )
   await writeToolSourceFiles(rootDir, inventory.sourceMessages, profile, renderI18nextSource)
   await writeJsonCatalogs(rootDir, inventory.baselineMessages)
+}
+
+/*
+ * General Translation keys its catalogs by a content hash the CLI computes
+ * itself, and the hash covers the authoring shape — the same text extracted
+ * from `<T>` and from `t()` lands under different keys. Reimplementing that
+ * here would couple the corpus to a private hashing detail, so the baseline is
+ * derived from a real `gtx-cli generate` run against the finished source tree
+ * instead: whatever keys GT produces for the unchanged messages are the keys
+ * its own merge will later recognize.
+ *
+ * Entries that must disappear during the measured run (the previous text of a
+ * changed message, and removed messages) get a synthetic key. GT drops stale
+ * entries by key lookup alone, so a synthetic key exercises that path exactly
+ * like a real one would, and the values stay real message text so the baseline
+ * keeps a realistic size.
+ */
+async function writeGtWorkspace(rootDir, inventory, profile, gtxCliPath) {
+  if (!gtxCliPath) {
+    throw new Error("The General Translation lane needs a resolved gtx-cli path")
+  }
+
+  await writeFile(
+    path.join(rootDir, "package.json"),
+    `${JSON.stringify(
+      {
+        name: "gt-e2e-workflow",
+        private: true,
+        version: "0.0.0",
+        dependencies: { "gt-react": await readGtReactVersion() },
+      },
+      null,
+      2
+    )}\n`,
+    "utf8"
+  )
+  await writeFile(
+    path.join(rootDir, "gt.config.json"),
+    `${JSON.stringify(
+      {
+        defaultLocale: "en",
+        locales: ["en", "de"],
+        src: ["src/generated/**/*.{js,jsx,ts,tsx}"],
+        files: { gt: { output: "src/locales/[locale].json" } },
+      },
+      null,
+      2
+    )}\n`,
+    "utf8"
+  )
+  await writeToolSourceFiles(rootDir, inventory.sourceMessages, profile, renderGtSource)
+
+  const localeRoot = path.join(rootDir, "src", "locales")
+  await runCommand(gtxCliPath, ["generate", "--quiet"], { cwd: rootDir })
+  const currentKeysByMessage = invertGtCatalog(
+    JSON.parse(await readFile(path.join(localeRoot, "en.json"), "utf8"))
+  )
+  await rm(localeRoot, { recursive: true, force: true })
+
+  const baseline = toGtBaselineCatalog(inventory.baselineMessages, currentKeysByMessage)
+  await mkdir(localeRoot, { recursive: true })
+  await Promise.all(
+    ["en", "de"].map((locale) =>
+      writeFile(
+        path.join(localeRoot, `${locale}.json`),
+        `${JSON.stringify(
+          Object.fromEntries(
+            Object.entries(baseline).map(([key, message]) => [key, translate(locale, message)])
+          ),
+          null,
+          2
+        )}\n`,
+        "utf8"
+      )
+    )
+  )
+  await cp(localeRoot, path.join(rootDir, ".baseline-locales"), { recursive: true })
+}
+
+async function readGtReactVersion() {
+  const manifest = new URL("../node_modules/gt-react/package.json", import.meta.url)
+  try {
+    return JSON.parse(await readFile(manifest, "utf8")).version
+  } catch {
+    throw new Error(
+      "Missing gt-react in the benchmark workspace. Run the repo-level benchmark script so dependencies are installed."
+    )
+  }
+}
+
+function invertGtCatalog(catalog) {
+  const keysByMessage = new Map()
+  for (const [key, message] of Object.entries(catalog)) {
+    if (typeof message !== "string") {
+      throw new TypeError(
+        `General Translation extracted a non-string source for ${key}; the corpus is meant to stay flat`
+      )
+    }
+    if (keysByMessage.has(message)) {
+      throw new Error(`General Translation extracted ${JSON.stringify(message)} under two keys`)
+    }
+    keysByMessage.set(message, key)
+  }
+  return keysByMessage
+}
+
+export function toGtBaselineCatalog(baselineMessages, currentKeysByMessage) {
+  const catalog = {}
+  for (const message of baselineMessages) {
+    const key = currentKeysByMessage.get(message) ?? syntheticGtKey(message)
+    if (catalog[key]) {
+      throw new Error(`General Translation baseline key collision at ${key}`)
+    }
+    catalog[key] = message
+  }
+  return catalog
+}
+
+/* Stale entries are only ever looked up by key, so any stable 16-hex key models
+ * one. Hashing the raw text keeps it deterministic; GT hashes a structured
+ * source descriptor instead, so the two cannot coincide. */
+function syntheticGtKey(message) {
+  return createHash("sha256").update(`stale:${message}`).digest("hex").slice(0, 16)
 }
 
 async function writeToolSourceFiles(rootDir, sourceMessages, profile, renderer) {
@@ -468,6 +600,54 @@ function renderI18nextSource(fileIndex, messages, extension, targetLines) {
 
   if (extension === "tsx") {
     body.push('  return <section>{values.join("\\\\n")}</section>')
+  } else {
+    body.push('  return values.join("\\n")')
+  }
+
+  body.push("}", "")
+  return withFiller(imports, body, fileIndex, targetLines)
+}
+
+export function renderGtSource(fileIndex, messages, extension, targetLines) {
+  const suffix = String(fileIndex).padStart(4, "0")
+
+  /*
+   * <T> only wraps a plain message. GT rejects a `{name}` placeholder in JSX
+   * children outright — it reads as a runtime expression and the CLI fails with
+   * "use a variable component like <Var>" — so a file whose messages are all
+   * interpolated keeps its JSX but skips the <T>. The chosen message is then
+   * left out of the t() list: GT keys JSX and string content separately, so
+   * authoring the same text both ways would put one logical message into the
+   * catalog under two keys and break the inventory comparison.
+   */
+  const transMessage =
+    extension === "tsx"
+      ? (messages.find((entry) => !entry.current.includes("{name}")) ?? null)
+      : null
+
+  const imports = [`import { ${transMessage ? "T, " : ""}useGT } from "gt-react"`]
+  const body = [
+    `export function ${extension === "tsx" ? "G" : "g"}tFixture${suffix}() {`,
+    "  const t = useGT()",
+    "  const values = [",
+  ]
+
+  for (const entry of messages) {
+    if (entry === transMessage) continue
+    body.push(`    t(${JSON.stringify(entry.current)}),`)
+  }
+
+  body.push("  ]")
+
+  if (extension === "tsx") {
+    body.push(
+      "  return (",
+      "    <section>",
+      ...(transMessage ? [`      <T>${escapeJsxText(transMessage.current)}</T>`] : []),
+      "      <span>{values.length}</span>",
+      "    </section>",
+      "  )"
+    )
   } else {
     body.push('  return values.join("\\n")')
   }

--- a/benchmarks/e2e-workflow/src/exec.mjs
+++ b/benchmarks/e2e-workflow/src/exec.mjs
@@ -1,0 +1,43 @@
+import path from "node:path"
+import { spawn } from "node:child_process"
+
+/*
+ * Shared by the measured runs in run.mjs and by corpus generation, which has to
+ * invoke the General Translation CLI once per profile to learn the message
+ * hashes it will key its catalogs by.
+ */
+export async function runCommand(command, args, options) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: options.cwd,
+      env: {
+        ...process.env,
+        ...options.env,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    })
+    let stdout = ""
+    let stderr = ""
+
+    child.stdout.setEncoding("utf8")
+    child.stderr.setEncoding("utf8")
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk
+    })
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk
+    })
+    child.on("error", reject)
+    child.on("close", (code, signal) => {
+      if (code !== 0) {
+        reject(
+          new Error(
+            `${path.basename(command)} ${args.join(" ")} failed with ${signal ?? code}\n${stdout}\n${stderr}`
+          )
+        )
+        return
+      }
+      resolve({ stdout, stderr })
+    })
+  })
+}

--- a/benchmarks/e2e-workflow/src/run.mjs
+++ b/benchmarks/e2e-workflow/src/run.mjs
@@ -11,10 +11,10 @@ import {
 } from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
-import { spawn } from "node:child_process"
 import { fileURLToPath } from "node:url"
 
 import { DEFAULT_SEED, PROFILE_DEFINITIONS, createWorkflowCorpus } from "./corpus.mjs"
+import { runCommand } from "./exec.mjs"
 import { parsePoMsgids } from "./po.mjs"
 
 const __dirname = import.meta.dirname
@@ -28,9 +28,10 @@ const TOOL_LABELS = {
   lingui: "Lingui",
   formatjs: "React Intl",
   i18nextCli: "i18next-cli",
+  gt: "General Translation",
 }
 
-const TOOL_ORDER = ["palamedes", "lingui", "formatjs", "i18nextCli"]
+const TOOL_ORDER = ["palamedes", "lingui", "formatjs", "i18nextCli", "gt"]
 /*
  * Directories any measured tool may leave behind as reusable state. Only
  * Palamedes writes one today; the others are listed so a future cache in one of
@@ -62,6 +63,7 @@ async function main() {
         profileName,
         rootDir: tempRoot,
         seed: args.seed,
+        toolPaths,
       })
       const validation = await validateCorpus(corpus, toolPaths)
       const profileResults = []
@@ -127,7 +129,8 @@ async function main() {
           "active catalog messages are normalized after each tool run and compared with the generated current inventory",
         toolScopes: {
           formatjs:
-            "source scan, extraction, content-hash ID generation, and one aggregated extracted-message JSON write; the React Intl extraction workflow does not update locale translation catalogs",
+            "source scan, extraction, content-hash ID generation, and one aggregated extracted-message JSON write; the React Intl extraction workflow does not update locale translation catalogs, so this lane covers less work than every other lane in the table",
+          gt: "source scan, extraction, content-hash keying, and merge/update of existing en/de catalogs; gtx-cli generate runs fully locally, seeds new entries with the source text, and drops removed entries immediately instead of marking them obsolete",
           otherTools:
             "source scan, extraction, merge/update of existing en/de catalogs, and catalog writes",
         },
@@ -196,6 +199,7 @@ async function resolveToolPaths(args) {
     lingui: path.join(benchmarkRoot, "node_modules", ".bin", `lingui${commandSuffix}`),
     formatjs: path.join(benchmarkRoot, "node_modules", ".bin", `formatjs${commandSuffix}`),
     i18nextCli: path.join(benchmarkRoot, "node_modules", ".bin", `i18next-cli${commandSuffix}`),
+    gt: path.join(benchmarkRoot, "node_modules", ".bin", `gtx-cli${commandSuffix}`),
   }
 
   for (const [tool, filename] of Object.entries(paths)) {
@@ -216,11 +220,13 @@ async function assertExecutable(tool, filename) {
 }
 
 async function readVersions(toolPaths) {
-  const [formatjsCli, linguiCli, i18nextCli, benchmarkPackage, palamedesVersion] =
+  const [formatjsCli, linguiCli, i18nextCli, gtxCli, gtReact, benchmarkPackage, palamedesVersion] =
     await Promise.all([
       readJson(path.join(benchmarkRoot, "node_modules", "@formatjs", "cli", "package.json")),
       readJson(path.join(benchmarkRoot, "node_modules", "@lingui", "cli", "package.json")),
       readJson(path.join(benchmarkRoot, "node_modules", "i18next-cli", "package.json")),
+      readJson(path.join(benchmarkRoot, "node_modules", "gtx-cli", "package.json")),
+      readJson(path.join(benchmarkRoot, "node_modules", "gt-react", "package.json")),
       readJson(path.join(benchmarkRoot, "package.json")),
       readCommandVersion(toolPaths.palamedes, ["version"]),
     ])
@@ -238,6 +244,10 @@ async function readVersions(toolPaths) {
     },
     i18nextCli: {
       cli: i18nextCli.version,
+    },
+    gt: {
+      cli: gtxCli.version,
+      react: gtReact.version,
     },
   }
 }
@@ -259,6 +269,9 @@ async function validateCorpus(corpus, toolPaths) {
     }
     tools[tool] = {
       activeMessagesByTarget,
+      ...(tool === "gt"
+        ? { preservedTranslations: await readGtPreservedTranslations(corpus) }
+        : {}),
     }
   }
 
@@ -266,6 +279,27 @@ async function validateCorpus(corpus, toolPaths) {
     expectedActiveMessages: corpus.currentMessages.length,
     tools,
   }
+}
+
+/*
+ * General Translation keys its catalogs by a content hash it computes itself.
+ * If that hash ever changes shape, every baseline key stops matching: the merge
+ * would reseed each entry with source text, the lane would quietly stop doing
+ * the catalog work it is timed against, and the message comparison above would
+ * still pass. Counting surviving translations pins that down.
+ */
+async function readGtPreservedTranslations(corpus) {
+  const catalog = await readJson(path.join(corpus.roots.gt, "src", "locales", "de.json"))
+  const preserved = Object.values(catalog).filter((value) => value.startsWith("[de] ")).length
+  const expected = corpus.sourceMessageCount - corpus.changedCount - corpus.newCount
+
+  if (preserved !== expected) {
+    throw new Error(
+      `${corpus.profileName}/gt: expected the merge to preserve ${expected} existing translations, found ${preserved}`
+    )
+  }
+
+  return preserved
 }
 
 /*
@@ -429,46 +463,13 @@ async function runTool(tool, cwd, toolPaths) {
         { cwd }
       )
     }
+    case "gt": {
+      return runCommand(toolPaths.gt, ["generate", "--quiet"], { cwd })
+    }
     default: {
       throw new Error(`Unknown tool: ${tool}`)
     }
   }
-}
-
-async function runCommand(command, args, options) {
-  return new Promise((resolve, reject) => {
-    const child = spawn(command, args, {
-      cwd: options.cwd,
-      env: {
-        ...process.env,
-        ...options.env,
-      },
-      stdio: ["ignore", "pipe", "pipe"],
-    })
-    let stdout = ""
-    let stderr = ""
-
-    child.stdout.setEncoding("utf8")
-    child.stderr.setEncoding("utf8")
-    child.stdout.on("data", (chunk) => {
-      stdout += chunk
-    })
-    child.stderr.on("data", (chunk) => {
-      stderr += chunk
-    })
-    child.on("error", reject)
-    child.on("close", (code, signal) => {
-      if (code !== 0) {
-        reject(
-          new Error(
-            `${path.basename(command)} ${args.join(" ")} failed with ${signal ?? code}\n${stdout}\n${stderr}`
-          )
-        )
-        return
-      }
-      resolve({ stdout, stderr })
-    })
-  })
 }
 
 function parsePalamedesTiming(stdout) {
@@ -491,6 +492,23 @@ async function readActiveMessages(tool, rootDir, locale) {
   if (tool === "i18nextCli") {
     const catalog = await readJson(path.join(rootDir, "src", "locales", locale, "translation.json"))
     return Object.keys(catalog).sort()
+  }
+
+  /*
+   * General Translation catalogs are keyed by content hash, so message identity
+   * lives in the source catalog. Target catalogs hold translations under those
+   * keys; mapping their keys back through the source catalog yields the message
+   * set, which is the same check the PO lanes get from comparing msgids.
+   */
+  if (tool === "gt") {
+    const source = await readJson(path.join(rootDir, "src", "locales", "en.json"))
+    if (locale === "en") {
+      return Object.values(source).sort()
+    }
+    const catalog = await readJson(path.join(rootDir, "src", "locales", `${locale}.json`))
+    return Object.keys(catalog)
+      .map((key) => source[key] ?? `<key ${key} missing from the source catalog>`)
+      .sort()
   }
 
   const source = await readFile(path.join(rootDir, "src", "locales", `${locale}.po`), "utf8")
@@ -549,6 +567,7 @@ function toolVersion(tool, versions) {
   if (tool === "palamedes") return versions.palamedes.cli
   if (tool === "lingui") return versions.lingui.cli
   if (tool === "formatjs") return versions.formatjs.cli
+  if (tool === "gt") return versions.gt.cli
   return versions.i18nextCli.cli
 }
 
@@ -648,6 +667,7 @@ function renderMarkdown(report) {
     `- Lingui CLI: ${report.versions.lingui.cli}`,
     `- React Intl extraction CLI (@formatjs/cli): ${report.versions.formatjs.cli}`,
     `- i18next-cli: ${report.versions.i18nextCli.cli}`,
+    `- General Translation CLI (gtx-cli): ${report.versions.gt.cli} (corpus authored against gt-react ${report.versions.gt.react})`,
     "",
     "## Methodology",
     "",
@@ -656,6 +676,7 @@ function renderMarkdown(report) {
     `- Reset: ${report.methodology.reset}`,
     `- Semantic check: ${report.methodology.semanticCheck}`,
     `- React Intl scope: ${report.methodology.toolScopes.formatjs}`,
+    `- General Translation scope: ${report.methodology.toolScopes.gt}`,
     `- Other tool scope: ${report.methodology.toolScopes.otherTools}`,
   ]
 
@@ -740,7 +761,10 @@ function renderMarkdown(report) {
     "- The i18next-cli corpus uses natural-language keys so semantic comparison can normalize active messages; key-based application architectures may have different catalog shapes."
   )
   lines.push(
-    "- The React Intl extraction workflow writes one extracted-message JSON artifact and does not update locale translation catalogs; its result is reported with that narrower scope instead of being presented as a catalog-merge equivalent."
+    "- **React Intl covers less work than every other lane.** `formatjs extract` writes one aggregated extracted-message JSON artifact and never reads or merges a locale catalog, so its median is not comparable to the catalog-update medians around it and must not be read as one."
+  )
+  lines.push(
+    "- The General Translation lane runs `gtx-cli generate`, which extracts and merges en/de catalogs entirely locally with no API key and no network access. It is GT's path for teams handling their own translations; GT's default workflow (`gtx-cli translate`) sends content to the GT API and is deliberately out of scope here."
   )
   lines.push(
     "- The harness reports source-message equivalence after each run instead of assuming every parser extracts the same result."

--- a/benchmarks/e2e-workflow/src/run.test.mjs
+++ b/benchmarks/e2e-workflow/src/run.test.mjs
@@ -3,9 +3,11 @@ import test from "node:test"
 
 import {
   formatJsId,
+  renderGtSource,
   renderLinguiSource,
   renderPalamedesSource,
   toFormatJsCatalog,
+  toGtBaselineCatalog,
 } from "./corpus.mjs"
 import { parsePoMsgids } from "./po.mjs"
 
@@ -72,6 +74,48 @@ test("React Intl baseline catalog uses the @formatjs/cli content-hash ID convent
     "t/eDuu": { defaultMessage: "Hello world" },
     QM7ITA: { defaultMessage: "Hello {name}" },
   })
+})
+
+test("General Translation lane authors every message exactly once", () => {
+  /*
+   * GT keys `<T>` children and `t()` strings separately, so a message authored
+   * both ways would reach the catalog under two keys and inflate the extracted
+   * inventory past the generated one.
+   */
+  const source = renderGtSource(1, SAMPLE_MESSAGES, "tsx", 0)
+
+  for (const message of SAMPLE_MESSAGES) {
+    const occurrences = source.split(message.current).length - 1
+    assert.equal(occurrences, 1, `${message.current} must be authored exactly once`)
+  }
+  assert.match(source, /import \{ T, useGT \} from "gt-react"/u)
+  assert.ok(source.includes("<T>Plain toolbar message</T>"))
+})
+
+test("General Translation lane skips <T> when every message is interpolated", () => {
+  /*
+   * GT rejects a `{name}` placeholder in JSX children — it reads as a runtime
+   * expression — so an all-interpolated file must keep its JSX but author the
+   * messages through t() only. Message index 0-14 of the generated inventory
+   * are all interpolated, which puts whole files in this state.
+   */
+  const interpolated = SAMPLE_MESSAGES.filter((entry) => entry.current.includes("{name}"))
+  const source = renderGtSource(1, interpolated, "tsx", 0)
+
+  assert.ok(!source.includes("<T>"), "no <T> may wrap an interpolated message")
+  assert.match(source, /import \{ useGT \} from "gt-react"/u)
+  assert.ok(source.includes("<section>"), "the file stays a JSX module")
+})
+
+test("General Translation baseline reuses real keys and synthesizes stale ones", () => {
+  const currentKeys = new Map([["Unchanged message", "aaaabbbbccccdddd"]])
+  const catalog = toGtBaselineCatalog(["Unchanged message", "Previous message"], currentKeys)
+
+  assert.equal(catalog.aaaabbbbccccdddd, "Unchanged message")
+
+  const staleKey = Object.keys(catalog).find((key) => key !== "aaaabbbbccccdddd")
+  assert.match(staleKey, /^[0-9a-f]{16}$/u, "a stale entry must look like a GT content hash")
+  assert.equal(catalog[staleKey], "Previous message")
 })
 
 test("parsePoMsgids reads multiline ICU msgids", () => {

--- a/docs/approach-comparison.md
+++ b/docs/approach-comparison.md
@@ -123,14 +123,23 @@ translation for content that is known before deploy, plus a wider product
 surface around template generation, local files, hosted translation, and
 dynamic translation paths for content that cannot be fixed ahead of time.
 
-That makes GT broader in product scope and less clean as a direct benchmark
-target.
+That makes GT broader in product scope than Palamedes. It does not, however,
+make GT unmeasurable: `gtx-cli generate` extracts from source and merges the
+configured locale catalogs entirely locally, with no API key and no network
+access, which is why it has its own lane in the
+[end-to-end workflow benchmark](./benchmark-e2e-workflow.md). GT documents that
+command for teams handling their own translations; its default path
+(`gtx-cli translate`) sends content to the GT API and is a different category of
+operation that the benchmark deliberately leaves alone.
 
-If you compare GT's compiler to Palamedes, you are only comparing one slice of
-what GT is trying to do. If you compare GT's translation workflow to Palamedes,
-you are no longer comparing the same category of product at all. GT is much
-closer to an integrated translation system with local-library escape hatches
-than to a narrowly scoped compile-and-runtime architecture.
+So the comparison has to name which GT you mean. Comparing GT's compiler to
+Palamedes covers one slice of what GT is trying to do. Comparing GT's hosted
+translation workflow to Palamedes compares two different products. Comparing
+`gtx-cli generate` to `pmds extract` is a fair like-for-like on the local
+extract-and-update step, and that is the only GT comparison this repository
+makes numerically. Beyond that step GT remains much closer to an integrated
+translation system with local-library escape hatches than to a narrowly scoped
+compile-and-runtime architecture.
 
 Still, GT is worth studying because it points at adjacent product opportunities.
 Its local template generation for inline-authored strings, richer translator
@@ -181,8 +190,11 @@ React Intl, i18next, Crowdin, Phrase, and Weblate documentation.
 That is the right way to read the benchmark story as well. The Lingui benchmark
 is not meant to imply that every i18n library should be forced into the same
 race. It exists because Lingui and Palamedes actually run on comparable
-operations. The broader comparison with `next-intl` and GT is better handled as
-an explanation of product shape, semantic choices, and architectural tradeoffs.
+operations, and the same test decides every other lane: GT earns a measured row
+because `gtx-cli generate` is a comparable local operation, while `next-intl`
+does not, because its extraction only exists inside a bundler build. Where the
+operations do not line up, the comparison belongs in product shape, semantic
+choices, and architectural tradeoffs instead of in a number.
 
 ## Further Reading
 

--- a/docs/benchmark-e2e-workflow.md
+++ b/docs/benchmark-e2e-workflow.md
@@ -7,13 +7,15 @@ run after source changes:
 - Lingui: `lingui extract`
 - React Intl: `formatjs extract`
 - i18next-cli: `i18next-cli extract`
+- General Translation: `gtx-cli generate`
 
 It is separate from the Lingui v6 hot-path benchmark. This harness
 includes source scanning, extraction, and output writes in one timed command.
-Palamedes, Lingui, and i18next-cli also update existing `en`
-and `de` catalogs. The React Intl lane instead uses `@formatjs/cli` to write one
-aggregated extracted-message JSON artifact; it does not provide a locale-catalog
-merge in this command, so its narrower scope is called out throughout the report.
+Palamedes, Lingui, i18next-cli, and General Translation also update existing
+`en` and `de` catalogs. The React Intl lane instead uses `@formatjs/cli` to
+write one aggregated extracted-message JSON artifact; it does not provide a
+locale-catalog merge in this command, so its narrower scope is called out
+throughout the report.
 
 ## What This Benchmark Times
 
@@ -23,6 +25,7 @@ The reported medians time one CLI command per tool:
 - Lingui: `lingui extract --config lingui.config.mjs`
 - React Intl: `formatjs extract "src/generated/**/*.{ts,tsx}" --out-file src/locales/extracted.json --id-interpolation-pattern "[sha512:contenthash:base64:6]"`
 - i18next-cli: `i18next-cli extract --config i18next.config.mjs --sync-all --trust-derived --quiet`
+- General Translation: `gtx-cli generate --quiet`
 
 That means the measured time includes:
 
@@ -32,7 +35,7 @@ That means the measured time includes:
 | Source parsing / code inspection            | Yes                           | This is the parser work needed to find messages. It is not a separate type-check or lint pass.                                                                                                                                    |
 | Message extraction                          | Yes                           | The command has to read the authored source syntax and produce the current message set.                                                                                                                                           |
 | Catalog update / merge                      | Except React Intl             | Existing catalogs start with unchanged, changed, and removed messages; the source tree also contains new messages. React Intl's extraction workflow overwrites one extracted-message artifact instead of merging locale catalogs. |
-| Catalog file writes                         | Yes                           | Three tools write updated `en` and `de` catalogs. React Intl's extraction workflow writes one aggregated JSON artifact with content-hash IDs.                                                                                     |
+| Catalog file writes                         | Yes                           | Four tools write updated `en` and `de` catalogs. React Intl's extraction workflow writes one aggregated JSON artifact with content-hash IDs.                                                                                      |
 | Semantic result validation                  | No                            | The harness checks the written catalogs after the command so bad extraction cannot publish timings, but that check is outside the measured median.                                                                                |
 | Runtime catalog/artifact compile            | No                            | Compiling catalogs into runtime artifacts is a separate benchmark surface.                                                                                                                                                        |
 | Type-checking, linting, bundling, app build | No                            | This benchmark is about catalog extraction/update workflows, not app validation.                                                                                                                                                  |
@@ -88,6 +91,32 @@ may see different catalog shapes and timings. React Intl source uses
 `defaultMessage` values rather than treating its generated content-hash IDs as
 message semantics.
 
+General Translation source uses `useGT()` strings and `<T>` components. Its
+catalogs are keyed by a content hash the CLI computes itself, so validation maps
+the target catalog's keys back through the source catalog instead of reading the
+keys as message text. Two GT specifics are worth knowing when reading its
+median: new entries are seeded with the source text rather than left empty, and
+removed entries are dropped immediately instead of being marked obsolete, so GT
+does slightly less bookkeeping than the PO lanes. The harness additionally
+asserts that the run preserved every existing translation — if GT's hashing ever
+changed shape, the merge would silently reseed each entry and the lane would
+stop doing the catalog work it is timed for.
+
+## Reading The React Intl Row
+
+The React Intl lane does less work than every other lane in the table.
+`formatjs extract` scans sources and writes one aggregated extracted-message
+artifact; it never reads an existing catalog, never merges, and never writes a
+per-locale file. Its median therefore answers a narrower question than the four
+catalog-update medians next to it and must not be read as a catalog-update
+number.
+
+It stays in the matrix because React Intl is one of the most widely used React
+i18n libraries, and dropping the second-largest tool in the field while keeping
+smaller ones would say more about lane selection than about performance. The
+honest handling is to keep the row and label its scope, which is what the
+generated report does on every run.
+
 ## Tools Not In The Matrix
 
 - **next-intl `useExtracted`** remains a stretch comparison. Extraction is
@@ -99,8 +128,12 @@ message semantics.
   which belongs to a compile benchmark.
 - **Vue I18n** has no first-party extraction CLI to time; discovery is commonly
   handled by editor tooling such as i18n Ally.
-- **General Translation** performs network/AI translation in its CLI workflow,
-  which is not comparable to these deterministic local extraction commands.
+- **Tolgee** has no local command that produces catalogs. Its CLI extracts
+  locally only through `tolgee extract print` and `tolgee extract check`, which
+  report to the console and write no files; catalogs reach the repository via
+  `tolgee pull`, which downloads an export from the Tolgee platform and needs an
+  API key. Timing a console dump against catalog-update commands would compare
+  even less than the React Intl row does.
 
 ## Cold And Warm
 
@@ -133,15 +166,17 @@ become warm ones.
 
 Latest checked full run:
 
-- timestamp: `2026-07-31T08:33:20.786Z`
+- timestamp: `2026-08-05T09:07:39.077Z`
 - Node: `v24.18.0`
 - platform: `darwin/arm64`
 - warmup: `3`
 - measured runs: `7`
-- Palamedes CLI: `1.9.0`
+- Palamedes CLI: `1.12.0`
 - Lingui CLI: `6.6.0`
-- React Intl extraction CLI (`@formatjs/cli`): `6.16.14`
+- React Intl extraction CLI (`@formatjs/cli`): `6.16.16`
 - i18next-cli: `1.67.3`
+- General Translation CLI (`gtx-cli`): `2.16.0`, corpus authored against
+  `gt-react` `11.1.4`
 
 ### Small
 
@@ -154,18 +189,20 @@ Corpus:
 
 Median results:
 
-| Tool        |      Median |
-| ----------- | ----------: |
-| Palamedes   |  `12.82 ms` |
-| Lingui      | `690.97 ms` |
-| React Intl  | `282.84 ms` |
-| i18next-cli | `404.93 ms` |
+| Tool                |      Median |
+| ------------------- | ----------: |
+| Palamedes           |  `14.11 ms` |
+| Lingui              | `747.18 ms` |
+| React Intl          | `288.59 ms` |
+| i18next-cli         | `625.87 ms` |
+| General Translation | `577.89 ms` |
 
-On this run, Palamedes measured `53.91x` faster than Lingui, `22.07x` faster
-than React Intl, and `31.59x` faster than i18next-cli.
+On this run, Palamedes measured `52.94x` faster than Lingui, `20.45x` faster
+than React Intl, `44.35x` faster than i18next-cli, and `40.95x` faster than
+General Translation.
 
-Warm lane: after touching `5` source files, Palamedes re-ran in `10.27 ms`
-against its own cold `12.82 ms`. The compared tools re-extract in full, so
+Warm lane: after touching `5` source files, Palamedes re-ran in `10.76 ms`
+against its own cold `14.11 ms`. The compared tools re-extract in full, so
 their warm medians repeat their cold ones.
 
 ### Medium
@@ -179,18 +216,20 @@ Corpus:
 
 Median results:
 
-| Tool        |      Median |
-| ----------- | ----------: |
-| Palamedes   |  `22.22 ms` |
-| Lingui      | `761.69 ms` |
-| React Intl  | `305.90 ms` |
-| i18next-cli | `618.69 ms` |
+| Tool                |      Median |
+| ------------------- | ----------: |
+| Palamedes           |  `23.80 ms` |
+| Lingui              | `836.69 ms` |
+| React Intl          | `344.09 ms` |
+| i18next-cli         | `658.40 ms` |
+| General Translation | `669.27 ms` |
 
-On this run, Palamedes measured `34.27x` faster than Lingui, `13.76x` faster
-than React Intl, and `27.84x` faster than i18next-cli.
+On this run, Palamedes measured `35.15x` faster than Lingui, `14.46x` faster
+than React Intl, `27.66x` faster than i18next-cli, and `28.12x` faster than
+General Translation.
 
-Warm lane: after touching `5` source files, Palamedes re-ran in `14.05 ms`
-against its own cold `22.22 ms`. The compared tools re-extract in full, so
+Warm lane: after touching `5` source files, Palamedes re-ran in `15.16 ms`
+against its own cold `23.80 ms`. The compared tools re-extract in full, so
 their warm medians repeat their cold ones.
 
 ### Realistic
@@ -207,21 +246,24 @@ read as a shape, not false precision):
 
 Median results:
 
-| Tool        |       Median |
-| ----------- | -----------: |
-| Palamedes   |   `82.14 ms` |
-| Lingui      | `2405.52 ms` |
-| React Intl  |  `470.81 ms` |
-| i18next-cli | `6256.98 ms` |
+| Tool                |       Median |
+| ------------------- | -----------: |
+| Palamedes           |   `83.89 ms` |
+| Lingui              | `2480.24 ms` |
+| React Intl          |  `475.85 ms` |
+| i18next-cli         | `6644.63 ms` |
+| General Translation | `6116.43 ms` |
 
-On this run, Palamedes measured `29.29x` faster than Lingui, `5.73x` faster
-than React Intl, and `76.18x` faster than i18next-cli.
+On this run, Palamedes measured `29.57x` faster than Lingui, `5.67x` faster
+than React Intl, `79.21x` faster than i18next-cli, and `72.91x` faster than
+General Translation.
 
-Warm lane: after touching `5` source files, Palamedes re-ran in `33.11 ms`
-against its own cold `82.14 ms` — the corpus where the cache has the most to
+Warm lane: after touching `5` source files, Palamedes re-ran in `33.08 ms`
+against its own cold `83.89 ms` — the corpus where the cache has the most to
 skip, and the shape of a real repository. The compared tools re-extract in
-full, so their warm medians repeat their cold ones (`2339.33 ms`, `470.60 ms`,
-and `6196.06 ms`), which is why this lane never enters a speedup ratio.
+full, so their warm medians repeat their cold ones (`2459.89 ms`, `481.17 ms`,
+`6708.17 ms`, and `5877.81 ms`), which is why this lane never enters a speedup
+ratio.
 
 ## Reading The Numbers
 

--- a/docs/proof-and-benchmarks.md
+++ b/docs/proof-and-benchmarks.md
@@ -114,14 +114,16 @@ See the full methodology here:
 
 - [Benchmarking against Lingui v6](https://github.com/sebastian-software/palamedes/blob/main/docs/benchmark-lingui-v6-preview.md)
 
-For the broader architectural picture, including `next-intl` and General Translation, see:
+For the broader architectural picture, including `next-intl` and where General
+Translation's measured lane ends, see:
 
 - [Comparing modern i18n approaches](https://github.com/sebastian-software/palamedes/blob/main/docs/approach-comparison.md)
 
 That separate harness measures Lingui macro rewrite through distinct Babel and
 SWC lanes instead of folding them into one number.
 
-For the end-to-end workflow comparison against Lingui, React Intl, and i18next-cli:
+For the end-to-end workflow comparison against Lingui, React Intl, i18next-cli,
+and General Translation:
 
 ```bash
 pnpm benchmark:e2e-workflow

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,7 +32,7 @@ importers:
         version: 10.8.0(jiti@2.7.0)(supports-color@10.2.2)
       eslint-config-setup:
         specifier: ^0.5.0
-        version: 0.5.2(@types/estree@1.0.9)(@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(@typescript-eslint/utils@8.65.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(oxlint@1.76.0)(storybook@10.5.3(@types/react@19.2.18)(prettier@3.9.4)(react@19.2.8))(supports-color@10.2.2)(typescript@6.0.3)(vitest@4.1.10(@edge-runtime/vm@3.2.0)(@types/node@24.13.3)(jsdom@29.1.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 0.5.2(@types/estree@1.0.9)(@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(@typescript-eslint/utils@8.65.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(oxlint@1.76.0)(storybook@10.5.3(@types/react@19.2.18)(prettier@3.9.4)(react@19.2.8))(supports-color@10.2.2)(typescript@6.0.3)(vitest@4.1.10(@edge-runtime/vm@3.2.0)(@types/node@24.13.3)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))
       oxfmt:
         specifier: ^0.61.0
         version: 0.61.0
@@ -44,7 +44,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@edge-runtime/vm@3.2.0)(@types/node@24.13.3)(jsdom@29.1.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.10(@edge-runtime/vm@3.2.0)(@types/node@24.13.3)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
 
   benchmarks/e2e-workflow:
     dependencies:
@@ -60,6 +60,12 @@ importers:
       '@lingui/format-po':
         specifier: 6.6.0
         version: 6.6.0
+      gt-react:
+        specifier: 11.1.4
+        version: 11.1.4(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      gtx-cli:
+        specifier: 2.16.0
+        version: 2.16.0(@babel/core@7.29.7(supports-color@10.2.2))(@types/react@19.2.18)(supports-color@10.2.2)
       i18next-cli:
         specifier: 1.67.3
         version: 1.67.3(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(typescript@6.0.3)
@@ -674,7 +680,7 @@ importers:
         version: 1.0.0(solid-js@1.9.14)
       '@solidjs/start':
         specifier: ^1.3.2
-        version: 1.3.2(@testing-library/jest-dom@6.9.1)(solid-js@1.9.14)(supports-color@10.2.2)(vinxi@0.5.11(@parcel/watcher@2.5.6)(@types/node@24.13.3)(@vercel/blob@2.4.0)(aws4fetch@1.0.20)(db0@0.3.4)(debug@4.4.3(supports-color@10.2.2))(ioredis@5.10.1(supports-color@10.2.2))(jiti@2.7.0)(lightningcss@1.33.0)(oxc-parser@0.127.0)(rolldown@1.2.2)(srvx@0.12.4)(supports-color@10.2.2)(terser@5.49.0)(tsx@4.21.0)(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))(yaml@2.9.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 1.3.2(@testing-library/jest-dom@6.9.1)(solid-js@1.9.14)(supports-color@10.2.2)(vinxi@0.5.11(@types/node@24.13.3)(@vercel/blob@2.4.0)(aws4fetch@1.0.20)(db0@0.3.4)(debug@4.4.3(supports-color@10.2.2))(ioredis@5.10.1(supports-color@10.2.2))(jiti@2.7.0)(lightningcss@1.33.0)(rolldown@1.2.2)(supports-color@10.2.2)(terser@5.49.0)(tsx@4.21.0)(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.27.7)(lightningcss@1.33.0)(postcss@8.5.25))(yaml@2.9.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
       solid-js:
         specifier: ^1.9.14
         version: 1.9.14
@@ -693,10 +699,10 @@ importers:
         version: 6.0.3
       vinxi:
         specifier: ^0.5.11
-        version: 0.5.11(@parcel/watcher@2.5.6)(@types/node@24.13.3)(@vercel/blob@2.4.0)(aws4fetch@1.0.20)(db0@0.3.4)(debug@4.4.3(supports-color@10.2.2))(ioredis@5.10.1(supports-color@10.2.2))(jiti@2.7.0)(lightningcss@1.33.0)(oxc-parser@0.127.0)(rolldown@1.2.2)(srvx@0.12.4)(supports-color@10.2.2)(terser@5.49.0)(tsx@4.21.0)(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))(yaml@2.9.0)
+        version: 0.5.11(@types/node@24.13.3)(@vercel/blob@2.4.0)(aws4fetch@1.0.20)(db0@0.3.4)(debug@4.4.3(supports-color@10.2.2))(ioredis@5.10.1(supports-color@10.2.2))(jiti@2.7.0)(lightningcss@1.33.0)(rolldown@1.2.2)(supports-color@10.2.2)(terser@5.49.0)(tsx@4.21.0)(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.27.7)(lightningcss@1.33.0)(postcss@8.5.25))(yaml@2.9.0)
       vite:
         specifier: ^8.2.0
-        version: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 8.2.0(@types/node@24.13.3)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/solidstart-route:
     dependencies:
@@ -717,7 +723,7 @@ importers:
         version: 1.0.0(solid-js@1.9.14)
       '@solidjs/start':
         specifier: ^1.3.2
-        version: 1.3.2(@testing-library/jest-dom@6.9.1)(solid-js@1.9.14)(supports-color@10.2.2)(vinxi@0.5.11(@parcel/watcher@2.5.6)(@types/node@24.13.3)(@vercel/blob@2.4.0)(aws4fetch@1.0.20)(db0@0.3.4)(debug@4.4.3(supports-color@10.2.2))(ioredis@5.10.1(supports-color@10.2.2))(jiti@2.7.0)(lightningcss@1.33.0)(oxc-parser@0.127.0)(rolldown@1.2.2)(srvx@0.12.4)(supports-color@10.2.2)(terser@5.49.0)(tsx@4.21.0)(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))(yaml@2.9.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 1.3.2(@testing-library/jest-dom@6.9.1)(solid-js@1.9.14)(supports-color@10.2.2)(vinxi@0.5.11(@types/node@24.13.3)(@vercel/blob@2.4.0)(aws4fetch@1.0.20)(db0@0.3.4)(debug@4.4.3(supports-color@10.2.2))(ioredis@5.10.1(supports-color@10.2.2))(jiti@2.7.0)(lightningcss@1.33.0)(rolldown@1.2.2)(supports-color@10.2.2)(terser@5.49.0)(tsx@4.21.0)(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))(yaml@2.9.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
       solid-js:
         specifier: ^1.9.14
         version: 1.9.14
@@ -736,7 +742,7 @@ importers:
         version: 6.0.3
       vinxi:
         specifier: ^0.5.11
-        version: 0.5.11(@parcel/watcher@2.5.6)(@types/node@24.13.3)(@vercel/blob@2.4.0)(aws4fetch@1.0.20)(db0@0.3.4)(debug@4.4.3(supports-color@10.2.2))(ioredis@5.10.1(supports-color@10.2.2))(jiti@2.7.0)(lightningcss@1.33.0)(oxc-parser@0.127.0)(rolldown@1.2.2)(srvx@0.12.4)(supports-color@10.2.2)(terser@5.49.0)(tsx@4.21.0)(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))(yaml@2.9.0)
+        version: 0.5.11(@types/node@24.13.3)(@vercel/blob@2.4.0)(aws4fetch@1.0.20)(db0@0.3.4)(debug@4.4.3(supports-color@10.2.2))(ioredis@5.10.1(supports-color@10.2.2))(jiti@2.7.0)(lightningcss@1.33.0)(rolldown@1.2.2)(supports-color@10.2.2)(terser@5.49.0)(tsx@4.21.0)(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))(yaml@2.9.0)
       vite:
         specifier: ^8.2.0
         version: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)
@@ -760,7 +766,7 @@ importers:
         version: 1.0.0(solid-js@1.9.14)
       '@solidjs/start':
         specifier: ^1.3.2
-        version: 1.3.2(@testing-library/jest-dom@6.9.1)(solid-js@1.9.14)(supports-color@10.2.2)(vinxi@0.5.11(@parcel/watcher@2.5.6)(@types/node@24.13.3)(@vercel/blob@2.4.0)(aws4fetch@1.0.20)(db0@0.3.4)(debug@4.4.3(supports-color@10.2.2))(ioredis@5.10.1(supports-color@10.2.2))(jiti@2.7.0)(lightningcss@1.33.0)(oxc-parser@0.127.0)(rolldown@1.2.2)(srvx@0.12.4)(supports-color@10.2.2)(terser@5.49.0)(tsx@4.21.0)(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))(yaml@2.9.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 1.3.2(@testing-library/jest-dom@6.9.1)(solid-js@1.9.14)(supports-color@10.2.2)(vinxi@0.5.11(@types/node@24.13.3)(@vercel/blob@2.4.0)(aws4fetch@1.0.20)(db0@0.3.4)(debug@4.4.3(supports-color@10.2.2))(ioredis@5.10.1(supports-color@10.2.2))(jiti@2.7.0)(lightningcss@1.33.0)(rolldown@1.2.2)(supports-color@10.2.2)(terser@5.49.0)(tsx@4.21.0)(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))(yaml@2.9.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
       solid-js:
         specifier: ^1.9.14
         version: 1.9.14
@@ -779,7 +785,7 @@ importers:
         version: 6.0.3
       vinxi:
         specifier: ^0.5.11
-        version: 0.5.11(@parcel/watcher@2.5.6)(@types/node@24.13.3)(@vercel/blob@2.4.0)(aws4fetch@1.0.20)(db0@0.3.4)(debug@4.4.3(supports-color@10.2.2))(ioredis@5.10.1(supports-color@10.2.2))(jiti@2.7.0)(lightningcss@1.33.0)(oxc-parser@0.127.0)(rolldown@1.2.2)(srvx@0.12.4)(supports-color@10.2.2)(terser@5.49.0)(tsx@4.21.0)(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))(yaml@2.9.0)
+        version: 0.5.11(@types/node@24.13.3)(@vercel/blob@2.4.0)(aws4fetch@1.0.20)(db0@0.3.4)(debug@4.4.3(supports-color@10.2.2))(ioredis@5.10.1(supports-color@10.2.2))(jiti@2.7.0)(lightningcss@1.33.0)(rolldown@1.2.2)(supports-color@10.2.2)(terser@5.49.0)(tsx@4.21.0)(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))(yaml@2.9.0)
       vite:
         specifier: ^8.2.0
         version: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)
@@ -803,7 +809,7 @@ importers:
         version: 1.0.0(solid-js@1.9.14)
       '@solidjs/start':
         specifier: ^1.3.2
-        version: 1.3.2(@testing-library/jest-dom@6.9.1)(solid-js@1.9.14)(supports-color@10.2.2)(vinxi@0.5.11(@parcel/watcher@2.5.6)(@types/node@24.13.3)(@vercel/blob@2.4.0)(aws4fetch@1.0.20)(db0@0.3.4)(debug@4.4.3(supports-color@10.2.2))(ioredis@5.10.1(supports-color@10.2.2))(jiti@2.7.0)(lightningcss@1.33.0)(oxc-parser@0.127.0)(rolldown@1.2.2)(srvx@0.12.4)(supports-color@10.2.2)(terser@5.49.0)(tsx@4.21.0)(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))(yaml@2.9.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 1.3.2(@testing-library/jest-dom@6.9.1)(solid-js@1.9.14)(supports-color@10.2.2)(vinxi@0.5.11(@types/node@24.13.3)(@vercel/blob@2.4.0)(aws4fetch@1.0.20)(db0@0.3.4)(debug@4.4.3(supports-color@10.2.2))(ioredis@5.10.1(supports-color@10.2.2))(jiti@2.7.0)(lightningcss@1.33.0)(rolldown@1.2.2)(supports-color@10.2.2)(terser@5.49.0)(tsx@4.21.0)(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))(yaml@2.9.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
       solid-js:
         specifier: ^1.9.14
         version: 1.9.14
@@ -822,7 +828,7 @@ importers:
         version: 6.0.3
       vinxi:
         specifier: ^0.5.11
-        version: 0.5.11(@parcel/watcher@2.5.6)(@types/node@24.13.3)(@vercel/blob@2.4.0)(aws4fetch@1.0.20)(db0@0.3.4)(debug@4.4.3(supports-color@10.2.2))(ioredis@5.10.1(supports-color@10.2.2))(jiti@2.7.0)(lightningcss@1.33.0)(oxc-parser@0.127.0)(rolldown@1.2.2)(srvx@0.12.4)(supports-color@10.2.2)(terser@5.49.0)(tsx@4.21.0)(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))(yaml@2.9.0)
+        version: 0.5.11(@types/node@24.13.3)(@vercel/blob@2.4.0)(aws4fetch@1.0.20)(db0@0.3.4)(debug@4.4.3(supports-color@10.2.2))(ioredis@5.10.1(supports-color@10.2.2))(jiti@2.7.0)(lightningcss@1.33.0)(rolldown@1.2.2)(supports-color@10.2.2)(terser@5.49.0)(tsx@4.21.0)(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))(yaml@2.9.0)
       vite:
         specifier: ^8.2.0
         version: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)
@@ -846,10 +852,10 @@ importers:
         version: 1.170.18(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@tanstack/react-start':
         specifier: ^1.168.34
-        version: 1.168.34(@vitejs/plugin-rsc@0.5.32(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25)))(react@19.2.8)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(crossws@0.4.10(srvx@0.12.4))(esbuild@0.28.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.2)(rollup@4.62.4)(supports-color@10.2.2)(vite-plugin-solid@2.11.14(@testing-library/jest-dom@7.0.0(@testing-library/dom@10.4.1))(solid-js@1.9.14)(supports-color@10.2.2)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
+        version: 1.168.35(@vitejs/plugin-rsc@0.5.32(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25)))(react@19.2.8)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(esbuild@0.28.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.2)(rollup@4.59.0)(supports-color@10.2.2)(vite-plugin-solid@2.11.14(@testing-library/jest-dom@7.0.0(@testing-library/dom@10.4.1))(solid-js@1.9.14)(supports-color@10.2.2)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
       '@tanstack/router-plugin':
         specifier: ^1.168.23
-        version: 1.168.23(@tanstack/react-router@1.170.18(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(esbuild@0.28.1)(rolldown@1.2.2)(rollup@4.62.4)(supports-color@10.2.2)(vite-plugin-solid@2.11.14(@testing-library/jest-dom@7.0.0(@testing-library/dom@10.4.1))(solid-js@1.9.14)(supports-color@10.2.2)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
+        version: 1.168.23(@tanstack/react-router@1.170.18(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(esbuild@0.28.1)(rolldown@1.2.2)(rollup@4.59.0)(supports-color@10.2.2)(vite-plugin-solid@2.11.14(@testing-library/jest-dom@7.0.0(@testing-library/dom@10.4.1))(solid-js@1.9.14)(supports-color@10.2.2)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
       react:
         specifier: ^19.2.8
         version: 19.2.8
@@ -904,10 +910,10 @@ importers:
         version: 1.170.18(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@tanstack/react-start':
         specifier: ^1.168.34
-        version: 1.168.34(@vitejs/plugin-rsc@0.5.32(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25)))(react@19.2.8)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(crossws@0.4.10(srvx@0.12.4))(esbuild@0.28.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.2)(rollup@4.62.4)(supports-color@10.2.2)(vite-plugin-solid@2.11.14(@testing-library/jest-dom@7.0.0(@testing-library/dom@10.4.1))(solid-js@1.9.14)(supports-color@10.2.2)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
+        version: 1.168.35(@vitejs/plugin-rsc@0.5.32(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25)))(react@19.2.8)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(esbuild@0.28.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.2)(rollup@4.59.0)(supports-color@10.2.2)(vite-plugin-solid@2.11.14(@testing-library/jest-dom@7.0.0(@testing-library/dom@10.4.1))(solid-js@1.9.14)(supports-color@10.2.2)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
       '@tanstack/router-plugin':
         specifier: ^1.168.23
-        version: 1.168.23(@tanstack/react-router@1.170.18(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(esbuild@0.28.1)(rolldown@1.2.2)(rollup@4.62.4)(supports-color@10.2.2)(vite-plugin-solid@2.11.14(@testing-library/jest-dom@7.0.0(@testing-library/dom@10.4.1))(solid-js@1.9.14)(supports-color@10.2.2)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
+        version: 1.168.23(@tanstack/react-router@1.170.18(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(esbuild@0.28.1)(rolldown@1.2.2)(rollup@4.59.0)(supports-color@10.2.2)(vite-plugin-solid@2.11.14(@testing-library/jest-dom@7.0.0(@testing-library/dom@10.4.1))(solid-js@1.9.14)(supports-color@10.2.2)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
       react:
         specifier: ^19.2.8
         version: 19.2.8
@@ -962,10 +968,10 @@ importers:
         version: 1.170.18(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@tanstack/react-start':
         specifier: ^1.168.34
-        version: 1.168.34(@vitejs/plugin-rsc@0.5.32(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25)))(react@19.2.8)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(crossws@0.4.10(srvx@0.12.4))(esbuild@0.28.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.2)(rollup@4.62.4)(supports-color@10.2.2)(vite-plugin-solid@2.11.14(@testing-library/jest-dom@7.0.0(@testing-library/dom@10.4.1))(solid-js@1.9.14)(supports-color@10.2.2)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
+        version: 1.168.35(@vitejs/plugin-rsc@0.5.32(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25)))(react@19.2.8)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(esbuild@0.28.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.2)(rollup@4.59.0)(supports-color@10.2.2)(vite-plugin-solid@2.11.14(@testing-library/jest-dom@7.0.0(@testing-library/dom@10.4.1))(solid-js@1.9.14)(supports-color@10.2.2)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
       '@tanstack/router-plugin':
         specifier: ^1.168.23
-        version: 1.168.23(@tanstack/react-router@1.170.18(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(esbuild@0.28.1)(rolldown@1.2.2)(rollup@4.62.4)(supports-color@10.2.2)(vite-plugin-solid@2.11.14(@testing-library/jest-dom@7.0.0(@testing-library/dom@10.4.1))(solid-js@1.9.14)(supports-color@10.2.2)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
+        version: 1.168.23(@tanstack/react-router@1.170.18(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(esbuild@0.28.1)(rolldown@1.2.2)(rollup@4.59.0)(supports-color@10.2.2)(vite-plugin-solid@2.11.14(@testing-library/jest-dom@7.0.0(@testing-library/dom@10.4.1))(solid-js@1.9.14)(supports-color@10.2.2)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
       react:
         specifier: ^19.2.8
         version: 19.2.8
@@ -1020,10 +1026,10 @@ importers:
         version: 1.170.18(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@tanstack/react-start':
         specifier: ^1.168.34
-        version: 1.168.34(@vitejs/plugin-rsc@0.5.32(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25)))(react@19.2.8)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(crossws@0.4.10(srvx@0.12.4))(esbuild@0.28.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.2)(rollup@4.62.4)(supports-color@10.2.2)(vite-plugin-solid@2.11.14(@testing-library/jest-dom@7.0.0(@testing-library/dom@10.4.1))(solid-js@1.9.14)(supports-color@10.2.2)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
+        version: 1.168.35(@vitejs/plugin-rsc@0.5.32(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25)))(react@19.2.8)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(esbuild@0.28.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.2)(rollup@4.59.0)(supports-color@10.2.2)(vite-plugin-solid@2.11.14(@testing-library/jest-dom@7.0.0(@testing-library/dom@10.4.1))(solid-js@1.9.14)(supports-color@10.2.2)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
       '@tanstack/router-plugin':
         specifier: ^1.168.23
-        version: 1.168.23(@tanstack/react-router@1.170.18(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(esbuild@0.28.1)(rolldown@1.2.2)(rollup@4.62.4)(supports-color@10.2.2)(vite-plugin-solid@2.11.14(@testing-library/jest-dom@7.0.0(@testing-library/dom@10.4.1))(solid-js@1.9.14)(supports-color@10.2.2)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
+        version: 1.168.23(@tanstack/react-router@1.170.18(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(esbuild@0.28.1)(rolldown@1.2.2)(rollup@4.59.0)(supports-color@10.2.2)(vite-plugin-solid@2.11.14(@testing-library/jest-dom@7.0.0(@testing-library/dom@10.4.1))(solid-js@1.9.14)(supports-color@10.2.2)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
       react:
         specifier: ^19.2.8
         version: 19.2.8
@@ -1118,7 +1124,7 @@ importers:
         version: link:../../packages/runtime
       hono:
         specifier: ^4.12.34
-        version: 4.12.34
+        version: 4.13.0
       react:
         specifier: ^19.2.8
         version: 19.2.8
@@ -1371,7 +1377,7 @@ importers:
         version: 3.6.1(typescript@6.0.3)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@edge-runtime/vm@3.2.0)(@types/node@24.13.3)(jsdom@29.1.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.10(@edge-runtime/vm@3.2.0)(@types/node@24.13.3)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/core:
     devDependencies:
@@ -1383,7 +1389,7 @@ importers:
         version: 3.6.1(typescript@6.0.3)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@edge-runtime/vm@3.2.0)(@types/node@24.13.3)(jsdom@29.1.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.10(@edge-runtime/vm@3.2.0)(@types/node@24.13.3)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/core-node:
     devDependencies:
@@ -1398,7 +1404,7 @@ importers:
         version: 3.6.1(typescript@6.0.3)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@edge-runtime/vm@3.2.0)(@types/node@24.13.3)(jsdom@29.1.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.10(@edge-runtime/vm@3.2.0)(@types/node@24.13.3)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
     optionalDependencies:
       '@palamedes/core-node-darwin-arm64':
         specifier: workspace:^
@@ -1432,7 +1438,7 @@ importers:
     dependencies:
       '@oxlint/plugins':
         specifier: ^1.76.0
-        version: 1.76.0
+        version: 1.77.0
       '@palamedes/core-node':
         specifier: workspace:^
         version: link:../core-node
@@ -1454,7 +1460,7 @@ importers:
         version: 3.6.1(typescript@6.0.3)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@edge-runtime/vm@3.2.0)(@types/node@24.13.3)(jsdom@29.1.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.10(@edge-runtime/vm@3.2.0)(@types/node@24.13.3)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/example-ui:
     devDependencies:
@@ -1479,7 +1485,7 @@ importers:
         version: 3.6.1(typescript@6.0.3)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@edge-runtime/vm@3.2.0)(@types/node@24.13.3)(jsdom@29.1.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.10(@edge-runtime/vm@3.2.0)(@types/node@24.13.3)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/next-plugin:
     dependencies:
@@ -1507,7 +1513,7 @@ importers:
         version: 3.6.1(typescript@6.0.3)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@edge-runtime/vm@3.2.0)(@types/node@24.13.3)(jsdom@29.1.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.10(@edge-runtime/vm@3.2.0)(@types/node@24.13.3)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/palamedes: {}
 
@@ -1531,7 +1537,7 @@ importers:
         version: 19.2.4(@types/react@19.2.18)
       jsdom:
         specifier: ^29.1.1
-        version: 29.1.1
+        version: 29.1.1(@noble/hashes@2.2.0)
       react:
         specifier: ^19.2.8
         version: 19.2.8
@@ -1546,7 +1552,7 @@ importers:
         version: 3.6.1(typescript@6.0.3)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@edge-runtime/vm@3.2.0)(@types/node@24.13.3)(jsdom@29.1.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.10(@edge-runtime/vm@3.2.0)(@types/node@24.13.3)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/remix:
     dependencies:
@@ -1580,7 +1586,7 @@ importers:
         version: 3.6.1(typescript@6.0.3)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@edge-runtime/vm@3.2.0)(@types/node@24.13.3)(jsdom@29.1.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.10(@edge-runtime/vm@3.2.0)(@types/node@24.13.3)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/runtime:
     devDependencies:
@@ -1598,7 +1604,7 @@ importers:
         version: 3.6.1(typescript@6.0.3)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@edge-runtime/vm@3.2.0)(@types/node@24.13.3)(jsdom@29.1.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.10(@edge-runtime/vm@3.2.0)(@types/node@24.13.3)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/site-ui:
     devDependencies:
@@ -1619,7 +1625,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@edge-runtime/vm@3.2.0)(@types/node@24.13.3)(jsdom@29.1.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.10(@edge-runtime/vm@3.2.0)(@types/node@24.13.3)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/solid:
     dependencies:
@@ -1647,7 +1653,7 @@ importers:
         version: 2.11.14(@testing-library/jest-dom@7.0.0(@testing-library/dom@10.4.1))(solid-js@1.9.14)(supports-color@10.2.2)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@edge-runtime/vm@3.2.0)(@types/node@24.13.3)(jsdom@29.1.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.10(@edge-runtime/vm@3.2.0)(@types/node@24.13.3)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/transform:
     dependencies:
@@ -1669,7 +1675,7 @@ importers:
         version: 3.6.1(typescript@6.0.3)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@edge-runtime/vm@3.2.0)(@types/node@24.13.3)(jsdom@29.1.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.10(@edge-runtime/vm@3.2.0)(@types/node@24.13.3)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/vite-plugin:
     dependencies:
@@ -1706,7 +1712,7 @@ importers:
         version: 2.11.14(@testing-library/jest-dom@7.0.0(@testing-library/dom@10.4.1))(solid-js@1.9.14)(supports-color@10.2.2)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@edge-runtime/vm@3.2.0)(@types/node@24.13.3)(jsdom@29.1.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.10(@edge-runtime/vm@3.2.0)(@types/node@24.13.3)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
 
   site:
     dependencies:
@@ -1771,6 +1777,10 @@ packages:
   '@adobe/css-tools@4.5.0':
     resolution: {integrity: sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==}
 
+  '@alcalzone/ansi-tokenize@0.1.3':
+    resolution: {integrity: sha512-3yWxPTq3UQ/FY9p1ErPxIyfT64elWaMvM9lIHnaqpyft63tkxodF5aUElYHrdisWve5cETkh1+KBw1yJuW0aRw==}
+    engines: {node: '>=14.13.1'}
+
   '@altano/repository-tools@2.0.3':
     resolution: {integrity: sha512-cSR/ZYDF6Wp9OeAJMyLYYN1GenAAhV17W+w38ELP+3c5Ltsy9jkkCymi33nz/qnXyef3n6Fbr1h2yt3dvUN5sQ==}
 
@@ -1805,6 +1815,10 @@ packages:
     resolution: {integrity: sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw==}
     engines: {node: ^22.18.0 || >=24.11.0}
 
+  '@babel/compat-data@7.29.0':
+    resolution: {integrity: sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/compat-data@7.29.7':
     resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
     engines: {node: '>=6.9.0'}
@@ -1812,6 +1826,10 @@ packages:
   '@babel/compat-data@8.0.0':
     resolution: {integrity: sha512-DOjnob/cXOUgDOozCDeq/aK2p5y8dUIVdf6tNhEV1HQRd6I8aQ4f4fbtHRVEvb6lP3BGomrKHiS8ICAASSVQSw==}
     engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@babel/core@7.29.0':
+    resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/core@7.29.7':
     resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
@@ -1831,6 +1849,10 @@ packages:
 
   '@babel/helper-annotate-as-pure@7.29.7':
     resolution: {integrity: sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.28.6':
+    resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-compilation-targets@7.29.7':
@@ -1866,6 +1888,12 @@ packages:
   '@babel/helper-module-imports@7.29.7':
     resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.28.6':
+    resolution: {integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
 
   '@babel/helper-module-transforms@7.29.7':
     resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
@@ -1911,6 +1939,10 @@ packages:
     resolution: {integrity: sha512-9Fr9QeyCAyi1BR1jKZ6uYQ24EIhQUx5ReHfQU7drOE+TPOb+w11/dsqLkMOT2U29OdCT71XajrOT8xDc1C7orA==}
     engines: {node: ^22.18.0 || >=24.11.0}
 
+  '@babel/helper-validator-option@7.27.1':
+    resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-option@7.29.7':
     resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
     engines: {node: '>=6.9.0'}
@@ -1918,6 +1950,10 @@ packages:
   '@babel/helper-validator-option@8.0.0':
     resolution: {integrity: sha512-U4Dybxh4WESWHt5XhBeExi4DrY0/DNK1aHpQbsrQXCUbFHuMweT0TpLEWKvaraV2Y6fS+ZXunsZ8zIuZIgvF2Q==}
     engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@babel/helpers@7.28.6':
+    resolution: {integrity: sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/helpers@7.29.7':
     resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
@@ -1963,6 +1999,12 @@ packages:
 
   '@babel/plugin-transform-modules-commonjs@7.29.7':
     resolution: {integrity: sha512-j0vCldybPC5b5dwCQOJ21uKtHzt7hxLygJTg9eF1ScfaikEDNfzn94XoW5Fi+seBR0nCyL23xaBFFkq7dTM8XQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx@7.29.7':
+    resolution: {integrity: sha512-WsZulLVBUHXVj2cUcPVx6UE21TpalB6bHbSFErKT0Ib++ax24jjXe73FqlWvdylFOjiuPHYi6VCcgRad1ItN+A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2041,6 +2083,12 @@ packages:
   '@bramus/specificity@2.4.2':
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
     hasBin: true
+
+  '@clack/core@1.0.0-alpha.6':
+    resolution: {integrity: sha512-eG5P45+oShFG17u9I1DJzLkXYB1hpUgTLi32EfsMjSHLEqJUR8BOBCVFkdbUX2g08eh/HCi6UxNGpPhaac1LAA==}
+
+  '@clack/prompts@1.0.0-alpha.6':
+    resolution: {integrity: sha512-75NCtYOgDHVBE2nLdKPTDYOaESxO0GLAKC7INREp5VbS988Xua1u+588VaGlcvXiLc/kSwc25Cd+4PeTSpY6QQ==}
 
   '@cloudflare/kv-asset-handler@0.4.2':
     resolution: {integrity: sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==}
@@ -2388,6 +2436,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.28.1':
     resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
     engines: {node: '>=18'}
@@ -2396,6 +2450,12 @@ packages:
 
   '@esbuild/android-arm64@0.25.12':
     resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -2412,6 +2472,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-arm@0.28.1':
     resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
     engines: {node: '>=18'}
@@ -2420,6 +2486,12 @@ packages:
 
   '@esbuild/android-x64@0.25.12':
     resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -2436,6 +2508,12 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.28.1':
     resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
     engines: {node: '>=18'}
@@ -2444,6 +2522,12 @@ packages:
 
   '@esbuild/darwin-x64@0.25.12':
     resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -2460,6 +2544,12 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.28.1':
     resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
     engines: {node: '>=18'}
@@ -2468,6 +2558,12 @@ packages:
 
   '@esbuild/freebsd-x64@0.25.12':
     resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -2484,6 +2580,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.28.1':
     resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
     engines: {node: '>=18'}
@@ -2492,6 +2594,12 @@ packages:
 
   '@esbuild/linux-arm@0.25.12':
     resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -2508,6 +2616,12 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.28.1':
     resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
     engines: {node: '>=18'}
@@ -2516,6 +2630,12 @@ packages:
 
   '@esbuild/linux-loong64@0.25.12':
     resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -2532,6 +2652,12 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.28.1':
     resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
     engines: {node: '>=18'}
@@ -2540,6 +2666,12 @@ packages:
 
   '@esbuild/linux-ppc64@0.25.12':
     resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -2556,6 +2688,12 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.28.1':
     resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
     engines: {node: '>=18'}
@@ -2564,6 +2702,12 @@ packages:
 
   '@esbuild/linux-s390x@0.25.12':
     resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -2580,6 +2724,12 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/linux-x64@0.28.1':
     resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
     engines: {node: '>=18'}
@@ -2588,6 +2738,12 @@ packages:
 
   '@esbuild/netbsd-arm64@0.25.12':
     resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -2604,6 +2760,12 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.28.1':
     resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
     engines: {node: '>=18'}
@@ -2612,6 +2774,12 @@ packages:
 
   '@esbuild/openbsd-arm64@0.25.12':
     resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -2628,6 +2796,12 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openbsd-x64@0.28.1':
     resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
     engines: {node: '>=18'}
@@ -2636,6 +2810,12 @@ packages:
 
   '@esbuild/openharmony-arm64@0.25.12':
     resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -2652,6 +2832,12 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/sunos-x64@0.28.1':
     resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
     engines: {node: '>=18'}
@@ -2660,6 +2846,12 @@ packages:
 
   '@esbuild/win32-arm64@0.25.12':
     resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -2676,6 +2868,12 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.28.1':
     resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
     engines: {node: '>=18'}
@@ -2684,6 +2882,12 @@ packages:
 
   '@esbuild/win32-x64@0.25.12':
     resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -2877,6 +3081,24 @@ packages:
         optional: true
       vue:
         optional: true
+
+  '@generaltranslation/format@0.1.4':
+    resolution: {integrity: sha512-ub2umepEL1ndO3bjXyhxmXtMcvq61AwGKhHW+Is5yDDyIy0zmA0V3xME7FVzCzMe9UY8R5F1PpCXZRvyGV9sOQ==}
+
+  '@generaltranslation/icu@0.1.1':
+    resolution: {integrity: sha512-9bbPLxsuQiXDw8h3W999NJiWzqnJPPfS8PkM7w+i53tDKGdv1g5F2XCkhr+eW+JyopbaOW8vTRRCep0wGLvrPA==}
+
+  '@generaltranslation/python-extractor@0.2.33':
+    resolution: {integrity: sha512-b/qxBgYfK3cUK/0w/xCdGfmHSdxpm3RYl6bP9MP1dzgHUe8Qb5uhXdkwe29blrraK1pkFC5TLSfMikek9KBd1A==}
+    engines: {node: '>=16.0.0'}
+
+  '@generaltranslation/react-core@11.1.4':
+    resolution: {integrity: sha512-brT0izkxFMUWW8QE0ziMdljwdOvF96hj8mUysSZQwexSw00pYFZ6UOg+B6EJNbW0pVT06dXMT/N4ZVIl2jpdUA==}
+    peerDependencies:
+      react: '>=18.0.0'
+
+  '@generaltranslation/supported-locales@2.1.13':
+    resolution: {integrity: sha512-5EpKebdIoU5yLdQTPAbrxFmUTUkXkHrGGgJipHqY0IbAGihPZp290yxfMMsjZXHmXOOzwjXT6q6UNQzzJW4KJw==}
 
   '@gerrit0/mini-shiki@3.23.0':
     resolution: {integrity: sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==}
@@ -3236,6 +3458,18 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@jsep-plugin/assignment@1.3.0':
+    resolution: {integrity: sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==}
+    engines: {node: '>= 10.16.0'}
+    peerDependencies:
+      jsep: ^0.4.0||^1.0.0
+
+  '@jsep-plugin/regex@1.0.4':
+    resolution: {integrity: sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==}
+    engines: {node: '>= 10.16.0'}
+    peerDependencies:
+      jsep: ^0.4.0||^1.0.0
+
   '@lingui/babel-plugin-extract-messages@6.6.0':
     resolution: {integrity: sha512-QfCS4SjZYvVZFaiF44e/mLsdzCqQvRSGoVJWkb8nc51FkNpOZkwFLiwLtRnWgvm0ce7GeG51czMsG7RFPPCXqw==}
     engines: {node: '>=22.19.0'}
@@ -3323,13 +3557,6 @@ packages:
   '@messageformat/parser@5.1.1':
     resolution: {integrity: sha512-3p0YRGCcTUCYvBKLIxtDDyrJ0YijGIwrTRu1DT8gIviIDZru8H23+FkY6MJBzM1n9n20CiM4VeDYuBsrrwnLjg==}
 
-  '@napi-rs/lzma-linux-x64-gnu@1.5.1':
-    resolution: {integrity: sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==}
-    engines: {node: ^22.20 || ^24.12 || >=25}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
   '@napi-rs/wasm-runtime@1.1.6':
     resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
     peerDependencies:
@@ -3390,6 +3617,10 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
+
+  '@noble/hashes@2.2.0':
+    resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
+    engines: {node: '>= 20.19.0'}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -4414,8 +4645,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@oxlint/plugins@1.76.0':
-    resolution: {integrity: sha512-twmbsVrYAjkaOw6I2pDiYSAxVLNOV8kcqMzajJ599SpqXzea+GjDCZVad1VUqNR/4thWjM4PER5n+3/TQtTkZQ==}
+  '@oxlint/plugins@1.77.0':
+    resolution: {integrity: sha512-6KtPXskPgpt+0Kyl2nNSxNnYXt7lbkxW1C7vi2L7xwtq/AisZlsmV+hnzOTEyM5tU1TxPv1GpTqpUBbZfPzBLg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
   '@parcel/watcher-android-arm64@2.5.6':
@@ -4517,6 +4748,9 @@ packages:
   '@parcel/watcher@2.5.6':
     resolution: {integrity: sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==}
     engines: {node: '>= 10.0.0'}
+
+  '@pinojs/redact@0.4.0':
+    resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -5031,18 +5265,8 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@rollup/rollup-android-arm-eabi@4.62.4':
-    resolution: {integrity: sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==}
-    cpu: [arm]
-    os: [android]
-
   '@rollup/rollup-android-arm64@4.59.0':
     resolution: {integrity: sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==}
-    cpu: [arm64]
-    os: [android]
-
-  '@rollup/rollup-android-arm64@4.62.4':
-    resolution: {integrity: sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==}
     cpu: [arm64]
     os: [android]
 
@@ -5051,18 +5275,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-arm64@4.62.4':
-    resolution: {integrity: sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==}
-    cpu: [arm64]
-    os: [darwin]
-
   '@rollup/rollup-darwin-x64@4.59.0':
     resolution: {integrity: sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@rollup/rollup-darwin-x64@4.62.4':
-    resolution: {integrity: sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==}
     cpu: [x64]
     os: [darwin]
 
@@ -5071,29 +5285,13 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
-  '@rollup/rollup-freebsd-arm64@4.62.4':
-    resolution: {integrity: sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==}
-    cpu: [arm64]
-    os: [freebsd]
-
   '@rollup/rollup-freebsd-x64@4.59.0':
     resolution: {integrity: sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==}
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-freebsd-x64@4.62.4':
-    resolution: {integrity: sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==}
-    cpu: [x64]
-    os: [freebsd]
-
   '@rollup/rollup-linux-arm-gnueabihf@4.59.0':
     resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
-    cpu: [arm]
-    os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-arm-gnueabihf@4.62.4':
-    resolution: {integrity: sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
@@ -5104,20 +5302,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.62.4':
-    resolution: {integrity: sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==}
-    cpu: [arm]
-    os: [linux]
-    libc: [musl]
-
   '@rollup/rollup-linux-arm64-gnu@4.59.0':
     resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-arm64-gnu@4.62.4':
-    resolution: {integrity: sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
@@ -5128,20 +5314,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-arm64-musl@4.62.4':
-    resolution: {integrity: sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
   '@rollup/rollup-linux-loong64-gnu@4.59.0':
     resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
-    cpu: [loong64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-loong64-gnu@4.62.4':
-    resolution: {integrity: sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==}
     cpu: [loong64]
     os: [linux]
     libc: [glibc]
@@ -5152,20 +5326,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-loong64-musl@4.62.4':
-    resolution: {integrity: sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==}
-    cpu: [loong64]
-    os: [linux]
-    libc: [musl]
-
   '@rollup/rollup-linux-ppc64-gnu@4.59.0':
     resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-ppc64-gnu@4.62.4':
-    resolution: {integrity: sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
@@ -5176,20 +5338,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-ppc64-musl@4.62.4':
-    resolution: {integrity: sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [musl]
-
   '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-riscv64-gnu@4.62.4':
-    resolution: {integrity: sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
@@ -5200,20 +5350,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-riscv64-musl@4.62.4':
-    resolution: {integrity: sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [musl]
-
   '@rollup/rollup-linux-s390x-gnu@4.59.0':
     resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-s390x-gnu@4.62.4':
-    resolution: {integrity: sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
@@ -5224,20 +5362,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-x64-gnu@4.62.4':
-    resolution: {integrity: sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
   '@rollup/rollup-linux-x64-musl@4.59.0':
     resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@rollup/rollup-linux-x64-musl@4.62.4':
-    resolution: {integrity: sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
@@ -5247,18 +5373,8 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
-  '@rollup/rollup-openbsd-x64@4.62.4':
-    resolution: {integrity: sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==}
-    cpu: [x64]
-    os: [openbsd]
-
   '@rollup/rollup-openharmony-arm64@4.59.0':
     resolution: {integrity: sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==}
-    cpu: [arm64]
-    os: [openharmony]
-
-  '@rollup/rollup-openharmony-arm64@4.62.4':
-    resolution: {integrity: sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==}
     cpu: [arm64]
     os: [openharmony]
 
@@ -5267,18 +5383,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-arm64-msvc@4.62.4':
-    resolution: {integrity: sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==}
-    cpu: [arm64]
-    os: [win32]
-
   '@rollup/rollup-win32-ia32-msvc@4.59.0':
     resolution: {integrity: sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==}
-    cpu: [ia32]
-    os: [win32]
-
-  '@rollup/rollup-win32-ia32-msvc@4.62.4':
-    resolution: {integrity: sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==}
     cpu: [ia32]
     os: [win32]
 
@@ -5287,18 +5393,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-gnu@4.62.4':
-    resolution: {integrity: sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==}
-    cpu: [x64]
-    os: [win32]
-
   '@rollup/rollup-win32-x64-msvc@4.59.0':
     resolution: {integrity: sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==}
-    cpu: [x64]
-    os: [win32]
-
-  '@rollup/rollup-win32-x64-msvc@4.62.4':
-    resolution: {integrity: sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==}
     cpu: [x64]
     os: [win32]
 
@@ -5629,8 +5725,8 @@ packages:
       react: '>=18.0.0 || >=19.0.0'
       react-dom: '>=18.0.0 || >=19.0.0'
 
-  '@tanstack/react-start-rsc@0.1.33':
-    resolution: {integrity: sha512-G4e1xwi/InoQmIGgNQSozcWASw68/o3NpbTz+exosdMGRZzLBeUDbj0swEAajxHm6jDEOQ/reSeIcDkcEfhMfw==}
+  '@tanstack/react-start-rsc@0.1.34':
+    resolution: {integrity: sha512-KHFZUS0DySJU+dU0NWNLnfXa3dJKrHWULqCa85RcQiavtSuKTGD2znuU9ZRLfcGVn99Nkcv9Xt8UMk+1BUGI7A==}
     engines: {node: '>=22.12.0'}
     peerDependencies:
       '@rspack/core': '>=2.0.0-0'
@@ -5646,15 +5742,15 @@ packages:
       react-server-dom-rspack:
         optional: true
 
-  '@tanstack/react-start-server@1.167.22':
-    resolution: {integrity: sha512-eH2PeHuLfL3R5YzE9+y2FfcE4Ld1LNV2ZfrCNVPJMMJFt+9nXDaRHg9BsEmc+JkTAGzz3FKLyQEoWwpbG6Ehqg==}
+  '@tanstack/react-start-server@1.167.23':
+    resolution: {integrity: sha512-dtA7XEzK0YowtIiMNRAb1s54FV7vjprK4z8pyAd0Z75QQgu3BPdR+uMunI0ZjzP1xc1yfVNDcLT+rukZrBU88A==}
     engines: {node: '>=22.12.0'}
     peerDependencies:
       react: '>=18.0.0 || >=19.0.0'
       react-dom: '>=18.0.0 || >=19.0.0'
 
-  '@tanstack/react-start@1.168.34':
-    resolution: {integrity: sha512-W5MDbD4QlDZHtEXlqN6bJUz7SdsPv6tbNPCih1i72FZqgQlhaxN1BoeoB8H+nN8M4tXRkfJD7VW75FCdQyaQDw==}
+  '@tanstack/react-start@1.168.35':
+    resolution: {integrity: sha512-Do6cFns980nYL0WKle1aCU+CrN2wxDMWv3wJpY4o9E5xajgrrXKmbaIKleZFhyIvdQsCHwXpdIy4Caz4f1ztfQ==}
     engines: {node: '>=22.12.0'}
     peerDependencies:
       '@rsbuild/core': ^2.0.0
@@ -5721,8 +5817,8 @@ packages:
     resolution: {integrity: sha512-QWfUZ3Yo923tdQn38LyKMU8rcTw69zc+T4dAvgTWV4O56SqFRsGfS0lSWIMhJRwXIx/bvdi7nTUBDdZtTHtpTQ==}
     engines: {node: '>=22.12.0'}
 
-  '@tanstack/start-plugin-core@1.171.25':
-    resolution: {integrity: sha512-YmMye36vohfxau/MaVpltjkpJlf+wfUBoZp3S6Ue53mpAnsHr6El3XQDmcp1wS4kicZmyX1SNcobJpVZc+2dOQ==}
+  '@tanstack/start-plugin-core@1.171.26':
+    resolution: {integrity: sha512-X0980UEPP1CYMcQt/BRYW1ncElas/3ZNnYgGfhI36XZNWcROJkfS4AHbAqZ94Y3ocFjK3EcUkaFWDIAqrpwPmA==}
     engines: {node: '>=22.12.0'}
     peerDependencies:
       '@rsbuild/core': ^2.0.0
@@ -5733,8 +5829,8 @@ packages:
       vite:
         optional: true
 
-  '@tanstack/start-server-core@1.169.17':
-    resolution: {integrity: sha512-u0N+PHJhMHnzfnlXYI9F+A/qweDe3E2X0mfkORPGIEkNQgvS548RA9fjwvixR2en5b848CfpEqUzwFhm/tQ40Q==}
+  '@tanstack/start-server-core@1.169.18':
+    resolution: {integrity: sha512-/ESLR7fCGAhaypuRGPfoHaFW6AkcF8RNj1/HcQOedutF3LBi9MdGaEiENg89ivQSqnPNi5cZbtrsrJ6regHhrA==}
     engines: {node: '>=22.12.0'}
 
   '@tanstack/start-storage-context@1.167.17':
@@ -6414,6 +6510,10 @@ packages:
   ansi-align@3.0.1:
     resolution: {integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==}
 
+  ansi-escapes@7.3.0:
+    resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
+    engines: {node: '>=18'}
+
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -6535,6 +6635,14 @@ packages:
 
   async@3.2.6:
     resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
+
+  atomic-sleep@1.0.0:
+    resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
+    engines: {node: '>=8.0.0'}
+
+  auto-bind@5.0.1:
+    resolution: {integrity: sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   autoprefixer@10.4.27:
     resolution: {integrity: sha512-NP9APE+tO+LuJGn7/9+cohklunJsXWiaWEfV3si4Gi/XHDwVNgkwr1J3RQYFIvPy76GmJ9/bW8vyoU1LcxwKHA==}
@@ -6674,14 +6782,14 @@ packages:
     resolution: {integrity: sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==}
     engines: {node: '>=18'}
 
-  brace-expansion@1.1.18:
-    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
+  brace-expansion@1.1.12:
+    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
-  brace-expansion@2.1.4:
-    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
+  brace-expansion@2.1.1:
+    resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
 
-  brace-expansion@5.0.9:
-    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
     engines: {node: 20 || >=22}
 
   braces@3.0.3:
@@ -6724,8 +6832,8 @@ packages:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
 
-  c12@3.3.4:
-    resolution: {integrity: sha512-cM0ApFQSBXuourJejzwv/AuPRvAxordTyParRVcHjjtXirtkzM0uK2L9TTn9s0cXZbG7E55jCivRQzoxYmRAlA==}
+  c12@3.3.3:
+    resolution: {integrity: sha512-750hTRvgBy5kcMNPdh95Qo+XUBeGo8C7nsKSmedDmaQI+E0r82DwHeM6vBewDe4rGFbnxoa4V9pw+sPh5+Iz8Q==}
     peerDependencies:
       magicast: '*'
     peerDependenciesMeta:
@@ -6826,12 +6934,16 @@ packages:
   citty@0.1.6:
     resolution: {integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==}
 
-  citty@0.2.2:
-    resolution: {integrity: sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==}
+  citty@0.2.1:
+    resolution: {integrity: sha512-kEV95lFBhQgtogAPlQfJJ0WGVSokvLr/UEoFPiKKOXF7pl98HfUVUD0ejsuTCld/9xH9vogSywZ5KqHzXrZpqg==}
 
   cli-boxes@3.0.0:
     resolution: {integrity: sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==}
     engines: {node: '>=10'}
+
+  cli-cursor@4.0.0:
+    resolution: {integrity: sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   cli-cursor@5.0.0:
     resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
@@ -6844,6 +6956,10 @@ packages:
   cli-table3@0.6.5:
     resolution: {integrity: sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==}
     engines: {node: 10.* || >= 12.*}
+
+  cli-truncate@4.0.0:
+    resolution: {integrity: sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==}
+    engines: {node: '>=18'}
 
   cli-width@4.1.0:
     resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
@@ -6863,6 +6979,10 @@ packages:
   cluster-key-slot@1.1.2:
     resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
     engines: {node: '>=0.10.0'}
+
+  code-excerpt@4.0.0:
+    resolution: {integrity: sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   collapse-white-space@2.1.0:
     resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
@@ -6887,6 +7007,10 @@ packages:
   commander@11.1.0:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
     engines: {node: '>=16'}
+
+  commander@12.1.0:
+    resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
+    engines: {node: '>=18'}
 
   commander@14.0.3:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
@@ -6969,6 +7093,10 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  convert-to-spaces@2.0.1:
+    resolution: {integrity: sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   cookie-es@1.2.3:
     resolution: {integrity: sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==}
 
@@ -7014,14 +7142,6 @@ packages:
 
   crossws@0.3.5:
     resolution: {integrity: sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==}
-
-  crossws@0.4.10:
-    resolution: {integrity: sha512-pz3oubH/dt12KjqsUB0IuXW4nwRDQ583iDsP4555Cpdqx0NoU7pGlWBcayyFI8f/l/idRpgjMEfwuOxSWJYlIA==}
-    peerDependencies:
-      srvx: '>=0.11.5'
-    peerDependenciesMeta:
-      srvx:
-        optional: true
 
   cspell-config-lib@10.0.1:
     resolution: {integrity: sha512-hMpo/0j6k7pbiqrLDOLJKD2IGP9XwhjKf2miiM6p84Xeo4nyuFZaxxDCQ68R851HSYFrrdltgpoipMbj1h2Tnw==}
@@ -7219,8 +7339,8 @@ packages:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
 
-  defu@6.1.7:
-    resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
+  defu@6.1.4:
+    resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
 
   denque@2.1.0:
     resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
@@ -7282,6 +7402,10 @@ packages:
   dot-prop@10.1.0:
     resolution: {integrity: sha512-MVUtAugQMOff5RnBy2d9N31iG0lNwg1qAoAOn7pOK5wf94WIaE3My2p3uwTQuvS2AcqchkcR3bHByjaM0mmi7Q==}
     engines: {node: '>=20'}
+
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
 
   dotenv@17.4.2:
     resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
@@ -7346,6 +7470,10 @@ packages:
     resolution: {integrity: sha512-pxP8eL2SwwaTRi/KHYwLYXinDs7gL3jxFcBYmEdYfZmZXbaVDvdppd0XBU8qVz03rDfKZMXg1omHCbsJjZrMsw==}
     engines: {node: '>=20'}
 
+  environment@1.1.0:
+    resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
+    engines: {node: '>=18'}
+
   err-code@2.0.3:
     resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
 
@@ -7395,6 +7523,9 @@ packages:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
 
+  es-toolkit@1.50.0:
+    resolution: {integrity: sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w==}
+
   esast-util-from-estree@2.0.0:
     resolution: {integrity: sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==}
 
@@ -7403,6 +7534,11 @@ packages:
 
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -7417,6 +7553,10 @@ packages:
 
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
+  escape-string-regexp@2.0.0:
+    resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
+    engines: {node: '>=8'}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -7876,6 +8016,9 @@ packages:
   fetchdts@0.1.7:
     resolution: {integrity: sha512-YoZjBdafyLIop9lSxXVI33oLD5kN31q4Td+CasofLLYeLXRFeOsuOw0Uo+XNRi9PZlbfdlN2GmRtm4tCEQ9/KA==}
 
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
+
   figures@6.1.0:
     resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
     engines: {node: '>=18'}
@@ -7913,8 +8056,8 @@ packages:
   flatted@3.4.3:
     resolution: {integrity: sha512-/zipXxyO6rGvuNGDiULY9MvEGSkb2gaG4GGH4ygMi0ZZzyMHdUZBmntJmx5x1G2VuPytCwGN4xsJP6cw+sK+vQ==}
 
-  follow-redirects@1.16.0:
-    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
+  follow-redirects@1.15.11:
+    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -7925,6 +8068,9 @@ packages:
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
+
+  foreach@2.0.6:
+    resolution: {integrity: sha512-k6GAGDyqLe9JaebCsFCoudPPWfihKu8pylYXRlqP1J7ms39iPoTtk2fviNglIeQEwdh0bQeKJ01ZPyuyQvKzwg==}
 
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
@@ -7976,6 +8122,9 @@ packages:
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
 
+  generaltranslation@9.1.0:
+    resolution: {integrity: sha512-MKwqtDsKpFv6iD3b4wijVztPztEJCEREqPUFLf6SWWLUvEt5ezuXqym6wxJ3AHBxtrTkNtitDK7QragWheTvpA==}
+
   generator-function@2.0.1:
     resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
     engines: {node: '>= 0.4'}
@@ -8026,8 +8175,8 @@ packages:
   get-tsconfig@4.14.0:
     resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
 
-  giget@3.3.1:
-    resolution: {integrity: sha512-r+mvuDjrjMpsdw46Kmeydb8bdHm7wOKw8wNBtTndkjbPjgAp5oUJUxRE76wZFknxIPokfWvep2qSXK37aXE6zg==}
+  giget@2.0.0:
+    resolution: {integrity: sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==}
     hasBin: true
 
   git-hooks-list@4.2.1:
@@ -8095,15 +8244,32 @@ packages:
     resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
     engines: {node: '>=6.0'}
 
+  gt-i18n@1.0.10:
+    resolution: {integrity: sha512-nBD1Orcx2R3gxy9N9AzbdlO6dKDIUCNCV80e58bceexdv3XXWDUMshqlaHdYLGwaVSFxkMGuMVwHm23ISPxqig==}
+
+  gt-react@11.1.4:
+    resolution: {integrity: sha512-CFQkYgafzamfnVxJOLG7x2HlEj9gkbTOyeWl7QK+flDzJ+/O+Nzm9asCvz3PX+w0jWvMYuC4eK3uyCHxG92NxQ==}
+    peerDependencies:
+      react: '>=18.0.0'
+      react-dom: '>=18.0.0'
+
+  gt-remark@1.0.11:
+    resolution: {integrity: sha512-1Z1m/4XfGWp8MNqoTa3cvwn3LX7WCwmgjgdFpiLif5TmG5LluHSR/ygG0F6gqibKAmBRYKK1Pgl3vqm6ziuZjg==}
+
+  gt@2.16.0:
+    resolution: {integrity: sha512-qjzeYFVAjVF+uL/KLBektkxzlY1v4Wad4VRdRwy4hJAiXeczxHOI8pwEA5VybxCELwlC9FhmNA06aA6yFHaTyg==}
+    hasBin: true
+
+  gtx-cli@2.16.0:
+    resolution: {integrity: sha512-JWItT64gS9/qFcZiN9E57/4grk2/mrkZ8BqAvk83P4bY87Ji3CHBj9BRl6xtZOE+5h4Kl0Ny6XFSJdXFInw6dQ==}
+    hasBin: true
+
   gzip-size@7.0.0:
     resolution: {integrity: sha512-O1Ld7Dr+nqPnmGpdhzLmMTQ4vAsD+rHwMm1NLUmoUFFymBOMKxCCrtDxqdBRYXdeEPEi3SyoR4TizJLQrnKBNA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   h3@1.15.10:
     resolution: {integrity: sha512-YzJeWSkDZxAhvmp8dexjRK5hxziRO7I9m0N53WhvYL5NiWfkUkzssVzY9jvGu0HBoLFW6+duYmNSn6MaZBCCtg==}
-
-  h3@1.15.11:
-    resolution: {integrity: sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==}
 
   h3@2.0.1-rc.20:
     resolution: {integrity: sha512-28ljodXuUp0fZovdiSRq4G9OgrxCztrJe5VdYzXAB7ueRvI7pIUqLU14Xi3XqdYJ/khXjfpUOOD2EQa6CmBgsg==}
@@ -8163,8 +8329,8 @@ packages:
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
-  hono@4.12.34:
-    resolution: {integrity: sha512-GqXJqY/xJkJmuloTrnV1ZEXG3fqte+VjkUqoRNZXcrUidiUOP4fMSIHHY4tsqZBK++kVyWmt/AAfSUuy57/eSA==}
+  hono@4.13.0:
+    resolution: {integrity: sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==}
     engines: {node: '>=16.9.0'}
 
   hookable@5.5.3:
@@ -8216,8 +8382,8 @@ packages:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
 
-  httpxy@0.5.5:
-    resolution: {integrity: sha512-uDjmnPyp1q4Sgzf3w+J/Fc6UqcCEj0x4Wjp7OqK5dGhNeDgpyrAmnS6ey8QWrX3SWDon2DMKf9sBa5X9+CVyMA==}
+  httpxy@0.3.1:
+    resolution: {integrity: sha512-XjG/CEoofEisMrnFr0D6U6xOZ4mRfnwcYQ9qvvnT4lvnX8BoeA3x3WofB75D+vZwpaobFVkBIHrZzoK40w8XSw==}
 
   human-signals@5.0.0:
     resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
@@ -8300,6 +8466,19 @@ packages:
   ini@6.0.0:
     resolution: {integrity: sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==}
     engines: {node: ^20.17.0 || >=22.9.0}
+
+  ink@5.2.1:
+    resolution: {integrity: sha512-BqcUyWrG9zq5HIwW6JcfFHsIYebJkWWb4fczNah1goUO0vv5vneIlfwuS85twyJ5hYR/y18FlAYUxrO9ChIWVg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      react: '>=18.0.0'
+      react-devtools-core: ^4.19.1
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      react-devtools-core:
+        optional: true
 
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
@@ -8404,6 +8583,14 @@ packages:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
 
+  is-fullwidth-code-point@4.0.0:
+    resolution: {integrity: sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==}
+    engines: {node: '>=12'}
+
+  is-fullwidth-code-point@5.1.0:
+    resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
+    engines: {node: '>=18'}
+
   is-generator-function@1.1.2:
     resolution: {integrity: sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==}
     engines: {node: '>= 0.4'}
@@ -8418,6 +8605,11 @@ packages:
   is-identifier@1.1.0:
     resolution: {integrity: sha512-NhOds0mDx9lJu+1lBRO0xbwFo5nobA7GCk/0e5xjr6+6XugX985+0OyGX35BNrTkPAsdLcIKg02HUQJOK8D8kw==}
     engines: {node: '>=18'}
+
+  is-in-ci@1.0.0:
+    resolution: {integrity: sha512-eUuAjybVTHMYWm/U+vBO1sY/JOCgoPCXRxzdju0K+K0BiGW0SChEL1MLC0PoCIR1OlPo5YAp8HuQoUlsWEICwg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   is-in-ssh@1.0.0:
     resolution: {integrity: sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==}
@@ -8631,6 +8823,10 @@ packages:
       canvas:
         optional: true
 
+  jsep@1.4.0:
+    resolution: {integrity: sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==}
+    engines: {node: '>= 10.16.0'}
+
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
     engines: {node: '>=6'}
@@ -8645,6 +8841,9 @@ packages:
   json-parse-even-better-errors@3.0.2:
     resolution: {integrity: sha512-fi0NG4bPjCHunUJffmLd0gxssIgkNmArMvis4iNah6Owg1MCJjWhEcDLmsK6iGkJq3tHwbDkTlce70/tmXN4cQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
+  json-pointer@0.6.2:
+    resolution: {integrity: sha512-vLWcKbOaXlO+jvRy4qNd+TI1QUPZzfJj1tpJ3vAXDych5XJf93ftpUKe5pKCrzyIIwgBJcOcCVRUfqQP25afBw==}
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
@@ -8666,6 +8865,15 @@ packages:
 
   jsonc-parser@3.3.1:
     resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
+
+  jsonpath-plus@10.4.0:
+    resolution: {integrity: sha512-T92WWatJXmhBbKsgH/0hl+jxjdXrifi5IKeMY02DWggRxX0UElcbVzPlmgLTbvsPeW1PasQ6xE2Q75stkhGbsA==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  jsonpointer@5.0.1:
+    resolution: {integrity: sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==}
+    engines: {node: '>=0.10.0'}
 
   jsx-ast-utils-x@0.1.0:
     resolution: {integrity: sha512-eQQBjBnsVtGacsG9uJNB8qOr3yA8rga4wAaGG1qRcBzSIvfhERLrWxMAM1hp5fcS6Abo8M4+bUBTekYR0qTPQw==}
@@ -8871,14 +9079,9 @@ packages:
   linkify-it@5.0.2:
     resolution: {integrity: sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==}
 
-  listhen@1.10.1:
-    resolution: {integrity: sha512-6nt/86SkqUQSLW1ofz8MxC6RhRMqOl3ONISe6qqvJ3xj09aJWQx6DhgSZpugs3PX4PXdOas/WD6A9jx6J2N19A==}
+  listhen@1.9.0:
+    resolution: {integrity: sha512-I8oW2+QL5KJo8zXNWX046M134WchxsXC7SawLPvRQpogCbkyQIaFxPE89A2HiwR7vAK2Dm2ERBAmyjTYGYEpBg==}
     hasBin: true
-    peerDependencies:
-      '@parcel/watcher': ^2.5.6
-    peerDependenciesMeta:
-      '@parcel/watcher':
-        optional: true
 
   load-plugin@6.0.3:
     resolution: {integrity: sha512-kc0X2FEUZr145odl68frm+lMJuQ23+rTXYmR6TImqPtbpmXC4vVXbWKDQ9IzndA0HfyQamWfKLhzsqGSTxE63w==}
@@ -8891,8 +9094,8 @@ packages:
     resolution: {integrity: sha512-XfegD5pyTAfb+GY6chk283Ox5z8WexG56OvM06RWLpAc/UHozO8X6xAxEkIitZOtsSMM1Yr3DkHgW5W+onLhCw==}
     engines: {node: '>=6'}
 
-  local-pkg@1.2.1:
-    resolution: {integrity: sha512-++gUqRDEvcnN6Zhqrr+y/CkVEHhlrR96vZn3nZZPYzMcBUyBtTKzB9NadClFIsIVSsu+3i9tfk/erqy9kAmt7Q==}
+  local-pkg@1.1.2:
+    resolution: {integrity: sha512-arhlxbFRmoQHl33a0Zkle/YWlmNwoyt6QNZEIJcqNbdrsix5Lvc4HyyI3EnwxTYlZYc32EbYrQ8SzEZ7dqgg9A==}
     engines: {node: '>=14'}
 
   locate-path@6.0.0:
@@ -8923,6 +9126,10 @@ packages:
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
 
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
@@ -9213,6 +9420,10 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
+  mimic-fn@2.1.0:
+    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
+    engines: {node: '>=6'}
+
   mimic-fn@4.0.0:
     resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
     engines: {node: '>=12'}
@@ -9239,6 +9450,9 @@ packages:
   minimatch@9.0.9:
     resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
@@ -9355,8 +9569,8 @@ packages:
       sass:
         optional: true
 
-  nitropack@2.13.4:
-    resolution: {integrity: sha512-tX7bT6zxNeMwkc6hxHiZeUoTOjVrcjoh1Z3cmxOlodIqjl4HISgqfGOmkWSayky3Nv9Z5+KQH52F8nmXJY5AAA==}
+  nitropack@2.13.2:
+    resolution: {integrity: sha512-R5TMzSBoTDG4gi6Y+pvvyCNnooShHePHsHxMLP9EXDGdrlR5RvNdSd4e5k8z0/EzP9Ske7ABRMDWg6O7Dm2OYw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -9367,6 +9581,10 @@ packages:
 
   node-addon-api@7.1.1:
     resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
+
+  node-addon-api@8.9.0:
+    resolution: {integrity: sha512-ekZMeaaIzSQTSpr7X2X3iJM7lTzgnx8ahAG9pJfT/7+14mlEM8ZYQ9cgCDvSSRbReFK0oHli3WrZdCiRsgAT9Q==}
+    engines: {node: ^18 || ^20 || >= 21}
 
   node-fetch-native@1.6.7:
     resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
@@ -9452,6 +9670,11 @@ packages:
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
+  nypm@0.6.5:
+    resolution: {integrity: sha512-K6AJy1GMVyfyMXRVB88700BJqNUkByijGJM8kEHpLdcAt+vSQAVfkWWHYzuRXHSY6xA2sNc5RjTj0p9rE2izVQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   object-deep-merge@2.0.1:
     resolution: {integrity: sha512-aKttDKcU3pyZqKcCkDhsMn70WmZFG2JGDQLP9EcLyTSIFQRCPWLAmBZRLJnrVUrhPG1jETEEbfdgbNtJf1LyMg==}
 
@@ -9489,6 +9712,10 @@ packages:
   ohash@2.0.11:
     resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
 
+  on-exit-leak-free@2.1.2:
+    resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
+    engines: {node: '>=14.0.0'}
+
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
@@ -9499,6 +9726,10 @@ packages:
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  onetime@5.1.2:
+    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
+    engines: {node: '>=6'}
 
   onetime@6.0.0:
     resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
@@ -9643,6 +9874,10 @@ packages:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
 
+  patch-console@2.0.0:
+    resolution: {integrity: sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -9695,6 +9930,16 @@ packages:
   picomatch@4.0.5:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
+
+  pino-abstract-transport@3.0.0:
+    resolution: {integrity: sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==}
+
+  pino-std-serializers@7.1.0:
+    resolution: {integrity: sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==}
+
+  pino@10.3.1:
+    resolution: {integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==}
+    hasBin: true
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
@@ -9902,6 +10147,10 @@ packages:
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
+  postcss@8.5.22:
+    resolution: {integrity: sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
   postcss@8.5.23:
     resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
     engines: {node: ^10 || ^12 || >=14}
@@ -9950,6 +10199,9 @@ packages:
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
 
+  process-warning@5.0.0:
+    resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
+
   process@0.11.10:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
@@ -9996,6 +10248,9 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
+  quick-format-unescaped@4.0.4:
+    resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
+
   quote-js-string@0.1.0:
     resolution: {integrity: sha512-Y3NoRtprEEZQD8RfxMCfS0ZTqc4e+i18OrXEXAvpM6TfC/3y+0L5rNbZiSnbBBEkDfFzbpd8o+cE8q3/anjMGA==}
     engines: {node: '>=22'}
@@ -10015,8 +10270,8 @@ packages:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
 
-  rc9@3.0.1:
-    resolution: {integrity: sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ==}
+  rc9@2.1.2:
+    resolution: {integrity: sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==}
 
   react-dom@19.2.8:
     resolution: {integrity: sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==}
@@ -10045,6 +10300,12 @@ packages:
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
+  react-reconciler@0.29.2:
+    resolution: {integrity: sha512-zZQqIiYgDCTP/f1N/mAR10nJGrPD2ZR+jDSEsKWJHYC7Cm2wodlwbR3upZRdC3cjIjSlTLNVyO7Iu0Yy7t2AYg==}
+    engines: {node: '>=0.10.0'}
+    peerDependencies:
+      react: ^18.3.1
+
   react-refresh@0.18.0:
     resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
     engines: {node: '>=0.10.0'}
@@ -10066,6 +10327,10 @@ packages:
       react: ^19.2.8
       react-dom: ^19.2.8
       webpack: ^5.59.0
+
+  react@18.3.1:
+    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
+    engines: {node: '>=0.10.0'}
 
   react@19.2.8:
     resolution: {integrity: sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==}
@@ -10104,6 +10369,13 @@ packages:
   readdirp@5.0.0:
     resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
     engines: {node: '>= 20.19.0'}
+
+  real-require@0.2.0:
+    resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
+    engines: {node: '>= 12.13.0'}
+
+  real-require@1.0.0:
+    resolution: {integrity: sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==}
 
   recast@0.23.11:
     resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
@@ -10253,6 +10525,10 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
+  restore-cursor@4.0.0:
+    resolution: {integrity: sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   restore-cursor@5.1.0:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
     engines: {node: '>=18'}
@@ -10296,11 +10572,6 @@ packages:
 
   rollup@4.59.0:
     resolution: {integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==}
-    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
-    hasBin: true
-
-  rollup@4.62.4:
-    resolution: {integrity: sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -10353,6 +10624,10 @@ packages:
   safe-regex@2.1.1:
     resolution: {integrity: sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==}
 
+  safe-stable-stringify@2.5.0:
+    resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
+    engines: {node: '>=10'}
+
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
@@ -10363,6 +10638,9 @@ packages:
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
+
+  scheduler@0.23.2:
+    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -10419,12 +10697,12 @@ packages:
     peerDependencies:
       seroval: ^1.0
 
-  seroval@1.5.6:
-    resolution: {integrity: sha512-rVQVWjjSvlINzaQPZH5JFqsqEsIWdTxY3iJZCnTL/5gQbXIRooVZKI60tVCkOVfzcRPejboxO2t0P89dg5mQaA==}
+  seroval@1.5.1:
+    resolution: {integrity: sha512-OwrZRZAfhHww0WEnKHDY8OM0U/Qs8OTfIDWhUD4BLpNJUfXK4cGmjiagGze086m+mhI+V2nD0gfbHEnJjb9STA==}
     engines: {node: '>=10'}
 
-  seroval@1.6.0:
-    resolution: {integrity: sha512-TBwwKfscTEgnBEWmYKKeCcmCGmrJi0LV6qNUY//WBA3MDesh/zfn+KOMq/ckpxM4gZ0ouAE706A1eenekM2sug==}
+  seroval@1.5.4:
+    resolution: {integrity: sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw==}
     engines: {node: '>=10'}
 
   serve-placeholder@2.0.2:
@@ -10498,6 +10776,9 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -10511,9 +10792,20 @@ packages:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
     engines: {node: '>=18'}
 
+  sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
   slash@5.1.0:
     resolution: {integrity: sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==}
     engines: {node: '>=14.16'}
+
+  slice-ansi@5.0.0:
+    resolution: {integrity: sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==}
+    engines: {node: '>=12'}
+
+  slice-ansi@7.1.2:
+    resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
+    engines: {node: '>=18'}
 
   smob@1.6.1:
     resolution: {integrity: sha512-KAkBqZl3c2GvNgNhcoyJae1aKldDW0LO279wF9bk1PnluRTETKBq0WyzRXxEhoQLk56yHaOY4JCBEKDuJIET5g==}
@@ -10536,6 +10828,9 @@ packages:
     engines: {node: '>=10'}
     peerDependencies:
       solid-js: ^1.7
+
+  sonic-boom@4.2.1:
+    resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
 
   sort-object-keys@2.1.0:
     resolution: {integrity: sha512-SOiEnthkJKPv2L6ec6HMwhUcN0/lppkeYuN1x63PbyPRrgSPIuBJCiYxYyvWRTtjMlOi14vQUCGUJqS6PLVm8g==}
@@ -10578,6 +10873,10 @@ packages:
   spdx-license-ids@3.0.23:
     resolution: {integrity: sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==}
 
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
+
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
@@ -10595,6 +10894,10 @@ packages:
     resolution: {integrity: sha512-o3yWv49B/o4QZk5ZcsALc6t0+eCelPc44zZsLtCQnZPDwFpDYSWcDnrv2TtMmMbQ7uKo3J0HTURCqckw23czNQ==}
     engines: {node: '>=12.0.0'}
 
+  stack-utils@2.0.6:
+    resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
+    engines: {node: '>=10'}
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
@@ -10610,6 +10913,9 @@ packages:
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  std-env@4.0.0:
+    resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
 
   std-env@4.2.0:
     resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
@@ -10703,6 +11009,10 @@ packages:
     resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
     engines: {node: '>=0.10.0'}
 
+  strip-bom@3.0.0:
+    resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
+    engines: {node: '>=4'}
+
   strip-final-newline@3.0.0:
     resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
     engines: {node: '>=12'}
@@ -10721,9 +11031,6 @@ packages:
 
   strip-literal@3.1.0:
     resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
-
-  strip-literal@4.0.0:
-    resolution: {integrity: sha512-PaqAvfUZKBwc/SLmNZtHmzK+v19Z4O4eS3cKPeGvbIv/U3pnyEq4Tuw3/4v/FwfM8VQaEawsyCcOQ0P+kpwWWw==}
 
   style-to-js@1.1.21:
     resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
@@ -10804,8 +11111,8 @@ packages:
   tar-stream@3.1.8:
     resolution: {integrity: sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==}
 
-  tar@7.5.22:
-    resolution: {integrity: sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==}
+  tar@7.5.19:
+    resolution: {integrity: sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==}
     engines: {node: '>=18'}
 
   teex@1.0.1:
@@ -10873,6 +11180,10 @@ packages:
   text-decoder@1.2.7:
     resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
 
+  thread-stream@4.2.0:
+    resolution: {integrity: sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ==}
+    engines: {node: '>=20'}
+
   throttleit@2.1.0:
     resolution: {integrity: sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==}
     engines: {node: '>=18'}
@@ -10886,10 +11197,6 @@ packages:
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
-
-  tinyclip@0.1.15:
-    resolution: {integrity: sha512-uo33abH+Ays0xYaDysoBt494Hb3hsEczMpcC0MwFl773pazORx4fmvKhclhR1wonUbB6vvpRsvVMwnhfqeMc+A==}
-    engines: {node: ^16.14.0 || >= 17.3.0}
 
   tinydate@1.3.0:
     resolution: {integrity: sha512-7cR8rLy2QhYHpsBDBVYnnWXm8uRTr38RoZakFSW7Bs7PzfMPNZthuMLkwqZv7MTu8lhQ91cOFYS5a7iFj2oR3w==}
@@ -10964,6 +11271,14 @@ packages:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
 
+  tree-sitter-python@0.25.0:
+    resolution: {integrity: sha512-eCmJx6zQa35GxaCtQD+wXHOhYqBxEL+bp71W/s3fcDMu06MrtzkVXR437dRrCrbrDbyLuUDJpAgycs7ncngLXw==}
+    peerDependencies:
+      tree-sitter: ^0.25.0
+    peerDependenciesMeta:
+      tree-sitter:
+        optional: true
+
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
 
@@ -10978,6 +11293,10 @@ packages:
 
   ts-pattern@5.9.0:
     resolution: {integrity: sha512-6s5V71mX8qBUmlgbrfL33xDUwO0fq48rxAu2LBE11WBeGdpCPOsXksQbZJHvHwhrd3QjUusd3mAOM5Gg0mFBLg==}
+
+  tsconfig-paths@4.2.0:
+    resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
+    engines: {node: '>=6'}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -11116,17 +11435,9 @@ packages:
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
 
-  unimport@6.4.0:
-    resolution: {integrity: sha512-JJOOuNMFq8b4ZPBKwQUxEcba4MplskDzYI1Lvrf8rJfWphZTWvPNXWa493qsPngHUmub89w6C7j+SeLWTE/UIQ==}
+  unimport@6.0.2:
+    resolution: {integrity: sha512-ZSOkrDw380w+KIPniY3smyXh2h7H9v2MNr9zejDuh239o5sdea44DRAYrv+rfUi2QGT186P2h0GPGKvy8avQ5g==}
     engines: {node: '>=18.12.0'}
-    peerDependencies:
-      oxc-parser: '*'
-      rolldown: ^1.0.0
-    peerDependenciesMeta:
-      oxc-parser:
-        optional: true
-      rolldown:
-        optional: true
 
   unist-util-inspect@8.1.0:
     resolution: {integrity: sha512-mOlg8Mp33pR0eeFpo5d2902ojqFFOKMMG2hF8bmH7ZlhnmjFgh0NI3/ZDwdaBJNbvrS7LZFVrBVtIE9KZ9s7vQ==}
@@ -11158,10 +11469,6 @@ packages:
 
   unplugin-utils@0.3.1:
     resolution: {integrity: sha512-5lWVjgi6vuHhJ526bI4nlCOmkCIF3nnfXkCMDeMJrtdvxTs6ZFCM8oNufGTsDbKv/tJ/xj8RpvXjRuPBZJuJog==}
-    engines: {node: '>=20.19.0'}
-
-  unplugin-utils@0.3.2:
-    resolution: {integrity: sha512-xVToRh2CTmLk2HnEG7ac4rl1MJTT3RFkpS8B++/SnB0kXvuaavD+n3m/vrzyWQOdJNSZQACnbz01pnppbwV5BA==}
     engines: {node: '>=20.19.0'}
 
   unplugin@2.3.11:
@@ -11270,10 +11577,6 @@ packages:
     resolution: {integrity: sha512-4luGP9LMYszMRZwsvyUd9MrxgEGZdZuZgpVQHEEX0lCYFESasVRvZd0EYpCkOIbJKHMuv0LskpXc/8Un+MJzEQ==}
     hasBin: true
 
-  untun@0.2.2:
-    resolution: {integrity: sha512-+NnOJcSiEtYsVgJmXUzQbJeRAFXJC4yPJYuh6kF9B0Rm6zunXcs/3GZOTllyocSbUDIxD6Bj7e/4ATw7sph1Sw==}
-    hasBin: true
-
   untyped@2.0.0:
     resolution: {integrity: sha512-nwNCjxJTjNuLCgFr42fEak5OcLuB3ecca+9ksPFNvtfYSLpjf+iJqSIaSnIile6ZPbKYxI5k2AfXqeopGudK/g==}
     hasBin: true
@@ -11289,9 +11592,6 @@ packages:
 
   uqr@0.1.2:
     resolution: {integrity: sha512-MJu7ypHq6QasgF5YRTjqscSzQp/W11zoUk6kvmlH+fmWEs63Y0Eib13hYFwAzagRJcVY8WVnlV+eBDUGMJ5IbA==}
-
-  uqr@0.1.3:
-    resolution: {integrity: sha512-0rjE8iEJe4YmT9TOhwsZtqCMRLc5DXZUI2UEYUUg63ikBkqqE5EYWaI0etFe/5KUcmcYwLih2RND1kq+hrUJXA==}
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
@@ -11545,6 +11845,9 @@ packages:
     resolution: {integrity: sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg==}
     engines: {node: '>=10.13.0'}
 
+  web-tree-sitter@0.26.11:
+    resolution: {integrity: sha512-Q5Dm3YTIXSXuH6FxX6RuzX2Qwpc4DPGiYMU87Wg5Z8OIStiQFiUex4zMDc0vBTw78EphaYJacncJghCHzbZptg==}
+
   web-worker@1.5.0:
     resolution: {integrity: sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==}
 
@@ -11704,6 +12007,9 @@ packages:
     resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
     engines: {node: '>=18'}
 
+  yoga-layout@3.2.1:
+    resolution: {integrity: sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==}
+
   youch-core@0.3.3:
     resolution: {integrity: sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==}
 
@@ -11732,6 +12038,11 @@ packages:
 snapshots:
 
   '@adobe/css-tools@4.5.0': {}
+
+  '@alcalzone/ansi-tokenize@0.1.3':
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 4.0.0
 
   '@altano/repository-tools@2.0.3': {}
 
@@ -11778,9 +12089,31 @@ snapshots:
       '@babel/helper-validator-identifier': 8.0.2
       js-tokens: 10.0.0
 
+  '@babel/compat-data@7.29.0': {}
+
   '@babel/compat-data@7.29.7': {}
 
   '@babel/compat-data@8.0.0': {}
+
+  '@babel/core@7.29.0(supports-color@10.2.2)':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/helpers': 7.28.6
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@10.2.2)
+      '@babel/types': 7.29.7
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3(supports-color@10.2.2)
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/core@7.29.7(supports-color@10.2.2)':
     dependencies:
@@ -11842,6 +12175,14 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.7
 
+  '@babel/helper-compilation-targets@7.28.6':
+    dependencies:
+      '@babel/compat-data': 7.29.0
+      '@babel/helper-validator-option': 7.27.1
+      browserslist: 4.28.7
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
   '@babel/helper-compilation-targets@7.29.7':
     dependencies:
       '@babel/compat-data': 7.29.7
@@ -11893,6 +12234,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)':
+    dependencies:
+      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/helper-module-imports': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@10.2.2)
@@ -11934,9 +12284,16 @@ snapshots:
 
   '@babel/helper-validator-identifier@8.0.2': {}
 
+  '@babel/helper-validator-option@7.27.1': {}
+
   '@babel/helper-validator-option@7.29.7': {}
 
   '@babel/helper-validator-option@8.0.0': {}
+
+  '@babel/helpers@7.28.6':
+    dependencies:
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
 
   '@babel/helpers@7.29.7':
     dependencies:
@@ -11956,15 +12313,20 @@ snapshots:
     dependencies:
       '@babel/types': 8.0.0
 
-  '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.7(supports-color@10.2.2))':
+  '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0(supports-color@10.2.2))':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.0(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0(supports-color@10.2.2))':
+    dependencies:
+      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.7(supports-color@10.2.2))':
     dependencies:
@@ -11981,6 +12343,17 @@ snapshots:
       '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-react-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-annotate-as-pure': 7.29.7
+      '@babel/helper-module-imports': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -12080,6 +12453,17 @@ snapshots:
   '@bramus/specificity@2.4.2':
     dependencies:
       css-tree: 3.2.1
+
+  '@clack/core@1.0.0-alpha.6':
+    dependencies:
+      picocolors: 1.1.1
+      sisteransi: 1.0.5
+
+  '@clack/prompts@1.0.0-alpha.6':
+    dependencies:
+      '@clack/core': 1.0.0-alpha.6
+      picocolors: 1.1.1
+      sisteransi: 1.0.5
 
   '@cloudflare/kv-asset-handler@0.4.2': {}
 
@@ -12427,10 +12811,16 @@ snapshots:
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
 
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
   '@esbuild/aix-ppc64@0.28.1':
     optional: true
 
   '@esbuild/android-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
     optional: true
 
   '@esbuild/android-arm64@0.28.1':
@@ -12439,10 +12829,16 @@ snapshots:
   '@esbuild/android-arm@0.25.12':
     optional: true
 
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
   '@esbuild/android-arm@0.28.1':
     optional: true
 
   '@esbuild/android-x64@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
     optional: true
 
   '@esbuild/android-x64@0.28.1':
@@ -12451,10 +12847,16 @@ snapshots:
   '@esbuild/darwin-arm64@0.25.12':
     optional: true
 
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
   '@esbuild/darwin-arm64@0.28.1':
     optional: true
 
   '@esbuild/darwin-x64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
     optional: true
 
   '@esbuild/darwin-x64@0.28.1':
@@ -12463,10 +12865,16 @@ snapshots:
   '@esbuild/freebsd-arm64@0.25.12':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.28.1':
     optional: true
 
   '@esbuild/freebsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
     optional: true
 
   '@esbuild/freebsd-x64@0.28.1':
@@ -12475,10 +12883,16 @@ snapshots:
   '@esbuild/linux-arm64@0.25.12':
     optional: true
 
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
   '@esbuild/linux-arm64@0.28.1':
     optional: true
 
   '@esbuild/linux-arm@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
     optional: true
 
   '@esbuild/linux-arm@0.28.1':
@@ -12487,10 +12901,16 @@ snapshots:
   '@esbuild/linux-ia32@0.25.12':
     optional: true
 
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
   '@esbuild/linux-ia32@0.28.1':
     optional: true
 
   '@esbuild/linux-loong64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
     optional: true
 
   '@esbuild/linux-loong64@0.28.1':
@@ -12499,10 +12919,16 @@ snapshots:
   '@esbuild/linux-mips64el@0.25.12':
     optional: true
 
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
   '@esbuild/linux-mips64el@0.28.1':
     optional: true
 
   '@esbuild/linux-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
     optional: true
 
   '@esbuild/linux-ppc64@0.28.1':
@@ -12511,10 +12937,16 @@ snapshots:
   '@esbuild/linux-riscv64@0.25.12':
     optional: true
 
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
   '@esbuild/linux-riscv64@0.28.1':
     optional: true
 
   '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
     optional: true
 
   '@esbuild/linux-s390x@0.28.1':
@@ -12523,10 +12955,16 @@ snapshots:
   '@esbuild/linux-x64@0.25.12':
     optional: true
 
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
   '@esbuild/linux-x64@0.28.1':
     optional: true
 
   '@esbuild/netbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
     optional: true
 
   '@esbuild/netbsd-arm64@0.28.1':
@@ -12535,10 +12973,16 @@ snapshots:
   '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
   '@esbuild/netbsd-x64@0.28.1':
     optional: true
 
   '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
     optional: true
 
   '@esbuild/openbsd-arm64@0.28.1':
@@ -12547,10 +12991,16 @@ snapshots:
   '@esbuild/openbsd-x64@0.25.12':
     optional: true
 
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
   '@esbuild/openbsd-x64@0.28.1':
     optional: true
 
   '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
     optional: true
 
   '@esbuild/openharmony-arm64@0.28.1':
@@ -12559,10 +13009,16 @@ snapshots:
   '@esbuild/sunos-x64@0.25.12':
     optional: true
 
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
   '@esbuild/sunos-x64@0.28.1':
     optional: true
 
   '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.7':
     optional: true
 
   '@esbuild/win32-arm64@0.28.1':
@@ -12571,10 +13027,16 @@ snapshots:
   '@esbuild/win32-ia32@0.25.12':
     optional: true
 
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
   '@esbuild/win32-ia32@0.28.1':
     optional: true
 
   '@esbuild/win32-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
     optional: true
 
   '@esbuild/win32-x64@0.28.1':
@@ -12712,7 +13174,9 @@ snapshots:
       '@eslint/core': 1.2.1
       levn: 0.4.1
 
-  '@exodus/bytes@1.15.1': {}
+  '@exodus/bytes@1.15.1(@noble/hashes@2.2.0)':
+    optionalDependencies:
+      '@noble/hashes': 2.2.0
 
   '@floating-ui/core@1.7.5':
     dependencies:
@@ -12758,6 +13222,31 @@ snapshots:
       '@formatjs/cli-native-linux-x64-musl': 1.0.8
       '@formatjs/cli-native-win32-x64': 1.1.11
 
+  '@generaltranslation/format@0.1.4':
+    dependencies:
+      '@generaltranslation/icu': 0.1.1
+
+  '@generaltranslation/icu@0.1.1': {}
+
+  '@generaltranslation/python-extractor@0.2.33':
+    dependencies:
+      generaltranslation: 9.1.0
+      tree-sitter-python: 0.25.0
+      web-tree-sitter: 0.26.11
+    transitivePeerDependencies:
+      - tree-sitter
+
+  '@generaltranslation/react-core@11.1.4(react@19.2.8)':
+    dependencies:
+      '@generaltranslation/format': 0.1.4
+      generaltranslation: 9.1.0
+      gt-i18n: 1.0.10
+      react: 19.2.8
+
+  '@generaltranslation/supported-locales@2.1.13':
+    dependencies:
+      generaltranslation: 9.1.0
+
   '@gerrit0/mini-shiki@3.23.0':
     dependencies:
       '@shikijs/engine-oniguruma': 3.23.0
@@ -12766,9 +13255,9 @@ snapshots:
       '@shikijs/types': 3.23.0
       '@shikijs/vscode-textmate': 10.0.2
 
-  '@hono/node-server@2.0.12(hono@4.12.34)':
+  '@hono/node-server@2.0.12(hono@4.13.0)':
     dependencies:
-      hono: 4.12.34
+      hono: 4.13.0
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -13056,6 +13545,14 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@jsep-plugin/assignment@1.3.0(jsep@1.4.0)':
+    dependencies:
+      jsep: 1.4.0
+
+  '@jsep-plugin/regex@1.0.4(jsep@1.4.0)':
+    dependencies:
+      jsep: 1.4.0
+
   '@lingui/babel-plugin-extract-messages@6.6.0':
     dependencies:
       '@lingui/conf': 6.6.0
@@ -13157,7 +13654,7 @@ snapshots:
       node-fetch: 2.7.0
       nopt: 8.1.0
       semver: 7.8.5
-      tar: 7.5.22
+      tar: 7.5.19
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -13211,9 +13708,6 @@ snapshots:
   '@messageformat/parser@5.1.1':
     dependencies:
       moo: 0.5.3
-
-  '@napi-rs/lzma-linux-x64-gnu@1.5.1':
-    optional: true
 
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
@@ -13275,6 +13769,8 @@ snapshots:
 
   '@next/swc-win32-x64-msvc@16.2.12':
     optional: true
+
+  '@noble/hashes@2.2.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -13860,7 +14356,7 @@ snapshots:
   '@oxlint/binding-win32-x64-msvc@1.76.0':
     optional: true
 
-  '@oxlint/plugins@1.76.0': {}
+  '@oxlint/plugins@1.77.0': {}
 
   '@parcel/watcher-android-arm64@2.5.6':
     optional: true
@@ -13931,6 +14427,8 @@ snapshots:
       '@parcel/watcher-win32-arm64': 2.5.6
       '@parcel/watcher-win32-ia32': 2.5.6
       '@parcel/watcher-win32-x64': 2.5.6
+
+  '@pinojs/redact@0.4.0': {}
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -14343,9 +14841,9 @@ snapshots:
     optionalDependencies:
       rollup: 4.59.0
 
-  '@rollup/plugin-alias@6.0.0(rollup@4.62.4)':
+  '@rollup/plugin-alias@6.0.0(rollup@4.59.0)':
     optionalDependencies:
-      rollup: 4.62.4
+      rollup: 4.59.0
 
   '@rollup/plugin-commonjs@28.0.9(rollup@4.59.0)':
     dependencies:
@@ -14359,9 +14857,9 @@ snapshots:
     optionalDependencies:
       rollup: 4.59.0
 
-  '@rollup/plugin-commonjs@29.0.2(rollup@4.62.4)':
+  '@rollup/plugin-commonjs@29.0.2(rollup@4.59.0)':
     dependencies:
-      '@rollup/pluginutils': 5.3.0(rollup@4.62.4)
+      '@rollup/pluginutils': 5.3.0(rollup@4.59.0)
       commondir: 1.0.1
       estree-walker: 2.0.2
       fdir: 6.5.0(picomatch@4.0.5)
@@ -14369,27 +14867,21 @@ snapshots:
       magic-string: 0.30.21
       picomatch: 4.0.5
     optionalDependencies:
-      rollup: 4.62.4
+      rollup: 4.59.0
 
-  '@rollup/plugin-inject@5.0.5(rollup@4.62.4)':
+  '@rollup/plugin-inject@5.0.5(rollup@4.59.0)':
     dependencies:
-      '@rollup/pluginutils': 5.3.0(rollup@4.62.4)
+      '@rollup/pluginutils': 5.3.0(rollup@4.59.0)
       estree-walker: 2.0.2
       magic-string: 0.30.21
     optionalDependencies:
-      rollup: 4.62.4
+      rollup: 4.59.0
 
   '@rollup/plugin-json@6.1.0(rollup@4.59.0)':
     dependencies:
       '@rollup/pluginutils': 5.3.0(rollup@4.59.0)
     optionalDependencies:
       rollup: 4.59.0
-
-  '@rollup/plugin-json@6.1.0(rollup@4.62.4)':
-    dependencies:
-      '@rollup/pluginutils': 5.3.0(rollup@4.62.4)
-    optionalDependencies:
-      rollup: 4.62.4
 
   '@rollup/plugin-node-resolve@16.0.3(rollup@4.59.0)':
     dependencies:
@@ -14401,16 +14893,6 @@ snapshots:
     optionalDependencies:
       rollup: 4.59.0
 
-  '@rollup/plugin-node-resolve@16.0.3(rollup@4.62.4)':
-    dependencies:
-      '@rollup/pluginutils': 5.3.0(rollup@4.62.4)
-      '@types/resolve': 1.20.2
-      deepmerge: 4.3.1
-      is-module: 1.0.0
-      resolve: 1.22.11
-    optionalDependencies:
-      rollup: 4.62.4
-
   '@rollup/plugin-replace@6.0.3(rollup@4.59.0)':
     dependencies:
       '@rollup/pluginutils': 5.3.0(rollup@4.59.0)
@@ -14418,20 +14900,13 @@ snapshots:
     optionalDependencies:
       rollup: 4.59.0
 
-  '@rollup/plugin-replace@6.0.3(rollup@4.62.4)':
-    dependencies:
-      '@rollup/pluginutils': 5.3.0(rollup@4.62.4)
-      magic-string: 0.30.21
-    optionalDependencies:
-      rollup: 4.62.4
-
-  '@rollup/plugin-terser@1.0.0(rollup@4.62.4)':
+  '@rollup/plugin-terser@1.0.0(rollup@4.59.0)':
     dependencies:
       serialize-javascript: 7.0.5
       smob: 1.6.1
       terser: 5.46.1
     optionalDependencies:
-      rollup: 4.62.4
+      rollup: 4.59.0
 
   '@rollup/pluginutils@5.3.0(rollup@4.59.0)':
     dependencies:
@@ -14440,14 +14915,6 @@ snapshots:
       picomatch: 4.0.5
     optionalDependencies:
       rollup: 4.59.0
-
-  '@rollup/pluginutils@5.3.0(rollup@4.62.4)':
-    dependencies:
-      '@types/estree': 1.0.9
-      estree-walker: 2.0.2
-      picomatch: 4.0.5
-    optionalDependencies:
-      rollup: 4.62.4
 
   '@rollup/pluginutils@5.4.0(rollup@4.59.0)':
     dependencies:
@@ -14460,151 +14927,76 @@ snapshots:
   '@rollup/rollup-android-arm-eabi@4.59.0':
     optional: true
 
-  '@rollup/rollup-android-arm-eabi@4.62.4':
-    optional: true
-
   '@rollup/rollup-android-arm64@4.59.0':
-    optional: true
-
-  '@rollup/rollup-android-arm64@4.62.4':
     optional: true
 
   '@rollup/rollup-darwin-arm64@4.59.0':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.62.4':
-    optional: true
-
   '@rollup/rollup-darwin-x64@4.59.0':
-    optional: true
-
-  '@rollup/rollup-darwin-x64@4.62.4':
     optional: true
 
   '@rollup/rollup-freebsd-arm64@4.59.0':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.62.4':
-    optional: true
-
   '@rollup/rollup-freebsd-x64@4.59.0':
-    optional: true
-
-  '@rollup/rollup-freebsd-x64@4.62.4':
     optional: true
 
   '@rollup/rollup-linux-arm-gnueabihf@4.59.0':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.62.4':
-    optional: true
-
   '@rollup/rollup-linux-arm-musleabihf@4.59.0':
-    optional: true
-
-  '@rollup/rollup-linux-arm-musleabihf@4.62.4':
     optional: true
 
   '@rollup/rollup-linux-arm64-gnu@4.59.0':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.62.4':
-    optional: true
-
   '@rollup/rollup-linux-arm64-musl@4.59.0':
-    optional: true
-
-  '@rollup/rollup-linux-arm64-musl@4.62.4':
     optional: true
 
   '@rollup/rollup-linux-loong64-gnu@4.59.0':
     optional: true
 
-  '@rollup/rollup-linux-loong64-gnu@4.62.4':
-    optional: true
-
   '@rollup/rollup-linux-loong64-musl@4.59.0':
-    optional: true
-
-  '@rollup/rollup-linux-loong64-musl@4.62.4':
     optional: true
 
   '@rollup/rollup-linux-ppc64-gnu@4.59.0':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-gnu@4.62.4':
-    optional: true
-
   '@rollup/rollup-linux-ppc64-musl@4.59.0':
-    optional: true
-
-  '@rollup/rollup-linux-ppc64-musl@4.62.4':
     optional: true
 
   '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.62.4':
-    optional: true
-
   '@rollup/rollup-linux-riscv64-musl@4.59.0':
-    optional: true
-
-  '@rollup/rollup-linux-riscv64-musl@4.62.4':
     optional: true
 
   '@rollup/rollup-linux-s390x-gnu@4.59.0':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.62.4':
-    optional: true
-
   '@rollup/rollup-linux-x64-gnu@4.59.0':
-    optional: true
-
-  '@rollup/rollup-linux-x64-gnu@4.62.4':
     optional: true
 
   '@rollup/rollup-linux-x64-musl@4.59.0':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.62.4':
-    optional: true
-
   '@rollup/rollup-openbsd-x64@4.59.0':
-    optional: true
-
-  '@rollup/rollup-openbsd-x64@4.62.4':
     optional: true
 
   '@rollup/rollup-openharmony-arm64@4.59.0':
     optional: true
 
-  '@rollup/rollup-openharmony-arm64@4.62.4':
-    optional: true
-
   '@rollup/rollup-win32-arm64-msvc@4.59.0':
-    optional: true
-
-  '@rollup/rollup-win32-arm64-msvc@4.62.4':
     optional: true
 
   '@rollup/rollup-win32-ia32-msvc@4.59.0':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.62.4':
-    optional: true
-
   '@rollup/rollup-win32-x64-gnu@4.59.0':
     optional: true
 
-  '@rollup/rollup-win32-x64-gnu@4.62.4':
-    optional: true
-
   '@rollup/rollup-win32-x64-msvc@4.59.0':
-    optional: true
-
-  '@rollup/rollup-win32-x64-msvc@4.62.4':
     optional: true
 
   '@sec-ant/readable-stream@0.4.1': {}
@@ -14721,23 +15113,47 @@ snapshots:
     dependencies:
       solid-js: 1.9.14
 
-  '@solidjs/start@1.3.2(@testing-library/jest-dom@6.9.1)(solid-js@1.9.14)(supports-color@10.2.2)(vinxi@0.5.11(@parcel/watcher@2.5.6)(@types/node@24.13.3)(@vercel/blob@2.4.0)(aws4fetch@1.0.20)(db0@0.3.4)(debug@4.4.3(supports-color@10.2.2))(ioredis@5.10.1(supports-color@10.2.2))(jiti@2.7.0)(lightningcss@1.33.0)(oxc-parser@0.127.0)(rolldown@1.2.2)(srvx@0.12.4)(supports-color@10.2.2)(terser@5.49.0)(tsx@4.21.0)(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))(yaml@2.9.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@solidjs/start@1.3.2(@testing-library/jest-dom@6.9.1)(solid-js@1.9.14)(supports-color@10.2.2)(vinxi@0.5.11(@types/node@24.13.3)(@vercel/blob@2.4.0)(aws4fetch@1.0.20)(db0@0.3.4)(debug@4.4.3(supports-color@10.2.2))(ioredis@5.10.1(supports-color@10.2.2))(jiti@2.7.0)(lightningcss@1.33.0)(rolldown@1.2.2)(supports-color@10.2.2)(terser@5.49.0)(tsx@4.21.0)(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.27.7)(lightningcss@1.33.0)(postcss@8.5.25))(yaml@2.9.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
-      '@tanstack/server-functions-plugin': 1.121.21(supports-color@10.2.2)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
-      '@vinxi/plugin-directives': 0.5.1(vinxi@0.5.11(@parcel/watcher@2.5.6)(@types/node@24.13.3)(@vercel/blob@2.4.0)(aws4fetch@1.0.20)(db0@0.3.4)(debug@4.4.3(supports-color@10.2.2))(ioredis@5.10.1(supports-color@10.2.2))(jiti@2.7.0)(lightningcss@1.33.0)(oxc-parser@0.127.0)(rolldown@1.2.2)(srvx@0.12.4)(supports-color@10.2.2)(terser@5.49.0)(tsx@4.21.0)(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))(yaml@2.9.0))
-      '@vinxi/server-components': 0.5.1(vinxi@0.5.11(@parcel/watcher@2.5.6)(@types/node@24.13.3)(@vercel/blob@2.4.0)(aws4fetch@1.0.20)(db0@0.3.4)(debug@4.4.3(supports-color@10.2.2))(ioredis@5.10.1(supports-color@10.2.2))(jiti@2.7.0)(lightningcss@1.33.0)(oxc-parser@0.127.0)(rolldown@1.2.2)(srvx@0.12.4)(supports-color@10.2.2)(terser@5.49.0)(tsx@4.21.0)(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))(yaml@2.9.0))
+      '@tanstack/server-functions-plugin': 1.121.21(supports-color@10.2.2)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@vinxi/plugin-directives': 0.5.1(vinxi@0.5.11(@types/node@24.13.3)(@vercel/blob@2.4.0)(aws4fetch@1.0.20)(db0@0.3.4)(debug@4.4.3(supports-color@10.2.2))(ioredis@5.10.1(supports-color@10.2.2))(jiti@2.7.0)(lightningcss@1.33.0)(rolldown@1.2.2)(supports-color@10.2.2)(terser@5.49.0)(tsx@4.21.0)(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.27.7)(lightningcss@1.33.0)(postcss@8.5.25))(yaml@2.9.0))
+      '@vinxi/server-components': 0.5.1(vinxi@0.5.11(@types/node@24.13.3)(@vercel/blob@2.4.0)(aws4fetch@1.0.20)(db0@0.3.4)(debug@4.4.3(supports-color@10.2.2))(ioredis@5.10.1(supports-color@10.2.2))(jiti@2.7.0)(lightningcss@1.33.0)(rolldown@1.2.2)(supports-color@10.2.2)(terser@5.49.0)(tsx@4.21.0)(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.27.7)(lightningcss@1.33.0)(postcss@8.5.25))(yaml@2.9.0))
       cookie-es: 2.0.0
-      defu: 6.1.7
+      defu: 6.1.4
       error-stack-parser: 2.1.4
       html-to-image: 1.11.13
       radix3: 1.1.2
-      seroval: 1.6.0
-      seroval-plugins: 1.5.1(seroval@1.6.0)
+      seroval: 1.5.1
+      seroval-plugins: 1.5.1(seroval@1.5.1)
       shiki: 1.29.2
       source-map-js: 1.2.1
       terracotta: 1.1.0(solid-js@1.9.14)
       tinyglobby: 0.2.15
-      vinxi: 0.5.11(@parcel/watcher@2.5.6)(@types/node@24.13.3)(@vercel/blob@2.4.0)(aws4fetch@1.0.20)(db0@0.3.4)(debug@4.4.3(supports-color@10.2.2))(ioredis@5.10.1(supports-color@10.2.2))(jiti@2.7.0)(lightningcss@1.33.0)(oxc-parser@0.127.0)(rolldown@1.2.2)(srvx@0.12.4)(supports-color@10.2.2)(terser@5.49.0)(tsx@4.21.0)(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))(yaml@2.9.0)
+      vinxi: 0.5.11(@types/node@24.13.3)(@vercel/blob@2.4.0)(aws4fetch@1.0.20)(db0@0.3.4)(debug@4.4.3(supports-color@10.2.2))(ioredis@5.10.1(supports-color@10.2.2))(jiti@2.7.0)(lightningcss@1.33.0)(rolldown@1.2.2)(supports-color@10.2.2)(terser@5.49.0)(tsx@4.21.0)(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.27.7)(lightningcss@1.33.0)(postcss@8.5.25))(yaml@2.9.0)
+      vite-plugin-solid: 2.11.11(@testing-library/jest-dom@6.9.1)(solid-js@1.9.14)(supports-color@10.2.2)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - '@testing-library/jest-dom'
+      - solid-js
+      - supports-color
+      - vite
+
+  '@solidjs/start@1.3.2(@testing-library/jest-dom@6.9.1)(solid-js@1.9.14)(supports-color@10.2.2)(vinxi@0.5.11(@types/node@24.13.3)(@vercel/blob@2.4.0)(aws4fetch@1.0.20)(db0@0.3.4)(debug@4.4.3(supports-color@10.2.2))(ioredis@5.10.1(supports-color@10.2.2))(jiti@2.7.0)(lightningcss@1.33.0)(rolldown@1.2.2)(supports-color@10.2.2)(terser@5.49.0)(tsx@4.21.0)(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))(yaml@2.9.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))':
+    dependencies:
+      '@tanstack/server-functions-plugin': 1.121.21(supports-color@10.2.2)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@vinxi/plugin-directives': 0.5.1(vinxi@0.5.11(@types/node@24.13.3)(@vercel/blob@2.4.0)(aws4fetch@1.0.20)(db0@0.3.4)(debug@4.4.3(supports-color@10.2.2))(ioredis@5.10.1(supports-color@10.2.2))(jiti@2.7.0)(lightningcss@1.33.0)(rolldown@1.2.2)(supports-color@10.2.2)(terser@5.49.0)(tsx@4.21.0)(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))(yaml@2.9.0))
+      '@vinxi/server-components': 0.5.1(vinxi@0.5.11(@types/node@24.13.3)(@vercel/blob@2.4.0)(aws4fetch@1.0.20)(db0@0.3.4)(debug@4.4.3(supports-color@10.2.2))(ioredis@5.10.1(supports-color@10.2.2))(jiti@2.7.0)(lightningcss@1.33.0)(rolldown@1.2.2)(supports-color@10.2.2)(terser@5.49.0)(tsx@4.21.0)(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))(yaml@2.9.0))
+      cookie-es: 2.0.0
+      defu: 6.1.4
+      error-stack-parser: 2.1.4
+      html-to-image: 1.11.13
+      radix3: 1.1.2
+      seroval: 1.5.1
+      seroval-plugins: 1.5.1(seroval@1.5.1)
+      shiki: 1.29.2
+      source-map-js: 1.2.1
+      terracotta: 1.1.0(solid-js@1.9.14)
+      tinyglobby: 0.2.15
+      vinxi: 0.5.11(@types/node@24.13.3)(@vercel/blob@2.4.0)(aws4fetch@1.0.20)(db0@0.3.4)(debug@4.4.3(supports-color@10.2.2))(ioredis@5.10.1(supports-color@10.2.2))(jiti@2.7.0)(lightningcss@1.33.0)(rolldown@1.2.2)(supports-color@10.2.2)(terser@5.49.0)(tsx@4.21.0)(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))(yaml@2.9.0)
       vite-plugin-solid: 2.11.11(@testing-library/jest-dom@6.9.1)(solid-js@1.9.14)(supports-color@10.2.2)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@testing-library/jest-dom'
@@ -14897,6 +15313,19 @@ snapshots:
       tailwindcss: 4.3.3
       vite: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)
 
+  '@tanstack/directive-functions-plugin@1.121.21(supports-color@10.2.2)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))':
+    dependencies:
+      '@babel/code-frame': 7.26.2
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/traverse': 7.29.7(supports-color@10.2.2)
+      '@babel/types': 7.29.7
+      '@tanstack/router-utils': 1.162.2(supports-color@10.2.2)
+      babel-dead-code-elimination: 1.0.12(supports-color@10.2.2)
+      tiny-invariant: 1.3.3
+      vite: 8.2.0(@types/node@24.13.3)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - supports-color
+
   '@tanstack/directive-functions-plugin@1.121.21(supports-color@10.2.2)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@babel/code-frame': 7.26.2
@@ -14929,15 +15358,14 @@ snapshots:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
 
-  '@tanstack/react-start-rsc@0.1.33(@vitejs/plugin-rsc@0.5.32(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25)))(react@19.2.8)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(crossws@0.4.10(srvx@0.12.4))(esbuild@0.28.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.2)(rollup@4.62.4)(supports-color@10.2.2)(vite-plugin-solid@2.11.14(@testing-library/jest-dom@7.0.0(@testing-library/dom@10.4.1))(solid-js@1.9.14)(supports-color@10.2.2)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))':
+  '@tanstack/react-start-rsc@0.1.34(@vitejs/plugin-rsc@0.5.32(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25)))(react@19.2.8)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(esbuild@0.28.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.2)(rollup@4.59.0)(supports-color@10.2.2)(vite-plugin-solid@2.11.14(@testing-library/jest-dom@7.0.0(@testing-library/dom@10.4.1))(solid-js@1.9.14)(supports-color@10.2.2)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))':
     dependencies:
       '@tanstack/react-router': 1.170.18(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@tanstack/router-core': 1.171.15
       '@tanstack/router-utils': 1.162.2(supports-color@10.2.2)
       '@tanstack/start-client-core': 1.170.14
       '@tanstack/start-fn-stubs': 1.162.0
-      '@tanstack/start-plugin-core': 1.171.25(@tanstack/react-router@1.170.18(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(crossws@0.4.10(srvx@0.12.4))(esbuild@0.28.1)(rolldown@1.2.2)(rollup@4.62.4)(supports-color@10.2.2)(vite-plugin-solid@2.11.14(@testing-library/jest-dom@7.0.0(@testing-library/dom@10.4.1))(solid-js@1.9.14)(supports-color@10.2.2)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
-      '@tanstack/start-server-core': 1.169.17(crossws@0.4.10(srvx@0.12.4))
+      '@tanstack/start-plugin-core': 1.171.26(@tanstack/react-router@1.170.18(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(esbuild@0.28.1)(rolldown@1.2.2)(rollup@4.59.0)(supports-color@10.2.2)(vite-plugin-solid@2.11.14(@testing-library/jest-dom@7.0.0(@testing-library/dom@10.4.1))(solid-js@1.9.14)(supports-color@10.2.2)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
       '@tanstack/start-storage-context': 1.167.17
       pathe: 2.0.3
       react: 19.2.8
@@ -14958,26 +15386,26 @@ snapshots:
       - vite-plugin-solid
       - webpack
 
-  '@tanstack/react-start-server@1.167.22(crossws@0.4.10(srvx@0.12.4))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@tanstack/react-start-server@1.167.23(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@tanstack/react-router': 1.170.18(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@tanstack/router-core': 1.171.15
-      '@tanstack/start-server-core': 1.169.17(crossws@0.4.10(srvx@0.12.4))
+      '@tanstack/start-server-core': 1.169.18
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
     transitivePeerDependencies:
       - crossws
 
-  '@tanstack/react-start@1.168.34(@vitejs/plugin-rsc@0.5.32(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25)))(react@19.2.8)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(crossws@0.4.10(srvx@0.12.4))(esbuild@0.28.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.2)(rollup@4.62.4)(supports-color@10.2.2)(vite-plugin-solid@2.11.14(@testing-library/jest-dom@7.0.0(@testing-library/dom@10.4.1))(solid-js@1.9.14)(supports-color@10.2.2)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))':
+  '@tanstack/react-start@1.168.35(@vitejs/plugin-rsc@0.5.32(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25)))(react@19.2.8)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(esbuild@0.28.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.2)(rollup@4.59.0)(supports-color@10.2.2)(vite-plugin-solid@2.11.14(@testing-library/jest-dom@7.0.0(@testing-library/dom@10.4.1))(solid-js@1.9.14)(supports-color@10.2.2)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))':
     dependencies:
       '@tanstack/react-router': 1.170.18(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@tanstack/react-start-client': 1.168.16(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@tanstack/react-start-rsc': 0.1.33(@vitejs/plugin-rsc@0.5.32(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25)))(react@19.2.8)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(crossws@0.4.10(srvx@0.12.4))(esbuild@0.28.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.2)(rollup@4.62.4)(supports-color@10.2.2)(vite-plugin-solid@2.11.14(@testing-library/jest-dom@7.0.0(@testing-library/dom@10.4.1))(solid-js@1.9.14)(supports-color@10.2.2)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
-      '@tanstack/react-start-server': 1.167.22(crossws@0.4.10(srvx@0.12.4))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tanstack/react-start-rsc': 0.1.34(@vitejs/plugin-rsc@0.5.32(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25)))(react@19.2.8)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(esbuild@0.28.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.2)(rollup@4.59.0)(supports-color@10.2.2)(vite-plugin-solid@2.11.14(@testing-library/jest-dom@7.0.0(@testing-library/dom@10.4.1))(solid-js@1.9.14)(supports-color@10.2.2)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
+      '@tanstack/react-start-server': 1.167.23(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@tanstack/router-utils': 1.162.2(supports-color@10.2.2)
       '@tanstack/start-client-core': 1.170.14
-      '@tanstack/start-plugin-core': 1.171.25(@tanstack/react-router@1.170.18(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(crossws@0.4.10(srvx@0.12.4))(esbuild@0.28.1)(rolldown@1.2.2)(rollup@4.62.4)(supports-color@10.2.2)(vite-plugin-solid@2.11.14(@testing-library/jest-dom@7.0.0(@testing-library/dom@10.4.1))(solid-js@1.9.14)(supports-color@10.2.2)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
-      '@tanstack/start-server-core': 1.169.17(crossws@0.4.10(srvx@0.12.4))
+      '@tanstack/start-plugin-core': 1.171.26(@tanstack/react-router@1.170.18(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(esbuild@0.28.1)(rolldown@1.2.2)(rollup@4.59.0)(supports-color@10.2.2)(vite-plugin-solid@2.11.14(@testing-library/jest-dom@7.0.0(@testing-library/dom@10.4.1))(solid-js@1.9.14)(supports-color@10.2.2)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
+      '@tanstack/start-server-core': 1.169.18
       pathe: 2.0.3
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
@@ -15009,8 +15437,8 @@ snapshots:
     dependencies:
       '@tanstack/history': 1.162.0
       cookie-es: 3.1.1
-      seroval: 1.6.0
-      seroval-plugins: 1.5.4(seroval@1.6.0)
+      seroval: 1.5.4
+      seroval-plugins: 1.5.4(seroval@1.5.4)
 
   '@tanstack/router-generator@1.167.21(supports-color@10.2.2)':
     dependencies:
@@ -15025,7 +15453,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/router-plugin@1.168.23(@tanstack/react-router@1.170.18(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(esbuild@0.28.1)(rolldown@1.2.2)(rollup@4.62.4)(supports-color@10.2.2)(vite-plugin-solid@2.11.14(@testing-library/jest-dom@7.0.0(@testing-library/dom@10.4.1))(solid-js@1.9.14)(supports-color@10.2.2)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))':
+  '@tanstack/router-plugin@1.168.23(@tanstack/react-router@1.170.18(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(esbuild@0.28.1)(rolldown@1.2.2)(rollup@4.59.0)(supports-color@10.2.2)(vite-plugin-solid@2.11.14(@testing-library/jest-dom@7.0.0(@testing-library/dom@10.4.1))(solid-js@1.9.14)(supports-color@10.2.2)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/template': 7.29.7
@@ -15034,7 +15462,7 @@ snapshots:
       '@tanstack/router-generator': 1.167.21(supports-color@10.2.2)
       '@tanstack/router-utils': 1.162.2(supports-color@10.2.2)
       chokidar: 5.0.0
-      unplugin: 3.3.0(esbuild@0.28.1)(rolldown@1.2.2)(rollup@4.62.4)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
+      unplugin: 3.3.0(esbuild@0.28.1)(rolldown@1.2.2)(rollup@4.59.0)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
       zod: 4.4.3
     optionalDependencies:
       '@tanstack/react-router': 1.170.18(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -15064,6 +15492,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@tanstack/server-functions-plugin@1.121.21(supports-color@10.2.2)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))':
+    dependencies:
+      '@babel/code-frame': 7.26.2
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@10.2.2)
+      '@babel/types': 7.29.7
+      '@tanstack/directive-functions-plugin': 1.121.21(supports-color@10.2.2)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
+      babel-dead-code-elimination: 1.0.12(supports-color@10.2.2)
+      tiny-invariant: 1.3.3
+    transitivePeerDependencies:
+      - supports-color
+      - vite
+
   '@tanstack/server-functions-plugin@1.121.21(supports-color@10.2.2)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@babel/code-frame': 7.26.2
@@ -15085,25 +15529,25 @@ snapshots:
       '@tanstack/router-core': 1.171.15
       '@tanstack/start-fn-stubs': 1.162.0
       '@tanstack/start-storage-context': 1.167.17
-      seroval: 1.6.0
+      seroval: 1.5.4
 
   '@tanstack/start-fn-stubs@1.162.0': {}
 
-  '@tanstack/start-plugin-core@1.171.25(@tanstack/react-router@1.170.18(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(crossws@0.4.10(srvx@0.12.4))(esbuild@0.28.1)(rolldown@1.2.2)(rollup@4.62.4)(supports-color@10.2.2)(vite-plugin-solid@2.11.14(@testing-library/jest-dom@7.0.0(@testing-library/dom@10.4.1))(solid-js@1.9.14)(supports-color@10.2.2)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))':
+  '@tanstack/start-plugin-core@1.171.26(@tanstack/react-router@1.170.18(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(esbuild@0.28.1)(rolldown@1.2.2)(rollup@4.59.0)(supports-color@10.2.2)(vite-plugin-solid@2.11.14(@testing-library/jest-dom@7.0.0(@testing-library/dom@10.4.1))(solid-js@1.9.14)(supports-color@10.2.2)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))':
     dependencies:
       '@babel/code-frame': 7.27.1
       '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/types': 7.29.7
       '@tanstack/router-core': 1.171.15
       '@tanstack/router-generator': 1.167.21(supports-color@10.2.2)
-      '@tanstack/router-plugin': 1.168.23(@tanstack/react-router@1.170.18(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(esbuild@0.28.1)(rolldown@1.2.2)(rollup@4.62.4)(supports-color@10.2.2)(vite-plugin-solid@2.11.14(@testing-library/jest-dom@7.0.0(@testing-library/dom@10.4.1))(solid-js@1.9.14)(supports-color@10.2.2)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
+      '@tanstack/router-plugin': 1.168.23(@tanstack/react-router@1.170.18(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(esbuild@0.28.1)(rolldown@1.2.2)(rollup@4.59.0)(supports-color@10.2.2)(vite-plugin-solid@2.11.14(@testing-library/jest-dom@7.0.0(@testing-library/dom@10.4.1))(solid-js@1.9.14)(supports-color@10.2.2)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
       '@tanstack/router-utils': 1.162.2(supports-color@10.2.2)
-      '@tanstack/start-server-core': 1.169.17(crossws@0.4.10(srvx@0.12.4))
+      '@tanstack/start-server-core': 1.169.18
       exsolve: 1.1.0
       lightningcss: 1.33.0
       pathe: 2.0.3
       picomatch: 4.0.5
-      seroval: 1.6.0
+      seroval: 1.5.4
       source-map: 0.7.6
       srvx: 0.11.22
       tinyglobby: 0.2.17
@@ -15127,15 +15571,15 @@ snapshots:
       - vite-plugin-solid
       - webpack
 
-  '@tanstack/start-server-core@1.169.17(crossws@0.4.10(srvx@0.12.4))':
+  '@tanstack/start-server-core@1.169.18':
     dependencies:
       '@tanstack/history': 1.162.0
       '@tanstack/router-core': 1.171.15
       '@tanstack/start-client-core': 1.170.14
       '@tanstack/start-storage-context': 1.167.17
       fetchdts: 0.1.7
-      h3-v2: h3@2.0.1-rc.20(crossws@0.4.10(srvx@0.12.4))
-      seroval: 1.6.0
+      h3-v2: h3@2.0.1-rc.20
+      seroval: 1.5.4
     transitivePeerDependencies:
       - crossws
 
@@ -15643,10 +16087,10 @@ snapshots:
       undici: 6.28.0
     optional: true
 
-  '@vercel/nft@1.5.0(rollup@4.62.4)(supports-color@10.2.2)':
+  '@vercel/nft@1.5.0(rollup@4.59.0)(supports-color@10.2.2)':
     dependencies:
       '@mapbox/node-pre-gyp': 2.0.3(supports-color@10.2.2)
-      '@rollup/pluginutils': 5.3.0(rollup@4.62.4)
+      '@rollup/pluginutils': 5.3.0(rollup@4.59.0)
       acorn: 8.17.0
       acorn-import-attributes: 1.9.5(acorn@8.17.0)
       async-sema: 3.1.1
@@ -15669,7 +16113,7 @@ snapshots:
       citty: 0.1.6
       clipboardy: 4.0.0
       consola: 3.4.2
-      defu: 6.1.7
+      defu: 6.1.4
       get-port-please: 3.2.0
       h3: 1.15.10
       http-shutdown: 1.2.2
@@ -15682,7 +16126,7 @@ snapshots:
       untun: 0.1.3
       uqr: 0.1.2
 
-  '@vinxi/plugin-directives@0.5.1(vinxi@0.5.11(@parcel/watcher@2.5.6)(@types/node@24.13.3)(@vercel/blob@2.4.0)(aws4fetch@1.0.20)(db0@0.3.4)(debug@4.4.3(supports-color@10.2.2))(ioredis@5.10.1(supports-color@10.2.2))(jiti@2.7.0)(lightningcss@1.33.0)(oxc-parser@0.127.0)(rolldown@1.2.2)(srvx@0.12.4)(supports-color@10.2.2)(terser@5.49.0)(tsx@4.21.0)(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))(yaml@2.9.0))':
+  '@vinxi/plugin-directives@0.5.1(vinxi@0.5.11(@types/node@24.13.3)(@vercel/blob@2.4.0)(aws4fetch@1.0.20)(db0@0.3.4)(debug@4.4.3(supports-color@10.2.2))(ioredis@5.10.1(supports-color@10.2.2))(jiti@2.7.0)(lightningcss@1.33.0)(rolldown@1.2.2)(supports-color@10.2.2)(terser@5.49.0)(tsx@4.21.0)(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.27.7)(lightningcss@1.33.0)(postcss@8.5.25))(yaml@2.9.0))':
     dependencies:
       '@babel/parser': 7.29.7
       acorn: 8.16.0
@@ -15693,18 +16137,42 @@ snapshots:
       magicast: 0.2.11
       recast: 0.23.11
       tslib: 2.8.1
-      vinxi: 0.5.11(@parcel/watcher@2.5.6)(@types/node@24.13.3)(@vercel/blob@2.4.0)(aws4fetch@1.0.20)(db0@0.3.4)(debug@4.4.3(supports-color@10.2.2))(ioredis@5.10.1(supports-color@10.2.2))(jiti@2.7.0)(lightningcss@1.33.0)(oxc-parser@0.127.0)(rolldown@1.2.2)(srvx@0.12.4)(supports-color@10.2.2)(terser@5.49.0)(tsx@4.21.0)(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))(yaml@2.9.0)
+      vinxi: 0.5.11(@types/node@24.13.3)(@vercel/blob@2.4.0)(aws4fetch@1.0.20)(db0@0.3.4)(debug@4.4.3(supports-color@10.2.2))(ioredis@5.10.1(supports-color@10.2.2))(jiti@2.7.0)(lightningcss@1.33.0)(rolldown@1.2.2)(supports-color@10.2.2)(terser@5.49.0)(tsx@4.21.0)(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.27.7)(lightningcss@1.33.0)(postcss@8.5.25))(yaml@2.9.0)
 
-  '@vinxi/server-components@0.5.1(vinxi@0.5.11(@parcel/watcher@2.5.6)(@types/node@24.13.3)(@vercel/blob@2.4.0)(aws4fetch@1.0.20)(db0@0.3.4)(debug@4.4.3(supports-color@10.2.2))(ioredis@5.10.1(supports-color@10.2.2))(jiti@2.7.0)(lightningcss@1.33.0)(oxc-parser@0.127.0)(rolldown@1.2.2)(srvx@0.12.4)(supports-color@10.2.2)(terser@5.49.0)(tsx@4.21.0)(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))(yaml@2.9.0))':
+  '@vinxi/plugin-directives@0.5.1(vinxi@0.5.11(@types/node@24.13.3)(@vercel/blob@2.4.0)(aws4fetch@1.0.20)(db0@0.3.4)(debug@4.4.3(supports-color@10.2.2))(ioredis@5.10.1(supports-color@10.2.2))(jiti@2.7.0)(lightningcss@1.33.0)(rolldown@1.2.2)(supports-color@10.2.2)(terser@5.49.0)(tsx@4.21.0)(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))(yaml@2.9.0))':
     dependencies:
-      '@vinxi/plugin-directives': 0.5.1(vinxi@0.5.11(@parcel/watcher@2.5.6)(@types/node@24.13.3)(@vercel/blob@2.4.0)(aws4fetch@1.0.20)(db0@0.3.4)(debug@4.4.3(supports-color@10.2.2))(ioredis@5.10.1(supports-color@10.2.2))(jiti@2.7.0)(lightningcss@1.33.0)(oxc-parser@0.127.0)(rolldown@1.2.2)(srvx@0.12.4)(supports-color@10.2.2)(terser@5.49.0)(tsx@4.21.0)(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))(yaml@2.9.0))
+      '@babel/parser': 7.29.7
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
+      acorn-loose: 8.5.2
+      acorn-typescript: 1.4.13(acorn@8.16.0)
+      astring: 1.9.0
+      magicast: 0.2.11
+      recast: 0.23.11
+      tslib: 2.8.1
+      vinxi: 0.5.11(@types/node@24.13.3)(@vercel/blob@2.4.0)(aws4fetch@1.0.20)(db0@0.3.4)(debug@4.4.3(supports-color@10.2.2))(ioredis@5.10.1(supports-color@10.2.2))(jiti@2.7.0)(lightningcss@1.33.0)(rolldown@1.2.2)(supports-color@10.2.2)(terser@5.49.0)(tsx@4.21.0)(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))(yaml@2.9.0)
+
+  '@vinxi/server-components@0.5.1(vinxi@0.5.11(@types/node@24.13.3)(@vercel/blob@2.4.0)(aws4fetch@1.0.20)(db0@0.3.4)(debug@4.4.3(supports-color@10.2.2))(ioredis@5.10.1(supports-color@10.2.2))(jiti@2.7.0)(lightningcss@1.33.0)(rolldown@1.2.2)(supports-color@10.2.2)(terser@5.49.0)(tsx@4.21.0)(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.27.7)(lightningcss@1.33.0)(postcss@8.5.25))(yaml@2.9.0))':
+    dependencies:
+      '@vinxi/plugin-directives': 0.5.1(vinxi@0.5.11(@types/node@24.13.3)(@vercel/blob@2.4.0)(aws4fetch@1.0.20)(db0@0.3.4)(debug@4.4.3(supports-color@10.2.2))(ioredis@5.10.1(supports-color@10.2.2))(jiti@2.7.0)(lightningcss@1.33.0)(rolldown@1.2.2)(supports-color@10.2.2)(terser@5.49.0)(tsx@4.21.0)(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.27.7)(lightningcss@1.33.0)(postcss@8.5.25))(yaml@2.9.0))
       acorn: 8.16.0
       acorn-loose: 8.5.2
       acorn-typescript: 1.4.13(acorn@8.16.0)
       astring: 1.9.0
       magicast: 0.2.11
       recast: 0.23.11
-      vinxi: 0.5.11(@parcel/watcher@2.5.6)(@types/node@24.13.3)(@vercel/blob@2.4.0)(aws4fetch@1.0.20)(db0@0.3.4)(debug@4.4.3(supports-color@10.2.2))(ioredis@5.10.1(supports-color@10.2.2))(jiti@2.7.0)(lightningcss@1.33.0)(oxc-parser@0.127.0)(rolldown@1.2.2)(srvx@0.12.4)(supports-color@10.2.2)(terser@5.49.0)(tsx@4.21.0)(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))(yaml@2.9.0)
+      vinxi: 0.5.11(@types/node@24.13.3)(@vercel/blob@2.4.0)(aws4fetch@1.0.20)(db0@0.3.4)(debug@4.4.3(supports-color@10.2.2))(ioredis@5.10.1(supports-color@10.2.2))(jiti@2.7.0)(lightningcss@1.33.0)(rolldown@1.2.2)(supports-color@10.2.2)(terser@5.49.0)(tsx@4.21.0)(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.27.7)(lightningcss@1.33.0)(postcss@8.5.25))(yaml@2.9.0)
+
+  '@vinxi/server-components@0.5.1(vinxi@0.5.11(@types/node@24.13.3)(@vercel/blob@2.4.0)(aws4fetch@1.0.20)(db0@0.3.4)(debug@4.4.3(supports-color@10.2.2))(ioredis@5.10.1(supports-color@10.2.2))(jiti@2.7.0)(lightningcss@1.33.0)(rolldown@1.2.2)(supports-color@10.2.2)(terser@5.49.0)(tsx@4.21.0)(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))(yaml@2.9.0))':
+    dependencies:
+      '@vinxi/plugin-directives': 0.5.1(vinxi@0.5.11(@types/node@24.13.3)(@vercel/blob@2.4.0)(aws4fetch@1.0.20)(db0@0.3.4)(debug@4.4.3(supports-color@10.2.2))(ioredis@5.10.1(supports-color@10.2.2))(jiti@2.7.0)(lightningcss@1.33.0)(rolldown@1.2.2)(supports-color@10.2.2)(terser@5.49.0)(tsx@4.21.0)(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))(yaml@2.9.0))
+      acorn: 8.16.0
+      acorn-loose: 8.5.2
+      acorn-typescript: 1.4.13(acorn@8.16.0)
+      astring: 1.9.0
+      magicast: 0.2.11
+      recast: 0.23.11
+      vinxi: 0.5.11(@types/node@24.13.3)(@vercel/blob@2.4.0)(aws4fetch@1.0.20)(db0@0.3.4)(debug@4.4.3(supports-color@10.2.2))(ioredis@5.10.1(supports-color@10.2.2))(jiti@2.7.0)(lightningcss@1.33.0)(rolldown@1.2.2)(supports-color@10.2.2)(terser@5.49.0)(tsx@4.21.0)(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))(yaml@2.9.0)
 
   '@vitejs/plugin-react@6.0.4(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
@@ -15732,7 +16200,7 @@ snapshots:
     optionalDependencies:
       react-server-dom-webpack: 19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
 
-  '@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)(vitest@4.1.10(@edge-runtime/vm@3.2.0)(@types/node@24.13.3)(jsdom@29.1.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))':
+  '@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)(vitest@4.1.10(@edge-runtime/vm@3.2.0)(@types/node@24.13.3)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))':
     dependencies:
       '@typescript-eslint/scope-manager': 8.61.0
       '@typescript-eslint/utils': 8.61.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
@@ -15740,7 +16208,7 @@ snapshots:
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
       typescript: 6.0.3
-      vitest: 4.1.10(@edge-runtime/vm@3.2.0)(@types/node@24.13.3)(jsdom@29.1.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.10(@edge-runtime/vm@3.2.0)(@types/node@24.13.3)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -15961,6 +16429,10 @@ snapshots:
     dependencies:
       string-width: 4.2.3
 
+  ansi-escapes@7.3.0:
+    dependencies:
+      environment: 1.1.0
+
   ansi-regex@5.0.1: {}
 
   ansi-regex@6.2.2: {}
@@ -16138,13 +16610,17 @@ snapshots:
 
   async@3.2.6: {}
 
-  autoprefixer@10.4.27(postcss@8.5.25):
+  atomic-sleep@1.0.0: {}
+
+  auto-bind@5.0.1: {}
+
+  autoprefixer@10.4.27(postcss@8.5.22):
     dependencies:
       browserslist: 4.28.7
       caniuse-lite: 1.0.30001806
       fraction.js: 5.3.4
       picocolors: 1.1.1
-      postcss: 8.5.25
+      postcss: 8.5.22
       postcss-value-parser: 4.2.0
 
   available-typed-arrays@1.0.7:
@@ -16269,16 +16745,16 @@ snapshots:
       widest-line: 5.0.0
       wrap-ansi: 9.0.2
 
-  brace-expansion@1.1.18:
+  brace-expansion@1.1.12:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.1.4:
+  brace-expansion@2.1.1:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.9:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -16321,20 +16797,20 @@ snapshots:
 
   bytes@3.1.2: {}
 
-  c12@3.3.4(magicast@0.5.2):
+  c12@3.3.3(magicast@0.5.2):
     dependencies:
       chokidar: 5.0.0
       confbox: 0.2.4
-      defu: 6.1.7
+      defu: 6.1.4
       dotenv: 17.4.2
       exsolve: 1.1.0
-      giget: 3.3.1
+      giget: 2.0.0
       jiti: 2.7.0
       ohash: 2.0.11
       pathe: 2.0.3
       perfect-debounce: 2.1.0
       pkg-types: 2.3.1
-      rc9: 3.0.1
+      rc9: 2.1.2
     optionalDependencies:
       magicast: 0.5.2
 
@@ -16421,9 +16897,13 @@ snapshots:
     dependencies:
       consola: 3.4.2
 
-  citty@0.2.2: {}
+  citty@0.2.1: {}
 
   cli-boxes@3.0.0: {}
+
+  cli-cursor@4.0.0:
+    dependencies:
+      restore-cursor: 4.0.0
 
   cli-cursor@5.0.0:
     dependencies:
@@ -16436,6 +16916,11 @@ snapshots:
       string-width: 4.2.3
     optionalDependencies:
       '@colors/colors': 1.5.0
+
+  cli-truncate@4.0.0:
+    dependencies:
+      slice-ansi: 5.0.0
+      string-width: 7.2.0
 
   cli-width@4.1.0: {}
 
@@ -16455,6 +16940,10 @@ snapshots:
 
   cluster-key-slot@1.1.2: {}
 
+  code-excerpt@4.0.0:
+    dependencies:
+      convert-to-spaces: 2.0.1
+
   collapse-white-space@2.1.0: {}
 
   color-convert@2.0.1:
@@ -16470,6 +16959,8 @@ snapshots:
   commander@10.0.1: {}
 
   commander@11.1.0: {}
+
+  commander@12.1.0: {}
 
   commander@14.0.3: {}
 
@@ -16548,6 +17039,8 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  convert-to-spaces@2.0.1: {}
+
   cookie-es@1.2.3: {}
 
   cookie-es@2.0.0: {}
@@ -16584,10 +17077,6 @@ snapshots:
   crossws@0.3.5:
     dependencies:
       uncrypto: 0.1.3
-
-  crossws@0.4.10(srvx@0.12.4):
-    optionalDependencies:
-      srvx: 0.12.4
 
   cspell-config-lib@10.0.1:
     dependencies:
@@ -16649,9 +17138,14 @@ snapshots:
     dependencies:
       '@cspell/cspell-types': 10.0.1
 
+  css-declaration-sorter@7.3.1(postcss@8.5.22):
+    dependencies:
+      postcss: 8.5.22
+
   css-declaration-sorter@7.3.1(postcss@8.5.25):
     dependencies:
       postcss: 8.5.25
+    optional: true
 
   css-select@5.2.2:
     dependencies:
@@ -16676,6 +17170,40 @@ snapshots:
   css.escape@1.5.1: {}
 
   cssesc@3.0.0: {}
+
+  cssnano-preset-default@7.0.11(postcss@8.5.22):
+    dependencies:
+      browserslist: 4.28.7
+      css-declaration-sorter: 7.3.1(postcss@8.5.22)
+      cssnano-utils: 5.0.1(postcss@8.5.22)
+      postcss: 8.5.22
+      postcss-calc: 10.1.1(postcss@8.5.22)
+      postcss-colormin: 7.0.6(postcss@8.5.22)
+      postcss-convert-values: 7.0.9(postcss@8.5.22)
+      postcss-discard-comments: 7.0.6(postcss@8.5.22)
+      postcss-discard-duplicates: 7.0.2(postcss@8.5.22)
+      postcss-discard-empty: 7.0.1(postcss@8.5.22)
+      postcss-discard-overridden: 7.0.1(postcss@8.5.22)
+      postcss-merge-longhand: 7.0.5(postcss@8.5.22)
+      postcss-merge-rules: 7.0.8(postcss@8.5.22)
+      postcss-minify-font-values: 7.0.1(postcss@8.5.22)
+      postcss-minify-gradients: 7.0.1(postcss@8.5.22)
+      postcss-minify-params: 7.0.6(postcss@8.5.22)
+      postcss-minify-selectors: 7.0.6(postcss@8.5.22)
+      postcss-normalize-charset: 7.0.1(postcss@8.5.22)
+      postcss-normalize-display-values: 7.0.1(postcss@8.5.22)
+      postcss-normalize-positions: 7.0.1(postcss@8.5.22)
+      postcss-normalize-repeat-style: 7.0.1(postcss@8.5.22)
+      postcss-normalize-string: 7.0.1(postcss@8.5.22)
+      postcss-normalize-timing-functions: 7.0.1(postcss@8.5.22)
+      postcss-normalize-unicode: 7.0.6(postcss@8.5.22)
+      postcss-normalize-url: 7.0.1(postcss@8.5.22)
+      postcss-normalize-whitespace: 7.0.1(postcss@8.5.22)
+      postcss-ordered-values: 7.0.2(postcss@8.5.22)
+      postcss-reduce-initial: 7.0.6(postcss@8.5.22)
+      postcss-reduce-transforms: 7.0.1(postcss@8.5.22)
+      postcss-svgo: 7.1.1(postcss@8.5.22)
+      postcss-unique-selectors: 7.0.5(postcss@8.5.22)
 
   cssnano-preset-default@7.0.11(postcss@8.5.25):
     dependencies:
@@ -16710,16 +17238,29 @@ snapshots:
       postcss-reduce-transforms: 7.0.1(postcss@8.5.25)
       postcss-svgo: 7.1.1(postcss@8.5.25)
       postcss-unique-selectors: 7.0.5(postcss@8.5.25)
+    optional: true
+
+  cssnano-utils@5.0.1(postcss@8.5.22):
+    dependencies:
+      postcss: 8.5.22
 
   cssnano-utils@5.0.1(postcss@8.5.25):
     dependencies:
       postcss: 8.5.25
+    optional: true
+
+  cssnano@7.1.3(postcss@8.5.22):
+    dependencies:
+      cssnano-preset-default: 7.0.11(postcss@8.5.22)
+      lilconfig: 3.1.3
+      postcss: 8.5.22
 
   cssnano@7.1.3(postcss@8.5.25):
     dependencies:
       cssnano-preset-default: 7.0.11(postcss@8.5.25)
       lilconfig: 3.1.3
       postcss: 8.5.25
+    optional: true
 
   csso@5.0.5:
     dependencies:
@@ -16729,10 +17270,10 @@ snapshots:
 
   damerau-levenshtein@1.0.8: {}
 
-  data-urls@7.0.0:
+  data-urls@7.0.0(@noble/hashes@2.2.0):
     dependencies:
       whatwg-mimetype: 5.0.0
-      whatwg-url: 16.0.1
+      whatwg-url: 16.0.1(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - '@noble/hashes'
 
@@ -16810,7 +17351,7 @@ snapshots:
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
 
-  defu@6.1.7: {}
+  defu@6.1.4: {}
 
   denque@2.1.0: {}
 
@@ -16860,6 +17401,8 @@ snapshots:
     dependencies:
       type-fest: 5.5.0
 
+  dotenv@16.6.1: {}
+
   dotenv@17.4.2: {}
 
   dunder-proto@1.0.1:
@@ -16904,6 +17447,8 @@ snapshots:
   env-paths@4.0.0:
     dependencies:
       is-safe-filename: 0.1.1
+
+  environment@1.1.0: {}
 
   err-code@2.0.3: {}
 
@@ -17005,6 +17550,8 @@ snapshots:
       is-date-object: 1.1.0
       is-symbol: 1.1.1
 
+  es-toolkit@1.50.0: {}
+
   esast-util-from-estree@2.0.0:
     dependencies:
       '@types/estree-jsx': 1.0.5
@@ -17048,6 +17595,35 @@ snapshots:
       '@esbuild/win32-ia32': 0.25.12
       '@esbuild/win32-x64': 0.25.12
 
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
+
   esbuild@0.28.1:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.28.1
@@ -17081,6 +17657,8 @@ snapshots:
 
   escape-html@1.0.3: {}
 
+  escape-string-regexp@2.0.0: {}
+
   escape-string-regexp@4.0.0: {}
 
   escape-string-regexp@5.0.0: {}
@@ -17094,14 +17672,14 @@ snapshots:
     dependencies:
       eslint: 10.8.0(jiti@2.7.0)(supports-color@10.2.2)
 
-  eslint-config-setup@0.5.2(@types/estree@1.0.9)(@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(@typescript-eslint/utils@8.65.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(oxlint@1.76.0)(storybook@10.5.3(@types/react@19.2.18)(prettier@3.9.4)(react@19.2.8))(supports-color@10.2.2)(typescript@6.0.3)(vitest@4.1.10(@edge-runtime/vm@3.2.0)(@types/node@24.13.3)(jsdom@29.1.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))):
+  eslint-config-setup@0.5.2(@types/estree@1.0.9)(@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(@typescript-eslint/utils@8.65.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(oxlint@1.76.0)(storybook@10.5.3(@types/react@19.2.18)(prettier@3.9.4)(react@19.2.8))(supports-color@10.2.2)(typescript@6.0.3)(vitest@4.1.10(@edge-runtime/vm@3.2.0)(@types/node@24.13.3)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))):
     dependencies:
       '@cspell/eslint-plugin': 10.0.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))
       '@eslint-react/eslint-plugin': 5.17.3(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
       '@eslint/js': 10.0.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))
       '@eslint/json': 2.0.1
       '@stylistic/eslint-plugin': 5.10.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))
-      '@vitest/eslint-plugin': 1.6.23(@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)(vitest@4.1.10(@edge-runtime/vm@3.2.0)(@types/node@24.13.3)(jsdom@29.1.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))
+      '@vitest/eslint-plugin': 1.6.23(@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)(vitest@4.1.10(@edge-runtime/vm@3.2.0)(@types/node@24.13.3)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))
       eslint: 10.8.0(jiti@2.7.0)(supports-color@10.2.2)
       eslint-config-prettier: 10.1.8(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))
       eslint-plugin-compat: 7.0.2(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))
@@ -17785,6 +18363,8 @@ snapshots:
 
   fetchdts@0.1.7: {}
 
+  fflate@0.8.3: {}
+
   figures@6.1.0:
     dependencies:
       is-unicode-supported: 2.1.0
@@ -17830,13 +18410,15 @@ snapshots:
 
   flatted@3.4.3: {}
 
-  follow-redirects@1.16.0(debug@4.4.3(supports-color@10.2.2)):
+  follow-redirects@1.15.11(debug@4.4.3(supports-color@10.2.2)):
     optionalDependencies:
       debug: 4.4.3(supports-color@10.2.2)
 
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
+
+  foreach@2.0.6: {}
 
   foreground-child@3.3.1:
     dependencies:
@@ -17875,6 +18457,12 @@ snapshots:
   functional-red-black-tree@1.0.1: {}
 
   functions-have-names@1.2.3: {}
+
+  generaltranslation@9.1.0:
+    dependencies:
+      '@generaltranslation/format': 0.1.4
+      '@generaltranslation/icu': 0.1.1
+      '@noble/hashes': 2.2.0
 
   generator-function@2.0.1: {}
 
@@ -17925,7 +18513,14 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
-  giget@3.3.1: {}
+  giget@2.0.0:
+    dependencies:
+      citty: 0.1.6
+      consola: 3.4.2
+      defu: 6.1.4
+      node-fetch-native: 1.6.7
+      nypm: 0.6.5
+      pathe: 2.0.3
 
   git-hooks-list@4.2.1: {}
 
@@ -17993,6 +18588,99 @@ snapshots:
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
 
+  gt-i18n@1.0.10:
+    dependencies:
+      '@generaltranslation/format': 0.1.4
+      generaltranslation: 9.1.0
+
+  gt-react@11.1.4(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+    dependencies:
+      '@generaltranslation/react-core': 11.1.4(react@19.2.8)
+      generaltranslation: 9.1.0
+      gt-i18n: 1.0.10
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+
+  gt-remark@1.0.11(supports-color@10.2.2):
+    dependencies:
+      mdast-util-find-and-replace: 3.0.2
+      mdast-util-gfm-footnote: 2.1.0(supports-color@10.2.2)
+      mdast-util-gfm-strikethrough: 2.0.0(supports-color@10.2.2)
+      mdast-util-gfm-table: 2.0.0(supports-color@10.2.2)
+      mdast-util-gfm-task-list-item: 2.0.0(supports-color@10.2.2)
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-gfm-task-list-item: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
+  gt@2.16.0(@babel/core@7.29.7(supports-color@10.2.2))(@types/react@19.2.18)(supports-color@10.2.2):
+    dependencies:
+      '@babel/generator': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/plugin-transform-react-jsx': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/traverse': 7.29.7(supports-color@10.2.2)
+      '@babel/types': 7.29.7
+      '@clack/prompts': 1.0.0-alpha.6
+      '@generaltranslation/format': 0.1.4
+      '@generaltranslation/icu': 0.1.1
+      '@generaltranslation/python-extractor': 0.2.33
+      '@generaltranslation/supported-locales': 2.1.13
+      chalk: 5.6.2
+      commander: 12.1.0
+      dotenv: 16.6.1
+      enhanced-resolve: 5.24.3
+      esbuild: 0.27.7
+      fast-glob: 3.3.3
+      fast-json-stable-stringify: 2.1.0
+      fflate: 0.8.3
+      generaltranslation: 9.1.0
+      gt-remark: 1.0.11(supports-color@10.2.2)
+      html-entities: 2.6.0
+      ink: 5.2.1(@types/react@19.2.18)(react@18.3.1)
+      json-pointer: 0.6.2
+      jsonpath-plus: 10.4.0
+      jsonpointer: 5.0.1
+      mdast-util-find-and-replace: 3.0.2
+      micromatch: 4.0.8
+      open: 10.2.0
+      pino: 10.3.1
+      react: 18.3.1
+      remark-frontmatter: 5.0.0(supports-color@10.2.2)
+      remark-mdx: 3.1.1(supports-color@10.2.2)
+      remark-parse: 11.0.0(supports-color@10.2.2)
+      remark-stringify: 11.0.0
+      resolve: 1.22.11
+      semver: 7.8.5
+      smol-toml: 1.7.1
+      tsconfig-paths: 4.2.0
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+      yaml: 2.9.0
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@types/react'
+      - bufferutil
+      - react-devtools-core
+      - supports-color
+      - tree-sitter
+      - utf-8-validate
+
+  gtx-cli@2.16.0(@babel/core@7.29.7(supports-color@10.2.2))(@types/react@19.2.18)(supports-color@10.2.2):
+    dependencies:
+      commander: 12.1.0
+      dotenv: 16.6.1
+      gt: 2.16.0(@babel/core@7.29.7(supports-color@10.2.2))(@types/react@19.2.18)(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@types/react'
+      - bufferutil
+      - react-devtools-core
+      - supports-color
+      - tree-sitter
+      - utf-8-validate
+
   gzip-size@7.0.0:
     dependencies:
       duplexer: 0.1.2
@@ -18001,7 +18689,7 @@ snapshots:
     dependencies:
       cookie-es: 1.2.3
       crossws: 0.3.5
-      defu: 6.1.7
+      defu: 6.1.4
       destr: 2.0.5
       iron-webcrypto: 1.2.1
       node-mock-http: 1.0.4
@@ -18009,24 +18697,10 @@ snapshots:
       ufo: 1.6.4
       uncrypto: 0.1.3
 
-  h3@1.15.11:
-    dependencies:
-      cookie-es: 1.2.3
-      crossws: 0.3.5
-      defu: 6.1.7
-      destr: 2.0.5
-      iron-webcrypto: 1.2.1
-      node-mock-http: 1.0.4
-      radix3: 1.1.2
-      ufo: 1.6.4
-      uncrypto: 0.1.3
-
-  h3@2.0.1-rc.20(crossws@0.4.10(srvx@0.12.4)):
+  h3@2.0.1-rc.20:
     dependencies:
       rou3: 0.8.1
       srvx: 0.11.22
-    optionalDependencies:
-      crossws: 0.4.10(srvx@0.12.4)
 
   has-bigints@1.1.0: {}
 
@@ -18119,7 +18793,7 @@ snapshots:
     dependencies:
       hermes-estree: 0.25.1
 
-  hono@4.12.34: {}
+  hono@4.13.0: {}
 
   hookable@5.5.3: {}
 
@@ -18131,9 +18805,9 @@ snapshots:
     dependencies:
       lru-cache: 11.5.1
 
-  html-encoding-sniffer@6.0.0:
+  html-encoding-sniffer@6.0.0(@noble/hashes@2.2.0):
     dependencies:
-      '@exodus/bytes': 1.15.1
+      '@exodus/bytes': 1.15.1(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - '@noble/hashes'
 
@@ -18162,7 +18836,7 @@ snapshots:
   http-proxy@1.18.1(debug@4.4.3(supports-color@10.2.2)):
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.16.0(debug@4.4.3(supports-color@10.2.2))
+      follow-redirects: 1.15.11(debug@4.4.3(supports-color@10.2.2))
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
@@ -18176,7 +18850,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  httpxy@0.5.5: {}
+  httpxy@0.3.1: {}
 
   human-signals@5.0.0: {}
 
@@ -18254,6 +18928,39 @@ snapshots:
   ini@4.1.3: {}
 
   ini@6.0.0: {}
+
+  ink@5.2.1(@types/react@19.2.18)(react@18.3.1):
+    dependencies:
+      '@alcalzone/ansi-tokenize': 0.1.3
+      ansi-escapes: 7.3.0
+      ansi-styles: 6.2.3
+      auto-bind: 5.0.1
+      chalk: 5.6.2
+      cli-boxes: 3.0.0
+      cli-cursor: 4.0.0
+      cli-truncate: 4.0.0
+      code-excerpt: 4.0.0
+      es-toolkit: 1.50.0
+      indent-string: 5.0.0
+      is-in-ci: 1.0.0
+      patch-console: 2.0.0
+      react: 18.3.1
+      react-reconciler: 0.29.2(react@18.3.1)
+      scheduler: 0.23.2
+      signal-exit: 3.0.7
+      slice-ansi: 7.1.2
+      stack-utils: 2.0.6
+      string-width: 7.2.0
+      type-fest: 4.41.0
+      widest-line: 5.0.0
+      wrap-ansi: 9.0.2
+      ws: 8.21.1
+      yoga-layout: 3.2.1
+    optionalDependencies:
+      '@types/react': 19.2.18
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   inline-style-parser@0.2.7: {}
 
@@ -18364,6 +19071,12 @@ snapshots:
 
   is-fullwidth-code-point@3.0.0: {}
 
+  is-fullwidth-code-point@4.0.0: {}
+
+  is-fullwidth-code-point@5.1.0:
+    dependencies:
+      get-east-asian-width: 1.6.0
+
   is-generator-function@1.1.2:
     dependencies:
       call-bound: 1.0.4
@@ -18382,6 +19095,8 @@ snapshots:
     dependencies:
       identifier-regex: 1.1.0
       super-regex: 1.1.0
+
+  is-in-ci@1.0.0: {}
 
   is-in-ssh@1.0.0: {}
 
@@ -18551,17 +19266,17 @@ snapshots:
 
   jsdoc-type-pratt-parser@7.2.0: {}
 
-  jsdom@29.1.1:
+  jsdom@29.1.1(@noble/hashes@2.2.0):
     dependencies:
       '@asamuzakjp/css-color': 5.1.11
       '@asamuzakjp/dom-selector': 7.1.1
       '@bramus/specificity': 2.4.2
       '@csstools/css-syntax-patches-for-csstree': 1.1.6(css-tree@3.2.1)
-      '@exodus/bytes': 1.15.1
+      '@exodus/bytes': 1.15.1(@noble/hashes@2.2.0)
       css-tree: 3.2.1
-      data-urls: 7.0.0
+      data-urls: 7.0.0(@noble/hashes@2.2.0)
       decimal.js: 10.6.0
-      html-encoding-sniffer: 6.0.0
+      html-encoding-sniffer: 6.0.0(@noble/hashes@2.2.0)
       is-potential-custom-element-name: 1.0.1
       lru-cache: 11.5.1
       parse5: 8.0.1
@@ -18572,10 +19287,12 @@ snapshots:
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
-      whatwg-url: 16.0.1
+      whatwg-url: 16.0.1(@noble/hashes@2.2.0)
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - '@noble/hashes'
+
+  jsep@1.4.0: {}
 
   jsesc@3.1.0: {}
 
@@ -18584,6 +19301,10 @@ snapshots:
   json-parse-even-better-errors@2.3.1: {}
 
   json-parse-even-better-errors@3.0.2: {}
+
+  json-pointer@0.6.2:
+    dependencies:
+      foreach: 2.0.6
 
   json-schema-traverse@0.4.1: {}
 
@@ -18600,6 +19321,14 @@ snapshots:
       semver: 7.8.5
 
   jsonc-parser@3.3.1: {}
+
+  jsonpath-plus@10.4.0:
+    dependencies:
+      '@jsep-plugin/assignment': 1.3.0(jsep@1.4.0)
+      '@jsep-plugin/regex': 1.0.4(jsep@1.4.0)
+      jsep: 1.4.0
+
+  jsonpointer@5.0.1: {}
 
   jsx-ast-utils-x@0.1.0: {}
 
@@ -18745,28 +19474,26 @@ snapshots:
     dependencies:
       uc.micro: 2.1.0
 
-  listhen@1.10.1(@parcel/watcher@2.5.6)(srvx@0.12.4):
+  listhen@1.9.0:
     dependencies:
+      '@parcel/watcher': 2.5.6
       '@parcel/watcher-wasm': 2.5.6
-      citty: 0.2.2
+      citty: 0.1.6
+      clipboardy: 4.0.0
       consola: 3.4.2
-      crossws: 0.4.10(srvx@0.12.4)
-      defu: 6.1.7
+      crossws: 0.3.5
+      defu: 6.1.4
       get-port-please: 3.2.0
-      h3: 1.15.11
+      h3: 1.15.10
       http-shutdown: 1.2.2
       jiti: 2.7.0
+      mlly: 1.8.2
       node-forge: 1.4.0
-      pathe: 2.0.3
-      std-env: 4.2.0
-      tinyclip: 0.1.15
+      pathe: 1.1.2
+      std-env: 3.10.0
       ufo: 1.6.4
-      untun: 0.2.2
-      uqr: 0.1.3
-    optionalDependencies:
-      '@parcel/watcher': 2.5.6
-    transitivePeerDependencies:
-      - srvx
+      untun: 0.1.3
+      uqr: 0.1.2
 
   load-plugin@6.0.3:
     dependencies:
@@ -18779,7 +19506,7 @@ snapshots:
 
   local-access@1.1.0: {}
 
-  local-pkg@1.2.1:
+  local-pkg@1.1.2:
     dependencies:
       mlly: 1.8.2
       pkg-types: 2.3.1
@@ -18807,6 +19534,10 @@ snapshots:
       yoctocolors: 2.1.2
 
   longest-streak@3.1.0: {}
+
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
 
   loupe@3.2.1: {}
 
@@ -19363,6 +20094,8 @@ snapshots:
 
   mime@4.1.0: {}
 
+  mimic-fn@2.1.0: {}
+
   mimic-fn@4.0.0: {}
 
   mimic-function@5.0.1: {}
@@ -19371,19 +20104,21 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.9
+      brace-expansion: 5.0.8
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.18
+      brace-expansion: 1.1.12
 
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 2.1.4
+      brace-expansion: 2.1.1
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.4
+      brace-expansion: 2.1.1
+
+  minimist@1.2.8: {}
 
   minipass@7.1.3: {}
 
@@ -19395,17 +20130,17 @@ snapshots:
 
   mkdist@2.4.1(typescript@6.0.3):
     dependencies:
-      autoprefixer: 10.4.27(postcss@8.5.25)
+      autoprefixer: 10.4.27(postcss@8.5.22)
       citty: 0.1.6
-      cssnano: 7.1.3(postcss@8.5.25)
-      defu: 6.1.7
+      cssnano: 7.1.3(postcss@8.5.22)
+      defu: 6.1.4
       esbuild: 0.25.12
       jiti: 1.21.7
       mlly: 1.8.1
       pathe: 2.0.3
       pkg-types: 2.3.1
-      postcss: 8.5.25
-      postcss-nested: 7.0.2(postcss@8.5.25)
+      postcss: 8.5.22
+      postcss-nested: 7.0.2(postcss@8.5.22)
       semver: 7.8.5
       tinyglobby: 0.2.17
     optionalDependencies:
@@ -19488,21 +20223,21 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  nitropack@2.13.4(@parcel/watcher@2.5.6)(@vercel/blob@2.4.0)(aws4fetch@1.0.20)(oxc-parser@0.127.0)(rolldown@1.2.2)(srvx@0.12.4)(supports-color@10.2.2)(vite@6.4.3(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25)):
+  nitropack@2.13.2(@vercel/blob@2.4.0)(aws4fetch@1.0.20)(rolldown@1.2.2)(supports-color@10.2.2)(vite@6.4.3(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.27.7)(lightningcss@1.33.0)(postcss@8.5.25)):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.2
-      '@rollup/plugin-alias': 6.0.0(rollup@4.62.4)
-      '@rollup/plugin-commonjs': 29.0.2(rollup@4.62.4)
-      '@rollup/plugin-inject': 5.0.5(rollup@4.62.4)
-      '@rollup/plugin-json': 6.1.0(rollup@4.62.4)
-      '@rollup/plugin-node-resolve': 16.0.3(rollup@4.62.4)
-      '@rollup/plugin-replace': 6.0.3(rollup@4.62.4)
-      '@rollup/plugin-terser': 1.0.0(rollup@4.62.4)
-      '@vercel/nft': 1.5.0(rollup@4.62.4)(supports-color@10.2.2)
+      '@rollup/plugin-alias': 6.0.0(rollup@4.59.0)
+      '@rollup/plugin-commonjs': 29.0.2(rollup@4.59.0)
+      '@rollup/plugin-inject': 5.0.5(rollup@4.59.0)
+      '@rollup/plugin-json': 6.1.0(rollup@4.59.0)
+      '@rollup/plugin-node-resolve': 16.0.3(rollup@4.59.0)
+      '@rollup/plugin-replace': 6.0.3(rollup@4.59.0)
+      '@rollup/plugin-terser': 1.0.0(rollup@4.59.0)
+      '@vercel/nft': 1.5.0(rollup@4.59.0)(supports-color@10.2.2)
       archiver: 7.0.1
-      c12: 3.3.4(magicast@0.5.2)
+      c12: 3.3.3(magicast@0.5.2)
       chokidar: 5.0.0
-      citty: 0.2.2
+      citty: 0.2.1
       compatx: 0.2.0
       confbox: 0.2.4
       consola: 3.4.2
@@ -19510,23 +20245,23 @@ snapshots:
       croner: 10.0.1
       crossws: 0.3.5
       db0: 0.3.4
-      defu: 6.1.7
+      defu: 6.1.4
       destr: 2.0.5
       dot-prop: 10.1.0
-      esbuild: 0.28.1
+      esbuild: 0.27.7
       escape-string-regexp: 5.0.0
       etag: 1.8.1
       exsolve: 1.0.8
       globby: 16.2.0
       gzip-size: 7.0.0
-      h3: 1.15.11
+      h3: 1.15.10
       hookable: 5.5.3
-      httpxy: 0.5.5
+      httpxy: 0.3.1
       ioredis: 5.10.1(supports-color@10.2.2)
       jiti: 2.7.0
       klona: 2.0.6
       knitwork: 1.3.0
-      listhen: 1.10.1(@parcel/watcher@2.5.6)(srvx@0.12.4)
+      listhen: 1.9.0
       magic-string: 0.30.21
       magicast: 0.5.2
       mime: 4.1.0
@@ -19540,20 +20275,20 @@ snapshots:
       pkg-types: 2.3.1
       pretty-bytes: 7.1.0
       radix3: 1.1.2
-      rollup: 4.62.4
-      rollup-plugin-visualizer: 7.0.1(rolldown@1.2.2)(rollup@4.62.4)
+      rollup: 4.59.0
+      rollup-plugin-visualizer: 7.0.1(rolldown@1.2.2)(rollup@4.59.0)
       scule: 1.3.0
       semver: 7.8.5
       serve-placeholder: 2.0.2
       serve-static: 2.2.1(supports-color@10.2.2)
       source-map: 0.7.6
-      std-env: 4.2.0
-      ufo: 1.6.4
+      std-env: 4.0.0
+      ufo: 1.6.3
       ultrahtml: 1.6.0
       uncrypto: 0.1.3
       unctx: 2.5.0
       unenv: 2.0.0-rc.24
-      unimport: 6.4.0(esbuild@0.28.1)(oxc-parser@0.127.0)(rolldown@1.2.2)(rollup@4.62.4)(vite@6.4.3(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
+      unimport: 6.0.2(esbuild@0.27.7)(rolldown@1.2.2)(rollup@4.59.0)(vite@6.4.3(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.27.7)(lightningcss@1.33.0)(postcss@8.5.25))
       unplugin-utils: 0.3.1
       unstorage: 1.17.5(@vercel/blob@2.4.0)(aws4fetch@1.0.20)(db0@0.3.4)(ioredis@5.10.1(supports-color@10.2.2))
       untyped: 2.0.0
@@ -19573,7 +20308,6 @@ snapshots:
       - '@farmfe/core'
       - '@libsql/client'
       - '@netlify/blobs'
-      - '@parcel/watcher'
       - '@planetscale/database'
       - '@rspack/core'
       - '@upstash/redis'
@@ -19589,11 +20323,118 @@ snapshots:
       - encoding
       - idb-keyval
       - mysql2
-      - oxc-parser
       - react-native-b4a
       - rolldown
       - sqlite3
-      - srvx
+      - supports-color
+      - unloader
+      - uploadthing
+      - vite
+      - webpack
+
+  nitropack@2.13.2(@vercel/blob@2.4.0)(aws4fetch@1.0.20)(rolldown@1.2.2)(supports-color@10.2.2)(vite@6.4.3(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25)):
+    dependencies:
+      '@cloudflare/kv-asset-handler': 0.4.2
+      '@rollup/plugin-alias': 6.0.0(rollup@4.59.0)
+      '@rollup/plugin-commonjs': 29.0.2(rollup@4.59.0)
+      '@rollup/plugin-inject': 5.0.5(rollup@4.59.0)
+      '@rollup/plugin-json': 6.1.0(rollup@4.59.0)
+      '@rollup/plugin-node-resolve': 16.0.3(rollup@4.59.0)
+      '@rollup/plugin-replace': 6.0.3(rollup@4.59.0)
+      '@rollup/plugin-terser': 1.0.0(rollup@4.59.0)
+      '@vercel/nft': 1.5.0(rollup@4.59.0)(supports-color@10.2.2)
+      archiver: 7.0.1
+      c12: 3.3.3(magicast@0.5.2)
+      chokidar: 5.0.0
+      citty: 0.2.1
+      compatx: 0.2.0
+      confbox: 0.2.4
+      consola: 3.4.2
+      cookie-es: 2.0.1
+      croner: 10.0.1
+      crossws: 0.3.5
+      db0: 0.3.4
+      defu: 6.1.4
+      destr: 2.0.5
+      dot-prop: 10.1.0
+      esbuild: 0.27.7
+      escape-string-regexp: 5.0.0
+      etag: 1.8.1
+      exsolve: 1.0.8
+      globby: 16.2.0
+      gzip-size: 7.0.0
+      h3: 1.15.10
+      hookable: 5.5.3
+      httpxy: 0.3.1
+      ioredis: 5.10.1(supports-color@10.2.2)
+      jiti: 2.7.0
+      klona: 2.0.6
+      knitwork: 1.3.0
+      listhen: 1.9.0
+      magic-string: 0.30.21
+      magicast: 0.5.2
+      mime: 4.1.0
+      mlly: 1.8.2
+      node-fetch-native: 1.6.7
+      node-mock-http: 1.0.4
+      ofetch: 1.5.1
+      ohash: 2.0.11
+      pathe: 2.0.3
+      perfect-debounce: 2.1.0
+      pkg-types: 2.3.1
+      pretty-bytes: 7.1.0
+      radix3: 1.1.2
+      rollup: 4.59.0
+      rollup-plugin-visualizer: 7.0.1(rolldown@1.2.2)(rollup@4.59.0)
+      scule: 1.3.0
+      semver: 7.8.5
+      serve-placeholder: 2.0.2
+      serve-static: 2.2.1(supports-color@10.2.2)
+      source-map: 0.7.6
+      std-env: 4.0.0
+      ufo: 1.6.3
+      ultrahtml: 1.6.0
+      uncrypto: 0.1.3
+      unctx: 2.5.0
+      unenv: 2.0.0-rc.24
+      unimport: 6.0.2(esbuild@0.27.7)(rolldown@1.2.2)(rollup@4.59.0)(vite@6.4.3(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
+      unplugin-utils: 0.3.1
+      unstorage: 1.17.5(@vercel/blob@2.4.0)(aws4fetch@1.0.20)(db0@0.3.4)(ioredis@5.10.1(supports-color@10.2.2))
+      untyped: 2.0.0
+      unwasm: 0.5.3
+      youch: 4.1.1
+      youch-core: 0.3.3
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@electric-sql/pglite'
+      - '@farmfe/core'
+      - '@libsql/client'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@rspack/core'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bare-abort-controller
+      - bare-buffer
+      - better-sqlite3
+      - bun-types-no-globals
+      - drizzle-orm
+      - encoding
+      - idb-keyval
+      - mysql2
+      - react-native-b4a
+      - rolldown
+      - sqlite3
       - supports-color
       - unloader
       - uploadthing
@@ -19601,6 +20442,8 @@ snapshots:
       - webpack
 
   node-addon-api@7.1.1: {}
+
+  node-addon-api@8.9.0: {}
 
   node-fetch-native@1.6.7: {}
 
@@ -19680,6 +20523,12 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
+  nypm@0.6.5:
+    dependencies:
+      citty: 0.2.1
+      pathe: 2.0.3
+      tinyexec: 1.2.4
+
   object-deep-merge@2.0.1: {}
 
   object-inspect@1.13.4: {}
@@ -19721,6 +20570,8 @@ snapshots:
 
   ohash@2.0.11: {}
 
+  on-exit-leak-free@2.1.2: {}
+
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
@@ -19730,6 +20581,10 @@ snapshots:
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
+
+  onetime@5.1.2:
+    dependencies:
+      mimic-fn: 2.1.0
 
   onetime@6.0.0:
     dependencies:
@@ -20057,6 +20912,8 @@ snapshots:
 
   parseurl@1.3.3: {}
 
+  patch-console@2.0.0: {}
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
@@ -20093,6 +20950,26 @@ snapshots:
 
   picomatch@4.0.5: {}
 
+  pino-abstract-transport@3.0.0:
+    dependencies:
+      split2: 4.2.0
+
+  pino-std-serializers@7.1.0: {}
+
+  pino@10.3.1:
+    dependencies:
+      '@pinojs/redact': 0.4.0
+      atomic-sleep: 1.0.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 3.0.0
+      pino-std-serializers: 7.1.0
+      process-warning: 5.0.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.5.0
+      sonic-boom: 4.2.1
+      thread-stream: 4.2.0
+
   pkg-types@1.3.1:
     dependencies:
       confbox: 0.1.8
@@ -20125,10 +21002,25 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
+  postcss-calc@10.1.1(postcss@8.5.22):
+    dependencies:
+      postcss: 8.5.22
+      postcss-selector-parser: 7.1.1
+      postcss-value-parser: 4.2.0
+
   postcss-calc@10.1.1(postcss@8.5.25):
     dependencies:
       postcss: 8.5.25
       postcss-selector-parser: 7.1.1
+      postcss-value-parser: 4.2.0
+    optional: true
+
+  postcss-colormin@7.0.6(postcss@8.5.22):
+    dependencies:
+      browserslist: 4.28.7
+      caniuse-api: 3.0.0
+      colord: 2.9.3
+      postcss: 8.5.22
       postcss-value-parser: 4.2.0
 
   postcss-colormin@7.0.6(postcss@8.5.25):
@@ -20138,35 +21030,79 @@ snapshots:
       colord: 2.9.3
       postcss: 8.5.25
       postcss-value-parser: 4.2.0
+    optional: true
+
+  postcss-convert-values@7.0.9(postcss@8.5.22):
+    dependencies:
+      browserslist: 4.28.7
+      postcss: 8.5.22
+      postcss-value-parser: 4.2.0
 
   postcss-convert-values@7.0.9(postcss@8.5.25):
     dependencies:
       browserslist: 4.28.7
       postcss: 8.5.25
       postcss-value-parser: 4.2.0
+    optional: true
+
+  postcss-discard-comments@7.0.6(postcss@8.5.22):
+    dependencies:
+      postcss: 8.5.22
+      postcss-selector-parser: 7.1.1
 
   postcss-discard-comments@7.0.6(postcss@8.5.25):
     dependencies:
       postcss: 8.5.25
       postcss-selector-parser: 7.1.1
+    optional: true
+
+  postcss-discard-duplicates@7.0.2(postcss@8.5.22):
+    dependencies:
+      postcss: 8.5.22
 
   postcss-discard-duplicates@7.0.2(postcss@8.5.25):
     dependencies:
       postcss: 8.5.25
+    optional: true
+
+  postcss-discard-empty@7.0.1(postcss@8.5.22):
+    dependencies:
+      postcss: 8.5.22
 
   postcss-discard-empty@7.0.1(postcss@8.5.25):
     dependencies:
       postcss: 8.5.25
+    optional: true
+
+  postcss-discard-overridden@7.0.1(postcss@8.5.22):
+    dependencies:
+      postcss: 8.5.22
 
   postcss-discard-overridden@7.0.1(postcss@8.5.25):
     dependencies:
       postcss: 8.5.25
+    optional: true
+
+  postcss-merge-longhand@7.0.5(postcss@8.5.22):
+    dependencies:
+      postcss: 8.5.22
+      postcss-value-parser: 4.2.0
+      stylehacks: 7.0.8(postcss@8.5.22)
 
   postcss-merge-longhand@7.0.5(postcss@8.5.25):
     dependencies:
       postcss: 8.5.25
       postcss-value-parser: 4.2.0
       stylehacks: 7.0.8(postcss@8.5.25)
+    optional: true
+
+  postcss-merge-rules@7.0.8(postcss@8.5.22):
+    dependencies:
+      browserslist: 4.28.7
+      caniuse-api: 3.0.0
+      cssnano-utils: 5.0.1(postcss@8.5.22)
+      postcss: 8.5.22
+      postcss-selector-parser: 7.1.1
 
   postcss-merge-rules@7.0.8(postcss@8.5.25):
     dependencies:
@@ -20175,10 +21111,24 @@ snapshots:
       cssnano-utils: 5.0.1(postcss@8.5.25)
       postcss: 8.5.25
       postcss-selector-parser: 7.1.1
+    optional: true
+
+  postcss-minify-font-values@7.0.1(postcss@8.5.22):
+    dependencies:
+      postcss: 8.5.22
+      postcss-value-parser: 4.2.0
 
   postcss-minify-font-values@7.0.1(postcss@8.5.25):
     dependencies:
       postcss: 8.5.25
+      postcss-value-parser: 4.2.0
+    optional: true
+
+  postcss-minify-gradients@7.0.1(postcss@8.5.22):
+    dependencies:
+      colord: 2.9.3
+      cssnano-utils: 5.0.1(postcss@8.5.22)
+      postcss: 8.5.22
       postcss-value-parser: 4.2.0
 
   postcss-minify-gradients@7.0.1(postcss@8.5.25):
@@ -20187,6 +21137,14 @@ snapshots:
       cssnano-utils: 5.0.1(postcss@8.5.25)
       postcss: 8.5.25
       postcss-value-parser: 4.2.0
+    optional: true
+
+  postcss-minify-params@7.0.6(postcss@8.5.22):
+    dependencies:
+      browserslist: 4.28.7
+      cssnano-utils: 5.0.1(postcss@8.5.22)
+      postcss: 8.5.22
+      postcss-value-parser: 4.2.0
 
   postcss-minify-params@7.0.6(postcss@8.5.25):
     dependencies:
@@ -20194,45 +21152,94 @@ snapshots:
       cssnano-utils: 5.0.1(postcss@8.5.25)
       postcss: 8.5.25
       postcss-value-parser: 4.2.0
+    optional: true
+
+  postcss-minify-selectors@7.0.6(postcss@8.5.22):
+    dependencies:
+      cssesc: 3.0.0
+      postcss: 8.5.22
+      postcss-selector-parser: 7.1.1
 
   postcss-minify-selectors@7.0.6(postcss@8.5.25):
     dependencies:
       cssesc: 3.0.0
       postcss: 8.5.25
       postcss-selector-parser: 7.1.1
+    optional: true
 
-  postcss-nested@7.0.2(postcss@8.5.25):
+  postcss-nested@7.0.2(postcss@8.5.22):
     dependencies:
-      postcss: 8.5.25
+      postcss: 8.5.22
       postcss-selector-parser: 7.1.1
+
+  postcss-normalize-charset@7.0.1(postcss@8.5.22):
+    dependencies:
+      postcss: 8.5.22
 
   postcss-normalize-charset@7.0.1(postcss@8.5.25):
     dependencies:
       postcss: 8.5.25
+    optional: true
+
+  postcss-normalize-display-values@7.0.1(postcss@8.5.22):
+    dependencies:
+      postcss: 8.5.22
+      postcss-value-parser: 4.2.0
 
   postcss-normalize-display-values@7.0.1(postcss@8.5.25):
     dependencies:
       postcss: 8.5.25
+      postcss-value-parser: 4.2.0
+    optional: true
+
+  postcss-normalize-positions@7.0.1(postcss@8.5.22):
+    dependencies:
+      postcss: 8.5.22
       postcss-value-parser: 4.2.0
 
   postcss-normalize-positions@7.0.1(postcss@8.5.25):
     dependencies:
       postcss: 8.5.25
       postcss-value-parser: 4.2.0
+    optional: true
+
+  postcss-normalize-repeat-style@7.0.1(postcss@8.5.22):
+    dependencies:
+      postcss: 8.5.22
+      postcss-value-parser: 4.2.0
 
   postcss-normalize-repeat-style@7.0.1(postcss@8.5.25):
     dependencies:
       postcss: 8.5.25
+      postcss-value-parser: 4.2.0
+    optional: true
+
+  postcss-normalize-string@7.0.1(postcss@8.5.22):
+    dependencies:
+      postcss: 8.5.22
       postcss-value-parser: 4.2.0
 
   postcss-normalize-string@7.0.1(postcss@8.5.25):
     dependencies:
       postcss: 8.5.25
       postcss-value-parser: 4.2.0
+    optional: true
+
+  postcss-normalize-timing-functions@7.0.1(postcss@8.5.22):
+    dependencies:
+      postcss: 8.5.22
+      postcss-value-parser: 4.2.0
 
   postcss-normalize-timing-functions@7.0.1(postcss@8.5.25):
     dependencies:
       postcss: 8.5.25
+      postcss-value-parser: 4.2.0
+    optional: true
+
+  postcss-normalize-unicode@7.0.6(postcss@8.5.22):
+    dependencies:
+      browserslist: 4.28.7
+      postcss: 8.5.22
       postcss-value-parser: 4.2.0
 
   postcss-normalize-unicode@7.0.6(postcss@8.5.25):
@@ -20240,15 +21247,34 @@ snapshots:
       browserslist: 4.28.7
       postcss: 8.5.25
       postcss-value-parser: 4.2.0
+    optional: true
+
+  postcss-normalize-url@7.0.1(postcss@8.5.22):
+    dependencies:
+      postcss: 8.5.22
+      postcss-value-parser: 4.2.0
 
   postcss-normalize-url@7.0.1(postcss@8.5.25):
     dependencies:
       postcss: 8.5.25
       postcss-value-parser: 4.2.0
+    optional: true
+
+  postcss-normalize-whitespace@7.0.1(postcss@8.5.22):
+    dependencies:
+      postcss: 8.5.22
+      postcss-value-parser: 4.2.0
 
   postcss-normalize-whitespace@7.0.1(postcss@8.5.25):
     dependencies:
       postcss: 8.5.25
+      postcss-value-parser: 4.2.0
+    optional: true
+
+  postcss-ordered-values@7.0.2(postcss@8.5.22):
+    dependencies:
+      cssnano-utils: 5.0.1(postcss@8.5.22)
+      postcss: 8.5.22
       postcss-value-parser: 4.2.0
 
   postcss-ordered-values@7.0.2(postcss@8.5.25):
@@ -20256,35 +21282,68 @@ snapshots:
       cssnano-utils: 5.0.1(postcss@8.5.25)
       postcss: 8.5.25
       postcss-value-parser: 4.2.0
+    optional: true
+
+  postcss-reduce-initial@7.0.6(postcss@8.5.22):
+    dependencies:
+      browserslist: 4.28.7
+      caniuse-api: 3.0.0
+      postcss: 8.5.22
 
   postcss-reduce-initial@7.0.6(postcss@8.5.25):
     dependencies:
       browserslist: 4.28.7
       caniuse-api: 3.0.0
       postcss: 8.5.25
+    optional: true
+
+  postcss-reduce-transforms@7.0.1(postcss@8.5.22):
+    dependencies:
+      postcss: 8.5.22
+      postcss-value-parser: 4.2.0
 
   postcss-reduce-transforms@7.0.1(postcss@8.5.25):
     dependencies:
       postcss: 8.5.25
       postcss-value-parser: 4.2.0
+    optional: true
 
   postcss-selector-parser@7.1.1:
     dependencies:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
+  postcss-svgo@7.1.1(postcss@8.5.22):
+    dependencies:
+      postcss: 8.5.22
+      postcss-value-parser: 4.2.0
+      svgo: 4.0.2
+
   postcss-svgo@7.1.1(postcss@8.5.25):
     dependencies:
       postcss: 8.5.25
       postcss-value-parser: 4.2.0
       svgo: 4.0.2
+    optional: true
+
+  postcss-unique-selectors@7.0.5(postcss@8.5.22):
+    dependencies:
+      postcss: 8.5.22
+      postcss-selector-parser: 7.1.1
 
   postcss-unique-selectors@7.0.5(postcss@8.5.25):
     dependencies:
       postcss: 8.5.25
       postcss-selector-parser: 7.1.1
+    optional: true
 
   postcss-value-parser@4.2.0: {}
+
+  postcss@8.5.22:
+    dependencies:
+      nanoid: 3.3.16
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   postcss@8.5.23:
     dependencies:
@@ -20328,6 +21387,8 @@ snapshots:
 
   process-nextick-args@2.0.1: {}
 
+  process-warning@5.0.0: {}
+
   process@0.11.10: {}
 
   promise-inflight@1.0.1: {}
@@ -20361,6 +21422,8 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
+  quick-format-unescaped@4.0.4: {}
+
   quote-js-string@0.1.0: {}
 
   radix3@1.1.2: {}
@@ -20376,9 +21439,9 @@ snapshots:
       iconv-lite: 0.7.3
       unpipe: 1.0.0
 
-  rc9@3.0.1:
+  rc9@2.1.2:
     dependencies:
-      defu: 6.1.7
+      defu: 6.1.4
       destr: 2.0.5
 
   react-dom@19.2.8(react@19.2.8):
@@ -20401,6 +21464,12 @@ snapshots:
 
   react-is@18.3.1: {}
 
+  react-reconciler@0.29.2(react@18.3.1):
+    dependencies:
+      loose-envify: 1.4.0
+      react: 18.3.1
+      scheduler: 0.23.2
+
   react-refresh@0.18.0: {}
 
   react-router@8.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
@@ -20418,6 +21487,10 @@ snapshots:
       react-dom: 19.2.8(react@19.2.8)
       webpack: 5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25)
       webpack-sources: 3.5.1
+
+  react@18.3.1:
+    dependencies:
+      loose-envify: 1.4.0
 
   react@19.2.8: {}
 
@@ -20471,6 +21544,10 @@ snapshots:
   readdirp@4.1.2: {}
 
   readdirp@5.0.0: {}
+
+  real-require@0.2.0: {}
+
+  real-require@1.0.0: {}
 
   recast@0.23.11:
     dependencies:
@@ -20727,6 +21804,11 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
+  restore-cursor@4.0.0:
+    dependencies:
+      onetime: 5.1.2
+      signal-exit: 3.0.7
+
   restore-cursor@5.1.0:
     dependencies:
       onetime: 7.0.0
@@ -20767,7 +21849,7 @@ snapshots:
     optionalDependencies:
       '@babel/code-frame': 7.29.7
 
-  rollup-plugin-visualizer@7.0.1(rolldown@1.2.2)(rollup@4.62.4):
+  rollup-plugin-visualizer@7.0.1(rolldown@1.2.2)(rollup@4.59.0):
     dependencies:
       open: 11.0.0
       picomatch: 4.0.5
@@ -20775,7 +21857,7 @@ snapshots:
       yargs: 18.0.0
     optionalDependencies:
       rolldown: 1.2.2
-      rollup: 4.62.4
+      rollup: 4.59.0
 
   rollup@4.59.0:
     dependencies:
@@ -20806,38 +21888,6 @@ snapshots:
       '@rollup/rollup-win32-ia32-msvc': 4.59.0
       '@rollup/rollup-win32-x64-gnu': 4.59.0
       '@rollup/rollup-win32-x64-msvc': 4.59.0
-      fsevents: 2.3.3
-
-  rollup@4.62.4:
-    dependencies:
-      '@types/estree': 1.0.9
-    optionalDependencies:
-      '@napi-rs/lzma-linux-x64-gnu': 1.5.1
-      '@rollup/rollup-android-arm-eabi': 4.62.4
-      '@rollup/rollup-android-arm64': 4.62.4
-      '@rollup/rollup-darwin-arm64': 4.62.4
-      '@rollup/rollup-darwin-x64': 4.62.4
-      '@rollup/rollup-freebsd-arm64': 4.62.4
-      '@rollup/rollup-freebsd-x64': 4.62.4
-      '@rollup/rollup-linux-arm-gnueabihf': 4.62.4
-      '@rollup/rollup-linux-arm-musleabihf': 4.62.4
-      '@rollup/rollup-linux-arm64-gnu': 4.62.4
-      '@rollup/rollup-linux-arm64-musl': 4.62.4
-      '@rollup/rollup-linux-loong64-gnu': 4.62.4
-      '@rollup/rollup-linux-loong64-musl': 4.62.4
-      '@rollup/rollup-linux-ppc64-gnu': 4.62.4
-      '@rollup/rollup-linux-ppc64-musl': 4.62.4
-      '@rollup/rollup-linux-riscv64-gnu': 4.62.4
-      '@rollup/rollup-linux-riscv64-musl': 4.62.4
-      '@rollup/rollup-linux-s390x-gnu': 4.62.4
-      '@rollup/rollup-linux-x64-gnu': 4.62.4
-      '@rollup/rollup-linux-x64-musl': 4.62.4
-      '@rollup/rollup-openbsd-x64': 4.62.4
-      '@rollup/rollup-openharmony-arm64': 4.62.4
-      '@rollup/rollup-win32-arm64-msvc': 4.62.4
-      '@rollup/rollup-win32-ia32-msvc': 4.62.4
-      '@rollup/rollup-win32-x64-gnu': 4.62.4
-      '@rollup/rollup-win32-x64-msvc': 4.62.4
       fsevents: 2.3.3
 
   rou3@0.8.1: {}
@@ -20897,6 +21947,8 @@ snapshots:
     dependencies:
       regexp-tree: 0.1.27
 
+  safe-stable-stringify@2.5.0: {}
+
   safer-buffer@2.1.2: {}
 
   sax@1.5.0: {}
@@ -20904,6 +21956,10 @@ snapshots:
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
+
+  scheduler@0.23.2:
+    dependencies:
+      loose-envify: 1.4.0
 
   scheduler@0.27.0: {}
 
@@ -20969,25 +22025,21 @@ snapshots:
 
   serialize-javascript@7.0.5: {}
 
-  seroval-plugins@1.5.1(seroval@1.6.0):
+  seroval-plugins@1.5.1(seroval@1.5.1):
     dependencies:
-      seroval: 1.6.0
+      seroval: 1.5.1
 
-  seroval-plugins@1.5.4(seroval@1.5.6):
+  seroval-plugins@1.5.4(seroval@1.5.4):
     dependencies:
-      seroval: 1.5.6
+      seroval: 1.5.4
 
-  seroval-plugins@1.5.4(seroval@1.6.0):
-    dependencies:
-      seroval: 1.6.0
+  seroval@1.5.1: {}
 
-  seroval@1.5.6: {}
-
-  seroval@1.6.0: {}
+  seroval@1.5.4: {}
 
   serve-placeholder@2.0.2:
     dependencies:
-      defu: 6.1.7
+      defu: 6.1.4
 
   serve-static@1.16.3(supports-color@10.2.2):
     dependencies:
@@ -21125,6 +22177,8 @@ snapshots:
 
   siginfo@2.0.0: {}
 
+  signal-exit@3.0.7: {}
+
   signal-exit@4.1.0: {}
 
   sirv-cli@3.0.1:
@@ -21144,7 +22198,19 @@ snapshots:
       mrmime: 2.0.1
       totalist: 3.0.1
 
+  sisteransi@1.0.5: {}
+
   slash@5.1.0: {}
+
+  slice-ansi@5.0.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 4.0.0
+
+  slice-ansi@7.1.2:
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
 
   smob@1.6.1: {}
 
@@ -21153,8 +22219,8 @@ snapshots:
   solid-js@1.9.14:
     dependencies:
       csstype: 3.2.3
-      seroval: 1.5.6
-      seroval-plugins: 1.5.4(seroval@1.5.6)
+      seroval: 1.5.4
+      seroval-plugins: 1.5.4(seroval@1.5.4)
 
   solid-refresh@0.6.3(solid-js@1.9.14)(supports-color@10.2.2):
     dependencies:
@@ -21168,6 +22234,10 @@ snapshots:
   solid-use@0.9.1(solid-js@1.9.14):
     dependencies:
       solid-js: 1.9.14
+
+  sonic-boom@4.2.1:
+    dependencies:
+      atomic-sleep: 1.0.0
 
   sort-object-keys@2.1.0: {}
 
@@ -21213,6 +22283,8 @@ snapshots:
 
   spdx-license-ids@3.0.23: {}
 
+  split2@4.2.0: {}
+
   sprintf-js@1.0.3: {}
 
   srvx@0.11.22: {}
@@ -21220,6 +22292,10 @@ snapshots:
   srvx@0.12.4: {}
 
   stable-hash-x@0.2.0: {}
+
+  stack-utils@2.0.6:
+    dependencies:
+      escape-string-regexp: 2.0.0
 
   stackback@0.0.2: {}
 
@@ -21230,6 +22306,8 @@ snapshots:
   statuses@2.0.2: {}
 
   std-env@3.10.0: {}
+
+  std-env@4.0.0: {}
 
   std-env@4.2.0: {}
 
@@ -21369,6 +22447,8 @@ snapshots:
 
   strip-bom-string@1.0.0: {}
 
+  strip-bom@3.0.0: {}
+
   strip-final-newline@3.0.0: {}
 
   strip-final-newline@4.0.0: {}
@@ -21382,10 +22462,6 @@ snapshots:
   strip-literal@3.1.0:
     dependencies:
       js-tokens: 9.0.1
-
-  strip-literal@4.0.0:
-    dependencies:
-      js-tokens: 10.0.0
 
   style-to-js@1.1.21:
     dependencies:
@@ -21402,11 +22478,18 @@ snapshots:
     optionalDependencies:
       '@babel/core': 8.0.1
 
+  stylehacks@7.0.8(postcss@8.5.22):
+    dependencies:
+      browserslist: 4.28.7
+      postcss: 8.5.22
+      postcss-selector-parser: 7.1.1
+
   stylehacks@7.0.8(postcss@8.5.25):
     dependencies:
       browserslist: 4.28.7
       postcss: 8.5.25
       postcss-selector-parser: 7.1.1
+    optional: true
 
   super-regex@1.1.0:
     dependencies:
@@ -21463,7 +22546,7 @@ snapshots:
       - bare-buffer
       - react-native-b4a
 
-  tar@7.5.22:
+  tar@7.5.19:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0
@@ -21482,6 +22565,22 @@ snapshots:
     dependencies:
       solid-js: 1.9.14
       solid-use: 0.9.1(solid-js@1.9.14)
+
+  terser-webpack-plugin@5.6.1(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.27.7)(lightningcss@1.33.0)(postcss@8.5.25)(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.27.7)(lightningcss@1.33.0)(postcss@8.5.25)):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      jest-worker: 27.5.1
+      schema-utils: 4.3.3
+      terser: 5.49.0
+      webpack: 5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.27.7)(lightningcss@1.33.0)(postcss@8.5.25)
+    optionalDependencies:
+      '@swc/core': 1.15.47
+      cssnano: 7.1.3(postcss@8.5.25)
+      csso: 5.0.5
+      esbuild: 0.27.7
+      lightningcss: 1.33.0
+      postcss: 8.5.25
+    optional: true
 
   terser-webpack-plugin@5.6.1(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25)(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25)):
     dependencies:
@@ -21518,6 +22617,10 @@ snapshots:
     transitivePeerDependencies:
       - react-native-b4a
 
+  thread-stream@4.2.0:
+    dependencies:
+      real-require: 1.0.0
+
   throttleit@2.1.0:
     optional: true
 
@@ -21528,8 +22631,6 @@ snapshots:
   tiny-invariant@1.3.3: {}
 
   tinybench@2.9.0: {}
-
-  tinyclip@0.1.15: {}
 
   tinydate@1.3.0: {}
 
@@ -21586,6 +22687,11 @@ snapshots:
 
   tree-kill@1.2.2: {}
 
+  tree-sitter-python@0.25.0:
+    dependencies:
+      node-addon-api: 8.9.0
+      node-gyp-build: 4.8.4
+
   trim-lines@3.0.1: {}
 
   trough@2.2.0: {}
@@ -21595,6 +22701,12 @@ snapshots:
       typescript: 6.0.3
 
   ts-pattern@5.9.0: {}
+
+  tsconfig-paths@4.2.0:
+    dependencies:
+      json5: 2.2.3
+      minimist: 1.2.8
+      strip-bom: 3.0.0
 
   tslib@2.8.1: {}
 
@@ -21708,7 +22820,7 @@ snapshots:
       '@rollup/pluginutils': 5.3.0(rollup@4.59.0)
       citty: 0.1.6
       consola: 3.4.2
-      defu: 6.1.7
+      defu: 6.1.4
       esbuild: 0.25.12
       fix-dts-default-cjs-exports: 1.0.1
       hookable: 5.5.3
@@ -21755,7 +22867,7 @@ snapshots:
   unenv@1.10.0:
     dependencies:
       consola: 3.4.2
-      defu: 6.1.7
+      defu: 6.1.4
       mime: 3.0.0
       node-fetch-native: 1.6.7
       pathe: 1.1.2
@@ -21805,30 +22917,55 @@ snapshots:
       trough: 2.2.0
       vfile: 6.0.3
 
-  unimport@6.4.0(esbuild@0.28.1)(oxc-parser@0.127.0)(rolldown@1.2.2)(rollup@4.62.4)(vite@6.4.3(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25)):
+  unimport@6.0.2(esbuild@0.27.7)(rolldown@1.2.2)(rollup@4.59.0)(vite@6.4.3(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.27.7)(lightningcss@1.33.0)(postcss@8.5.25)):
     dependencies:
-      acorn: 8.18.0
+      acorn: 8.17.0
       escape-string-regexp: 5.0.0
       estree-walker: 3.0.3
-      local-pkg: 1.2.1
-      magic-string: 1.1.0
+      local-pkg: 1.1.2
+      magic-string: 0.30.21
       mlly: 1.8.2
       pathe: 2.0.3
       picomatch: 4.0.5
       pkg-types: 2.3.1
       scule: 1.3.0
-      strip-literal: 4.0.0
+      strip-literal: 3.1.0
       tinyglobby: 0.2.17
-      unplugin: 3.3.0(esbuild@0.28.1)(rolldown@1.2.2)(rollup@4.62.4)(vite@6.4.3(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
-      unplugin-utils: 0.3.2
-    optionalDependencies:
-      oxc-parser: 0.127.0
-      rolldown: 1.2.2
+      unplugin: 3.3.0(esbuild@0.27.7)(rolldown@1.2.2)(rollup@4.59.0)(vite@6.4.3(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.27.7)(lightningcss@1.33.0)(postcss@8.5.25))
+      unplugin-utils: 0.3.1
     transitivePeerDependencies:
       - '@farmfe/core'
       - '@rspack/core'
       - bun-types-no-globals
       - esbuild
+      - rolldown
+      - rollup
+      - unloader
+      - vite
+      - webpack
+
+  unimport@6.0.2(esbuild@0.27.7)(rolldown@1.2.2)(rollup@4.59.0)(vite@6.4.3(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25)):
+    dependencies:
+      acorn: 8.17.0
+      escape-string-regexp: 5.0.0
+      estree-walker: 3.0.3
+      local-pkg: 1.1.2
+      magic-string: 0.30.21
+      mlly: 1.8.2
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      pkg-types: 2.3.1
+      scule: 1.3.0
+      strip-literal: 3.1.0
+      tinyglobby: 0.2.17
+      unplugin: 3.3.0(esbuild@0.27.7)(rolldown@1.2.2)(rollup@4.59.0)(vite@6.4.3(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
+      unplugin-utils: 0.3.1
+    transitivePeerDependencies:
+      - '@farmfe/core'
+      - '@rspack/core'
+      - bun-types-no-globals
+      - esbuild
+      - rolldown
       - rollup
       - unloader
       - vite
@@ -21882,11 +23019,6 @@ snapshots:
       pathe: 2.0.3
       picomatch: 4.0.5
 
-  unplugin-utils@0.3.2:
-    dependencies:
-      pathe: 2.0.3
-      picomatch: 4.0.5
-
   unplugin@2.3.11:
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -21894,19 +23026,31 @@ snapshots:
       picomatch: 4.0.5
       webpack-virtual-modules: 0.6.2
 
-  unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.2)(rollup@4.62.4)(vite@6.4.3(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25)):
+  unplugin@3.3.0(esbuild@0.27.7)(rolldown@1.2.2)(rollup@4.59.0)(vite@6.4.3(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.27.7)(lightningcss@1.33.0)(postcss@8.5.25)):
     dependencies:
       '@jridgewell/remapping': 2.3.5
       picomatch: 4.0.5
       webpack-virtual-modules: 0.6.2
     optionalDependencies:
-      esbuild: 0.28.1
+      esbuild: 0.27.7
       rolldown: 1.2.2
-      rollup: 4.62.4
+      rollup: 4.59.0
+      vite: 6.4.3(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)
+      webpack: 5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.27.7)(lightningcss@1.33.0)(postcss@8.5.25)
+
+  unplugin@3.3.0(esbuild@0.27.7)(rolldown@1.2.2)(rollup@4.59.0)(vite@6.4.3(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25)):
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      picomatch: 4.0.5
+      webpack-virtual-modules: 0.6.2
+    optionalDependencies:
+      esbuild: 0.27.7
+      rolldown: 1.2.2
+      rollup: 4.59.0
       vite: 6.4.3(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)
       webpack: 5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25)
 
-  unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.2)(rollup@4.62.4)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25)):
+  unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.2)(rollup@4.59.0)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25)):
     dependencies:
       '@jridgewell/remapping': 2.3.5
       picomatch: 4.0.5
@@ -21914,7 +23058,7 @@ snapshots:
     optionalDependencies:
       esbuild: 0.28.1
       rolldown: 1.2.2
-      rollup: 4.62.4
+      rollup: 4.59.0
       vite: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)
       webpack: 5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25)
 
@@ -21967,12 +23111,10 @@ snapshots:
       consola: 3.4.2
       pathe: 1.1.2
 
-  untun@0.2.2: {}
-
   untyped@2.0.0:
     dependencies:
       citty: 0.1.6
-      defu: 6.1.7
+      defu: 6.1.4
       jiti: 2.7.0
       knitwork: 1.3.0
       scule: 1.3.0
@@ -21999,8 +23141,6 @@ snapshots:
       picocolors: 1.1.1
 
   uqr@0.1.2: {}
-
-  uqr@0.1.3: {}
 
   uri-js@4.4.1:
     dependencies:
@@ -22064,11 +23204,11 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vinxi@0.5.11(@parcel/watcher@2.5.6)(@types/node@24.13.3)(@vercel/blob@2.4.0)(aws4fetch@1.0.20)(db0@0.3.4)(debug@4.4.3(supports-color@10.2.2))(ioredis@5.10.1(supports-color@10.2.2))(jiti@2.7.0)(lightningcss@1.33.0)(oxc-parser@0.127.0)(rolldown@1.2.2)(srvx@0.12.4)(supports-color@10.2.2)(terser@5.49.0)(tsx@4.21.0)(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))(yaml@2.9.0):
+  vinxi@0.5.11(@types/node@24.13.3)(@vercel/blob@2.4.0)(aws4fetch@1.0.20)(db0@0.3.4)(debug@4.4.3(supports-color@10.2.2))(ioredis@5.10.1(supports-color@10.2.2))(jiti@2.7.0)(lightningcss@1.33.0)(rolldown@1.2.2)(supports-color@10.2.2)(terser@5.49.0)(tsx@4.21.0)(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.27.7)(lightningcss@1.33.0)(postcss@8.5.25))(yaml@2.9.0):
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))
+      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))
       '@types/micromatch': 4.0.10
       '@vinxi/listhen': 1.5.6
       boxen: 8.0.1
@@ -22077,7 +23217,7 @@ snapshots:
       consola: 3.4.2
       crossws: 0.3.5
       dax-sh: 0.43.2
-      defu: 6.1.7
+      defu: 6.1.4
       es-module-lexer: 1.7.0
       esbuild: 0.25.12
       get-port-please: 3.2.0
@@ -22085,7 +23225,7 @@ snapshots:
       hookable: 5.5.3
       http-proxy: 1.18.1(debug@4.4.3(supports-color@10.2.2))
       micromatch: 4.0.8
-      nitropack: 2.13.4(@parcel/watcher@2.5.6)(@vercel/blob@2.4.0)(aws4fetch@1.0.20)(oxc-parser@0.127.0)(rolldown@1.2.2)(srvx@0.12.4)(supports-color@10.2.2)(vite@6.4.3(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
+      nitropack: 2.13.2(@vercel/blob@2.4.0)(aws4fetch@1.0.20)(rolldown@1.2.2)(supports-color@10.2.2)(vite@6.4.3(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.27.7)(lightningcss@1.33.0)(postcss@8.5.25))
       node-fetch-native: 1.6.7
       path-to-regexp: 6.3.0
       pathe: 1.1.2
@@ -22113,7 +23253,6 @@ snapshots:
       - '@farmfe/core'
       - '@libsql/client'
       - '@netlify/blobs'
-      - '@parcel/watcher'
       - '@planetscale/database'
       - '@rspack/core'
       - '@types/node'
@@ -22136,13 +23275,98 @@ snapshots:
       - less
       - lightningcss
       - mysql2
-      - oxc-parser
       - react-native-b4a
       - rolldown
       - sass
       - sass-embedded
       - sqlite3
-      - srvx
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - unloader
+      - uploadthing
+      - webpack
+      - xml2js
+      - yaml
+
+  vinxi@0.5.11(@types/node@24.13.3)(@vercel/blob@2.4.0)(aws4fetch@1.0.20)(db0@0.3.4)(debug@4.4.3(supports-color@10.2.2))(ioredis@5.10.1(supports-color@10.2.2))(jiti@2.7.0)(lightningcss@1.33.0)(rolldown@1.2.2)(supports-color@10.2.2)(terser@5.49.0)(tsx@4.21.0)(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))(yaml@2.9.0):
+    dependencies:
+      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))
+      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))
+      '@types/micromatch': 4.0.10
+      '@vinxi/listhen': 1.5.6
+      boxen: 8.0.1
+      chokidar: 4.0.3
+      citty: 0.1.6
+      consola: 3.4.2
+      crossws: 0.3.5
+      dax-sh: 0.43.2
+      defu: 6.1.4
+      es-module-lexer: 1.7.0
+      esbuild: 0.25.12
+      get-port-please: 3.2.0
+      h3: 1.15.10
+      hookable: 5.5.3
+      http-proxy: 1.18.1(debug@4.4.3(supports-color@10.2.2))
+      micromatch: 4.0.8
+      nitropack: 2.13.2(@vercel/blob@2.4.0)(aws4fetch@1.0.20)(rolldown@1.2.2)(supports-color@10.2.2)(vite@6.4.3(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
+      node-fetch-native: 1.6.7
+      path-to-regexp: 6.3.0
+      pathe: 1.1.2
+      radix3: 1.1.2
+      resolve: 1.22.11
+      serve-placeholder: 2.0.2
+      serve-static: 1.16.3(supports-color@10.2.2)
+      tinyglobby: 0.2.15
+      ufo: 1.6.3
+      unctx: 2.5.0
+      unenv: 1.10.0
+      unstorage: 1.17.5(@vercel/blob@2.4.0)(aws4fetch@1.0.20)(db0@0.3.4)(ioredis@5.10.1(supports-color@10.2.2))
+      vite: 6.4.3(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)
+      zod: 4.3.6
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@electric-sql/pglite'
+      - '@farmfe/core'
+      - '@libsql/client'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@rspack/core'
+      - '@types/node'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bare-abort-controller
+      - bare-buffer
+      - better-sqlite3
+      - bun-types-no-globals
+      - db0
+      - debug
+      - drizzle-orm
+      - encoding
+      - idb-keyval
+      - ioredis
+      - jiti
+      - less
+      - lightningcss
+      - mysql2
+      - react-native-b4a
+      - rolldown
+      - sass
+      - sass-embedded
+      - sqlite3
       - stylus
       - sugarss
       - supports-color
@@ -22174,6 +23398,21 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  vite-plugin-solid@2.11.11(@testing-library/jest-dom@6.9.1)(solid-js@1.9.14)(supports-color@10.2.2)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)):
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@types/babel__core': 7.20.5
+      babel-preset-solid: 1.9.12(@babel/core@7.29.7(supports-color@10.2.2))(solid-js@1.9.14)
+      merge-anything: 5.1.7
+      solid-js: 1.9.14
+      solid-refresh: 0.6.3(solid-js@1.9.14)(supports-color@10.2.2)
+      vite: 8.2.0(@types/node@24.13.3)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)
+      vitefu: 1.1.2(vite@8.2.0(@types/node@24.13.3)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
+    optionalDependencies:
+      '@testing-library/jest-dom': 6.9.1
+    transitivePeerDependencies:
+      - supports-color
 
   vite-plugin-solid@2.11.11(@testing-library/jest-dom@6.9.1)(solid-js@1.9.14)(supports-color@10.2.2)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
@@ -22210,7 +23449,7 @@ snapshots:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
-      postcss: 8.5.25
+      postcss: 8.5.22
       rollup: 4.59.0
       tinyglobby: 0.2.17
     optionalDependencies:
@@ -22218,6 +23457,22 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.7.0
       lightningcss: 1.33.0
+      terser: 5.49.0
+      tsx: 4.21.0
+      yaml: 2.9.0
+
+  vite@8.2.0(@types/node@24.13.3)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0):
+    dependencies:
+      lightningcss: 1.33.0
+      picomatch: 4.0.5
+      postcss: 8.5.25
+      rolldown: 1.2.2
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 24.13.3
+      esbuild: 0.27.7
+      fsevents: 2.3.3
+      jiti: 2.7.0
       terser: 5.49.0
       tsx: 4.21.0
       yaml: 2.9.0
@@ -22238,6 +23493,10 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.9.0
 
+  vitefu@1.1.2(vite@8.2.0(@types/node@24.13.3)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)):
+    optionalDependencies:
+      vite: 8.2.0(@types/node@24.13.3)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)
+
   vitefu@1.1.2(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)):
     optionalDependencies:
       vite: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)
@@ -22246,7 +23505,7 @@ snapshots:
     optionalDependencies:
       vite: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)
 
-  vitest@4.1.10(@edge-runtime/vm@3.2.0)(@types/node@24.13.3)(jsdom@29.1.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)):
+  vitest@4.1.10(@edge-runtime/vm@3.2.0)(@types/node@24.13.3)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
@@ -22271,7 +23530,7 @@ snapshots:
     optionalDependencies:
       '@edge-runtime/vm': 3.2.0
       '@types/node': 24.13.3
-      jsdom: 29.1.1
+      jsdom: 29.1.1(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - msw
 
@@ -22287,11 +23546,11 @@ snapshots:
 
   waku@1.0.0-beta.8(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25)))(react@19.2.8)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
-      '@hono/node-server': 2.0.12(hono@4.12.34)
+      '@hono/node-server': 2.0.12(hono@4.13.0)
       '@vitejs/plugin-react': 6.0.5(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
       '@vitejs/plugin-rsc': 0.5.32(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25)))(react@19.2.8)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
       dotenv: 17.4.2
-      hono: 4.12.34
+      hono: 4.13.0
       magic-string: 1.1.0
       picocolors: 1.1.1
       react: 19.2.8
@@ -22321,6 +23580,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
 
+  web-tree-sitter@0.26.11: {}
+
   web-worker@1.5.0: {}
 
   webidl-conversions@3.0.1: {}
@@ -22330,6 +23591,48 @@ snapshots:
   webpack-sources@3.5.1: {}
 
   webpack-virtual-modules@0.6.2: {}
+
+  webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.27.7)(lightningcss@1.33.0)(postcss@8.5.25):
+    dependencies:
+      '@types/eslint-scope': 3.7.7
+      '@types/estree': 1.0.9
+      '@types/json-schema': 7.0.15
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.18.0
+      acorn-import-phases: 1.0.4(acorn@8.18.0)
+      browserslist: 4.28.7
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.24.3
+      es-module-lexer: 2.3.1
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.3.2
+      mime-types: 2.1.35
+      neo-async: 2.6.2
+      schema-utils: 4.3.3
+      tapable: 2.3.3
+      terser-webpack-plugin: 5.6.1(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.27.7)(lightningcss@1.33.0)(postcss@8.5.25)(webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.27.7)(lightningcss@1.33.0)(postcss@8.5.25))
+      watchpack: 2.5.2
+      webpack-sources: 3.5.1
+    transitivePeerDependencies:
+      - '@minify-html/node'
+      - '@swc/core'
+      - '@swc/css'
+      - '@swc/html'
+      - clean-css
+      - cssnano
+      - csso
+      - esbuild
+      - html-minifier-terser
+      - lightningcss
+      - postcss
+      - uglify-js
+    optional: true
 
   webpack@5.105.4(@swc/core@1.15.47)(cssnano@7.1.3(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25):
     dependencies:
@@ -22374,9 +23677,9 @@ snapshots:
 
   whatwg-mimetype@5.0.0: {}
 
-  whatwg-url@16.0.1:
+  whatwg-url@16.0.1(@noble/hashes@2.2.0):
     dependencies:
-      '@exodus/bytes': 1.15.1
+      '@exodus/bytes': 1.15.1(@noble/hashes@2.2.0)
       tr46: 6.0.0
       webidl-conversions: 8.0.1
     transitivePeerDependencies:
@@ -22513,6 +23816,8 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yoctocolors@2.1.2: {}
+
+  yoga-layout@3.2.1: {}
 
   youch-core@0.3.3:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -34,6 +34,9 @@ allowBuilds:
   "@swc/core": true
   esbuild: true
   sharp: true
+  # Native build for gtx-cli's Python extractor. The benchmark lane only
+  # extracts from TypeScript sources, so the binding is never loaded.
+  tree-sitter-python: false
   unrs-resolver: true
 minimumReleaseAgeExclude:
   - "@oxc-parser/binding-android-arm-eabi@0.132.0"
@@ -65,3 +68,11 @@ minimumReleaseAgeExclude:
   - "@react-router/node@8.3.0"
   - "@react-router/serve@8.3.0"
   - react-router@8.3.0
+  - "@generaltranslation/python-extractor@0.2.33"
+  - "@generaltranslation/react-core@11.1.4"
+  - "@generaltranslation/supported-locales@2.1.13"
+  - generaltranslation@9.1.0
+  - gt-i18n@1.0.10
+  - gt-react@11.1.4
+  - gt@2.16.0
+  - gtx-cli@2.16.0

--- a/scripts/verify-site-bench-data.mjs
+++ b/scripts/verify-site-bench-data.mjs
@@ -26,13 +26,15 @@ const readmePath = join(repoRoot, "README.md")
 const report = readFileSync(reportPath, "utf8")
 const benchTs = readFileSync(benchTsPath, "utf8")
 const readme = readFileSync(readmePath, "utf8")
-const tools = ["Palamedes", "Lingui", "React Intl", "i18next-cli"]
+const tools = ["Palamedes", "Lingui", "React Intl", "i18next-cli", "General Translation"]
 const comparedTools = tools.filter((tool) => tool !== "Palamedes")
 const ratioFields = {
   Lingui: "lingui",
   "React Intl": "formatjs",
   "i18next-cli": "i18nextCli",
+  "General Translation": "gt",
 }
+const toolPattern = tools.join("|")
 
 function parseSection(name) {
   const section = report.split(new RegExp(`^## ${name}$`, "m"))[1]
@@ -55,13 +57,16 @@ function parseSection(name) {
   const body = warmStart === -1 ? afterCold : afterCold.slice(0, warmStart)
   const medians = {}
   for (const match of body.matchAll(
-    /^\|\s+(Palamedes|Lingui|React Intl|i18next-cli)\s+\|\s+([\d.]+) ms\s+\|/gm
+    new RegExp(String.raw`^\|\s+(${toolPattern})\s+\|\s+([\d.]+) ms\s+\|`, "gm")
   )) {
     medians[match[1]] = Number(match[2])
   }
   const speedups = {}
   for (const match of body.matchAll(
-    /^\|\s+Palamedes vs (Lingui|React Intl|i18next-cli)\s+\|\s+Palamedes\s+\|\s+([\d.]+)x\s+\|/gm
+    new RegExp(
+      String.raw`^\|\s+Palamedes vs (${toolPattern})\s+\|\s+Palamedes\s+\|\s+([\d.]+)x\s+\|`,
+      "gm"
+    )
   )) {
     speedups[match[1]] = match[2]
   }
@@ -193,7 +198,7 @@ function parseBenchSection(name) {
   }
   const medians = {}
   for (const match of body.matchAll(
-    /\{ tool: "(Palamedes|Lingui|React Intl|i18next-cli)", medianMs: ([\d.]+)/g
+    new RegExp(String.raw`\{ tool: "(${toolPattern})", medianMs: ([\d.]+)`, "g")
   )) {
     medians[match[1]] = Number(match[2])
   }

--- a/site/app/data/bench.ts
+++ b/site/app/data/bench.ts
@@ -24,7 +24,7 @@ export interface BenchCorpus {
    * asserted against the checked-in report by scripts/verify-site-bench-data.mjs
    * so the numbers quoted in prose (hero, ProofStrip) can't silently drift.
    */
-  ratios: { lingui: string; formatjs: string; i18nextCli: string }
+  ratios: { lingui: string; formatjs: string; i18nextCli: string; gt: string }
 }
 
 /*
@@ -49,7 +49,7 @@ export interface BenchWarm {
 }
 
 export const BENCH_META = {
-  generated: "2026-07-31",
+  generated: "2026-08-05",
   node: "v24.18.0",
   platform: "darwin/arm64",
   runs: 7,
@@ -68,15 +68,17 @@ export const BENCH_SMALL: BenchCorpus = {
   title: "Small corpus — 80 files, 640 messages (median of 7 runs)",
   corpus: "80 files, 640 messages",
   rows: [
-    { tool: "Palamedes", medianMs: 12.82, accent: true },
-    { tool: "Lingui", medianMs: 690.97 },
-    { tool: "React Intl", medianMs: 282.84 },
-    { tool: "i18next-cli", medianMs: 404.93 },
+    { tool: "Palamedes", medianMs: 14.11, accent: true },
+    { tool: "Lingui", medianMs: 747.18 },
+    { tool: "React Intl", medianMs: 288.59 },
+    { tool: "i18next-cli", medianMs: 625.87 },
+    { tool: "General Translation", medianMs: 577.89 },
   ],
   ratios: {
-    lingui: "53.91×",
-    formatjs: "22.07×",
-    i18nextCli: "31.59×",
+    lingui: "52.94×",
+    formatjs: "20.45×",
+    i18nextCli: "44.35×",
+    gt: "40.95×",
   },
 }
 
@@ -85,15 +87,17 @@ export const BENCH_MEDIUM: BenchCorpus = {
   title: "Medium corpus — 240 files, 1920 messages (median of 7 runs)",
   corpus: "240 files, 1920 messages",
   rows: [
-    { tool: "Palamedes", medianMs: 22.22, accent: true },
-    { tool: "Lingui", medianMs: 761.69 },
-    { tool: "React Intl", medianMs: 305.9 },
-    { tool: "i18next-cli", medianMs: 618.69 },
+    { tool: "Palamedes", medianMs: 23.8, accent: true },
+    { tool: "Lingui", medianMs: 836.69 },
+    { tool: "React Intl", medianMs: 344.09 },
+    { tool: "i18next-cli", medianMs: 658.4 },
+    { tool: "General Translation", medianMs: 669.27 },
   ],
   ratios: {
-    lingui: "34.27×",
-    formatjs: "13.76×",
-    i18nextCli: "27.84×",
+    lingui: "35.15×",
+    formatjs: "14.46×",
+    i18nextCli: "27.66×",
+    gt: "28.12×",
   },
 }
 
@@ -102,15 +106,17 @@ export const BENCH_REALISTIC: BenchCorpus = {
   title: "Realistic corpus — 1,500 files across ~400k lines, 6,000 messages (median of 7 runs)",
   corpus: "1,500 files (750 with i18n), ~400k lines, 6,000 messages",
   rows: [
-    { tool: "Palamedes", medianMs: 82.14, accent: true },
-    { tool: "Lingui", medianMs: 2405.52 },
-    { tool: "React Intl", medianMs: 470.81 },
-    { tool: "i18next-cli", medianMs: 6256.98 },
+    { tool: "Palamedes", medianMs: 83.89, accent: true },
+    { tool: "Lingui", medianMs: 2480.24 },
+    { tool: "React Intl", medianMs: 475.85 },
+    { tool: "i18next-cli", medianMs: 6644.63 },
+    { tool: "General Translation", medianMs: 6116.43 },
   ],
   ratios: {
-    lingui: "29.29×",
-    formatjs: "5.73×",
-    i18nextCli: "76.18×",
+    lingui: "29.57×",
+    formatjs: "5.67×",
+    i18nextCli: "79.21×",
+    gt: "72.91×",
   },
 }
 
@@ -125,22 +131,22 @@ export const BENCH_SMALL_WARM: BenchWarm = {
   id: "small",
   corpus: "80 files, 640 messages",
   touchedFiles: 5,
-  coldMs: 12.82,
-  warmMs: 10.27,
+  coldMs: 14.11,
+  warmMs: 10.76,
 }
 
 export const BENCH_MEDIUM_WARM: BenchWarm = {
   id: "medium",
   corpus: "240 files, 1920 messages",
   touchedFiles: 5,
-  coldMs: 22.22,
-  warmMs: 14.05,
+  coldMs: 23.8,
+  warmMs: 15.16,
 }
 
 export const BENCH_REALISTIC_WARM: BenchWarm = {
   id: "realistic",
   corpus: "1,500 files (750 with i18n), ~400k lines, 6,000 messages",
   touchedFiles: 5,
-  coldMs: 82.14,
-  warmMs: 33.11,
+  coldMs: 83.89,
+  warmMs: 33.08,
 }

--- a/site/app/data/rivals.ts
+++ b/site/app/data/rivals.ts
@@ -85,7 +85,7 @@ function speedup(tool: string): string {
 }
 
 const NO_BENCHMARK =
-  "Not measured. The checked harness covers Lingui, React Intl, and i18next-cli; anything else would be a guess."
+  "Not measured. The checked harness covers Lingui, React Intl, i18next-cli, and General Translation; anything else would be a guess."
 
 /*
  * The argument that applies to every page: extraction and catalog work is
@@ -409,7 +409,7 @@ plural(seats, {
       {
         criterion: "Extract + update speed",
         rival: NO_BENCHMARK,
-        palamedes: "Checked report covers Lingui, React Intl and i18next only",
+        palamedes: "Checked report covers Lingui, React Intl, i18next and General Translation",
       },
       {
         criterion: "Host boundary",
@@ -636,7 +636,7 @@ function buyLabel(seats) {
       {
         criterion: "Extract + update speed",
         rival: NO_BENCHMARK,
-        palamedes: "Checked report covers Lingui, React Intl and i18next only",
+        palamedes: "Checked report covers Lingui, React Intl, i18next and General Translation",
       },
     ],
     code: {
@@ -745,8 +745,9 @@ function buyLabel(seats) {
       },
       {
         criterion: "Extract + update speed",
-        rival: NO_BENCHMARK,
-        palamedes: "Checked report covers Lingui, React Intl and i18next only",
+        rival:
+          "Not measurable locally. `tolgee extract print` reports to the console and writes no files; catalogs arrive through `tolgee pull` from the platform.",
+        palamedes: "Checked report covers Lingui, React Intl, i18next and General Translation",
       },
     ],
     code: {
@@ -863,7 +864,7 @@ function buyLabel(seats) {
       {
         criterion: "Extract + update speed",
         rival: "Not applicable — there is nothing to extract",
-        palamedes: "Checked report covers Lingui, React Intl and i18next only",
+        palamedes: "Checked report covers Lingui, React Intl, i18next and General Translation",
       },
     ],
     code: {

--- a/site/app/data/topics.ts
+++ b/site/app/data/topics.ts
@@ -223,7 +223,7 @@ export default async function CheckoutHeading({ seats }) {
       },
       {
         q: "Which tools are covered?",
-        a: "Lingui, React Intl and i18next-cli. Tools the harness has not measured are not given a speed claim anywhere on this site, because a guess dressed as a benchmark is worse than no number.",
+        a: "Lingui, React Intl, i18next-cli and General Translation. Tools the harness has not measured are not given a speed claim anywhere on this site, because a guess dressed as a benchmark is worse than no number.",
       },
       {
         q: "Does faster extraction mean a smaller bundle?",


### PR DESCRIPTION
## Why

The benchmark doc excluded General Translation with the claim that it "performs network/AI translation in its CLI workflow, which is not comparable to these deterministic local extraction commands." That was wrong on both counts.

`gtx-cli generate` extracts from source and merges the configured locale catalogs entirely locally. Verified against gtx-cli 2.16.0 by instrumenting `http.request`, `https.request`, `net.Socket.connect`, and `fetch`: zero network calls, no API key required. It is the path GT documents for teams handling their own translations; `gtx-cli translate` is the hosted path and stays out of scope.

The merge is a real catalog update, not a source dump — confirmed by experiment before the lane was written:

| Case | Behavior |
| --- | --- |
| unchanged | existing translation preserved |
| changed | new hash, entry seeded with source text, old entry dropped |
| new | added |
| removed | filtered out |

## What changed

**General Translation joins the matrix** as a fifth lane running `gtx-cli generate --quiet`. The corpus renders `useGT()` strings and `<T>` components. GT rejects `{name}` placeholders in JSX children, so files whose messages are all interpolated keep their JSX and author through `t()` only.

GT keys catalogs by a content hash it computes itself, so the baseline catalogs are derived from a real `gtx-cli generate` run instead of a reimplementation of that hashing — the lane cannot silently break when GT changes it. Entries that must disappear during the measured run get a synthetic key; GT drops stale entries by key lookup alone, so that models the real path.

**A new assertion guards the merge.** The harness checks that each run preserved every existing translation (528 / 1,584 / 4,950). Without it, a changed hash shape would reseed every entry, the lane would quietly stop doing the catalog work it is timed for, and the message comparison would still pass.

**React Intl keeps its row and gets an explicit scope section** instead of a footnote. `formatjs extract` writes one aggregated artifact and never merges, so its median answers a narrower question than the four around it. It stays because react-intl is the second-largest tool in the field (3.3M weekly downloads vs Lingui's 1.35M); dropping it while adding a smaller one would say more about lane selection than about performance.

**Tolgee is documented as excluded, with a checked reason.** Its CLI extracts locally only through `tolgee extract print` and `tolgee extract check`, which report to the console and write no files; catalogs arrive via `tolgee pull` from the platform.

## Numbers

Re-recorded on the rebased tree (pmds 1.12.0, @formatjs/cli 6.16.16, gtx-cli 2.16.0):

| Profile | Palamedes | Lingui | React Intl | i18next-cli | General Translation |
| --- | ---: | ---: | ---: | ---: | ---: |
| small | 14.11 ms | 747.18 ms | 288.59 ms | 625.87 ms | 577.89 ms |
| medium | 23.80 ms | 836.69 ms | 344.09 ms | 658.40 ms | 669.27 ms |
| realistic | 83.89 ms | 2480.24 ms | 475.85 ms | 6644.63 ms | 6116.43 ms |

GT sits mid-field on the small corpora and lands near i18next on the realistic one (72.91x), where half the 1,500 files carry no i18n at all and still get scanned in full.

## Notes for the reviewer

- `pnpm-workspace.yaml` sets `tree-sitter-python: false`. gtx-cli pulls it in for its Python extractor; this lane only extracts TypeScript, so the native binding is never loaded.
- `runCommand` moved to `src/exec.mjs` because corpus generation now has to invoke the GT CLI once per profile to learn its hashes.
- Unrelated to this change: the workspace no longer builds on a nightly older than the `cold_path` stabilization (`oxc_data_structures 0.141.0`). Everything here was built and tested with `cargo +stable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)