### PR TITLE
feat(next): initialize i18n in server functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1172,6 +1172,7 @@ dependencies = [
  "oxc_ast_visit",
  "oxc_parser",
  "oxc_span",
+ "oxc_syntax",
  "rayon",
  "regex",
  "serde",

--- a/crates/palamedes-node/src/transform.rs
+++ b/crates/palamedes-node/src/transform.rs
@@ -4,6 +4,12 @@ use napi_derive::napi;
 use crate::shared::{checked_u32, to_napi_error};
 
 #[napi(object)]
+pub struct NativeServerFunctionTransformOptions {
+    pub initializer_module: String,
+    pub initializer_export: String,
+}
+
+#[napi(object)]
 pub struct NativeTransformOptions {
     pub runtime_module: Option<String>,
     pub runtime_import_name: Option<String>,
@@ -12,6 +18,7 @@ pub struct NativeTransformOptions {
     pub keep_source_fallbacks: Option<bool>,
     /// @deprecated Use `keepSourceFallbacks` with the inverse value.
     pub strip_message_field: Option<bool>,
+    pub server_functions: Option<NativeServerFunctionTransformOptions>,
 }
 
 #[napi(object)]
@@ -49,6 +56,12 @@ impl From<NativeTransformOptions> for palamedes::NativeTransformOptions {
             strip_non_essential_props: value.strip_non_essential_props,
             keep_source_fallbacks: value.keep_source_fallbacks,
             strip_message_field: value.strip_message_field,
+            server_functions: value.server_functions.map(|options| {
+                palamedes::ServerFunctionTransformOptions {
+                    initializer_module: options.initializer_module,
+                    initializer_export: options.initializer_export,
+                }
+            }),
         }
     }
 }

--- a/crates/palamedes/Cargo.toml
+++ b/crates/palamedes/Cargo.toml
@@ -17,6 +17,7 @@ oxc_ast = "0.143.0"
 oxc_ast_visit = "0.143.0"
 oxc_parser = "0.143.0"
 oxc_span = "0.143.0"
+oxc_syntax = "0.143.0"
 rayon = "1.12.0"
 regex = "1.12.3"
 serde = { version = "1.0.228", features = ["derive"] }

--- a/crates/palamedes/src/error.rs
+++ b/crates/palamedes/src/error.rs
@@ -189,6 +189,24 @@ pub enum PalamedesError {
         /// Source filename, line, and column.
         location: String,
     },
+    /// A macro in a Server Function parameter runs before body instrumentation.
+    #[error(
+        "Eager Palamedes macro in a Server Function parameter initializer executes before request i18n initialization. Move the default into the function body. Location: {location}. Use an explicit `if (value === undefined)` guard when only undefined should trigger the default; do not use `??=`."
+    )]
+    ServerFunctionParameterMacro {
+        /// Source filename, line, and column.
+        location: String,
+    },
+    /// Server Function instrumentation received an invalid import target.
+    #[error(
+        "Invalid Server Function initializer import: module `{initializer_module}` and export `{initializer_export}` must identify a non-empty module and a valid named JavaScript export."
+    )]
+    InvalidServerFunctionInitializer {
+        /// Configured module specifier.
+        initializer_module: String,
+        /// Configured named export.
+        initializer_export: String,
+    },
     /// A JSX message macro was nested inside another JSX message macro.
     #[error(
         "Nested i18n macro is not extractable as a single message at {location}. Move the full sentence into <Plural> branches or use plural() so translators receive the complete sentence."

--- a/crates/palamedes/src/lib.rs
+++ b/crates/palamedes/src/lib.rs
@@ -109,7 +109,7 @@ pub use source::{
 };
 pub use transform::{
     transform_macros, NativeTransformEdit, NativeTransformOptions, NativeTransformResult,
-    NativeTransformSourceMap,
+    NativeTransformSourceMap, ServerFunctionTransformOptions,
 };
 
 /// Published `ferrocat` version used by the Rust core.

--- a/crates/palamedes/src/transform/mod.rs
+++ b/crates/palamedes/src/transform/mod.rs
@@ -1,6 +1,7 @@
 mod imports;
 mod messages;
 mod runtime;
+mod server_functions;
 mod visitor;
 
 #[cfg(test)]
@@ -19,6 +20,7 @@ use crate::error::{PalamedesError, PalamedesResult};
 use crate::translation_scope::{source_location, validate_translation_macro_scopes};
 
 use self::imports::ImportCollector;
+use self::server_functions::{initializer_import, ServerFunctionTransform};
 use self::visitor::TransformVisitor;
 
 #[derive(Debug, Clone)]
@@ -53,6 +55,20 @@ pub struct NativeTransformOptions {
     /// should use the positive option instead.
     #[serde(rename = "stripMessageField")]
     pub strip_message_field: Option<bool>,
+    /// Instruments recognized Server Functions with a request initializer.
+    #[serde(rename = "serverFunctions")]
+    pub server_functions: Option<ServerFunctionTransformOptions>,
+}
+
+/// Configuration for framework Server Function instrumentation.
+#[derive(Debug, Deserialize)]
+pub struct ServerFunctionTransformOptions {
+    /// Module that exports the initializer.
+    #[serde(rename = "initializerModule")]
+    pub initializer_module: String,
+    /// Named initializer export.
+    #[serde(rename = "initializerExport")]
+    pub initializer_export: String,
 }
 
 impl NativeTransformOptions {
@@ -128,6 +144,17 @@ pub fn transform_macros(
 ) -> PalamedesResult<NativeTransformResult> {
     let options = options.unwrap_or_default();
 
+    if let Some(server_functions) = &options.server_functions {
+        if server_functions.initializer_module.is_empty()
+            || !oxc_syntax::identifier::is_identifier_name(&server_functions.initializer_export)
+        {
+            return Err(PalamedesError::InvalidServerFunctionInitializer {
+                initializer_module: server_functions.initializer_module.clone(),
+                initializer_export: server_functions.initializer_export.clone(),
+            });
+        }
+    }
+
     let runtime_module = options
         .runtime_module
         .clone()
@@ -180,16 +207,18 @@ pub fn transform_macros(
         });
     }
 
