### PR TITLE
feat(next): split Server Function catalogs by module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,10 @@
 
 ### Performance Improvements
 
+- Next.js Server Functions now compile per-source message fragments and follow
+  the server ESM graph through locale-specific lazy imports. Action requests
+  load only the active locale's fragments for evaluated action modules and
+  transitive helpers instead of copying the complete locale catalog.
 - React and Solid now share one internal message renderer between their root
   and `compiled` entrypoints. This removes parallel runtime implementations
   while preserving the parser-free production boundary; lazy raw patterns use

--- a/examples/nextjs-cookie/src/lib/action-messages.ts
+++ b/examples/nextjs-cookie/src/lib/action-messages.ts
@@ -1,0 +1,7 @@
+import { t } from "@palamedes/core/macro"
+
+import type { Locale } from "./i18n"
+
+export function translateServerActionProof(locale: Locale): string {
+  return t`Server action confirmed locale ${locale}.`
+}

--- a/examples/nextjs-cookie/src/lib/actions.ts
+++ b/examples/nextjs-cookie/src/lib/actions.ts
@@ -3,7 +3,7 @@
 import { cookies } from "next/headers"
 import { revalidatePath } from "next/cache"
 import { redirect } from "next/navigation"
-import { t } from "@palamedes/core/macro"
+import { translateServerActionProof } from "./action-messages"
 import { getLocaleLabel, type Locale, LOCALES, LOCALE_COOKIE } from "./i18n"
 import { getLocale } from "./i18n.server"
 
@@ -42,8 +42,4 @@ async function createServerActionProof() {
     handledAt: new Date().toISOString(),
     message: translateServerActionProof(locale),
   }
-}
-
-function translateServerActionProof(locale: Locale) {
-  return t`Server action confirmed locale ${locale}.`
 }

--- a/examples/nextjs-cookie/src/palamedes.server.ts
+++ b/examples/nextjs-cookie/src/palamedes.server.ts
@@ -1,8 +1,12 @@
 import "server-only"
 
-import { createActiveServerI18n } from "./lib/i18n.server"
+import { createExampleI18n } from "./lib/i18n"
+import { getLocale, serverI18nScope } from "./lib/i18n.server"
 
 /** Initialize request-local i18n for every instrumented Server Function. */
 export async function initializeServerFunctionI18n(): Promise<void> {
-  await createActiveServerI18n()
+  const { locale } = await getLocale()
+  const i18n = createExampleI18n()
+  i18n.activate(locale)
+  serverI18nScope.activate(i18n)
 }

--- a/packages/next-plugin/README.md
+++ b/packages/next-plugin/README.md
@@ -167,13 +167,13 @@ the project root or `src` directory:
 ```ts
 // src/palamedes.server.ts
 import { createI18n } from "@palamedes/core/compiled"
-import { getLocale, serverI18n } from "./lib/i18n.server"
+import { getLocale, serverI18nScope } from "./lib/i18n.server"
 
 export async function initializeServerFunctionI18n(): Promise<void> {
-  const locale = await getLocale()
+  const { locale } = await getLocale()
   const i18n = createI18n()
   i18n.activate(locale)
-  serverI18n.activate(i18n)
+  serverI18nScope.activate(i18n)
 }
 ```
 
@@ -213,6 +213,13 @@ lazy import per locale containing only that module's compiled ids. Static ESM
 imports naturally bring along registrations from transitive helpers. After the
 application initializer activates its instance, Palamedes imports only the
 active locale's registered fragments and loads them into that instance.
+
+Registration must happen before the initializer runs to affect the current
+request. A module first reached through a dynamic import inside the action body
+registers its fragments too late for that invocation; those registrations are
+available to subsequent requests. Keep translating helpers in the static ESM
+dependency graph, or load their messages explicitly before translating during
+the first request.
 
 Generated locale imports are deduplicated across concurrent and later requests
 by the server module runtime. The request-local `load()` calls still merge each

--- a/packages/next-plugin/README.md
+++ b/packages/next-plugin/README.md
@@ -166,10 +166,14 @@ the project root or `src` directory:
 
 ```ts
 // src/palamedes.server.ts
-import { createActiveServerI18n } from "./lib/i18n.server"
+import { createI18n } from "@palamedes/core/compiled"
+import { getLocale, serverI18n } from "./lib/i18n.server"
 
 export async function initializeServerFunctionI18n(): Promise<void> {
-  await createActiveServerI18n()
+  const locale = await getLocale()
+  const i18n = createI18n()
+  i18n.activate(locale)
+  serverI18n.activate(i18n)
 }
 ```
 
@@ -202,9 +206,27 @@ only receives an imported callback has no local async body for Palamedes to
 instrument; keep the callback inline or mark its implementation explicitly.
 
 The initializer belongs to the application. It should resolve the request
-locale, load and activate a fresh catalog, and be request-memoized or otherwise
-idempotent. The plugin resolves exactly one `palamedes.server` module from the
+locale, create and activate a fresh request-local i18n instance, and be
+request-memoized or otherwise idempotent. It does not load a whole locale
+catalog: for each message-bearing server module, the transform registers one
+lazy import per locale containing only that module's compiled ids. Static ESM
+imports naturally bring along registrations from transitive helpers. After the
+application initializer activates its instance, Palamedes imports only the
+active locale's registered fragments and loads them into that instance.
+
+Generated locale imports are deduplicated across concurrent and later requests
+by the server module runtime. The request-local `load()` calls still merge each
+fragment into the fresh instance; they scale with the messages represented in
+the currently evaluated server graph rather than with the complete locale
+catalog. The plugin resolves exactly one `palamedes.server` module from the
 project root or `src` directory and keeps its absolute import address internal.
+
+Registration follows module evaluation, not a per-action bundler manifest. A
+long-lived server runtime can therefore retain registrations from more than one
+action graph, so a later action may load a superset of its own dependency
+closure. This affects the upper performance bound, not lookup correctness:
+Palamedes still imports only the active locale and only the selected ids from
+each registered source module.
 
 Parameter defaults execute before the function body. Palamedes therefore
 rejects eager macros in Server Function parameter initializers, including

--- a/packages/next-plugin/build.config.ts
+++ b/packages/next-plugin/build.config.ts
@@ -1,7 +1,12 @@
 import { defineBuildConfig } from "unbuild"
 
 export default defineBuildConfig({
-  entries: ["./src/index", "./src/server"],
+  entries: [
+    "./src/index",
+    "./src/server",
+    "./src/server-function-entry",
+    "./src/server-function-initializer",
+  ],
   declaration: true,
   failOnWarn: false,
   rollup: {

--- a/packages/next-plugin/package.json
+++ b/packages/next-plugin/package.json
@@ -63,6 +63,26 @@
         "default": "./dist/server.cjs"
       }
     },
+    "./server-function-initializer": {
+      "import": {
+        "types": "./dist/server-function-initializer.d.mts",
+        "default": "./dist/server-function-initializer.mjs"
+      },
+      "require": {
+        "types": "./dist/server-function-initializer.d.cts",
+        "default": "./dist/server-function-initializer.cjs"
+      }
+    },
+    "./server-function-entry": {
+      "import": {
+        "types": "./dist/server-function-entry.d.mts",
+        "default": "./dist/server-function-entry.mjs"
+      },
+      "require": {
+        "types": "./dist/server-function-entry.d.cts",
+        "default": "./dist/server-function-entry.cjs"
+      }
+    },
     "./palamedes-loader": "./palamedes-loader.cjs",
     "./palamedes-po-loader": "./palamedes-po-loader.cjs"
   },
