### PR TITLE
fix(audit): enforce placeholder and review-marker integrity

### DIFF
--- a/crates/palamedes-cli/src/commands/audit.rs
+++ b/crates/palamedes-cli/src/commands/audit.rs
@@ -21,7 +21,7 @@ pub struct AuditOptions {
     /// Print the machine-readable audit result as JSON.
     #[arg(long)]
     json: bool,
-    /// Fail on error or warning diagnostics.
+    /// Fail on error, warning, or info diagnostics.
     #[arg(long, default_value = "error")]
     fail_on: FailOn,
 }
@@ -30,6 +30,7 @@ pub struct AuditOptions {
 enum FailOn {
     Error,
     Warning,
+    Info,
 }
 
 impl Command for AuditOptions {
@@ -55,6 +56,17 @@ impl Command for AuditOptions {
 
     fn verdict(&self, output: &Self::Output) -> Result<(), CliError> {
         match self.fail_on {
+            FailOn::Info
+                if output.summary.errors > 0
+                    || output.summary.warnings > 0
+                    || output.summary.infos > 0 =>
+            {
+                Err(CliError::AuditFailedOnInfo {
+                    errors: output.summary.errors,
+                    warnings: output.summary.warnings,
+                    infos: output.summary.infos,
+                })
+            }
             FailOn::Warning if output.summary.errors > 0 || output.summary.warnings > 0 => {
                 Err(CliError::AuditFailedOnWarning {
                     errors: output.summary.errors,

--- a/crates/palamedes-cli/src/error.rs
+++ b/crates/palamedes-cli/src/error.rs
@@ -36,6 +36,14 @@ pub enum CliError {
     AuditFailedOnError { errors: usize },
     #[error("Catalog audit failed with {errors} error(s) and {warnings} warning(s).")]
     AuditFailedOnWarning { errors: usize, warnings: usize },
+    #[error(
+        "Catalog audit failed with {errors} error(s), {warnings} warning(s), and {infos} info diagnostic(s)."
+    )]
+    AuditFailedOnInfo {
+        errors: usize,
+        warnings: usize,
+        infos: usize,
+    },
     #[error("Catalog completeness below {threshold} for {locales}.")]
     CompletenessBelowThreshold { threshold: String, locales: String },
     #[error("Extraction failed for {failures} source file(s); catalogs were not updated.")]

--- a/crates/palamedes-cli/tests/audit_exit.rs
+++ b/crates/palamedes-cli/tests/audit_exit.rs
@@ -1,0 +1,68 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[test]
+fn audit_info_threshold_fails_on_fuzzy_markers_without_changing_the_default() {
+    let fixture = fixture_dir("audit-info-threshold");
+    fs::create_dir_all(fixture.join("locales/en")).expect("create source catalog dir");
+    fs::create_dir_all(fixture.join("locales/de")).expect("create target catalog dir");
+    fs::write(
+        fixture.join("palamedes.yaml"),
+        r#"locales: [en, de]
+source-locale: en
+catalogs:
+  - path: locales/{locale}/messages
+    include: [app]
+"#,
+    )
+    .expect("write config");
+    fs::write(
+        fixture.join("locales/en/messages.po"),
+        "msgid \"Save\"\nmsgstr \"Save\"\n",
+    )
+    .expect("write source catalog");
+    fs::write(
+        fixture.join("locales/de/messages.po"),
+        "#, fuzzy\nmsgid \"Save\"\nmsgstr \"Speichern\"\n",
+    )
+    .expect("write target catalog");
+
+    let default = audit(&fixture, &[]);
+    assert!(default.status.success(), "{default:?}");
+
+    let fail_on_info = audit(&fixture, &["--fail-on", "info"]);
+    assert_eq!(fail_on_info.status.code(), Some(1), "{fail_on_info:?}");
+    assert!(
+        String::from_utf8_lossy(&fail_on_info.stdout).contains("1 info"),
+        "{fail_on_info:?}"
+    );
+    assert!(
+        String::from_utf8_lossy(&fail_on_info.stderr)
+            .contains("Catalog audit failed with 0 error(s), 0 warning(s), and 1 info"),
+        "{fail_on_info:?}"
+    );
+
+    fs::remove_dir_all(fixture).expect("cleanup");
+}
+
+fn audit(cwd: &Path, arguments: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_pmds"))
+        .arg("audit")
+        .args(arguments)
+        .current_dir(cwd)
+        .output()
+        .expect("run pmds audit")
+}
+
+fn fixture_dir(name: &str) -> PathBuf {
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time")
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "palamedes-cli-{name}-{}-{stamp}",
+        std::process::id()
+    ))
+}

--- a/crates/palamedes/src/catalog_audit.rs
+++ b/crates/palamedes/src/catalog_audit.rs
@@ -3,8 +3,9 @@ use std::fs;
 use std::path::PathBuf;
 
 use ferrocat::{
-    parse_catalog_for_review, CatalogAuditIcuOptions, CatalogAuditOptions, IcuSyntaxPolicy,
-    NormalizedParsedCatalog, ParseCatalogOptions,
+    canonicalize_icu_with_policy, parse_catalog_for_review, parse_icu, CatalogAuditIcuOptions,
+    CatalogAuditOptions, CatalogMessage, EffectiveTranslationRef, IcuMessage, IcuNode,
+    IcuSyntaxPolicy, NormalizedParsedCatalog, ParseCatalogOptions,
 };
 use ferrocat_po::audit_catalogs as ferrocat_audit_catalogs;
 use serde::{Deserialize, Serialize};
@@ -183,9 +184,144 @@ pub fn audit_catalogs(request: CatalogAuditRequest) -> PalamedesResult<CatalogAu
                 name: diagnostic.name,
             });
         }
+        if request.checks.icu_compatibility.unwrap_or(true) {
+            add_plain_argument_occurrence_diagnostics(
+                &loaded,
+                &request.config.source_locale,
+                &target_locales,
+                &paths_by_locale,
+                &mut result,
+            );
+        }
     }
 
     Ok(result)
+}
+
+fn add_plain_argument_occurrence_diagnostics(
+    loaded: &[LoadedAuditCatalog],
+    source_locale: &str,
+    target_locales: &[String],
+    paths_by_locale: &BTreeMap<String, PathBuf>,
+    result: &mut CatalogAuditResult,
+) {
+    let Some(source_catalog) = loaded
+        .iter()
+        .find(|loaded| loaded.catalog.parsed_catalog().locale.as_deref() == Some(source_locale))
+        .map(|loaded| &loaded.catalog)
+    else {
+        return;
+    };
+
+    for target_locale in target_locales {
+        let Some(target_catalog) = loaded
+            .iter()
+            .find(|loaded| {
+                loaded.catalog.parsed_catalog().locale.as_deref() == Some(target_locale.as_str())
+            })
+            .map(|loaded| &loaded.catalog)
+        else {
+            continue;
+        };
+        let Some(target_path) = paths_by_locale.get(target_locale) else {
+            continue;
+        };
+
+        for (key, source_message) in source_catalog.iter() {
+            if source_message.obsolete.is_some() {
+                continue;
+            }
+            let Some(target_message) = target_catalog
+                .get(key)
+                .filter(|message| message.obsolete.is_none())
+            else {
+                continue;
+            };
+            let Some(target_value) = singular_translation(target_message)
+                .filter(|translation| !translation.trim().is_empty())
+            else {
+                continue;
+            };
+            let Some(source_counts) = plain_argument_occurrences(&key.msgid) else {
+                continue;
+            };
+            let Some(target_counts) = plain_argument_occurrences(target_value) else {
+                continue;
+            };
+
+            for (name, source_count) in source_counts {
+                let Some(target_count) = target_counts.get(&name).copied() else {
+                    continue;
+                };
+                if source_count == target_count {
+                    continue;
+                }
+
+                result.summary.diagnostics += 1;
+                result.summary.errors += 1;
+                result.diagnostics.push(CatalogAuditDiagnostic {
+                    severity: CatalogDiagnosticSeverity::Error,
+                    code: "icu.argument_occurrence_mismatch".to_owned(),
+                    message: format!(
+                        "ICU argument `{name}` appears {source_count} occurrence(s) in the source and {target_count} in the translation."
+                    ),
+                    catalog_path: target_path.to_string_lossy().into_owned(),
+                    locale: Some(target_locale.clone()),
+                    source_key: Some(CatalogDiagnosticSourceKey {
+                        message: key.msgid.clone(),
+                        context: key.msgctxt.clone(),
+                    }),
+                    name: Some(name),
+                });
+            }
+        }
+    }
+}
+
+fn singular_translation(message: &CatalogMessage) -> Option<&str> {
+    match message.effective_translation() {
+        EffectiveTranslationRef::Singular(value) => Some(value),
+        EffectiveTranslationRef::Plural(_) => None,
+    }
+}
+
+fn plain_argument_occurrences(value: &str) -> Option<BTreeMap<String, usize>> {
+    let canonical = canonicalize_icu_with_policy(value, IcuSyntaxPolicy::RuntimeLiteralApostrophes);
+    let message = parse_icu(&canonical).ok()?;
+    let mut counts = BTreeMap::new();
+    count_plain_arguments(&message, &mut counts).then_some(counts)
+}
+
+fn count_plain_arguments(message: &IcuMessage, counts: &mut BTreeMap<String, usize>) -> bool {
+    count_plain_argument_nodes(&message.nodes, counts)
+}
+
+fn count_plain_argument_nodes(nodes: &[IcuNode], counts: &mut BTreeMap<String, usize>) -> bool {
+    for node in nodes {
+        let name = match node {
+            IcuNode::Argument { name }
+            | IcuNode::Number { name, .. }
+            | IcuNode::Date { name, .. }
+            | IcuNode::Time { name, .. }
+            | IcuNode::List { name, .. }
+            | IcuNode::Duration { name, .. }
+            | IcuNode::Ago { name, .. }
+            | IcuNode::Name { name, .. } => Some(name),
+            IcuNode::Select { .. } | IcuNode::Plural { .. } => return false,
+            IcuNode::Tag { children, .. } => {
+                if !count_plain_argument_nodes(children, counts) {
+                    return false;
+                }
+                None
+            }
+            IcuNode::Literal(_) | IcuNode::Pound => None,
+            _ => None,
+        };
+        if let Some(name) = name {
+            *counts.entry(name.clone()).or_default() += 1;
+        }
+    }
+    true
 }
 
 impl CatalogAuditCheckOptions {
@@ -361,6 +497,112 @@ msgstr "Hallo {firstName}"
             .iter()
             .any(|diagnostic| diagnostic.code == "catalog.missing_locale"
                 && diagnostic.locale.as_deref() == Some("es")));