-    if collector.macro_imports.is_empty() {
+    if collector.macro_imports.is_empty() && options.server_functions.is_none() {
         return Ok(unchanged_result(source));
     }
 
-    validate_translation_macro_scopes(&parsed.program, filename, source, |local_name| {
-        collector
-            .macro_imports
-            .get(local_name)
-            .map(|macro_info| macro_info.imported_name.clone())
-    })?;
+    if !collector.macro_imports.is_empty() {
+        validate_translation_macro_scopes(&parsed.program, filename, source, |local_name| {
+            collector
+                .macro_imports
+                .get(local_name)
+                .map(|macro_info| macro_info.imported_name.clone())
+        })?;
+    }
 
     let mut visitor = TransformVisitor::new(filename, source, &collector.macro_imports, &options);
     visitor.visit_program(&parsed.program);
@@ -198,17 +227,34 @@ pub fn transform_macros(
         return Err(error);
     }
 
-    if visitor.replacements.is_empty() {
-        return Ok(unchanged_result(source));
+    let mut server_function_transform = options.server_functions.as_ref().map(|_| {
+        ServerFunctionTransform::run(
+            &parsed.program,
+            source,
+            filename,
+            &collector.macro_imports,
+            &collector.used_identifier_names,
+        )
+    });
+    if let Some(error) = server_function_transform
+        .as_mut()
+        .and_then(|transform| transform.error.take())
+    {
+        return Err(error);
     }
 
     let mut replacements = visitor.replacements;
-    for (start, end) in collector.macro_import_ranges {
-        replacements.push(Replacement {
-            start,
-            end,
-            text: String::new(),
-        });
+    if !replacements.is_empty() {
+        for (start, end) in collector.macro_import_ranges {
+            replacements.push(Replacement {
+                start,
+                end,
+                text: String::new(),
+            });
+        }
+    }
+    if let Some(transform) = &server_function_transform {
+        replacements.extend(transform.replacements.iter().cloned());
     }
 
     if replacements.is_empty() {
@@ -216,6 +262,17 @@ pub fn transform_macros(
     }
 
     let mut prefix = String::new();
+
+    if let (Some(server_options), Some(transform)) =
+        (&options.server_functions, &server_function_transform)
+    {
+        if !transform.replacements.is_empty() {
+            prefix.push_str(&initializer_import(
+                server_options,
+                &transform.initializer_alias,
+            ));
+        }
+    }
 
     let needs_runtime_import = !collector.has_reusable_runtime_import
         || effective_runtime_import_name != runtime_import_name;

--- a/crates/palamedes/src/transform/server_functions.rs
+++ b/crates/palamedes/src/transform/server_functions.rs
@@ -1,0 +1,384 @@
+use std::collections::{HashMap, HashSet};
+
+use oxc_ast::ast::{
+    ArrowFunctionBody, ArrowFunctionExpression, CallExpression, Declaration, Expression,
+    FormalParameters, Function, FunctionBody, ImportOrExportKind, JSXElement, Program, Statement,
+    TaggedTemplateExpression, VariableDeclaration,
+};
+use oxc_ast::ast_kind::AstKind;
+use oxc_ast_visit::{walk, Visit};
+use oxc_span::GetSpan;
+
+use crate::error::PalamedesError;
+use crate::translation_scope::source_location;
+
+use super::imports::ImportedMacro;
+use super::messages::identifier_name;
+use super::{Replacement, ServerFunctionTransformOptions};
+
+const INITIALIZER_ALIAS: &str = "__palamedesServerFunctionInitializer";
+const EAGER_JS_MACROS: [&str; 4] = ["t", "plural", "select", "selectOrdinal"];
+const EAGER_JSX_MACROS: [&str; 3] = ["Plural", "Select", "SelectOrdinal"];
+
+pub(super) struct ServerFunctionTransform {
+    pub replacements: Vec<Replacement>,
+    pub initializer_alias: String,
+    pub error: Option<PalamedesError>,
+}
+
+impl ServerFunctionTransform {
+    pub(super) fn run<'a>(
+        program: &Program<'a>,
+        source: &'a str,
+        filename: &'a str,
+        macro_imports: &'a HashMap<String, ImportedMacro>,
+        used_identifier_names: &HashSet<String>,
+    ) -> Self {
+        let initializer_alias = unique_identifier(INITIALIZER_ALIAS, used_identifier_names);
+        let module_function_spans = module_server_function_spans(program);
+        let (replacements, error) = {
+            let mut visitor = ServerFunctionVisitor {
+                source,
+                filename,
+                macro_imports,
+                module_function_spans: &module_function_spans,
+                initializer_alias: &initializer_alias,
+                replacements: Vec::new(),
+                error: None,
+            };
+            visitor.visit_program(program);
+            (visitor.replacements, visitor.error)
+        };
+
+        Self {
+            replacements,
+            initializer_alias,
+            error,
+        }
+    }
+}
+
+pub(super) fn initializer_import(options: &ServerFunctionTransformOptions, alias: &str) -> String {
+    let module = serde_json::to_string(&options.initializer_module)
+        .expect("serializing a Rust string as JSON cannot fail");
+    format!(
+        "import {{ {} as {alias} }} from {module};\n",
+        options.initializer_export
+    )
+}
+
+fn unique_identifier(base: &str, used: &HashSet<String>) -> String {
+    if !used.contains(base) {
+        return base.to_string();
+    }
+
+    let mut counter = 2;
+    loop {
+        let candidate = format!("{base}{counter}");
+        if !used.contains(&candidate) {
+            return candidate;
+        }
+        counter += 1;
+    }
+}
+
+fn has_use_server_directive(body: &FunctionBody<'_>) -> bool {
+    body.directives
+        .iter()
+        .any(|directive| directive.directive.as_str() == "use server")
+}
+
+fn module_server_function_spans(program: &Program<'_>) -> HashSet<(u32, u32)> {
+    if !program
+        .directives
+        .iter()
+        .any(|directive| directive.directive.as_str() == "use server")
+    {
+        return HashSet::new();
+    }
+
+    let mut named_exports = HashSet::new();
+    for statement in &program.body {
+        if let Statement::ExportNamedDeclaration(export) = statement {
+            if export.export_kind == ImportOrExportKind::Value {
+                for specifier in &export.specifiers {
+                    if specifier.export_kind == ImportOrExportKind::Value {
+                        named_exports.insert(specifier.local.name().to_string());
+                    }
+                }
+            }
+        }
+        if let Statement::ExportDefaultDeclaration(export) = statement {
+            if let Some(Expression::Identifier(identifier)) = export
+                .declaration
+                .as_expression()
+                .map(Expression::get_inner_expression)
+            {
+                named_exports.insert(identifier.name.to_string());
+            }
+        }
+    }
+
+    let mut spans = HashSet::new();
+    for statement in &program.body {
+        match statement {
+            Statement::ExportDeclaration(export) => {
+                record_declaration_functions(&export.declaration, None, &mut spans);
+            }
+            Statement::ExportDefaultDeclaration(export) => match &export.declaration {
+                oxc_ast::ast::ExportDefaultDeclarationKind::FunctionDeclaration(function) => {
+                    record_function(function, &mut spans);
+                }
+                declaration => {
+                    if let Some(expression) = declaration.as_expression() {
+                        record_expression_function(expression, &mut spans);
+                    }
+                }
+            },
+            Statement::FunctionDeclaration(function) => {
+                let name = function.id.as_ref().map(|id| id.name.as_str());
+                if name.is_some_and(|name| named_exports.contains(name)) {
+                    record_function(function, &mut spans);
+                }
+            }
+            Statement::VariableDeclaration(declaration) => {
+                record_variable_functions(declaration, Some(&named_exports), &mut spans);
+            }
+            _ => {}
+        }
+    }
+    spans
+}
+
+fn record_declaration_functions(
+    declaration: &Declaration<'_>,
+    named_exports: Option<&HashSet<String>>,
+    spans: &mut HashSet<(u32, u32)>,
+) {
+    match declaration {
+        Declaration::FunctionDeclaration(function) => {
+            let should_record = named_exports.is_none_or(|exports| {
+                function
+                    .id
+                    .as_ref()
+                    .is_some_and(|id| exports.contains(id.name.as_str()))
+            });
+            if should_record {
+                record_function(function, spans);
+            }
+        }
+        Declaration::VariableDeclaration(declaration) => {
+            record_variable_functions(declaration, named_exports, spans);
+        }
+        _ => {}
+    }
+}
+
+fn record_variable_functions(
+    declaration: &VariableDeclaration<'_>,
+    named_exports: Option<&HashSet<String>>,
+    spans: &mut HashSet<(u32, u32)>,
+) {
+    for declarator in &declaration.declarations {
+        let should_record = named_exports.is_none_or(|exports| {
+            declarator
+                .id
+                .get_identifier_name()
+                .is_some_and(|name| exports.contains(name.as_str()))
+        });
+        if should_record {
+            if let Some(initializer) = &declarator.init {
+                record_expression_function(initializer, spans);
+            }
+        }
+    }
+}
+
+fn record_function(function: &Function<'_>, spans: &mut HashSet<(u32, u32)>) {
+    if function.r#async && function.body.is_some() {
+        spans.insert((function.span.start, function.span.end));
+    }
+}
+
+fn record_expression_function(expression: &Expression<'_>, spans: &mut HashSet<(u32, u32)>) {
+    match expression.get_inner_expression() {
+        Expression::ArrowFunctionExpression(function) if function.r#async => {
+            spans.insert((function.span.start, function.span.end));
+        }
+        Expression::FunctionExpression(function) if function.r#async && function.body.is_some() => {
+            spans.insert((function.span.start, function.span.end));
+        }
+        _ => {}
+    }
+}
+
+struct ServerFunctionVisitor<'a> {
+    source: &'a str,
+    filename: &'a str,
+    macro_imports: &'a HashMap<String, ImportedMacro>,
+    module_function_spans: &'a HashSet<(u32, u32)>,
+    initializer_alias: &'a str,
+    replacements: Vec<Replacement>,
+    error: Option<PalamedesError>,
+}
+
+impl ServerFunctionVisitor<'_> {
+    fn validate_parameters(&mut self, params: &FormalParameters<'_>) -> bool {
+        let mut validator = EagerParameterMacroVisitor {
+            macro_imports: self.macro_imports,
+            function_depth: 0,
+            macro_offset: None,
+        };
+        validator.visit_formal_parameters(params);
+        if let Some(offset) = validator.macro_offset {
+            self.error = Some(PalamedesError::ServerFunctionParameterMacro {
+                location: source_location(self.source, self.filename, offset),
+            });
+            return false;
+        }
+        true
+    }
+
+    fn instrument_body(&mut self, body: &FunctionBody<'_>) {
+        let offset = body
+            .directives
+            .last()
+            .map_or(body.span.start as usize + 1, |directive| {
+                directive.span.end as usize
+            });
+        self.replacements.push(Replacement {
+            start: offset,
+            end: offset,
+            text: format!("\n  await {}();", self.initializer_alias),
+        });
+    }
+}
+
+impl<'a> Visit<'a> for ServerFunctionVisitor<'_> {
+    fn visit_function(&mut self, it: &Function<'a>, flags: oxc_syntax::scope::ScopeFlags) {
+        if self.error.is_some() {
+            return;
+        }
+        let is_server_function = it.r#async
+            && it.body.as_ref().is_some_and(|body| {
+                has_use_server_directive(body)
+                    || self
+                        .module_function_spans
+                        .contains(&(it.span.start, it.span.end))
+            });
+        if is_server_function && self.validate_parameters(&it.params) {
+            self.instrument_body(it.body.as_ref().expect("checked above"));
+        }
+        if self.error.is_none() {
+            walk::walk_function(self, it, flags);
+        }
+    }
+
+    fn visit_arrow_function_expression(&mut self, it: &ArrowFunctionExpression<'a>) {
+        if self.error.is_some() {
+            return;
+        }
+        let inline = match &it.body {
+            ArrowFunctionBody::FunctionBody(body) => has_use_server_directive(body),
+            _ => false,
+        };
+        let is_server_function = it.r#async
+            && (inline
+                || self
+                    .module_function_spans
+                    .contains(&(it.span.start, it.span.end)));
+        if is_server_function && self.validate_parameters(&it.params) {
+            match &it.body {
+                ArrowFunctionBody::FunctionBody(body) => self.instrument_body(body),
+                body => {
+                    let span = body.span();
+                    self.replacements.push(Replacement {
+                        start: span.start as usize,
+                        end: span.start as usize,
+                        text: format!("{{\n  await {}();\n  return ", self.initializer_alias),
+                    });
+                    self.replacements.push(Replacement {
+                        start: span.end as usize,
+                        end: span.end as usize,
+                        text: ";\n}".to_string(),
+                    });
+                }
+            }
+        }
+        if self.error.is_none() {
+            walk::walk_arrow_function_expression(self, it);
+        }
+    }
+}
+
+struct EagerParameterMacroVisitor<'a> {
+    macro_imports: &'a HashMap<String, ImportedMacro>,
+    function_depth: usize,
+    macro_offset: Option<usize>,
+}
+
+impl EagerParameterMacroVisitor<'_> {
+    fn check(&mut self, local_name: &str, expected: &[&str], offset: usize) {
+        if self.macro_offset.is_some() || self.function_depth > 0 {
+            return;
+        }
+        if self
+            .macro_imports
+            .get(local_name)
+            .is_some_and(|imported| expected.contains(&imported.imported_name.as_str()))
+        {
+            self.macro_offset = Some(offset);
+        }
+    }
+}
+
+impl<'a> Visit<'a> for EagerParameterMacroVisitor<'_> {
+    fn enter_node(&mut self, kind: AstKind<'a>) {
+        if matches!(
+            kind,
+            AstKind::Function(_) | AstKind::ArrowFunctionExpression(_)
+        ) {
+            self.function_depth += 1;
+        }
+    }
+
+    fn leave_node(&mut self, kind: AstKind<'a>) {
+        if matches!(
+            kind,
+            AstKind::Function(_) | AstKind::ArrowFunctionExpression(_)
+        ) {
+            self.function_depth = self.function_depth.saturating_sub(1);
+        }
+    }
+
+    fn visit_tagged_template_expression(&mut self, it: &TaggedTemplateExpression<'a>) {
+        if let Some(local_name) = identifier_name(&it.tag) {
+            self.check(local_name, &["t"], it.span.start as usize);
+        }
+        if self.macro_offset.is_none() {
+            walk::walk_tagged_template_expression(self, it);
+        }
+    }
+
+    fn visit_call_expression(&mut self, it: &CallExpression<'a>) {
+        if let Some(local_name) = identifier_name(&it.callee) {
+            self.check(local_name, &EAGER_JS_MACROS, it.span.start as usize);
+        }
+        if self.macro_offset.is_none() {
+            walk::walk_call_expression(self, it);
+        }
+    }
+
+    fn visit_jsx_element(&mut self, it: &JSXElement<'a>) {
+        if let Some(local_name) = it.opening_element.name.get_identifier_name() {
+            self.check(
+                local_name.as_str(),
+                &EAGER_JSX_MACROS,
+                it.span.start as usize,
+            );
+        }
+        if self.macro_offset.is_none() {
+            walk::walk_jsx_element(self, it);
+        }
+    }
+}