@@ -70,7 +90,8 @@
     "@palamedes/config": "workspace:^",
     "@palamedes/core-node": "workspace:^",
     "@palamedes/runtime": "workspace:^",
-    "@palamedes/transform": "workspace:^"
+    "@palamedes/transform": "workspace:^",
+    "picomatch": "^4.0.5"
   },
   "peerDependencies": {
     "next": "^16"

--- a/packages/next-plugin/palamedes-loader.cjs
+++ b/packages/next-plugin/palamedes-loader.cjs
@@ -1,32 +1,180 @@
 "use strict"
 
+const { createHash } = require("node:crypto")
+const { realpathSync, statSync } = require("node:fs")
+const path = require("node:path")
+const { loadPalamedesConfigSync } = require("@palamedes/config")
 const { transformPalamedesMacros } = require("@palamedes/transform")
+const picomatch = require("picomatch")
+
+const SELECTED_MESSAGES_QUERY = "palamedes-selected"
+const configCache = new Map()
+
+function canonicalPath(value) {
+  try {
+    return realpathSync.native(value)
+  } catch {
+    return path.resolve(value)
+  }
+}
+
+function normalizePath(value) {
+  return value.split(path.sep).join("/")
+}
+
+function loadConfigCached(configPath) {
+  const key = configPath ?? ""
+  const cached = configCache.get(key)
+  if (cached) {
+    try {
+      if (statSync(cached.config.configPath).mtimeMs === cached.mtimeMs) {
+        return cached.config
+      }
+    } catch {
+      // Config moved, changed, or is not stat-able; reload it below.
+    }
+  }
+
+  const config = loadPalamedesConfigSync({ configPath })
+  try {
+    configCache.set(key, {
+      config,
+      mtimeMs: statSync(config.configPath).mtimeMs,
+    })
+  } catch {
+    // Tests and virtual configs may not have a stat-able config file.
+  }
+  return config
+}
+
+function catalogMatchesSource(config, catalog, sourcePath) {
+  const source = normalizePath(canonicalPath(sourcePath))
+  const include = catalog.include.map((pattern) => {
+    const absolute = path.resolve(config.rootDir, pattern)
+    try {
+      if (statSync(absolute).isDirectory()) {
+        return `${normalizePath(absolute)}/**/*.{js,jsx,ts,tsx,mdx}`
+      }
+    } catch {
+      // Keep non-existent paths and explicit glob patterns unchanged.
+    }
+    return normalizePath(absolute)
+  })
+  const exclude = (catalog.exclude ?? ["**/node_modules/**"]).map((pattern) =>
+    normalizePath(path.resolve(config.rootDir, pattern))
+  )
+
+  return (
+    include.some((pattern) => picomatch.isMatch(source, pattern)) &&
+    !exclude.some((pattern) => picomatch.isMatch(source, pattern))
+  )
+}
+
+function catalogResourcePath(config, catalog, locale) {
+  const extension = catalog.format ?? "po"
+  if (extension !== "po") {
+    throw new Error(
+      `Palamedes Next Server Function message splitting currently supports PO catalogs only. Catalog ${catalog.path} uses format ${extension}.`
+    )
+  }
+  const configuredPath = path.resolve(config.rootDir, catalog.path.replace("{locale}", locale))
+  const parsed = path.parse(configuredPath)
+  return path.format({ dir: parsed.dir, name: parsed.name, ext: `.${extension}` })
+}
+
+function relativeImport(fromFile, targetFile) {
+  let relative = normalizePath(path.relative(path.dirname(fromFile), targetFile))
+  if (!relative.startsWith(".")) {
+    relative = `./${relative}`
+  }
+  return relative
+}
+
+function messageLoaderRegistration(config, sourcePath, compiledIds) {
+  const catalogs = config.catalogs.filter((catalog) =>
+    catalogMatchesSource(config, catalog, sourcePath)
+  )
+  if (catalogs.length === 0) {
+    return null
+  }
+
+  const selection = Buffer.from(JSON.stringify(compiledIds)).toString("base64url")
+  const modulePath = normalizePath(
+    path.relative(canonicalPath(config.rootDir), canonicalPath(sourcePath))
+  )
+  const moduleKey = createHash("sha256").update(modulePath).digest("hex").slice(0, 12)
+  const registrations = catalogs.map((catalog, catalogIndex) => {
+    const loaders = config.locales
+      .map((locale) => {
+        const resourcePath = catalogResourcePath(config, catalog, locale)
+        const specifier = `${relativeImport(sourcePath, resourcePath)}?${SELECTED_MESSAGES_QUERY}=${selection}`
+        return `${JSON.stringify(locale)}: () => import(${JSON.stringify(specifier)}).then(({ messages }) => messages)`
+      })
+      .join(", ")
+    return `registerMessageLoaders(${JSON.stringify(`${moduleKey}:${catalogIndex}`)}, { ${loaders} });`
+  })
+
+  return (
+    `\nimport { registerMessageLoaders } from "@palamedes/runtime";\n` +
+    `${registrations.join("\n")}\n`
+  )
+}
 
 module.exports = function palamedesLoader(source, inputSourceMap) {
   const callback = this.async ? this.async() : null
   const options = typeof this.getOptions === "function" ? this.getOptions() : {}
+  let result
 
   try {
-    const result = transformPalamedesMacros(String(source), this.resourcePath, {
+    result = transformPalamedesMacros(String(source), this.resourcePath, {
       runtimeModule: options.runtimeModule,
       keepSourceFallbacks: options.keepSourceFallbacks,
       stripNonEssentialProps: options.stripNonEssentialProps,
       serverFunctions: options.serverFunctions,
       sourceMap: this.sourceMap,
     })
-
-    if (callback) {
-      callback(null, result.code, result.map ?? inputSourceMap ?? null)
-      return
-    }
-
-    return result.code
   } catch (error) {
     if (callback) {
       callback(error)
       return
     }
+    throw error
+  }
 
+  if (options.serverMessageSplitting !== true || result.compiledIds?.length === 0) {
+    if (callback) {
+      callback(null, result.code, result.map ?? inputSourceMap ?? null)
+      return
+    }
+    return result.code
+  }
+
+  try {
+    const config = loadConfigCached(options.configPath)
+    if (typeof this.addDependency === "function" && config.configPath) {
+      this.addDependency(config.configPath)
+    }
+    const registration = messageLoaderRegistration(config, this.resourcePath, result.compiledIds)
+    let code = result.code
+    if (registration) {
+      code += registration
+    } else if (typeof this.emitWarning === "function") {
+      this.emitWarning(
+        new Error(
+          `Palamedes Server Function message splitting: ${this.resourcePath} uses messages but is not included in any configured catalog.`
+        )
+      )
+    }
+    if (callback) {
+      callback(null, code, result.map ?? inputSourceMap ?? null)
+      return
+    }
+    return code
+  } catch (error) {
+    if (callback) {
+      callback(error)
+      return
+    }
     throw error
   }
 }

--- a/packages/next-plugin/palamedes-loader.cjs
+++ b/packages/next-plugin/palamedes-loader.cjs
@@ -48,9 +48,12 @@ function loadConfigCached(configPath) {
 }
 
 function catalogMatchesSource(config, catalog, sourcePath) {
+  // Keep catalog include/exclude matching in sync with catalogMatchesSource in
+  // packages/vite-plugin/src/index.ts.
+  const rootDir = canonicalPath(config.rootDir)
   const source = normalizePath(canonicalPath(sourcePath))
   const include = catalog.include.map((pattern) => {
-    const absolute = path.resolve(config.rootDir, pattern)
+    const absolute = path.resolve(rootDir, pattern)
     try {
       if (statSync(absolute).isDirectory()) {
         return `${normalizePath(absolute)}/**/*.{js,jsx,ts,tsx,mdx}`
@@ -61,7 +64,7 @@ function catalogMatchesSource(config, catalog, sourcePath) {
     return normalizePath(absolute)
   })
   const exclude = (catalog.exclude ?? ["**/node_modules/**"]).map((pattern) =>
-    normalizePath(path.resolve(config.rootDir, pattern))
+    normalizePath(path.resolve(rootDir, pattern))
   )
 
   return (
@@ -141,7 +144,7 @@ module.exports = function palamedesLoader(source, inputSourceMap) {
     throw error
   }
 
-  if (options.serverMessageSplitting !== true || result.compiledIds?.length === 0) {
+  if (options.serverMessageSplitting !== true || !result.compiledIds?.length) {
     if (callback) {
       callback(null, result.code, result.map ?? inputSourceMap ?? null)
       return

--- a/packages/next-plugin/palamedes-po-loader.cjs
+++ b/packages/next-plugin/palamedes-po-loader.cjs
@@ -3,7 +3,10 @@
 const { statSync } = require("node:fs")
 const path = require("node:path")
 const { loadPalamedesConfig } = require("@palamedes/config")
-const { compileCatalogModule } = require("@palamedes/core-node")
+const { compileCatalogArtifactSelected, compileCatalogModule } = require("@palamedes/core-node")
+const { createCatalogLoaderResult, createMissingErrorMessage } = require("@palamedes/transform")
+
+const SELECTED_MESSAGES_QUERY = "palamedes-selected"
 
 /*
  * Loading the config walks the filesystem upward and parses the file; doing
@@ -43,29 +46,49 @@ module.exports = function palamedesPoLoader() {
   ;(async () => {
     const cfg = await loadConfigCached(options.configPath)
     const locale = path.basename(this.resourcePath, ".po")
-    const result = compileCatalogModule(
-      {
-        rootDir: cfg.rootDir,
-        locales: cfg.locales,
-        sourceLocale: cfg.sourceLocale,
-        fallbackLocales: cfg.fallbackLocales,
-        pseudoLocale: cfg.pseudoLocale,
-        catalogs: cfg.catalogs,
-      },
-      this.resourcePath,
-      {
-        locale,
-        pseudoLocale: cfg.pseudoLocale,
-        failOnMissing,
-        failOnCompileError,
-        missingFailureHint:
-          "You see this error because `failOnMissing=true` in Palamedes Next plugin configuration.",
-        compileFailureHint:
-          "These errors fail the build because `failOnCompileError=true` in the Palamedes Next plugin configuration.",
-        diagnosticsWarningHint:
-          "You can fail the build on error diagnostics by setting `failOnCompileError=true` in the Palamedes Next plugin configuration.",
+    const artifactConfig = {
+      rootDir: cfg.rootDir,
+      locales: cfg.locales,
+      sourceLocale: cfg.sourceLocale,
+      fallbackLocales: cfg.fallbackLocales,
+      pseudoLocale: cfg.pseudoLocale,
+      catalogs: cfg.catalogs,
+    }
+    const loaderOptions = {
+      locale,
+      pseudoLocale: cfg.pseudoLocale,
+      failOnMissing,
+      failOnCompileError,
+      missingFailureHint:
+        "You see this error because `failOnMissing=true` in Palamedes Next plugin configuration.",
+      compileFailureHint:
+        "These errors fail the build because `failOnCompileError=true` in the Palamedes Next plugin configuration.",
+      diagnosticsWarningHint:
+        "You can fail the build on error diagnostics by setting `failOnCompileError=true` in the Palamedes Next plugin configuration.",
+    }
+    const selection = new URLSearchParams(this.resourceQuery ?? "").get(SELECTED_MESSAGES_QUERY)
+    let result
+    if (selection) {
+      const compiledIds = JSON.parse(Buffer.from(selection, "base64url").toString("utf8"))
+      if (!Array.isArray(compiledIds) || !compiledIds.every((id) => typeof id === "string")) {
+        throw new TypeError("Invalid Palamedes selected-message query.")
       }
-    )
+      const artifact = compileCatalogArtifactSelected(
+        artifactConfig,
+        this.resourcePath,
+        compiledIds
+      )
+      result = {
+        ...createCatalogLoaderResult(artifact, loaderOptions),
+        watchFiles: artifact.watchFiles,
+      }
+      const resolvedLocale = artifact.resolvedLocaleChain?.[0] ?? locale
+      if (!failOnMissing && resolvedLocale !== cfg.pseudoLocale && artifact.missing.length > 0) {
+        result.warnings.push(createMissingErrorMessage(resolvedLocale, artifact.missing))
+      }
+    } else {
+      result = compileCatalogModule(artifactConfig, this.resourcePath, loaderOptions)
+    }
     if (typeof this.addDependency === "function") {
       if (cfg.configPath) {
         this.addDependency(cfg.configPath)

--- a/packages/next-plugin/src/index.test.ts
+++ b/packages/next-plugin/src/index.test.ts
@@ -11,7 +11,8 @@ afterEach(() => {
 })
 
 const nextExampleRoot = fileURLToPath(new URL("../../../examples/nextjs-cookie", import.meta.url))
-const serverEntryModule = "@palamedes/next-plugin/server-function-initializer"
+const serverInitializerModule = "@palamedes/next-plugin/server-function-initializer"
+const serverEntryModule = "@palamedes/next-plugin/server-function-entry"
 
 function useNextExampleProject(): void {
   vi.spyOn(process, "cwd").mockReturnValue(nextExampleRoot)
@@ -103,7 +104,16 @@ describe("withPalamedes turbopack config", () => {
   it("matches Server Function directives and forwards the initializer when configured", () => {
     useNextExampleProject()
     const config = withPalamedes({}, { serverFunctions: true })
-    const rule = getRules(config)["*"] as RuleItem
+    const configuredRules = getRules(config)["*"] as RuleItem[]
+    const rule = configuredRules.find((candidate) =>
+      conditionList(candidate).some(
+        (condition) =>
+          typeof condition === "object" &&
+          condition !== null &&
+          "not" in condition &&
+          condition.not === "browser"
+      )
+    )!
     const content = (
       conditionList(rule).find(
         (condition) => typeof condition === "object" && condition !== null && "content" in condition
@@ -113,13 +123,26 @@ describe("withPalamedes turbopack config", () => {
     expect(content.test('async function save() { "use server" }')).toBe(true)
     expect(rule.loaders?.[0]?.options).toMatchObject({
       serverFunctions: {
-        initializerModule: serverEntryModule,
+        initializerModule: serverInitializerModule,
         initializerExport: "initializeServerFunctionI18n",
       },
+      serverMessageSplitting: true,
     })
     expect(config.turbopack?.resolveAlias).toMatchObject({
       [serverEntryModule]: "./src/palamedes.server.ts",
     })
+  })
+
+  it("keeps server message loaders out of the Turbopack browser graph", () => {
+    useNextExampleProject()
+    const configuredRules = getRules(withPalamedes({}, { serverFunctions: true }))[
+      "*"
+    ] as RuleItem[]
+    const browserRule = configuredRules.find((candidate) =>
+      conditionList(candidate).includes("browser")
+    )
+
+    expect(browserRule?.loaders?.[0]?.options).not.toHaveProperty("serverMessageSplitting")
   })
 
   it("requires the conventional Server Function entry module when enabled", () => {
@@ -204,28 +227,44 @@ type WebpackRule = {
   use?: { loader: string; options?: Record<string, unknown> }[]
 }
 
-function collectWebpackRules(config: ReturnType<typeof withPalamedes>): WebpackRule[] {
+function collectWebpackRules(
+  config: ReturnType<typeof withPalamedes>,
+  context: Record<string, unknown> = {}
+): WebpackRule[] {
   const rules: WebpackRule[] = []
   const webpack = config.webpack as (
     config: { module: { rules: WebpackRule[] } },
     context: unknown
   ) => unknown
-  webpack({ module: { rules } }, {})
+  webpack({ module: { rules } }, context)
   return rules
 }
 
 describe("withPalamedes webpack config", () => {
   it("forwards Server Function instrumentation to webpack", () => {
     useNextExampleProject()
-    const rules = collectWebpackRules(withPalamedes({}, { serverFunctions: true }))
+    const rules = collectWebpackRules(withPalamedes({}, { serverFunctions: true }), {
+      isServer: true,
+    })
     const transformRule = rules.find((rule) => rule.use?.[0]?.loader.includes("palamedes-loader"))
 
     expect(transformRule?.use?.[0]?.options).toMatchObject({
       serverFunctions: {
-        initializerModule: serverEntryModule,
+        initializerModule: serverInitializerModule,
         initializerExport: "initializeServerFunctionI18n",
       },
+      serverMessageSplitting: true,
     })
+  })
+
+  it("keeps server message loaders out of the webpack client compiler", () => {
+    useNextExampleProject()
+    const rules = collectWebpackRules(withPalamedes({}, { serverFunctions: true }), {
+      isServer: false,
+    })
+    const transformRule = rules.find((rule) => rule.use?.[0]?.loader.includes("palamedes-loader"))
+
+    expect(transformRule?.use?.[0]?.options).not.toHaveProperty("serverMessageSplitting")
   })
 
   it("excludes node_modules from the po loader rule", () => {

--- a/packages/next-plugin/src/index.ts
+++ b/packages/next-plugin/src/index.ts
@@ -28,6 +28,7 @@ const MACRO_CONTENT_PATTERN = new RegExp(
 )
 const SERVER_FUNCTION_CONTENT_PATTERN = /["']use server["']/
 const SERVER_FUNCTION_INITIALIZER_MODULE = "@palamedes/next-plugin/server-function-initializer"
+const SERVER_FUNCTION_ENTRY_MODULE = "@palamedes/next-plugin/server-function-entry"
 const SERVER_FUNCTION_INITIALIZER_EXPORT = "initializeServerFunctionI18n"
 const SERVER_FUNCTION_ENTRY_EXTENSIONS = [
   ".ts",
@@ -304,39 +305,53 @@ export function withPalamedes(
     failOnCompileError,
     ...(configPath ? { configPath } : {}),
   }
+  const transformLoaderOptions = {
+    runtimeModule,
+    keepSourceFallbacks,
+    stripNonEssentialProps,
+    ...(configPath ? { configPath } : {}),
+    ...(serverFunctions ? { serverFunctions } : {}),
+  }
 
   const rules: TurbopackRules = { ...baseConfig.turbopack?.rules }
 
   // Transform local JS/TS files that actually import Palamedes macros. The
   // include/exclude options translate into the rule condition so they behave
   // the same under Turbopack as in the webpack branch below.
-  appendTurbopackRule(rules, "*", {
-    condition: {
-      all: [
-        { not: "foreign" },
-        { path: include },
-        { not: { path: exclude } },
+  const transformConditions = [
+    { not: "foreign" },
+    { path: include },
+    { not: { path: exclude } },
+    {
+      content: serverFunctions
+        ? new RegExp(`${MACRO_CONTENT_PATTERN.source}|${SERVER_FUNCTION_CONTENT_PATTERN.source}`)
+        : MACRO_CONTENT_PATTERN,
+    },
+  ]
+  if (serverFunctions) {
+    // Turbopack's built-in browser condition lets one unified graph produce a
+    // plain client transform and a server transform with lazy message
+    // sidecars. Keeping the rules disjoint prevents server-only catalog
+    // loaders from entering browser chunks.
+    appendTurbopackRule(rules, "*", {
+      condition: { all: [...transformConditions, "browser"] },
+      loaders: [{ loader: oxcLoaderPath, options: transformLoaderOptions }],
+    })
+    appendTurbopackRule(rules, "*", {
+      condition: { all: [...transformConditions, { not: "browser" }] },
+      loaders: [
         {
-          content: serverFunctions
-            ? new RegExp(
-                `${MACRO_CONTENT_PATTERN.source}|${SERVER_FUNCTION_CONTENT_PATTERN.source}`
-              )
-            : MACRO_CONTENT_PATTERN,
+          loader: oxcLoaderPath,
+          options: { ...transformLoaderOptions, serverMessageSplitting: true },
         },
       ],
-    },
-    loaders: [
-      {
-        loader: oxcLoaderPath,
-        options: {
-          runtimeModule,
-          keepSourceFallbacks,
-          stripNonEssentialProps,
-          ...(serverFunctions ? { serverFunctions } : {}),
-        },
-      },
-    ],
-  })
+    })
+  } else {
+    appendTurbopackRule(rules, "*", {
+      condition: { all: transformConditions },
+      loaders: [{ loader: oxcLoaderPath, options: transformLoaderOptions }],
+    })
+  }
 
   // Compile local .po files
   if (enablePoLoader) {
@@ -366,7 +381,7 @@ export function withPalamedes(
         ? {
             resolveAlias: {
               ...baseConfig.turbopack?.resolveAlias,
-              [SERVER_FUNCTION_INITIALIZER_MODULE]: serverFunctionEntry.turbopackAlias,
+              [SERVER_FUNCTION_ENTRY_MODULE]: serverFunctionEntry.turbopackAlias,
             },
           }
         : {}),
@@ -379,13 +394,13 @@ export function withPalamedes(
         config.resolve ??= {}
         if (Array.isArray(config.resolve.alias)) {
           config.resolve.alias.push({
-            name: SERVER_FUNCTION_INITIALIZER_MODULE,
+            name: SERVER_FUNCTION_ENTRY_MODULE,
             alias: serverFunctionEntry.absolutePath,
           })
         } else {
           config.resolve.alias = {
             ...config.resolve.alias,
-            [SERVER_FUNCTION_INITIALIZER_MODULE]: serverFunctionEntry.absolutePath,
+            [SERVER_FUNCTION_ENTRY_MODULE]: serverFunctionEntry.absolutePath,
           }
         }
       }
@@ -399,10 +414,8 @@ export function withPalamedes(
           {
             loader: oxcLoaderPath,
             options: {
-              runtimeModule,
-              keepSourceFallbacks,
-              stripNonEssentialProps,
-              ...(serverFunctions ? { serverFunctions } : {}),
+              ...transformLoaderOptions,
+              ...(serverFunctions && context.isServer ? { serverMessageSplitting: true } : {}),
             },
           },
         ],

--- a/packages/next-plugin/src/palamedes-loader.test.ts
+++ b/packages/next-plugin/src/palamedes-loader.test.ts
@@ -1,5 +1,8 @@
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises"
 import { createRequire } from "node:module"
 import Module from "node:module"
+import os from "node:os"
+import path from "node:path"
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
@@ -104,6 +107,57 @@ describe("palamedes-loader.cjs", () => {
     expect(loadPalamedesConfigSync).not.toHaveBeenCalled()
   })
 
+  it("skips server splitting when the transform does not report compiled ids", async () => {
+    transformPalamedesMacros.mockReturnValue({
+      code: "export const translated = true",
+      map: null,
+    })
+
+    const output = await runLoader({ serverMessageSplitting: true })
+
+    expect(output).toBe("export const translated = true")
+    expect(loadPalamedesConfigSync).not.toHaveBeenCalled()
+  })
+
+  it("matches catalogs when the configured root resolves through a symlink", async () => {
+    const fixtureDirectory = await mkdtemp(path.join(os.tmpdir(), "palamedes-next-loader-"))
+    const realRoot = path.join(fixtureDirectory, "real-root")
+    const linkedRoot = path.join(fixtureDirectory, "linked-root")
+    const resourcePath = path.join(realRoot, "src", "page.tsx")
+
+    try {
+      await mkdir(path.dirname(resourcePath), { recursive: true })
+      await writeFile(resourcePath, "")
+      await symlink(realRoot, linkedRoot, process.platform === "win32" ? "junction" : "dir")
+      transformPalamedesMacros.mockReturnValue({
+        code: "export const translated = true",
+        map: null,
+        compiledIds: ["id-a"],
+      })
+      loadPalamedesConfigSync.mockReturnValue({
+        configPath: path.join(linkedRoot, "palamedes.yaml"),
+        rootDir: linkedRoot,
+        locales: ["en"],
+        sourceLocale: "en",
+        catalogs: [{ path: "src/locales/{locale}", include: ["src/**/*.tsx"] }],
+      })
+      const warnings: Error[] = []
+
+      const output = await runLoader(
+        { serverMessageSplitting: true },
+        {
+          resourcePath,
+          emitWarning: (warning: Error) => warnings.push(warning),
+        }
+      )
+
+      expect(output).toContain('import { registerMessageLoaders } from "@palamedes/runtime";')
+      expect(warnings).toEqual([])
+    } finally {
+      await rm(fixtureDirectory, { force: true, recursive: true })
+    }
+  })
+
   it("rejects server splitting for catalog formats without a Next loader", async () => {
     transformPalamedesMacros.mockReturnValue({
       code: "export const translated = true",
@@ -140,8 +194,8 @@ async function runLoader(
   return new Promise<string>((resolve, reject) => {
     loader.call(
       {
-        ...extraContext,
         resourcePath: "/repo/src/page.tsx",
+        ...extraContext,
         sourceMap: true,
         getOptions() {
           return options

--- a/packages/next-plugin/src/palamedes-loader.test.ts
+++ b/packages/next-plugin/src/palamedes-loader.test.ts
@@ -10,15 +10,28 @@ const moduleLoader = Module as unknown as {
 }
 const originalLoad = moduleLoader._load
 const transformPalamedesMacros = vi.fn()
+const loadPalamedesConfigSync = vi.fn()
 
 beforeEach(() => {
+  vi.clearAllMocks()
   transformPalamedesMacros.mockReturnValue({
     code: "export const translated = true",
     map: null,
+    compiledIds: [],
+  })
+  loadPalamedesConfigSync.mockReturnValue({
+    configPath: "/repo/palamedes.yaml",
+    rootDir: "/repo",
+    locales: ["en", "de"],
+    sourceLocale: "en",
+    catalogs: [{ path: "src/locales/{locale}", include: ["src/**/*.tsx"] }],
   })
   moduleLoader._load = (request, parent, isMain) => {
     if (request === "@palamedes/transform") {
       return { transformPalamedesMacros }
+    }
+    if (request === "@palamedes/config") {
+      return { loadPalamedesConfigSync }
     }
     return originalLoad.call(Module, request, parent, isMain)
   }
@@ -57,15 +70,77 @@ describe("palamedes-loader.cjs", () => {
       })
     )
   })
+
+  it("registers active-locale imports for a server module's compiled ids", async () => {
+    transformPalamedesMacros.mockReturnValue({
+      code: "export const translated = true",
+      map: null,
+      compiledIds: ["id-a", "id-b"],
+    })
+    const dependencies: string[] = []
+
+    const output = await runLoader(
+      { serverMessageSplitting: true },
+      { addDependency: (file: string) => dependencies.push(file) }
+    )
+
+    expect(output).toContain('import { registerMessageLoaders } from "@palamedes/runtime";')
+    expect(output).toContain('"en": () => import("./locales/en.po?palamedes-selected=')
+    expect(output).toContain('"de": () => import("./locales/de.po?palamedes-selected=')
+    expect(output).toContain(".then(({ messages }) => messages)")
+    expect(dependencies).toEqual(["/repo/palamedes.yaml"])
+  })
+
+  it("does not add server message imports to a client transform", async () => {
+    transformPalamedesMacros.mockReturnValue({
+      code: "export const translated = true",
+      map: null,
+      compiledIds: ["id-a"],
+    })
+
+    const output = await runLoader({ serverMessageSplitting: false })
+
+    expect(output).not.toContain("registerMessageLoaders")
+    expect(loadPalamedesConfigSync).not.toHaveBeenCalled()
+  })
+
+  it("rejects server splitting for catalog formats without a Next loader", async () => {
+    transformPalamedesMacros.mockReturnValue({
+      code: "export const translated = true",
+      map: null,
+      compiledIds: ["id-a"],
+    })
+    loadPalamedesConfigSync.mockReturnValue({
+      configPath: "/repo/palamedes.yaml",
+      rootDir: "/repo",
+      locales: ["en"],
+      sourceLocale: "en",
+      catalogs: [
+        {
+          path: "src/locales/{locale}",
+          include: ["src/**/*.tsx"],
+          format: "fcl",
+        },
+      ],
+    })
+
+    await expect(runLoader({ serverMessageSplitting: true })).rejects.toThrow(
+      "Palamedes Next Server Function message splitting currently supports PO catalogs only"
+    )
+  })
 })
 
-async function runLoader(options: Record<string, unknown>): Promise<string> {
+async function runLoader(
+  options: Record<string, unknown>,
+  extraContext: Record<string, unknown> = {}
+): Promise<string> {
   delete require.cache[require.resolve(loaderPath)]
   const loader = require(loaderPath) as (this: unknown, source: string) => void
 
   return new Promise<string>((resolve, reject) => {
     loader.call(
       {
+        ...extraContext,
         resourcePath: "/repo/src/page.tsx",
         sourceMap: true,
         getOptions() {

--- a/packages/next-plugin/src/palamedes-po-loader.test.ts
+++ b/packages/next-plugin/src/palamedes-po-loader.test.ts
@@ -13,9 +13,13 @@ const moduleLoader = Module as unknown as {
 const originalLoad = moduleLoader._load
 
 const loadPalamedesConfig = vi.fn()
+const compileCatalogArtifactSelected = vi.fn()
 const compileCatalogModule = vi.fn()
+const createCatalogLoaderResult = vi.fn()
+const createMissingErrorMessage = vi.fn()
 
 beforeEach(() => {
+  vi.clearAllMocks()
   loadPalamedesConfig.mockResolvedValue({
     configPath: "/repo/palamedes.yaml",
     rootDir: "/repo",
@@ -30,6 +34,18 @@ beforeEach(() => {
     warnings: [],
     watchFiles: ["/repo/src/locales/en.po"],
   })
+  compileCatalogArtifactSelected.mockReturnValue({
+    messages: { greeting: "Hallo" },
+    missing: [],
+    diagnostics: [],
+    watchFiles: ["/repo/src/locales/de.po"],
+    resolvedLocaleChain: ["de"],
+  })
+  createCatalogLoaderResult.mockReturnValue({
+    code: 'export const messages={"greeting":"Hallo"};export default { messages };',
+    warnings: [],
+  })
+  createMissingErrorMessage.mockReturnValue("Missing selected translation")
   vi.spyOn(console, "warn").mockImplementation(() => {})
 
   moduleLoader._load = (request, parent, isMain) => {
@@ -37,7 +53,10 @@ beforeEach(() => {
       return { loadPalamedesConfig }
     }
     if (request === "@palamedes/core-node") {
-      return { compileCatalogModule }
+      return { compileCatalogArtifactSelected, compileCatalogModule }
+    }
+    if (request === "@palamedes/transform") {
+      return { createCatalogLoaderResult, createMissingErrorMessage }
     }
     return originalLoad.call(Module, request, parent, isMain)
   }
@@ -104,6 +123,42 @@ describe("palamedes-po-loader.cjs", () => {
       /Compilation error for 1 translation/
     )
     expect(console.warn).not.toHaveBeenCalled()
+  })
+
+  it("compiles only the ids encoded by a generated sidecar import", async () => {
+    const selection = Buffer.from(JSON.stringify(["id-a", "id-b"])).toString("base64url")
+
+    const result = await runLoader({}, { resourceQuery: `?palamedes-selected=${selection}` })
+
+    expect(compileCatalogArtifactSelected).toHaveBeenCalledWith(
+      expect.objectContaining({ rootDir: "/repo" }),
+      "/repo/src/locales/de.po",
+      ["id-a", "id-b"]
+    )
+    expect(createCatalogLoaderResult).toHaveBeenCalledWith(
+      expect.objectContaining({ messages: { greeting: "Hallo" } }),
+      expect.objectContaining({ locale: "de" })
+    )
+    expect(compileCatalogModule).not.toHaveBeenCalled()
+    expect(result.code).toContain('"greeting":"Hallo"')
+  })
+
+  it("warns about selected messages missing from a non-pseudo locale", async () => {
+    compileCatalogArtifactSelected.mockReturnValue({
+      messages: {},
+      missing: [{ sourceKey: { message: "Missing" } }],
+      diagnostics: [],
+      watchFiles: [],
+      resolvedLocaleChain: ["de"],
+    })
+    const selection = Buffer.from(JSON.stringify(["id-missing"])).toString("base64url")
+    const emitWarning = vi.fn()
+
+    await runLoader({}, { resourceQuery: `?palamedes-selected=${selection}`, emitWarning })
+
+    expect(emitWarning).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "Missing selected translation" })
+    )
   })
 })
 

--- a/packages/next-plugin/src/server-function-entry.ts
+++ b/packages/next-plugin/src/server-function-entry.ts
@@ -1,0 +1,9 @@
+/**
+ * Replaced with the application's palamedes.server module.
+ * @internal
+ */
+export async function initializeServerFunctionI18n(): Promise<never> {
+  throw new Error(
+    "Palamedes could not resolve the application Server Function initializer. Enable serverFunctions in withPalamedes() and provide one palamedes.server module."
+  )
+}

--- a/packages/next-plugin/src/server-function-initializer.test.ts
+++ b/packages/next-plugin/src/server-function-initializer.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  getI18n: vi.fn(),
+  initializeApplication: vi.fn(),
+  loadRegisteredMessages: vi.fn(),
+}))
+
+vi.mock("@palamedes/next-plugin/server-function-entry", () => ({
+  initializeServerFunctionI18n: mocks.initializeApplication,
+}))
+
+vi.mock("@palamedes/runtime", () => ({
+  getI18n: mocks.getI18n,
+  loadRegisteredMessages: mocks.loadRegisteredMessages,
+}))
+
+import { initializeServerFunctionI18n } from "./server-function-initializer"
+
+describe("Server Function initializer adapter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.initializeApplication.mockResolvedValue(undefined)
+    mocks.loadRegisteredMessages.mockResolvedValue(undefined)
+  })
+
+  it("loads the active locale's registered graph messages after app initialization", async () => {
+    const i18n = { locale: "de", _: vi.fn(), load: vi.fn() }
+    mocks.getI18n.mockReturnValue(i18n)
+
+    await initializeServerFunctionI18n()
+
+    expect(mocks.initializeApplication).toHaveBeenCalledOnce()
+    expect(mocks.getI18n).toHaveBeenCalledOnce()
+    expect(mocks.loadRegisteredMessages).toHaveBeenCalledWith(i18n, "de")
+    expect(mocks.initializeApplication.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.loadRegisteredMessages.mock.invocationCallOrder[0]!
+    )
+  })
+})

--- a/packages/next-plugin/src/server-function-initializer.ts
+++ b/packages/next-plugin/src/server-function-initializer.ts
@@ -1,0 +1,12 @@
+import { initializeServerFunctionI18n as initializeApplicationServerFunctionI18n } from "@palamedes/next-plugin/server-function-entry"
+import { getI18n, loadRegisteredMessages } from "@palamedes/runtime"
+
+/**
+ * Generated Server Function imports target this adapter entry.
+ * @internal
+ */
+export async function initializeServerFunctionI18n(): Promise<void> {
+  await initializeApplicationServerFunctionI18n()
+  const i18n = getI18n()
+  await loadRegisteredMessages(i18n, i18n.locale)
+}

--- a/packages/runtime/src/index.test.ts
+++ b/packages/runtime/src/index.test.ts
@@ -5,6 +5,8 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 import {
   type I18nInstance,
   getI18n,
+  loadRegisteredMessages,
+  registerMessageLoaders,
   registerMessages,
   resetI18nRuntime,
   setClientI18n,
@@ -152,5 +154,94 @@ describe("registerMessages", () => {
     registerMessages({ "reg-plain": { keyF: "F" } })
 
     expect(() => setClientI18n(createTestI18n("reg-plain"))).not.toThrow()
+  })
+
+  it("loads eager registrations into a request-local server instance", async () => {
+    const messages = { keyG: "G" }
+    registerMessages({ "reg-server-eager": messages })
+    const i18n = createLoadableI18n("reg-server-eager")
+
+    await expect(loadRegisteredMessages(i18n, "reg-server-eager")).resolves.toBe(i18n)
+    expect(i18n.loaded["reg-server-eager"]).toEqual([messages])
+    expect(i18n.loaded["reg-server-eager"]?.[0]).toBe(messages)
+  })
+
+  it("loads only the requested locale from lazy module registrations", async () => {
+    const en = { keyH: "H" }
+    const de = { keyH: "H-de" }
+    const loadEn = vi.fn(async () => en)
+    const loadDe = vi.fn(async () => de)
+    registerMessageLoaders("reg-server-locale", {
+      en: loadEn,
+      de: loadDe,
+    })
+    const i18n = createLoadableI18n("de")
+
+    await loadRegisteredMessages(i18n, "de")
+
+    expect(loadEn).not.toHaveBeenCalled()
+    expect(loadDe).toHaveBeenCalledOnce()
+    expect(i18n.loaded.de).toEqual([de])
+  })
+
+  it("deduplicates lazy imports across concurrent and later requests", async () => {
+    const messages = { keyI: "I" }
+    const load = vi.fn(async () => messages)
+    registerMessageLoaders("reg-server-dedupe", { "reg-server-dedupe": load })
+    const first = createLoadableI18n("reg-server-dedupe")
+    const second = createLoadableI18n("reg-server-dedupe")
+
+    await Promise.all([
+      loadRegisteredMessages(first, "reg-server-dedupe"),
+      loadRegisteredMessages(second, "reg-server-dedupe"),
+    ])
+    await loadRegisteredMessages(first, "reg-server-dedupe")
+
+    expect(load).toHaveBeenCalledOnce()
+    expect(first.loaded["reg-server-dedupe"]).toEqual([messages, messages])
+    expect(second.loaded["reg-server-dedupe"]).toEqual([messages])
+  })
+
+  it("retries a failed lazy import", async () => {
+    const load = vi
+      .fn<() => Promise<Record<string, string>>>()
+      .mockRejectedValueOnce(new Error("temporary import failure"))
+      .mockResolvedValueOnce({ keyJ: "J" })
+    registerMessageLoaders("reg-server-retry", { "reg-server-retry": load })
+    const i18n = createLoadableI18n("reg-server-retry")
+
+    await expect(loadRegisteredMessages(i18n, "reg-server-retry")).rejects.toThrow(
+      "temporary import failure"
+    )
+    await expect(loadRegisteredMessages(i18n, "reg-server-retry")).resolves.toBe(i18n)
+
+    expect(load).toHaveBeenCalledTimes(2)
+  })
+
+  it("replaces a stable loader registration during HMR", async () => {
+    const first = vi.fn(async () => ({ keyK: "old" }))
+    const second = vi.fn(async () => ({ keyK: "new" }))
+    registerMessageLoaders("reg-server-hmr", { "reg-server-hmr": first })
+    const i18n = createLoadableI18n("reg-server-hmr")
+    await loadRegisteredMessages(i18n, "reg-server-hmr")
+
+    registerMessageLoaders("reg-server-hmr", { "reg-server-hmr": second })
+    await loadRegisteredMessages(i18n, "reg-server-hmr")
+
+    expect(first).toHaveBeenCalledOnce()
+    expect(second).toHaveBeenCalledOnce()
+    expect(i18n.loaded["reg-server-hmr"]).toEqual([{ keyK: "old" }, { keyK: "new" }])
+  })
+
+  it("rejects a non-loadable instance only when graph messages exist", async () => {
+    const i18n = createTestI18n("reg-server-unloadable")
+
+    await expect(loadRegisteredMessages(i18n, "reg-server-empty")).resolves.toBe(i18n)
+    registerMessageLoaders("reg-server-unloadable", {
+      "reg-server-unloadable": async () => ({ keyL: "L" }),
+    })
+    await expect(loadRegisteredMessages(i18n, "reg-server-unloadable")).rejects.toThrow(
+      "cannot load generated graph-split messages"
+    )
   })
 })

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -9,11 +9,19 @@ const CLIENT_I18N_KEY = Symbol.for("palamedes.runtime.clientI18n")
 const SERVER_I18N_GETTER_KEY = Symbol.for("palamedes.runtime.serverI18nGetter")
 const SERVER_SCOPE_STATE_KEY = Symbol.for("palamedes.runtime.serverI18nScopeState")
 const REGISTERED_MESSAGES_KEY = Symbol.for("palamedes.runtime.registeredMessages")
+const REGISTERED_MESSAGE_LOADERS_KEY = Symbol.for("palamedes.runtime.registeredMessageLoaders")
 
 export type RegisteredMessages = Record<string, Record<string, unknown>>
 
 type MessageLoadingI18n = I18nInstance & {
   load?: (locale: string, messages: Record<string, unknown>) => void
+}
+
+export type RegisteredMessageLoader = () => Promise<Record<string, unknown>>
+
+type RegisteredMessageLoaderState = {
+  loaders: Record<string, RegisteredMessageLoader>
+  resources: Map<string, Promise<Record<string, unknown>>>
 }
 
 export type ServerI18nScope<T extends I18nInstance = I18nInstance> = {
@@ -45,6 +53,7 @@ type GlobalRuntimeState = typeof globalThis & {
     get(): I18nInstance | undefined
   }
   [REGISTERED_MESSAGES_KEY]?: Map<string, Record<string, unknown>[]>
+  [REGISTERED_MESSAGE_LOADERS_KEY]?: Map<string, RegisteredMessageLoaderState>
 }
 
 function globalRuntimeState(): GlobalRuntimeState {
@@ -65,6 +74,19 @@ function getRegisteredMessages(
 
   const registered = new Map<string, Record<string, unknown>[]>()
   state[REGISTERED_MESSAGES_KEY] = registered
+  return registered
+}
+
+function getRegisteredMessageLoaders(
+  state = globalRuntimeState()
+): Map<string, RegisteredMessageLoaderState> {
+  const existing = state[REGISTERED_MESSAGE_LOADERS_KEY]
+  if (existing) {
+    return existing
+  }
+
+  const registered = new Map<string, RegisteredMessageLoaderState>()
+  state[REGISTERED_MESSAGE_LOADERS_KEY] = registered
   return registered
 }
 
@@ -102,6 +124,78 @@ export function registerMessages(catalogs: RegisteredMessages): void {
       active.load(locale, messages)
     }
   }
+}
+
+/**
+ * Register locale-specific message loaders for one generated source-module
+ * sidecar. Server adapters use these lazy resources so the ESM graph
+ * determines message membership while each request materializes only its
+ * active locale.
+ *
+ * `key` is stable across rebuilds. Re-registering it replaces the prior
+ * loaders and their resources, which keeps development HMR from retaining a
+ * stale sidecar forever.
+ */
+export function registerMessageLoaders(
+  key: string,
+  loaders: Record<string, RegisteredMessageLoader>
+): void {
+  getRegisteredMessageLoaders().set(key, {
+    loaders,
+    resources: new Map(),
+  })
+}
+
+/**
+ * Load every message fragment currently present in the server module graph for
+ * `locale` into a request-local i18n instance. Resources are deduplicated
+ * across concurrent and later requests; loading into the instance remains
+ * additive and preserves each generated compiled-catalog object as-is.
+ */
+export async function loadRegisteredMessages<T extends I18nInstance>(
+  i18n: T,
+  locale: string
+): Promise<T> {
+  const loadable = i18n as MessageLoadingI18n
+  const registered = globalRuntimeState()[REGISTERED_MESSAGES_KEY]
+  const eagerMessages = registered?.get(locale) ?? []
+  const lazyResources: Promise<Record<string, unknown>>[] = []
+
+  for (const state of getRegisteredMessageLoaders().values()) {
+    const loader = state.loaders[locale]
+    if (!loader) {
+      continue
+    }
+
+    let resource = state.resources.get(locale)
+    if (!resource) {
+      resource = loader().catch((error: unknown) => {
+        state.resources.delete(locale)
+        throw error
+      })
+      state.resources.set(locale, resource)
+    }
+    lazyResources.push(resource)
+  }
+
+  if (eagerMessages.length === 0 && lazyResources.length === 0) {
+    return i18n
+  }
+  if (!loadable.load) {
+    throw new TypeError(
+      "The active i18n instance cannot load generated graph-split messages. Provide an instance with load(locale, messages)."
+    )
+  }
+
+  const lazyMessages = await Promise.all(lazyResources)
+  for (const messages of eagerMessages) {
+    loadable.load(locale, messages)
+  }
+  for (const messages of lazyMessages) {
+    loadable.load(locale, messages)
+  }
+
+  return i18n
 }
 
 export function setClientI18n<T extends I18nInstance>(i18n: T): T {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1501,6 +1501,9 @@ importers:
       '@palamedes/transform':
         specifier: workspace:^
         version: link:../transform
+      picomatch:
+        specifier: ^4.0.5
+        version: 4.0.5
     devDependencies:
       next:
         specifier: 16.2.12


### PR DESCRIPTION
Depends on #543.

## What changed

- compile selected PO fragments per message-bearing server source module
- emit one lazy dynamic import per configured locale and load only the active locale
- let static ESM evaluation register fragments from transitive helpers
- keep generated catalog imports out of the browser compiler under both Turbopack and webpack
- initialize an empty request-local i18n instance first, then load the registered graph fragments
- cache locale imports across concurrent and later requests while preserving retry and HMR behavior
- document the application-facing `serverFunctions: true` setup; internal initializer module names remain hidden

## Why

The initial Server Function support in #543 loads the complete active-locale catalog inside the application initializer. This makes request initialization scale with the whole catalog even when an action and its dependency graph use only a small subset.

This stack moves catalog selection into the compile phase. In the example, the action translation lives in a transitive helper, proving that the sidecar follows normal ESM module evaluation rather than requiring the macro to live in the action file itself.

## Impact

The request still creates an isolated i18n instance, but imports only selected compiled ids for the active locale. On the example catalog this changes the action fragment from 29 messages to 1. An illustrative local Next 16.2.12 production/Webpack run measured warm English action requests at 3.10 ms median / 3.66 ms p95 versus 3.28 ms / 3.91 ms with full-catalog initialization. At this size the timing delta is small and close to noise; the main benefit is the scaling behavior.

Registration follows module evaluation, not a per-action bundler manifest. A long-lived server runtime can therefore retain registrations from multiple previously evaluated action graphs, so a later action may load a superset of its own closure. This affects the upper performance bound, not correctness: each registered module still imports only the active locale and only its selected ids.

Selected Server Function splitting currently supports PO catalogs. FCL configurations fail with an explicit build error instead of generating an unhandled import.

## Validation

- `RUSTUP_TOOLCHAIN=stable pnpm --config.verify-deps-before-run=false agent:check`
- Next 16.2.12 production build with Turbopack
- Next 16.2.12 production build with webpack
- production Server Action probes for English and German
- transitive helper sidecar verified in the generated Turbopack chunks