+    }
+
+    #[test]
+    fn reports_changed_argument_occurrences_in_plain_messages() {
+        let fixture = create_fixture_dir("catalog-audit-repeated-arguments");
+        let locale_dir = fixture.join("src/locales");
+        fs::create_dir_all(&locale_dir).expect("locale dir");
+        fs::write(
+            locale_dir.join("en.po"),
+            r#"msgid ""
+msgstr ""
+"Language: en\n"
+
+msgid "{count} of {count} sites covered"
+msgstr ""
+
+msgid "Owner: {name}"
+msgstr ""
+"#,
+        )
+        .expect("write en");
+        fs::write(
+            locale_dir.join("de.po"),
+            r#"msgid ""
+msgstr ""
+"Language: de\n"
+
+msgid "{count} of {count} sites covered"
+msgstr "{count} Standorte abgedeckt"
+
+msgid "Owner: {name}"
+msgstr "{name}, Eigentümer: {name}"
+"#,
+        )
+        .expect("write de");
+
+        let result = audit_catalogs(CatalogAuditRequest {
+            config: config(&fixture),
+            locales: vec!["de".to_owned()],
+            checks: CatalogAuditCheckOptions::default(),
+            metadata: Vec::new(),
+        })
+        .expect("audit");
+
+        let occurrence_diagnostics = result
+            .diagnostics
+            .iter()
+            .filter(|diagnostic| diagnostic.code == "icu.argument_occurrence_mismatch")
+            .collect::<Vec<_>>();
+        assert_eq!(occurrence_diagnostics.len(), 2);
+        assert!(occurrence_diagnostics.iter().all(|diagnostic| {
+            diagnostic.severity == crate::CatalogDiagnosticSeverity::Error
+                && diagnostic.locale.as_deref() == Some("de")
+        }));
+        assert!(occurrence_diagnostics.iter().any(|diagnostic| {
+            diagnostic.name.as_deref() == Some("count")
+                && diagnostic.message.contains("2 occurrence(s) in the source")
+                && diagnostic.message.contains("1 in the translation")
+        }));
+        assert!(occurrence_diagnostics.iter().any(|diagnostic| {
+            diagnostic.name.as_deref() == Some("name")
+                && diagnostic.message.contains("1 occurrence(s) in the source")
+                && diagnostic.message.contains("2 in the translation")
+        }));
+    }
+
+    #[test]
+    fn allows_argument_occurrence_differences_in_choice_messages() {
+        let fixture = create_fixture_dir("catalog-audit-choice-arguments");
+        let locale_dir = fixture.join("src/locales");
+        fs::create_dir_all(&locale_dir).expect("locale dir");
+        fs::write(
+            locale_dir.join("en.po"),
+            r#"msgid ""
+msgstr ""
+"Language: en\n"
+
+msgid "{count, plural, one {{site} is covered} other {{site} and {count} sites are covered}}"
+msgstr ""
+"#,
+        )
+        .expect("write en");
+        fs::write(
+            locale_dir.join("de.po"),
+            r#"msgid ""
+msgstr ""
+"Language: de\n"
+
+msgid "{count, plural, one {{site} is covered} other {{site} and {count} sites are covered}}"
+msgstr "{count, plural, one {Eine Site ist abgedeckt} other {{site} und weitere Sites sind abgedeckt}}"
+"#,
+        )
+        .expect("write de");
+
+        let result = audit_catalogs(CatalogAuditRequest {
+            config: config(&fixture),
+            locales: vec!["de".to_owned()],
+            checks: CatalogAuditCheckOptions::default(),
+            metadata: Vec::new(),
+        })
+        .expect("audit");
+
+        assert!(!result
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "icu.argument_occurrence_mismatch"));
     }
 
     #[test]

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -128,6 +128,7 @@ pmds audit --locale de fr
 pmds audit --locale de,fr
 pmds audit --json
 pmds audit --fail-on warning