--- a/crates/palamedes/src/transform/server_functions.rs
+++ b/crates/palamedes/src/transform/server_functions.rs
@@ -201,14 +201,29 @@ fn record_function(function: &Function<'_>, spans: &mut HashSet<(u32, u32)>) {
 }
 
 fn record_expression_function(expression: &Expression<'_>, spans: &mut HashSet<(u32, u32)>) {
-    match expression.get_inner_expression() {
-        Expression::ArrowFunctionExpression(function) if function.r#async => {
-            spans.insert((function.span.start, function.span.end));
+    let mut collector = ExportedInitializerFunctionCollector { spans };
+    collector.visit_expression(expression.get_inner_expression());
+}
+
+struct ExportedInitializerFunctionCollector<'a> {
+    spans: &'a mut HashSet<(u32, u32)>,
+}
+
+impl<'a> Visit<'a> for ExportedInitializerFunctionCollector<'_> {
+    fn visit_function(&mut self, it: &Function<'a>, flags: oxc_syntax::scope::ScopeFlags) {
+        if it.r#async && it.body.is_some() {
+            record_function(it, self.spans);
+            return;
         }
-        Expression::FunctionExpression(function) if function.r#async && function.body.is_some() => {
-            spans.insert((function.span.start, function.span.end));
+        walk::walk_function(self, it, flags);
+    }
+
+    fn visit_arrow_function_expression(&mut self, it: &ArrowFunctionExpression<'a>) {
+        if it.r#async {
+            self.spans.insert((it.span.start, it.span.end));
+            return;
         }
-        _ => {}
+        walk::walk_arrow_function_expression(self, it);
     }
 }
 

--- a/crates/palamedes/src/transform/tests.rs
+++ b/crates/palamedes/src/transform/tests.rs
@@ -1,5 +1,6 @@
 use super::{
     transform_macros as transform_macros_raw, NativeTransformOptions, NativeTransformResult,
+    ServerFunctionTransformOptions,
 };
 use crate::error::PalamedesResult;
 use crate::icu_text::compiled_message_key;
@@ -26,6 +27,194 @@ fn transform_macros(
     }
 
     Ok(result)