+pmds audit --fail-on info
 ```
 
 Options:
@@ -137,7 +138,12 @@ Options:
 | `-c, --config <path>`  | Use a specific config file.                                                                  |
 | `--locale <locale...>` | Audit only selected target locales. Space-separated and comma-separated values are accepted. |
 | `--json`               | Print the machine-readable audit result.                                                     |
-| `--fail-on <level>`    | Fail on `error` or `warning`. Default: `error`.                                              |
+| `--fail-on <level>`    | Fail on `error`, `warning`, or `info`. Default: `error`.                                     |
+
+`--fail-on info` makes informational diagnostics such as
+`catalog.fuzzy_flag` fail the command, which is useful when CI must reject every
+catalog entry that still carries a review marker. The default remains
+`--fail-on error`.
 
 ## `pmds report`
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -84,6 +84,7 @@ pnpm exec pmds lint --no-cache
 pnpm exec pmds audit
 pnpm exec pmds audit --json
 pnpm exec pmds audit --fail-on warning
+pnpm exec pmds audit --fail-on info
 pnpm exec pmds report
 pnpm exec pmds report --locale de,fr --fail-if-below 95
 pnpm exec pmds report --json
@@ -94,6 +95,8 @@ pnpm exec pmds catalog convert src/locales/de.po --to fcl --output src/locales/d
 `pmds audit` reports missing translations, extra catalog entries, obsolete
 messages, fuzzy review markers, and ICU compatibility issues through the same `ferrocat`
 catalog engine that powers Palamedes builds.
+Use `--fail-on info` when informational findings such as `catalog.fuzzy_flag`
+must fail CI; the default continues to fail only on errors.
 
 `pmds lint` is non-mutating and checks Palamedes authoring across the same
 configured sources as extraction. It supports stable human and JSON output,


### PR DESCRIPTION
## Summary

- detect changed ICU argument occurrence counts in plain messages while leaving plural/select branch restructuring to the existing compatibility rules
- add `pmds audit --fail-on info` so repositories can make fuzzy review markers CI-blocking without changing the default threshold
- document the new threshold and cover both fixes with behavioral and binary exit-code tests

## Root cause

The catalog compatibility audit compared ICU arguments by name, so repeated uses collapsed into a single semantic key. Separately, the CLI exposed only `error` and `warning` thresholds even though fuzzy markers are informational diagnostics.

## Impact

Catalogs can no longer silently drop or duplicate a repeated argument in a plain translation. Projects that require reviewed catalogs can opt into an informational CI threshold, while existing invocations retain the current error-only default.

## Validation

- `env CI=true RUSTUP_TOOLCHAIN=stable pnpm --config.verify-deps-before-run=false agent:check`
- `env RUSTUP_TOOLCHAIN=stable cargo test -p palamedes`
- `env RUSTUP_TOOLCHAIN=stable cargo test -p palamedes-cli`

Closes #540
Closes #541