+}
+
+fn server_function_options() -> NativeTransformOptions {
+    NativeTransformOptions {
+        server_functions: Some(ServerFunctionTransformOptions {
+            initializer_module: "@/i18n/server-action".to_string(),
+            initializer_export: "initServerActionI18n".to_string(),
+        }),
+        keep_source_fallbacks: Some(true),
+        ..NativeTransformOptions::default()
+    }
+}
+
+#[test]
+fn instruments_inline_server_functions_without_macros() {
+    let source = r#"export function Component() {
+  return async function save() {
+    "use server";
+    await persist();
+  };
+}
+"#;
+    let result = transform_macros_raw(source, "action.ts", Some(server_function_options()))
+        .expect("inline Server Function should be instrumented");
+
+    assert!(result.has_changed);
+    assert_eq!(
+        result.code.matches("from \"@/i18n/server-action\"").count(),
+        1
+    );
+    assert!(result.code.contains(
+        "\"use server\";\n  await __palamedesServerFunctionInitializer();\n    await persist();"
+    ));
+}
+
+#[test]
+fn instruments_only_exported_async_functions_in_server_modules() {
+    let source = r#""use server";
+
+export async function save() { await persist(); }
+export const remove = async () => destroy();
+async function renamed() { await rename(); }
+export { renamed as renameAction };
+const hidden = async () => hide();
+export function syncFunction() {}
+"#;
+    let result = transform_macros_raw(source, "actions.ts", Some(server_function_options()))
+        .expect("server module exports should be instrumented");
+
+    assert_eq!(
+        result
+            .code
+            .matches("await __palamedesServerFunctionInitializer();")
+            .count(),
+        3
+    );
+    assert!(result.code.contains(
+        "export const remove = async () => {\n  await __palamedesServerFunctionInitializer();\n  return destroy();\n};"
+    ));
+    assert!(result.code.contains("const hidden = async () => hide();"));
+    assert!(result.code.contains("export function syncFunction() {}"));
+}
+
+#[test]
+fn instruments_async_functions_exported_by_default_identifier() {
+    let source = r#""use server";
+async function save() { await persist(); }
+export default save;
+"#;
+    let result = transform_macros_raw(source, "actions.ts", Some(server_function_options()))
+        .expect("default-exported local Server Function should be instrumented");
+
+    assert_eq!(
+        result
+            .code
+            .matches("await __palamedesServerFunctionInitializer();")
+            .count(),
+        1
+    );
+}
+
+#[test]
+fn imports_the_initializer_once_and_avoids_authored_bindings() {
+    let source = r#""use server";
+const __palamedesServerFunctionInitializer = "occupied";
+export async function first() {}
+export async function second() {}
+"#;
+    let result = transform_macros_raw(source, "actions.ts", Some(server_function_options()))
+        .expect("initializer alias should avoid collisions");
+
+    assert_eq!(
+        result.code.matches("from \"@/i18n/server-action\"").count(),
+        1
+    );
+    assert!(result
+        .code
+        .contains("import { initServerActionI18n as __palamedesServerFunctionInitializer2 }"));
+    assert_eq!(
+        result
+            .code
+            .matches("await __palamedesServerFunctionInitializer2();")
+            .count(),
+        2
+    );
+}
+
+#[test]
+fn rejects_eager_macros_in_server_function_parameter_defaults() {
+    for source in [
+        r#"import { t } from "@palamedes/core/macro";
+export async function save(message = t`Fallback`) { "use server"; return message; }
+"#,
+        r#"import { t } from "@palamedes/core/macro";
+export async function save({ nested: { message = t`Fallback` } } = {}) { "use server"; return message; }
+"#,
+    ] {
+        let error = transform_macros_raw(source, "action.ts", Some(server_function_options()))
+            .expect_err("eager parameter macro must fail");
+        let message = error.to_string();
+        assert!(message.contains(
+            "Eager Palamedes macro in a Server Function parameter initializer executes before request i18n initialization"
+        ));
+        assert!(message.contains("Move the default into the function body"));
+        assert!(message.contains("if (value === undefined)"));
+    }
+}
+
+#[test]
+fn permits_deferred_macros_inside_parameter_callbacks() {
+    let source = r#"import { t } from "@palamedes/core/macro";
+export async function save(format = () => t`Fallback`) { "use server"; return format(); }
+"#;
+    let result = transform_macros_raw(source, "action.ts", Some(server_function_options()))
+        .expect("a callback default does not run the macro before initialization");
+
+    assert!(result.has_changed);
+    assert!(result
+        .code
+        .contains("await __palamedesServerFunctionInitializer();"));
+    assert!(result.code.contains("getI18n()._("));
+}
+
+#[test]
+fn combines_concise_server_action_and_macro_transforms() {
+    let source = r#""use server";
+import { t } from "@palamedes/core/macro";
+export const label = async () => t`Saved`;
+"#;
+    let result = transform_macros_raw(source, "actions.ts", Some(server_function_options()))
+        .expect("overlapping concise arrow and macro transforms should compose");
+
+    assert!(result
+        .code
+        .contains("await __palamedesServerFunctionInitializer();"));
+    assert!(result.code.contains("return getI18n()._("));
+    assert!(!result.code.contains("@palamedes/core/macro"));
+}
+
+#[test]
+fn leaves_server_functions_unchanged_without_opt_in() {
+    let source = r#"export async function save() { "use server"; await persist(); }
+"#;
+    let result = transform_macros_raw(source, "action.ts", None)
+        .expect("unconfigured transform should leave Server Functions alone");
+
+    assert!(!result.has_changed);
+    assert_eq!(result.code, source);
+}
+
+#[test]
+fn rejects_invalid_server_function_initializer_exports() {
+    let error = transform_macros_raw(
+        r#"export async function save() { "use server"; }"#,
+        "action.ts",
+        Some(NativeTransformOptions {
+            server_functions: Some(ServerFunctionTransformOptions {
+                initializer_module: "./i18n".to_string(),
+                initializer_export: "init();".to_string(),
+            }),
+            ..NativeTransformOptions::default()
+        }),
+    )
+    .expect_err("invalid generated import syntax must be rejected");
+
+    assert!(error
+        .to_string()
+        .contains("Invalid Server Function initializer import"));
 }
 
 #[test]

--- a/crates/palamedes/src/transform/tests.rs
+++ b/crates/palamedes/src/transform/tests.rs
@@ -109,6 +109,30 @@ export default save;
 }
 
 #[test]
+fn instruments_async_callbacks_inside_exported_action_initializers() {
+    let source = r#""use server";
+const hidden = withAuth(async () => hide());
+export const save = withAuth(async () => persist());
+"#;
+    let result = transform_macros_raw(source, "actions.ts", Some(server_function_options()))
+        .expect("wrapped Server Function callback should be instrumented");
+
+    assert_eq!(
+        result
+            .code
+            .matches("await __palamedesServerFunctionInitializer();")
+            .count(),
+        1
+    );
+    assert!(result.code.contains(
+        "export const save = withAuth(async () => {\n  await __palamedesServerFunctionInitializer();\n  return persist();\n})"
+    ));
+    assert!(result
+        .code
+        .contains("const hidden = withAuth(async () => hide())"));
+}
+
+#[test]
 fn imports_the_initializer_once_and_avoids_authored_bindings() {
     let source = r#""use server";
 const __palamedesServerFunctionInitializer = "occupied";

--- a/docs/api/next-plugin.md
+++ b/docs/api/next-plugin.md
@@ -30,6 +30,9 @@ interface WithPalamedesOptions {
   runtimeModule?: string
   keepSourceFallbacks?: boolean
   workspaceRoot?: string
+  serverFunctions?: {
+    initializer: string
+  }
 }
 ```
 
@@ -42,6 +45,7 @@ Defaults:
 - `failOnCompileError`: `false`
 - `runtimeModule`: `"@palamedes/runtime"`
 - `keepSourceFallbacks`: `true` in development, `false` in production
+- `serverFunctions`: disabled unless an initializer is configured
 
 ## Usage
 
@@ -50,6 +54,36 @@ const { withPalamedes } = require("@palamedes/next-plugin")
 
 module.exports = withPalamedes({})
 ```
+
+## Server Functions
+
+Next Server Functions and Actions execute as requests separate from the page
+render. Configure a request initializer when those functions use Palamedes
+directly or through helpers:
+
+```js
+module.exports = withPalamedes(
+  {},
+  {
+    serverFunctions: {
+      initializer: "@/lib/i18n.server#initServerActionI18n",
+    },
+  }
+)
+```
+
+The initializer is a named async export owned by the application. It should
+resolve the locale, load and activate a fresh request-local i18n instance, and
+be request-memoized or idempotent. Palamedes awaits it at the start of every
+recognized async Server Function, whether or not that function contains a
+macro itself. Recognition covers inline `"use server"` directives and async
+exports from top-level `"use server"` modules.
+
+Eager macros in formal parameter initializers are rejected because parameter
+defaults execute before injected body statements. Move the fallback into the
+function body with `if (value === undefined)` when matching JavaScript's
+default-parameter behavior; `??=` also treats `null` as absent and is not an
+equivalent rewrite.
 
 ## App Router Client Catalog Boundary
 

--- a/docs/api/next-plugin.md
+++ b/docs/api/next-plugin.md
@@ -30,9 +30,7 @@ interface WithPalamedesOptions {
   runtimeModule?: string
   keepSourceFallbacks?: boolean
   workspaceRoot?: string
-  serverFunctions?: {
-    initializer: string
-  }
+  serverFunctions?: boolean
 }
 ```
 
@@ -45,7 +43,7 @@ Defaults:
 - `failOnCompileError`: `false`
 - `runtimeModule`: `"@palamedes/runtime"`
 - `keepSourceFallbacks`: `true` in development, `false` in production
-- `serverFunctions`: disabled unless an initializer is configured
+- `serverFunctions`: `false`
 
 ## Usage
 
@@ -58,26 +56,39 @@ module.exports = withPalamedes({})
 ## Server Functions
 
 Next Server Functions and Actions execute as requests separate from the page
-render. Configure a request initializer when those functions use Palamedes
-directly or through helpers:
+render. First expose the application-owned initializer through the conventional
+server entry module:
+
+```ts
+// src/palamedes.server.ts
+import { createActiveServerI18n } from "./lib/i18n.server"
+
+export async function initializeServerFunctionI18n(): Promise<void> {
+  await createActiveServerI18n()
+}
+```
+
+Then enable instrumentation once in the Next configuration:
 
 ```js
 module.exports = withPalamedes(
   {},
   {
-    serverFunctions: {
-      initializer: "@/lib/i18n.server#initServerActionI18n",
-    },
+    serverFunctions: true,
   }
 )
 ```
 
-The initializer is a named async export owned by the application. It should
-resolve the locale, load and activate a fresh request-local i18n instance, and
-be request-memoized or idempotent. Palamedes awaits it at the start of every
-recognized async Server Function, whether or not that function contains a
-macro itself. Recognition covers inline `"use server"` directives and async
-exports from top-level `"use server"` modules.
+The entry can be named `palamedes.server.ts`, `.tsx`, `.js`, `.jsx`, `.mts`,
+`.mjs`, `.cts`, or `.cjs` and live in either the project root or `src`.
+Exactly one entry must exist, and it must export
+`initializeServerFunctionI18n`. The initializer should resolve the locale,
+load and activate a fresh request-local i18n instance, and be request-memoized
+or idempotent. Palamedes keeps the module address internal and awaits the
+initializer at the start of every recognized async Server Function, whether or
+not that function contains a macro itself. Recognition covers inline
+`"use server"` directives and async exports from top-level `"use server"`
+modules.
 
 Eager macros in formal parameter initializers are rejected because parameter
 defaults execute before injected body statements. Move the fallback into the

--- a/examples/nextjs-cookie/next.config.mjs
+++ b/examples/nextjs-cookie/next.config.mjs
@@ -1,3 +1,10 @@
 import { withPalamedes } from "@palamedes/next-plugin"
 
-export default withPalamedes()
+export default withPalamedes(
+  {},
+  {
+    serverFunctions: {
+      initializer: "@/lib/i18n.server#initServerActionI18n",
+    },
+  }
+)

--- a/examples/nextjs-cookie/next.config.mjs
+++ b/examples/nextjs-cookie/next.config.mjs
@@ -3,8 +3,6 @@ import { withPalamedes } from "@palamedes/next-plugin"
 export default withPalamedes(
   {},
   {
-    serverFunctions: {
-      initializer: "@/lib/i18n.server#initServerActionI18n",
-    },
+    serverFunctions: true,
   }
 )

--- a/examples/nextjs-cookie/scripts/rsc-scope-production.test.mjs
+++ b/examples/nextjs-cookie/scripts/rsc-scope-production.test.mjs
@@ -53,6 +53,41 @@ async function assertLocale(locale, expected) {
   }
 }
 
+async function assertServerActionLocale(locale, expected) {
+  const initialResponse = await fetch(`${baseUrl}/server-action-probe`, {
+    headers: { "accept-language": locale },
+  })
+  const initialBody = await initialResponse.text()
+  const actionName = initialBody.match(/name="(\$ACTION_ID_[^"]+)"/)?.[1]
+
+  if (!actionName) {
+    throw new Error(`Could not find the generated Server Action form field for ${locale}`)
+  }
+
+  const formData = new FormData()
+  formData.set(actionName, "")
+
+  const actionResponse = await fetch(`${baseUrl}/server-action-probe`, {
+    method: "POST",
+    headers: {
+      "accept-language": locale,
+      origin: baseUrl,
+    },
+    body: formData,
+  })
+  const actionBody = await actionResponse.text()
+
+  if (
+    actionResponse.status !== 200 ||
+    !actionBody.includes(`data-action-locale="${locale}"`) ||
+    !actionBody.includes(`>${expected}</output>`)
+  ) {
+    throw new Error(
+      `Expected ${locale} Server Action to return its localized request result, got ${actionResponse.status} at ${actionResponse.url}: ${actionBody.slice(0, 500)}`
+    )
+  }
+}
+
 const server = spawn(process.execPath, [nextCli, "start", "--port", String(port)], {
   cwd: new URL("..", import.meta.url),
   env: { ...process.env, NODE_ENV: "production" },
@@ -73,7 +108,16 @@ try {
       index % 2 === 0 ? assertLocale("en", "More tickets") : assertLocale("de", "Mehr Tickets")
     )
   )
-  console.log("Next.js production RSC scope remained request-local across suspension")
+  await Promise.all(
+    Array.from({ length: 12 }, (_, index) =>
+      index % 2 === 0
+        ? assertServerActionLocale("en", "Server action confirmed locale en.")
+        : assertServerActionLocale("de", "Server-Action bestätigte Sprache de.")
+    )
+  )
+  console.log(
+    "Next.js production RSC and Server Action scopes remained request-local across suspension"
+  )
 } catch (error) {
   console.error(serverOutput)
   throw error

--- a/examples/nextjs-cookie/src/app/server-action-probe/page.tsx
+++ b/examples/nextjs-cookie/src/app/server-action-probe/page.tsx
@@ -1,0 +1,18 @@
+import { redirectServerActionProof } from "@/lib/actions"
+
+type ServerActionProbeProps = {
+  searchParams: Promise<{ locale?: string; message?: string }>
+}
+
+export default async function ServerActionProbe({ searchParams }: ServerActionProbeProps) {
+  const { locale, message } = await searchParams
+
+  return (
+    <main>
+      <form action={redirectServerActionProof}>
+        <button type="submit">Run Server Action</button>
+      </form>
+      <output data-action-locale={locale ?? "pending"}>{message ?? "pending"}</output>
+    </main>
+  )
+}

--- a/examples/nextjs-cookie/src/lib/actions.ts
+++ b/examples/nextjs-cookie/src/lib/actions.ts
@@ -2,9 +2,10 @@
 
 import { cookies } from "next/headers"
 import { revalidatePath } from "next/cache"
+import { redirect } from "next/navigation"
 import { t } from "@palamedes/core/macro"
 import { getLocaleLabel, type Locale, LOCALES, LOCALE_COOKIE } from "./i18n"
-import { createActiveServerI18n, runWithServerI18n } from "./i18n.server"
+import { getLocale } from "./i18n.server"
 
 export async function setLocaleAction(locale: Locale) {
   if (!LOCALES.includes(locale)) {
@@ -22,12 +23,27 @@ export async function setLocaleAction(locale: Locale) {
 }
 
 export async function getServerActionProof() {
-  const { i18n, locale } = await createActiveServerI18n()
+  return createServerActionProof()
+}
 
-  return runWithServerI18n(i18n, () => ({
+export async function redirectServerActionProof() {
+  const proof = await createServerActionProof()
+  const query = new URLSearchParams({ locale: proof.locale, message: proof.message })
+  redirect(`/server-action-probe?${query}`)
+}
+
+async function createServerActionProof() {
+  await Promise.resolve()
+  const { locale } = await getLocale()
+
+  return {
     locale,
     localeLabel: getLocaleLabel(locale),
     handledAt: new Date().toISOString(),
-    message: t`Server action confirmed locale ${locale}.`,
-  }))
+    message: translateServerActionProof(locale),
+  }
+}
+
+function translateServerActionProof(locale: Locale) {
+  return t`Server action confirmed locale ${locale}.`
 }

--- a/examples/nextjs-cookie/src/lib/i18n.server.ts
+++ b/examples/nextjs-cookie/src/lib/i18n.server.ts
@@ -60,6 +60,11 @@ export async function createActiveServerI18n(locale?: Locale): Promise<{
   return active
 }
 
+/** Request initializer injected into every recognized Server Function. */
+export async function initServerActionI18n(): Promise<void> {
+  await createActiveServerI18n()
+}
+
 export function runWithServerI18n<Result>(i18n: PalamedesI18n, callback: () => Result): Result {
   return serverI18nScope.run(i18n, callback)
 }

--- a/examples/nextjs-cookie/src/lib/i18n.server.ts
+++ b/examples/nextjs-cookie/src/lib/i18n.server.ts
@@ -60,11 +60,6 @@ export async function createActiveServerI18n(locale?: Locale): Promise<{
   return active
 }
 
-/** Request initializer injected into every recognized Server Function. */
-export async function initServerActionI18n(): Promise<void> {
-  await createActiveServerI18n()
-}
-
 export function runWithServerI18n<Result>(i18n: PalamedesI18n, callback: () => Result): Result {
   return serverI18nScope.run(i18n, callback)
 }

--- a/examples/nextjs-cookie/src/palamedes.server.ts
+++ b/examples/nextjs-cookie/src/palamedes.server.ts
@@ -1,0 +1,8 @@
+import "server-only"
+
+import { createActiveServerI18n } from "./lib/i18n.server"
+
+/** Initialize request-local i18n for every instrumented Server Function. */
+export async function initializeServerFunctionI18n(): Promise<void> {
+  await createActiveServerI18n()
+}

--- a/packages/core-node/src/generated/palamedes-node-types.ts
+++ b/packages/core-node/src/generated/palamedes-node-types.ts
@@ -401,6 +401,10 @@ export interface NativeSourceAnalysisResult {
   messages: Array<NativeExtractedMessage>;
   diagnostics: Array<NativeSourceDiagnostic>;
 }
+export interface NativeServerFunctionTransformOptions {
+  initializerModule: string;
+  initializerExport: string;
+}
 export interface NativeTransformOptions {
   runtimeModule?: string;
   runtimeImportName?: string;
@@ -409,6 +413,7 @@ export interface NativeTransformOptions {
   keepSourceFallbacks?: boolean;
   /** @deprecated Use `keepSourceFallbacks` with the inverse value. */
   stripMessageField?: boolean;
+  serverFunctions?: NativeServerFunctionTransformOptions;
 }
 export interface NativeTransformEdit {
   start: number;

--- a/packages/next-plugin/README.md
+++ b/packages/next-plugin/README.md
@@ -91,6 +91,10 @@ export async function createActiveServerI18n() {
   serverI18n.activate(active.i18n)
   return active
 }
+
+export async function initServerActionI18n() {
+  await createActiveServerI18n()
+}
 ```
 
 ```tsx
@@ -158,6 +162,53 @@ before adopting that Next release.
 
 References: [Next.js Server and Client Components](https://nextjs.org/docs/app/getting-started/server-and-client-components), [Next.js data fetching and request-scoped React cache](https://nextjs.org/docs/app/getting-started/fetching-data), and [React `cache`](https://react.dev/reference/react/cache).
 
+### Server Functions and Actions
+
+A Server Function starts a separate request, so initialization performed while
+rendering a page does not cover it. Opt into automatic initialization with a
+named async initializer:
+
+```js
+const { withPalamedes } = require("@palamedes/next-plugin")
+
+module.exports = withPalamedes(
+  {},
+  {
+    serverFunctions: {
+      initializer: "@/lib/i18n.server#initServerActionI18n",
+    },
+  }
+)
+```
+
+Palamedes instruments every async function recognized by Next or React: async
+exports in a module with a top-level `"use server"` directive, and async
+functions with their own `"use server"` directive. It injects one initializer
+import per module and awaits the initializer after the function's directive
+prologue. This also covers actions without a local macro; sync and async helper
+calls then inherit the initialized request scope.
+
+The initializer belongs to the application. It should resolve the request
+locale, load and activate a fresh catalog, and be request-memoized or otherwise
+idempotent. The `module#namedExport` value must resolve from every instrumented
+module.
+
+Parameter defaults execute before the function body. Palamedes therefore
+rejects eager macros in Server Function parameter initializers, including
+nested destructuring defaults. Move such defaults into the body and preserve
+JavaScript default-parameter semantics explicitly:
+
+```ts
+export async function save(message?: string) {
+  "use server"
+  if (message === undefined) message = t`Fallback`
+}
+```
+
+Do not replace this guard with `??=` unless `null` should also select the
+fallback. Server Function instrumentation is opt-in and currently targets the
+Next.js integration.
+
 ## Options
 
 ```js
@@ -174,6 +225,9 @@ module.exports = withPalamedes(
     failOnCompileError: false,
     keepSourceFallbacks: undefined,
     workspaceRoot: undefined,
+    serverFunctions: {
+      initializer: "@/lib/i18n.server#initServerActionI18n",
+    },
   }
 )
 ```

--- a/packages/next-plugin/README.md
+++ b/packages/next-plugin/README.md
@@ -186,12 +186,20 @@ module.exports = withPalamedes(
 )
 ```
 
-Palamedes instruments every async function recognized by Next or React: async
-exports in a module with a top-level `"use server"` directive, and async
-functions with their own `"use server"` directive. It injects one initializer
-import per module and awaits the initializer after the function's directive
-prologue. This also covers actions without a local macro; sync and async helper
-calls then inherit the initialized request scope.
+Palamedes instruments directive-visible async functions: direct exports and
+locally declared named exports in a module with a top-level `"use server"`
+directive, async callbacks nested in an exported initializer such as
+`export const save = withAuth(async () => ...)`, and async functions with their
+own `"use server"` directive. It injects one initializer import per module and
+awaits the initializer after the function's directive prologue. This also
+covers actions without a local macro; sync and async helper calls then inherit
+the initialized request scope.
+
+A re-export such as `export { save } from "./save"` has no function body to
+instrument at the re-export site. Put `"use server"` in the implementation
+module or on the implementation function itself. Likewise, a wrapper call that
+only receives an imported callback has no local async body for Palamedes to
+instrument; keep the callback inline or mark its implementation explicitly.
 
 The initializer belongs to the application. It should resolve the request
 locale, load and activate a fresh catalog, and be request-memoized or otherwise

--- a/packages/next-plugin/README.md
+++ b/packages/next-plugin/README.md
@@ -91,10 +91,6 @@ export async function createActiveServerI18n() {
   serverI18n.activate(active.i18n)
   return active
 }
-
-export async function initServerActionI18n() {
-  await createActiveServerI18n()
-}
 ```
 
 ```tsx
@@ -165,8 +161,19 @@ References: [Next.js Server and Client Components](https://nextjs.org/docs/app/g
 ### Server Functions and Actions
 
 A Server Function starts a separate request, so initialization performed while
-rendering a page does not cover it. Opt into automatic initialization with a
-named async initializer:
+rendering a page does not cover it. Add a conventional server entry module in
+the project root or `src` directory:
+
+```ts
+// src/palamedes.server.ts
+import { createActiveServerI18n } from "./lib/i18n.server"
+
+export async function initializeServerFunctionI18n(): Promise<void> {
+  await createActiveServerI18n()
+}
+```
+
+Then opt into automatic initialization with a flag:
 
 ```js
 const { withPalamedes } = require("@palamedes/next-plugin")
@@ -174,9 +181,7 @@ const { withPalamedes } = require("@palamedes/next-plugin")
 module.exports = withPalamedes(
   {},
   {
-    serverFunctions: {
-      initializer: "@/lib/i18n.server#initServerActionI18n",
-    },
+    serverFunctions: true,
   }
 )
 ```
@@ -190,8 +195,8 @@ calls then inherit the initialized request scope.
 
 The initializer belongs to the application. It should resolve the request
 locale, load and activate a fresh catalog, and be request-memoized or otherwise
-idempotent. The `module#namedExport` value must resolve from every instrumented
-module.
+idempotent. The plugin resolves exactly one `palamedes.server` module from the
+project root or `src` directory and keeps its absolute import address internal.
 
 Parameter defaults execute before the function body. Palamedes therefore
 rejects eager macros in Server Function parameter initializers, including
@@ -225,9 +230,7 @@ module.exports = withPalamedes(
     failOnCompileError: false,
     keepSourceFallbacks: undefined,
     workspaceRoot: undefined,
-    serverFunctions: {
-      initializer: "@/lib/i18n.server#initServerActionI18n",
-    },
+    serverFunctions: true,
   }
 )
 ```

--- a/packages/next-plugin/palamedes-loader.cjs
+++ b/packages/next-plugin/palamedes-loader.cjs
@@ -11,6 +11,7 @@ module.exports = function palamedesLoader(source, inputSourceMap) {
       runtimeModule: options.runtimeModule,
       keepSourceFallbacks: options.keepSourceFallbacks,
       stripNonEssentialProps: options.stripNonEssentialProps,
+      serverFunctions: options.serverFunctions,
       sourceMap: this.sourceMap,
     })
 

--- a/packages/next-plugin/src/index.test.ts
+++ b/packages/next-plugin/src/index.test.ts
@@ -1,10 +1,21 @@
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
 import { afterEach, describe, expect, it, vi } from "vitest"
 
 import { withPalamedes } from "./index"
 
 afterEach(() => {
   vi.unstubAllEnvs()
+  vi.restoreAllMocks()
 })
+
+const nextExampleRoot = fileURLToPath(new URL("../../../examples/nextjs-cookie", import.meta.url))
+const serverEntryModule = "@palamedes/next-plugin/server-function-initializer"
+
+function useNextExampleProject(): void {
+  vi.spyOn(process, "cwd").mockReturnValue(nextExampleRoot)
+}
 
 type RuleItem = {
   condition?: unknown
@@ -90,14 +101,8 @@ describe("withPalamedes turbopack config", () => {
   })
 
   it("matches Server Function directives and forwards the initializer when configured", () => {
-    const config = withPalamedes(
-      {},
-      {
-        serverFunctions: {
-          initializer: "@/i18n/server-action#initServerActionI18n",
-        },
-      }
-    )
+    useNextExampleProject()
+    const config = withPalamedes({}, { serverFunctions: true })
     const rule = getRules(config)["*"] as RuleItem
     const content = (
       conditionList(rule).find(
@@ -108,19 +113,21 @@ describe("withPalamedes turbopack config", () => {
     expect(content.test('async function save() { "use server" }')).toBe(true)
     expect(rule.loaders?.[0]?.options).toMatchObject({
       serverFunctions: {
-        initializerModule: "@/i18n/server-action",
-        initializerExport: "initServerActionI18n",
+        initializerModule: serverEntryModule,
+        initializerExport: "initializeServerFunctionI18n",
       },
+    })
+    expect(config.turbopack?.resolveAlias).toMatchObject({
+      [serverEntryModule]: "./src/palamedes.server.ts",
     })
   })
 
-  it("rejects malformed Server Function initializer specifiers", () => {
-    expect(() =>
-      withPalamedes({}, { serverFunctions: { initializer: "@/i18n/server-action" } })
-    ).toThrow('Expected "module#namedExport"')
-    expect(() =>
-      withPalamedes({}, { serverFunctions: { initializer: "module#not-valid()" } })
-    ).toThrow('Expected "module#namedExport"')
+  it("requires the conventional Server Function entry module when enabled", () => {
+    vi.spyOn(process, "cwd").mockReturnValue(path.join(nextExampleRoot, "missing"))
+
+    expect(() => withPalamedes({}, { serverFunctions: true })).toThrow(
+      "requires a palamedes.server module"
+    )
   })
 
   it("appends to user-supplied turbopack rules instead of overwriting them", () => {
@@ -209,15 +216,14 @@ function collectWebpackRules(config: ReturnType<typeof withPalamedes>): WebpackR
 
 describe("withPalamedes webpack config", () => {
   it("forwards Server Function instrumentation to webpack", () => {
-    const rules = collectWebpackRules(
-      withPalamedes({}, { serverFunctions: { initializer: "./i18n#initServerActionI18n" } })
-    )
+    useNextExampleProject()
+    const rules = collectWebpackRules(withPalamedes({}, { serverFunctions: true }))
     const transformRule = rules.find((rule) => rule.use?.[0]?.loader.includes("palamedes-loader"))
 
     expect(transformRule?.use?.[0]?.options).toMatchObject({
       serverFunctions: {
-        initializerModule: "./i18n",
-        initializerExport: "initServerActionI18n",
+        initializerModule: serverEntryModule,
+        initializerExport: "initializeServerFunctionI18n",
       },
     })
   })

--- a/packages/next-plugin/src/index.test.ts
+++ b/packages/next-plugin/src/index.test.ts
@@ -89,6 +89,40 @@ describe("withPalamedes turbopack config", () => {
     expect(content.test('import { t } from "other-i18n"')).toBe(false)
   })
 
+  it("matches Server Function directives and forwards the initializer when configured", () => {
+    const config = withPalamedes(
+      {},
+      {
+        serverFunctions: {
+          initializer: "@/i18n/server-action#initServerActionI18n",
+        },
+      }
+    )
+    const rule = getRules(config)["*"] as RuleItem
+    const content = (
+      conditionList(rule).find(
+        (condition) => typeof condition === "object" && condition !== null && "content" in condition
+      ) as { content: RegExp }
+    ).content
+
+    expect(content.test('async function save() { "use server" }')).toBe(true)
+    expect(rule.loaders?.[0]?.options).toMatchObject({
+      serverFunctions: {
+        initializerModule: "@/i18n/server-action",
+        initializerExport: "initServerActionI18n",
+      },
+    })
+  })
+
+  it("rejects malformed Server Function initializer specifiers", () => {
+    expect(() =>
+      withPalamedes({}, { serverFunctions: { initializer: "@/i18n/server-action" } })
+    ).toThrow('Expected "module#namedExport"')
+    expect(() =>
+      withPalamedes({}, { serverFunctions: { initializer: "module#not-valid()" } })
+    ).toThrow('Expected "module#namedExport"')
+  })
+
   it("appends to user-supplied turbopack rules instead of overwriting them", () => {
     const userRule = {
       condition: { path: /\.svg$/ },
@@ -174,6 +208,20 @@ function collectWebpackRules(config: ReturnType<typeof withPalamedes>): WebpackR
 }
 
 describe("withPalamedes webpack config", () => {
+  it("forwards Server Function instrumentation to webpack", () => {
+    const rules = collectWebpackRules(
+      withPalamedes({}, { serverFunctions: { initializer: "./i18n#initServerActionI18n" } })
+    )
+    const transformRule = rules.find((rule) => rule.use?.[0]?.loader.includes("palamedes-loader"))
+
+    expect(transformRule?.use?.[0]?.options).toMatchObject({
+      serverFunctions: {
+        initializerModule: "./i18n",
+        initializerExport: "initServerActionI18n",
+      },
+    })
+  })
+
   it("excludes node_modules from the po loader rule", () => {
     const poRule = collectWebpackRules(withPalamedes()).find((rule) =>
       rule.test?.source.includes("po")

--- a/packages/next-plugin/src/index.ts
+++ b/packages/next-plugin/src/index.ts
@@ -27,6 +27,18 @@ const MACRO_CONTENT_PATTERN = new RegExp(
   PALAMEDES_MACRO_PACKAGES.map((name) => name.replaceAll(/[.*+?^${}()|[\]\\/]/gu, "\\$&")).join("|")
 )
 const SERVER_FUNCTION_CONTENT_PATTERN = /["']use server["']/
+const SERVER_FUNCTION_INITIALIZER_MODULE = "@palamedes/next-plugin/server-function-initializer"
+const SERVER_FUNCTION_INITIALIZER_EXPORT = "initializeServerFunctionI18n"
+const SERVER_FUNCTION_ENTRY_EXTENSIONS = [
+  ".ts",
+  ".tsx",
+  ".js",
+  ".jsx",
+  ".mts",
+  ".mjs",
+  ".cts",
+  ".cjs",
+] as const
 
 /*
  * A Turbopack rule array is either the loader "shorthand" (a flat list of
@@ -146,32 +158,40 @@ export type WithPalamedesOptions = {
 
   /**
    * Initialize request-local i18n at the start of every recognized Next.js
-   * Server Function. The value uses `module#namedExport` syntax.
+   * Server Function. Requires a `palamedes.server` entry module exporting
+   * `initializeServerFunctionI18n`.
    *
-   * @example { initializer: "@/i18n/server-action#initServerActionI18n" }
+   * @default false
    */
-  serverFunctions?: {
-    initializer: string
-  }
+  serverFunctions?: boolean
 }
 
-function parseServerFunctionInitializer(initializer: string) {
-  const separator = initializer.lastIndexOf("#")
-  const initializerModule = initializer.slice(0, separator)
-  const initializerExport = initializer.slice(separator + 1)
-  const identifierPattern = /^(?:[$_]|\p{ID_Start})(?:[$_]|\p{ID_Continue}|\u200C|\u200D)*$/u
+function resolveServerFunctionInitializer(enabled: boolean | undefined) {
+  if (!enabled) return
 
-  if (
-    separator <= 0 ||
-    separator === initializer.length - 1 ||
-    !identifierPattern.test(initializerExport)
-  ) {
+  const projectRoot = process.cwd()
+  const candidates = ["src", ""].flatMap((directory) =>
+    SERVER_FUNCTION_ENTRY_EXTENSIONS.map((extension) =>
+      path.join(projectRoot, directory, `palamedes.server${extension}`)
+    )
+  )
+  const matches = candidates.filter((candidate) => existsSync(candidate))
+
+  if (matches.length === 0) {
     throw new Error(
-      `Invalid Palamedes Server Function initializer ${JSON.stringify(initializer)}. Expected "module#namedExport".`
+      "Palamedes Server Function instrumentation requires a palamedes.server module in the project root or src directory. Export initializeServerFunctionI18n from that module."
+    )
+  }
+  if (matches.length > 1) {
+    throw new Error(
+      `Palamedes found multiple Server Function entry modules: ${matches.join(", ")}. Keep exactly one palamedes.server module.`
     )
   }
 
-  return { initializerModule, initializerExport }
+  return {
+    absolutePath: matches[0]!,
+    turbopackAlias: `./${path.relative(projectRoot, matches[0]!).split(path.sep).join("/")}`,
+  }
 }
 
 function resolveWorkspaceRoot(explicitRoot?: string) {
@@ -263,8 +283,12 @@ export function withPalamedes(
   const runtimeModule = resolveMacroRuntimeModule(explicitRuntimeModule)
   const keepSourceFallbacks = explicitKeepSourceFallbacks ?? process.env.NODE_ENV !== "production"
   const stripNonEssentialProps = process.env.NODE_ENV === "production"
-  const serverFunctions = serverFunctionOptions
-    ? parseServerFunctionInitializer(serverFunctionOptions.initializer)
+  const serverFunctionEntry = resolveServerFunctionInitializer(serverFunctionOptions)
+  const serverFunctions = serverFunctionEntry
+    ? {
+        initializerModule: SERVER_FUNCTION_INITIALIZER_MODULE,
+        initializerExport: SERVER_FUNCTION_INITIALIZER_EXPORT,
+      }
     : undefined
   const workspaceRoot = resolveWorkspaceRoot(explicitWorkspaceRoot)
   const configuredTurbopackRoot = baseConfig.turbopack?.root ?? workspaceRoot
@@ -338,11 +362,34 @@ export function withPalamedes(
     turbopack: {
       ...baseConfig.turbopack,
       ...(configuredTurbopackRoot ? { root: configuredTurbopackRoot } : {}),
+      ...(serverFunctionEntry
+        ? {
+            resolveAlias: {
+              ...baseConfig.turbopack?.resolveAlias,
+              [SERVER_FUNCTION_INITIALIZER_MODULE]: serverFunctionEntry.turbopackAlias,
+            },
+          }
+        : {}),
       rules,
     },
 
     // Webpack configuration
     webpack(config, context) {
+      if (serverFunctionEntry) {
+        config.resolve ??= {}
+        if (Array.isArray(config.resolve.alias)) {
+          config.resolve.alias.push({
+            name: SERVER_FUNCTION_INITIALIZER_MODULE,
+            alias: serverFunctionEntry.absolutePath,
+          })
+        } else {
+          config.resolve.alias = {
+            ...config.resolve.alias,
+            [SERVER_FUNCTION_INITIALIZER_MODULE]: serverFunctionEntry.absolutePath,
+          }
+        }
+      }
+
       // Add the OXC transform loader for JS/TS files
       config.module.rules.push({
         test: include,

--- a/packages/next-plugin/src/index.ts
+++ b/packages/next-plugin/src/index.ts
@@ -26,6 +26,7 @@ type TurbopackLoaderItem = Exclude<TurbopackRuleConfigItem["loaders"], undefined
 const MACRO_CONTENT_PATTERN = new RegExp(
   PALAMEDES_MACRO_PACKAGES.map((name) => name.replaceAll(/[.*+?^${}()|[\]\\/]/gu, "\\$&")).join("|")
 )
+const SERVER_FUNCTION_CONTENT_PATTERN = /["']use server["']/
 
 /*
  * A Turbopack rule array is either the loader "shorthand" (a flat list of
@@ -142,6 +143,35 @@ export type WithPalamedesOptions = {
    * If omitted, Palamedes will try to detect a workspace root from process.cwd().
    */
   workspaceRoot?: string
+
+  /**
+   * Initialize request-local i18n at the start of every recognized Next.js
+   * Server Function. The value uses `module#namedExport` syntax.
+   *
+   * @example { initializer: "@/i18n/server-action#initServerActionI18n" }
+   */
+  serverFunctions?: {
+    initializer: string
+  }
+}
+
+function parseServerFunctionInitializer(initializer: string) {
+  const separator = initializer.lastIndexOf("#")
+  const initializerModule = initializer.slice(0, separator)
+  const initializerExport = initializer.slice(separator + 1)
+  const identifierPattern = /^(?:[$_]|\p{ID_Start})(?:[$_]|\p{ID_Continue}|\u200C|\u200D)*$/u
+
+  if (
+    separator <= 0 ||
+    separator === initializer.length - 1 ||
+    !identifierPattern.test(initializerExport)
+  ) {
+    throw new Error(
+      `Invalid Palamedes Server Function initializer ${JSON.stringify(initializer)}. Expected "module#namedExport".`
+    )
+  }
+
+  return { initializerModule, initializerExport }
 }
 
 function resolveWorkspaceRoot(explicitRoot?: string) {
@@ -227,11 +257,15 @@ export function withPalamedes(
     runtimeModule: explicitRuntimeModule,
     keepSourceFallbacks: explicitKeepSourceFallbacks,
     workspaceRoot: explicitWorkspaceRoot,
+    serverFunctions: serverFunctionOptions,
   } = options
 
   const runtimeModule = resolveMacroRuntimeModule(explicitRuntimeModule)
   const keepSourceFallbacks = explicitKeepSourceFallbacks ?? process.env.NODE_ENV !== "production"
   const stripNonEssentialProps = process.env.NODE_ENV === "production"
+  const serverFunctions = serverFunctionOptions
+    ? parseServerFunctionInitializer(serverFunctionOptions.initializer)
+    : undefined
   const workspaceRoot = resolveWorkspaceRoot(explicitWorkspaceRoot)
   const configuredTurbopackRoot = baseConfig.turbopack?.root ?? workspaceRoot
   const outputFileTracingRoot =
@@ -258,13 +292,24 @@ export function withPalamedes(
         { not: "foreign" },
         { path: include },
         { not: { path: exclude } },
-        { content: MACRO_CONTENT_PATTERN },
+        {
+          content: serverFunctions
+            ? new RegExp(
+                `${MACRO_CONTENT_PATTERN.source}|${SERVER_FUNCTION_CONTENT_PATTERN.source}`
+              )
+            : MACRO_CONTENT_PATTERN,
+        },
       ],
     },
     loaders: [
       {
         loader: oxcLoaderPath,
-        options: { runtimeModule, keepSourceFallbacks, stripNonEssentialProps },
+        options: {
+          runtimeModule,
+          keepSourceFallbacks,
+          stripNonEssentialProps,
+          ...(serverFunctions ? { serverFunctions } : {}),
+        },
       },
     ],
   })
@@ -306,7 +351,12 @@ export function withPalamedes(
         use: [
           {
             loader: oxcLoaderPath,
-            options: { runtimeModule, keepSourceFallbacks, stripNonEssentialProps },
+            options: {
+              runtimeModule,
+              keepSourceFallbacks,
+              stripNonEssentialProps,
+              ...(serverFunctions ? { serverFunctions } : {}),
+            },
           },
         ],
       })

--- a/packages/next-plugin/src/palamedes-loader.test.ts
+++ b/packages/next-plugin/src/palamedes-loader.test.ts
@@ -36,6 +36,10 @@ describe("palamedes-loader.cjs", () => {
       runtimeModule: "@acme/custom-runtime",
       keepSourceFallbacks: false,
       stripNonEssentialProps: true,
+      serverFunctions: {
+        initializerModule: "@/i18n/server-action",
+        initializerExport: "initServerActionI18n",
+      },
     })
 
     expect(output).toBe("export const translated = true")
@@ -46,6 +50,10 @@ describe("palamedes-loader.cjs", () => {
         runtimeModule: "@acme/custom-runtime",
         keepSourceFallbacks: false,
         stripNonEssentialProps: true,
+        serverFunctions: {
+          initializerModule: "@/i18n/server-action",
+          initializerExport: "initServerActionI18n",
+        },
       })
     )
   })

--- a/packages/transform/src/detect.ts
+++ b/packages/transform/src/detect.ts
@@ -21,6 +21,14 @@ export function mightContainPalamedesMacros(code: string): boolean {
 }
 
 /**
+ * Quickly check whether source may contain a Server Function directive.
+ * The native pass performs the semantic AST check.
+ */
+export function mightContainServerFunctions(code: string): boolean {
+  return code.includes('"use server"') || code.includes("'use server'")
+}
+
+/**
  * Find all Palamedes macro imports in an AST
  */
 export function findMacroImports(program: unknown): Map<string, ImportInfo> {

--- a/packages/transform/src/transform.test.ts
+++ b/packages/transform/src/transform.test.ts
@@ -65,6 +65,27 @@ function View() { return <Select value={kind} other="Other" />; }
     expect(result.map).toBeNull()
   })
 
+  it("runs Server Function instrumentation without a macro import when configured", () => {
+    const code = `export async function save() { "use server"; await persist(); }`
+    const result = transformPalamedesMacrosRaw(code, "action.ts", {
+      serverFunctions: {
+        initializerModule: "@/i18n/server-action",
+        initializerExport: "initServerActionI18n",
+      },
+    })
+
+    expect(result.hasChanged).toBe(true)
+    expect(result.code).toContain("await __palamedesServerFunctionInitializer()")
+  })
+
+  it("does not instrument Server Functions without opt-in", () => {
+    const code = `export async function save() { "use server"; await persist(); }`
+    const result = transformPalamedesMacrosRaw(code, "action.ts")
+
+    expect(result.hasChanged).toBe(false)
+    expect(result.code).toBe(code)
+  })
+
   it("transforms tagged templates into compact runtime lookups", () => {
     const code = `
 import { t } from "@palamedes/core/macro";

--- a/packages/transform/src/transform.ts
+++ b/packages/transform/src/transform.ts
@@ -1,7 +1,7 @@
 import { transformMacrosNative, type NativeTransformResult } from "@palamedes/core-node"
 
 import type { SourceMap, TransformOptions, TransformResult } from "./types"
-import { mightContainPalamedesMacros } from "./detect"
+import { mightContainPalamedesMacros, mightContainServerFunctions } from "./detect"
 
 function buildTransformOutput(
   filename: string,
@@ -38,7 +38,10 @@ export function transformPalamedesMacros(
   filename: string,
   options: TransformOptions = {}
 ): TransformResult {
-  if (!mightContainPalamedesMacros(code)) {
+  const mightNeedServerFunctionTransform =
+    options.serverFunctions !== undefined && mightContainServerFunctions(code)
+
+  if (!mightContainPalamedesMacros(code) && !mightNeedServerFunctionTransform) {
     return { code, hasChanged: false, compiledIds: [], map: null }
   }
 


### PR DESCRIPTION
## Summary

- add opt-in OXC instrumentation for inline and module-level Next/React Server Functions
- initialize every recognized action before its body, including actions that only reach macros through synchronous or asynchronous helpers
- reject eager macro defaults in formal parameters and document the safe body rewrite
- exercise concurrent English/German Server Action POSTs under Turbopack and webpack

## Configuration

```js
withPalamedes({}, {
  serverFunctions: true,
})
```

The application exposes its locale and catalog initialization through a conventional
`palamedes.server` entry module. Palamedes keeps the generated import and bundler alias internal.

## Validation

- `env RUSTUP_TOOLCHAIN=stable pnpm agent:check`
- Next.js production build and concurrent RSC/Server Action scope proof with Turbopack
- the same production proof with webpack

Implements the decision-complete Next.js phase of #531. Waku and TanStack Start remain follow-up work.

Refs #531
