### PR TITLE
feat(core): expose translation candidate and patch APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1177,6 +1177,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "sha2",
  "string_wizard",
  "tempfile",
  "thiserror",

--- a/crates/palamedes-node/src/catalog.rs
+++ b/crates/palamedes-node/src/catalog.rs
@@ -5,7 +5,8 @@ use napi::bindgen_prelude::{Either, Result};
 use napi_derive::napi;
 
 use crate::catalog_config::{
-    CatalogArtifactRequest, CatalogArtifactSelectedRequest, CatalogConfigFormat,
+    CatalogArtifactConfig, CatalogArtifactRequest, CatalogArtifactSelectedRequest,
+    CatalogConfigFormat,
 };
 use crate::shared::{checked_u32, to_napi_error};
 
@@ -109,6 +110,134 @@ pub struct CatalogParseResult {
     pub headers: HashMap<String, String>,
     pub messages: Vec<ParsedCatalogMessage>,
     pub diagnostics: Vec<CatalogDiagnostic>,
+}
+
+#[napi(object)]
+pub struct TranslationCandidateId {
+    pub catalog: String,
+    pub locale: String,
+    pub message: String,
+    pub context: Option<String>,
+}
+
+#[napi(object)]
+pub struct TranslationCandidateRequest {
+    pub config: CatalogArtifactConfig,
+    pub locales: Option<Vec<String>>,
+    pub targets: Option<Vec<TranslationCandidateId>>,
+    pub max_origins: Option<u32>,
+}
+
+#[napi(string_enum)]
+pub enum TranslationValueKind {
+    Singular,
+    Plural,
+}
+
+#[napi(string_enum)]
+pub enum TranslationPluralKind {
+    Cardinal,
+    Ordinal,
+}
+
+#[napi(object)]
+pub struct TranslationValue {
+    pub kind: TranslationValueKind,
+    pub value: Option<String>,
+    pub variable: Option<String>,
+    pub plural_kind: Option<TranslationPluralKind>,
+    pub offset: Option<u32>,
+    pub values: Option<HashMap<String, String>>,
+}
+
+#[napi(object)]
+pub struct TranslationWorkflowOrigin {
+    pub file: String,
+    pub scope: Option<String>,
+}
+
+#[napi(object)]
+pub struct TranslationReviewState {
+    pub translated: bool,
+    pub fuzzy: bool,
+    pub obsolete: bool,
+}
+
+#[napi(object)]
+pub struct TranslationCandidate {
+    pub id: TranslationCandidateId,
+    pub target_path: String,
+    pub format: CatalogConfigFormat,
+    pub source: TranslationValue,
+    pub translation: TranslationValue,
+    pub comments: Vec<String>,
+    pub origins: Vec<TranslationWorkflowOrigin>,
+    pub review: TranslationReviewState,
+    pub machine: Option<MachineMetadata>,
+    pub fingerprint: String,
+}
+
+#[napi(object)]
+pub struct TranslationWorkflowDiagnostic {
+    pub code: String,
+    pub message: String,
+    pub id: Option<TranslationCandidateId>,
+}
+
+#[napi(object)]
+pub struct TranslationCandidateResult {
+    pub candidates: Vec<TranslationCandidate>,
+    pub diagnostics: Vec<TranslationWorkflowDiagnostic>,
+}
+
+#[napi(object)]
+pub struct TranslationMachineProvenance {
+    pub ai: Option<AiProvenance>,
+}
+
+#[napi(object)]
+pub struct TranslationPatch {
+    pub id: TranslationCandidateId,
+    pub fingerprint: String,
+    pub translation: TranslationValue,
+    pub machine: Option<TranslationMachineProvenance>,
+}
+
+#[napi(object)]
+pub struct TranslationPatchRequest {
+    pub config: CatalogArtifactConfig,
+    pub patches: Vec<TranslationPatch>,
+    pub po: Option<PoOutputOptions>,
+}
+
+#[napi(string_enum)]
+pub enum TranslationPatchOutcomeStatus {
+    Applied,
+    Unchanged,
+    Rejected,
+    NotApplied,
+}
+
+#[napi(object)]
+pub struct TranslationPatchOutcome {
+    pub id: TranslationCandidateId,
+    pub status: TranslationPatchOutcomeStatus,
+}
+
+#[napi(object)]
+pub struct TranslationPatchStats {
+    pub requested: u32,
+    pub applied: u32,
+    pub unchanged: u32,
+    pub catalogs_updated: u32,
+}
+
+#[napi(object)]
+pub struct TranslationPatchResult {
+    pub updated: bool,
+    pub stats: TranslationPatchStats,
+    pub outcomes: Vec<TranslationPatchOutcome>,
+    pub diagnostics: Vec<TranslationWorkflowDiagnostic>,
 }
 
 #[napi(object)]
@@ -604,6 +733,292 @@ impl From<palamedes::CatalogParseResult> for CatalogParseResult {
                 .map(CatalogDiagnostic::from)
                 .collect(),
         }
+    }
+}
+
+impl From<TranslationCandidateId> for palamedes::TranslationCandidateId {
+    fn from(value: TranslationCandidateId) -> Self {
+        Self {
+            catalog: value.catalog,
+            locale: value.locale,
+            message: value.message,
+            context: value.context,
+        }
+    }
+}
+
+impl From<palamedes::TranslationCandidateId> for TranslationCandidateId {
+    fn from(value: palamedes::TranslationCandidateId) -> Self {
+        Self {
+            catalog: value.catalog,
+            locale: value.locale,
+            message: value.message,
+            context: value.context,
+        }
+    }
+}
+
+impl TryFrom<TranslationCandidateRequest> for palamedes::TranslationCandidateRequest {
+    type Error = napi::Error;
+
+    fn try_from(value: TranslationCandidateRequest) -> Result<Self> {
+        Ok(Self {
+            config: value.config.into(),
+            locales: value.locales.unwrap_or_default(),
+            targets: value
+                .targets
+                .unwrap_or_default()
+                .into_iter()
+                .map(palamedes::TranslationCandidateId::from)
+                .collect(),
+            max_origins: value.max_origins.map_or(8, |limit| limit as usize),
+        })
+    }
+}
+
+impl TryFrom<TranslationValue> for palamedes::TranslationValue {
+    type Error = napi::Error;
+
+    fn try_from(value: TranslationValue) -> Result<Self> {
+        match value.kind {
+            TranslationValueKind::Singular => {
+                let Some(value) = value.value else {
+                    return Err(napi::Error::from_reason(
+                        "Singular translation values require `value`.",
+                    ));
+                };
+                Ok(Self::Singular { value })
+            }
+            TranslationValueKind::Plural => {
+                let Some(variable) = value.variable else {
+                    return Err(napi::Error::from_reason(
+                        "Plural translation values require `variable`.",
+                    ));
+                };
+                let Some(plural_kind) = value.plural_kind else {
+                    return Err(napi::Error::from_reason(
+                        "Plural translation values require `pluralKind`.",
+                    ));
+                };
+                let Some(values) = value.values else {
+                    return Err(napi::Error::from_reason(
+                        "Plural translation values require `values`.",
+                    ));
+                };
+                Ok(Self::Plural {
+                    variable,
+                    plural_kind: match plural_kind {
+                        TranslationPluralKind::Cardinal => {
+                            palamedes::TranslationPluralKind::Cardinal
+                        }
+                        TranslationPluralKind::Ordinal => palamedes::TranslationPluralKind::Ordinal,
+                    },
+                    offset: value.offset.unwrap_or(0),
+                    values: values.into_iter().collect(),
+                })
+            }
+        }
+    }
+}
+
+impl From<palamedes::TranslationValue> for TranslationValue {
+    fn from(value: palamedes::TranslationValue) -> Self {
+        match value {
+            palamedes::TranslationValue::Singular { value } => Self {
+                kind: TranslationValueKind::Singular,
+                value: Some(value),
+                variable: None,
+                plural_kind: None,
+                offset: None,
+                values: None,
+            },
+            palamedes::TranslationValue::Plural {
+                variable,
+                plural_kind,
+                offset,
+                values,
+            } => Self {
+                kind: TranslationValueKind::Plural,
+                value: None,
+                variable: Some(variable),
+                plural_kind: Some(match plural_kind {
+                    palamedes::TranslationPluralKind::Cardinal => TranslationPluralKind::Cardinal,
+                    palamedes::TranslationPluralKind::Ordinal => TranslationPluralKind::Ordinal,
+                }),
+                offset: Some(offset),
+                values: Some(values.into_iter().collect()),
+            },
+        }
+    }
+}
+
+impl From<palamedes::TranslationWorkflowOrigin> for TranslationWorkflowOrigin {
+    fn from(value: palamedes::TranslationWorkflowOrigin) -> Self {
+        Self {
+            file: value.file,
+            scope: value.scope,
+        }
+    }
+}
+
+impl From<palamedes::TranslationReviewState> for TranslationReviewState {
+    fn from(value: palamedes::TranslationReviewState) -> Self {
+        Self {
+            translated: value.translated,
+            fuzzy: value.fuzzy,
+            obsolete: value.obsolete,
+        }
+    }
+}
+
+impl From<palamedes::TranslationCandidate> for TranslationCandidate {
+    fn from(value: palamedes::TranslationCandidate) -> Self {
+        Self {
+            id: value.id.into(),
+            target_path: value.target_path,
+            format: match value.format {
+                palamedes::PalamedesCatalogFormat::Po => CatalogConfigFormat::Po,
+                palamedes::PalamedesCatalogFormat::Fcl => CatalogConfigFormat::Fcl,
+            },
+            source: value.source.into(),
+            translation: value.translation.into(),
+            comments: value.comments,
+            origins: value
+                .origins
+                .into_iter()
+                .map(TranslationWorkflowOrigin::from)
+                .collect(),
+            review: value.review.into(),
+            machine: value.machine.map(MachineMetadata::from),
+            fingerprint: value.fingerprint,
+        }
+    }
+}
+
+impl From<palamedes::TranslationWorkflowDiagnostic> for TranslationWorkflowDiagnostic {
+    fn from(value: palamedes::TranslationWorkflowDiagnostic) -> Self {
+        Self {
+            code: value.code,
+            message: value.message,
+            id: value.id.map(TranslationCandidateId::from),
+        }
+    }
+}
+
+impl From<palamedes::TranslationCandidateResult> for TranslationCandidateResult {
+    fn from(value: palamedes::TranslationCandidateResult) -> Self {
+        Self {
+            candidates: value
+                .candidates
+                .into_iter()
+                .map(TranslationCandidate::from)
+                .collect(),
+            diagnostics: value
+                .diagnostics
+                .into_iter()
+                .map(TranslationWorkflowDiagnostic::from)
+                .collect(),
+        }
+    }
+}
+
+impl From<AiProvenance> for palamedes::AiProvenance {
+    fn from(value: AiProvenance) -> Self {
+        Self {
+            model: value.model,
+            confidence: value.confidence.map(|confidence| confidence as f32),
+        }
+    }
+}
+
+impl From<TranslationMachineProvenance> for palamedes::TranslationMachineProvenance {
+    fn from(value: TranslationMachineProvenance) -> Self {
+        Self {
+            ai: value.ai.map(palamedes::AiProvenance::from),
+        }
+    }
+}
+
+impl TryFrom<TranslationPatch> for palamedes::TranslationPatch {
+    type Error = napi::Error;
+
+    fn try_from(value: TranslationPatch) -> Result<Self> {
+        Ok(Self {
+            id: value.id.into(),
+            fingerprint: value.fingerprint,
+            translation: value.translation.try_into()?,
+            machine: value.machine.map(Into::into),
+        })
+    }
+}
+
+impl TryFrom<TranslationPatchRequest> for palamedes::TranslationPatchRequest {
+    type Error = napi::Error;
+
+    fn try_from(value: TranslationPatchRequest) -> Result<Self> {
+        Ok(Self {
+            config: value.config.into(),
+            patches: value
+                .patches
+                .into_iter()
+                .map(palamedes::TranslationPatch::try_from)
+                .collect::<Result<Vec<_>>>()?,
+            po: value.po.map(Into::into),
+        })
+    }
+}
+
+impl From<palamedes::TranslationPatchOutcomeStatus> for TranslationPatchOutcomeStatus {
+    fn from(value: palamedes::TranslationPatchOutcomeStatus) -> Self {
+        match value {
+            palamedes::TranslationPatchOutcomeStatus::Applied => Self::Applied,
+            palamedes::TranslationPatchOutcomeStatus::Unchanged => Self::Unchanged,
+            palamedes::TranslationPatchOutcomeStatus::Rejected => Self::Rejected,
+            palamedes::TranslationPatchOutcomeStatus::NotApplied => Self::NotApplied,
+        }
+    }
+}
+
+impl From<palamedes::TranslationPatchOutcome> for TranslationPatchOutcome {
+    fn from(value: palamedes::TranslationPatchOutcome) -> Self {
+        Self {
+            id: value.id.into(),
+            status: value.status.into(),
+        }
+    }
+}
+
+impl TryFrom<palamedes::TranslationPatchStats> for TranslationPatchStats {
+    type Error = napi::Error;
+
+    fn try_from(value: palamedes::TranslationPatchStats) -> Result<Self> {
+        Ok(Self {
+            requested: checked_u32(value.requested, "stats.requested")?,
+            applied: checked_u32(value.applied, "stats.applied")?,
+            unchanged: checked_u32(value.unchanged, "stats.unchanged")?,
+            catalogs_updated: checked_u32(value.catalogs_updated, "stats.catalogsUpdated")?,
+        })
+    }
+}
+
+impl TryFrom<palamedes::TranslationPatchResult> for TranslationPatchResult {
+    type Error = napi::Error;
+
+    fn try_from(value: palamedes::TranslationPatchResult) -> Result<Self> {
+        Ok(Self {
+            updated: value.updated,
+            stats: value.stats.try_into()?,
+            outcomes: value
+                .outcomes
+                .into_iter()
+                .map(TranslationPatchOutcome::from)
+                .collect(),
+            diagnostics: value
+                .diagnostics
+                .into_iter()
+                .map(TranslationWorkflowDiagnostic::from)
+                .collect(),
+        })
     }
 }
 
@@ -1207,6 +1622,38 @@ pub fn parse_catalog(request: CatalogParseRequest) -> Result<CatalogParseResult>
     palamedes::parse_catalog(&request)
         .map(CatalogParseResult::from)
         .map_err(to_napi_error)
+}
+
+#[napi]
+#[allow(clippy::needless_pass_by_value)]
+/// Enumerates provider-neutral translation candidates across configured catalogs.
+///
+/// # Errors
+///
+/// Returns an error when a configured catalog cannot be read or parsed.
+pub fn list_translation_candidates(
+    request: TranslationCandidateRequest,
+) -> Result<TranslationCandidateResult> {
+    let request = request.try_into()?;
+    palamedes::list_translation_candidates(&request)
+        .map(TranslationCandidateResult::from)
+        .map_err(to_napi_error)
+}
+
+#[napi]
+#[allow(clippy::needless_pass_by_value)]
+/// Validates and atomically applies provider-neutral translation patches.
+///
+/// # Errors
+///
+/// Returns an error when a configured catalog cannot be read, rendered, or replaced.
+pub fn apply_translation_patches(
+    request: TranslationPatchRequest,
+) -> Result<TranslationPatchResult> {
+    let request = request.try_into()?;
+    palamedes::apply_translation_patches(request)
+        .map_err(to_napi_error)
+        .and_then(TranslationPatchResult::try_from)
 }
 
 #[napi]

--- a/crates/palamedes/Cargo.toml
+++ b/crates/palamedes/Cargo.toml
@@ -22,6 +22,7 @@ rayon = "1.12.0"
 regex = "1.12.3"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1"
+sha2 = "0.11.0"
 string_wizard = "1.2.2"
 tempfile = "3.27.0"
 thiserror = "2.0.18"

--- a/crates/palamedes/fixtures/translation-workflow.de.po
+++ b/crates/palamedes/fixtures/translation-workflow.de.po
@@ -1,0 +1,44 @@
+msgid ""
+msgstr ""
+"Language: de\n"
+"X-Custom: keep-me\n"
+
+#. Greeting shown on the home page
+#: src/home.tsx#HomePage
+#: src/shared.ts#formatGreeting
+msgid "Hello"
+msgstr ""
+
+#. Action label
+#: src/menu.tsx#Menu
+msgctxt "verb"
+msgid "Open"
+msgstr ""
+
+#. State label
+msgctxt "adjective"
+msgid "Open"
+msgstr "Offen"
+
+#. File count
+#: src/files.tsx#FileCount
+msgid "{count, plural, one {# file} other {# files}}"
+msgstr ""
+
+# Translator-owned review note
+#. Existing translated entry
+#: src/review.tsx#ReviewPanel
+#, fuzzy, x-custom
+msgid "Review me"
+msgstr "Bitte prüfen"
+
+#. Machine-managed entry
+#@ lock: {{LOCK}}
+#@ ai: example/model:0.75
+msgid "Machine"
+msgstr "Maschinell"
+
+#~ #. Historic entry
+#~ #, fuzzy
+#~ msgid "Old"
+#~ msgstr "Alt"

--- a/crates/palamedes/src/catalog_update.rs
+++ b/crates/palamedes/src/catalog_update.rs
@@ -189,7 +189,7 @@ pub struct ParsedCatalogMessage {
 }
 
 /// Machine metadata attached to one translated catalog entry.
-#[derive(Debug, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MachineMetadata {
     /// Integrity lock for the current translation payload.
@@ -200,7 +200,7 @@ pub struct MachineMetadata {
 }
 
 /// AI provenance for machine-managed content.
-#[derive(Debug, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AiProvenance {
     /// Model identifier used to produce the translation.

--- a/crates/palamedes/src/error.rs
+++ b/crates/palamedes/src/error.rs
@@ -26,6 +26,15 @@ pub enum PalamedesError {
         /// Underlying filesystem error.
         source: std::io::Error,
     },
+    /// Preparing an atomic translation-catalog replacement failed.
+    #[error("Failed to prepare catalog update for {path}: {source}")]
+    WriteFile {
+        /// Catalog path whose replacement was being prepared.
+        path: PathBuf,
+        #[source]
+        /// Underlying filesystem error.
+        source: std::io::Error,
+    },
     /// The worker pool for parallel extraction could not be created.
     #[error("Could not create the extraction worker pool: {message}")]
     ExtractionPool {

--- a/crates/palamedes/src/lib.rs
+++ b/crates/palamedes/src/lib.rs
@@ -42,6 +42,7 @@ mod source_macros;
 #[cfg(test)]
 mod test_support;
 mod transform;
+mod translation_candidates;
 mod translation_scope;
 
 use ferrocat::{parse_po as ferrocat_parse_po, MsgStr, PoFile, PoItem};
@@ -110,6 +111,14 @@ pub use source::{
 pub use transform::{
     transform_macros, NativeTransformEdit, NativeTransformOptions, NativeTransformResult,
     NativeTransformSourceMap, ServerFunctionTransformOptions,
+};
+pub use translation_candidates::{
+    apply_translation_patches, list_translation_candidates, TranslationCandidate,
+    TranslationCandidateId, TranslationCandidateRequest, TranslationCandidateResult,
+    TranslationMachineProvenance, TranslationPatch, TranslationPatchOutcome,
+    TranslationPatchOutcomeStatus, TranslationPatchRequest, TranslationPatchResult,
+    TranslationPatchStats, TranslationPluralKind, TranslationReviewState, TranslationValue,
+    TranslationWorkflowDiagnostic, TranslationWorkflowOrigin,
 };
 
 /// Published `ferrocat` version used by the Rust core.

--- a/crates/palamedes/src/translation_candidates.rs
+++ b/crates/palamedes/src/translation_candidates.rs
@@ -1,0 +1,1610 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::io::Write;
+use std::path::PathBuf;
+
+use ferrocat::{
+    convert_catalog, convert_catalog_file, machine_translation_hash, parse_catalog,
+    CatalogFileFormat as FerrocatCatalogFileFormat, CatalogMessage, CatalogMessageKey, CatalogMode,
+    ConvertCatalogFileOptions, ConvertCatalogOptions, EffectiveTranslationRef, MsgStr,
+    ParseCatalogOptions, PoFile, PoItem, SerializeOptions, TranslationShape,
+};
+use ferrocat_icu::{parse_icu, stringify_icu, IcuMessage, IcuNode, IcuOption, IcuPluralKind};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::catalog_artifact::resolve_catalog_path;
+use crate::catalog_update::{po_serialize_options, AiProvenance, MachineMetadata};
+use crate::{
+    CatalogArtifactConfig, CatalogConfig, PalamedesCatalogFormat, PalamedesError, PalamedesResult,
+    PoOutputOptions,
+};
+
+const DEFAULT_MAX_ORIGINS: usize = 8;
+const CANDIDATE_FINGERPRINT_NAMESPACE: &[u8] = b"palamedes:translation-candidate:v1";
+
+/// Stable catalog and message identity used by translation workflow APIs.
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TranslationCandidateId {
+    /// Configured catalog path pattern, used as the catalog scope.
+    pub catalog: String,
+    /// Target catalog locale.
+    pub locale: String,
+    /// Source message identity.
+    pub message: String,
+    /// Optional gettext context that disambiguates equal source messages.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context: Option<String>,
+}
+
+/// Request for enumerating translation candidates across configured catalogs.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TranslationCandidateRequest {
+    /// Catalog configuration used to resolve catalog files and locales.
+    pub config: CatalogArtifactConfig,
+    /// Optional target-locale subset. Empty selects every configured non-source locale.
+    #[serde(default)]
+    pub locales: Vec<String>,
+    /// Explicit identities for re-run or review. Empty selects missing active entries.
+    #[serde(default)]
+    pub targets: Vec<TranslationCandidateId>,
+    /// Maximum number of origins exposed per candidate.
+    #[serde(default = "default_max_origins")]
+    pub max_origins: usize,
+}
+
+/// Result of translation candidate enumeration.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TranslationCandidateResult {
+    /// Deterministically ordered translation candidates.
+    pub candidates: Vec<TranslationCandidate>,
+    /// Structured diagnostics for unknown or duplicate explicit targets.
+    pub diagnostics: Vec<TranslationWorkflowDiagnostic>,
+}
+
+/// One provider-neutral unit of translation work.
+#[derive(Clone, Debug, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TranslationCandidate {
+    /// Stable catalog/message identity.
+    pub id: TranslationCandidateId,
+    /// Resolved catalog path on disk.
+    pub target_path: String,
+    /// Catalog storage format.
+    pub format: PalamedesCatalogFormat,
+    /// Source content, projected into singular or top-level plural form.
+    pub source: TranslationValue,
+    /// Current target content in the same provider-neutral representation when possible.
+    pub translation: TranslationValue,
+    /// Extracted translator-facing comments.
+    pub comments: Vec<String>,
+    /// Bounded source origins.
+    pub origins: Vec<TranslationWorkflowOrigin>,
+    /// Current technical translation and review state.
+    pub review: TranslationReviewState,
+    /// Native Ferrocat machine provenance for the current value.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub machine: Option<MachineMetadata>,
+    /// Per-candidate optimistic concurrency fingerprint.
+    pub fingerprint: String,
+}
+
+/// Source origin exposed to translation workflow consumers.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TranslationWorkflowOrigin {
+    /// Source filename.
+    pub file: String,
+    /// Optional stable authoring scope within the file.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scope: Option<String>,
+}
+
+/// Current technical state of a translation candidate.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TranslationReviewState {
+    /// Whether all effective target values are non-empty.
+    pub translated: bool,
+    /// Whether the catalog entry carries the native fuzzy review flag.
+    pub fuzzy: bool,
+    /// Whether the catalog entry is obsolete.
+    pub obsolete: bool,
+}
+
+/// Cardinal or ordinal ICU plural behavior.
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum TranslationPluralKind {
+    /// Cardinal plural such as one/other.
+    Cardinal,
+    /// Ordinal plural such as one/two/few/other.
+    Ordinal,
+}
+
+/// Format-neutral singular or plural translation content.
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum TranslationValue {
+    /// One translation string.
+    Singular {
+        /// Singular source or target value.
+        value: String,
+    },
+    /// One top-level ICU plural projected into selector branches.
+    Plural {
+        /// ICU argument used for plural selection.
+        variable: String,
+        /// Cardinal or ordinal plural behavior.
+        plural_kind: TranslationPluralKind,
+        /// ICU plural offset.
+        offset: u32,
+        /// Values keyed by ICU selector, for example `one`, `other`, or `=0`.
+        values: BTreeMap<String, String>,
+    },
+}
+
+/// Machine provenance attached to a completed translation patch.
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TranslationMachineProvenance {
+    /// Optional native AI provenance. Absence still marks the value as machine-managed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ai: Option<AiProvenance>,
+}
+
+/// One completed translation patch.
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TranslationPatch {
+    /// Stable identity returned by candidate enumeration.
+    pub id: TranslationCandidateId,
+    /// Fingerprint returned with the candidate.
+    pub fingerprint: String,
+    /// Completed singular or plural target value.
+    pub translation: TranslationValue,
+    /// Optional native machine provenance. Core computes the integrity lock.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub machine: Option<TranslationMachineProvenance>,
+}
+
+/// Request for validating and applying a batch of translation patches.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TranslationPatchRequest {
+    /// Catalog configuration used to resolve target files.
+    pub config: CatalogArtifactConfig,
+    /// Completed translation patches applied as one validation batch.
+    pub patches: Vec<TranslationPatch>,
+    /// Optional PO-specific output controls used when replacing PO catalogs.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub po: Option<PoOutputOptions>,
+}
+
+/// Result of a translation patch batch.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TranslationPatchResult {
+    /// Whether at least one catalog changed on disk.
+    pub updated: bool,
+    /// Deterministic patch and catalog counters.
+    pub stats: TranslationPatchStats,
+    /// One outcome per requested patch in request order.
+    pub outcomes: Vec<TranslationPatchOutcome>,
+    /// Structured validation diagnostics. Any error leaves all catalogs unchanged.
+    pub diagnostics: Vec<TranslationWorkflowDiagnostic>,
+}
+
+/// Aggregate translation patch counters.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TranslationPatchStats {
+    /// Requested patch count.
+    pub requested: usize,
+    /// Patches written with a changed target value or provenance.
+    pub applied: usize,
+    /// Valid patches whose rendered catalog was already equivalent.
+    pub unchanged: usize,
+    /// Catalog files atomically replaced.
+    pub catalogs_updated: usize,
+}
+
+/// Status of one requested translation patch.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum TranslationPatchOutcomeStatus {
+    /// Patch was applied and changed its catalog.
+    Applied,
+    /// Patch was valid but already represented by the catalog.
+    Unchanged,
+    /// Patch was rejected by validation.
+    Rejected,
+    /// Patch was valid but not written because another patch invalidated the atomic batch.
+    NotApplied,
+}
+
+/// Outcome for one requested translation patch.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TranslationPatchOutcome {
+    /// Stable identity of the requested patch.
+    pub id: TranslationCandidateId,
+    /// Result status.
+    pub status: TranslationPatchOutcomeStatus,
+}
+
+/// Structured translation workflow diagnostic.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TranslationWorkflowDiagnostic {
+    /// Stable machine-readable diagnostic code.
+    pub code: String,
+    /// Human-readable explanation.
+    pub message: String,
+    /// Associated candidate identity, when available.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<TranslationCandidateId>,
+}
+
+#[derive(Debug)]
+struct LoadedCatalog {
+    scope: String,
+    locale: String,
+    path: PathBuf,
+    format: PalamedesCatalogFormat,
+    original: String,
+    po: PoFile,
+    messages: BTreeMap<CatalogMessageKey, CatalogMessage>,
+    ambiguous_messages: BTreeSet<CatalogMessageKey>,
+}
+
+#[derive(Debug)]
+struct PreparedCatalog {
+    path: PathBuf,
+    format: PalamedesCatalogFormat,
+    locale: String,
+    content: String,
+    changed: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct CatalogBatchKey {
+    catalog_index: usize,
+    locale: String,
+}
+
+/// Enumerates missing targets by default, or explicitly selected entries for re-run/review.
+///
+/// # Errors
+///
+/// Returns an error when a selected catalog cannot be read or parsed.
+pub fn list_translation_candidates(
+    request: &TranslationCandidateRequest,
+) -> PalamedesResult<TranslationCandidateResult> {
+    let locales = selected_locales(&request.config, &request.locales);
+    let explicit = !request.targets.is_empty();
+    let mut requested = BTreeMap::<TranslationCandidateId, usize>::new();
+    let mut diagnostics = Vec::new();
+    for target in &request.targets {
+        let count = requested.entry(target.clone()).or_default();
+        *count += 1;
+        if *count == 2 {
+            diagnostics.push(workflow_diagnostic(
+                "translation.duplicate_target",
+                "Explicit candidate target was requested more than once.",
+                Some(target.clone()),
+            ));
+        }
+    }
+
+    let mut candidates = Vec::new();
+    let mut seen = BTreeSet::new();
+    for catalog in &request.config.catalogs {
+        for locale in &locales {
+            let loaded = load_catalog(&request.config, catalog, locale)?;
+            for (key, message) in &loaded.messages {
+                let id = TranslationCandidateId {
+                    catalog: loaded.scope.clone(),
+                    locale: locale.clone(),
+                    message: key.msgid.clone(),
+                    context: key.msgctxt.clone(),
+                };
+                if loaded.ambiguous_messages.contains(key) {
+                    if !explicit || requested.contains_key(&id) {
+                        seen.insert(id.clone());
+                        diagnostics.push(workflow_diagnostic(
+                            "translation.ambiguous_message",
+                            "Catalog contains more than one definition for the selected message identity.",
+                            Some(id),
+                        ));
+                    }
+                    continue;
+                }
+                let selected = if explicit {
+                    requested.contains_key(&id)
+                } else {
+                    message.obsolete.is_none() && !is_translated(message)
+                };
+                if !selected {
+                    continue;
+                }
+                let candidate = build_candidate(&loaded, key, message, request.max_origins);
+                seen.insert(id);
+                candidates.push(candidate);
+            }
+        }
+    }
+
+    if explicit {
+        for id in requested.keys().filter(|id| !seen.contains(*id)) {
+            diagnostics.push(workflow_diagnostic(
+                "translation.unknown_target",
+                "Explicit candidate target did not resolve to a configured catalog message.",
+                Some(id.clone()),
+            ));
+        }
+    }
+    candidates.sort_by(|left, right| left.id.cmp(&right.id));
+    diagnostics.sort_by(|left, right| diagnostic_sort_key(left).cmp(&diagnostic_sort_key(right)));
+    Ok(TranslationCandidateResult {
+        candidates,
+        diagnostics,
+    })
+}
+
+/// Validates a patch batch completely, then atomically replaces each changed catalog file.
+///
+/// Validation errors are returned as structured diagnostics and leave every original file
+/// unchanged. Successful multi-catalog batches provide per-file atomic replacement.
+///
+/// # Errors
+///
+/// Returns an error when catalogs cannot be read, parsed, rendered, or replaced.
+pub fn apply_translation_patches(
+    request: TranslationPatchRequest,
+) -> PalamedesResult<TranslationPatchResult> {
+    let requested_count = request.patches.len();
+    if request.patches.is_empty() {
+        return Ok(TranslationPatchResult {
+            updated: false,
+            stats: TranslationPatchStats::default(),
+            outcomes: Vec::new(),
+            diagnostics: Vec::new(),
+        });
+    }
+
+    let mut diagnostics = Vec::new();
+    let mut rejected = BTreeSet::new();
+    let mut changed_patches = BTreeSet::new();
+    let mut identities = BTreeMap::<TranslationCandidateId, usize>::new();
+    let mut groups = BTreeMap::<CatalogBatchKey, Vec<usize>>::new();
+
+    for (index, patch) in request.patches.iter().enumerate() {
+        if let Some(previous) = identities.insert(patch.id.clone(), index) {
+            rejected.insert(previous);
+            rejected.insert(index);
+            diagnostics.push(workflow_diagnostic(
+                "translation.duplicate_patch",
+                "A translation patch identity occurs more than once in the batch.",
+                Some(patch.id.clone()),
+            ));
+        }
+
+        let matches = request
+            .config
+            .catalogs
+            .iter()
+            .enumerate()
+            .filter(|(_, catalog)| catalog.path == patch.id.catalog)
+            .map(|(catalog_index, _)| catalog_index)
+            .collect::<Vec<_>>();
+        match matches.as_slice() {
+            [] => {
+                rejected.insert(index);
+                diagnostics.push(workflow_diagnostic(
+                    "translation.unknown_catalog",
+                    "Patch catalog scope is not present in the supplied configuration.",
+                    Some(patch.id.clone()),
+                ));
+            }
+            [catalog_index] => {
+                if !request
+                    .config
+                    .locales
+                    .iter()
+                    .any(|locale| locale == &patch.id.locale)
+                {
+                    rejected.insert(index);
+                    diagnostics.push(workflow_diagnostic(
+                        "translation.unknown_locale",
+                        "Patch locale is not present in the supplied configuration.",
+                        Some(patch.id.clone()),
+                    ));
+                } else {
+                    groups
+                        .entry(CatalogBatchKey {
+                            catalog_index: *catalog_index,
+                            locale: patch.id.locale.clone(),
+                        })
+                        .or_default()
+                        .push(index);
+                }
+            }
+            _ => {
+                rejected.insert(index);
+                diagnostics.push(workflow_diagnostic(
+                    "translation.ambiguous_catalog",
+                    "Patch catalog scope matches multiple configured catalogs.",
+                    Some(patch.id.clone()),
+                ));
+            }
+        }
+    }
+
+    let mut prepared = Vec::new();
+    for (batch, patch_indexes) in groups {
+        let catalog = &request.config.catalogs[batch.catalog_index];
+        let mut loaded = load_catalog(&request.config, catalog, &batch.locale)?;
+        for &patch_index in &patch_indexes {
+            if rejected.contains(&patch_index) {
+                continue;
+            }
+            let patch = &request.patches[patch_index];
+            let key = CatalogMessageKey::new(patch.id.message.clone(), patch.id.context.clone());
+            if loaded.ambiguous_messages.contains(&key) {
+                rejected.insert(patch_index);
+                diagnostics.push(workflow_diagnostic(
+                    "translation.ambiguous_message",
+                    "Catalog contains more than one definition for the patch identity.",
+                    Some(patch.id.clone()),
+                ));
+                continue;
+            }
+            let Some(message) = loaded.messages.get(&key) else {
+                rejected.insert(patch_index);
+                diagnostics.push(workflow_diagnostic(
+                    "translation.unknown_message",
+                    "Patch identity does not exist in the resolved catalog.",
+                    Some(patch.id.clone()),
+                ));
+                continue;
+            };
+            let current = build_candidate(&loaded, &key, message, usize::MAX);
+            if current.fingerprint != patch.fingerprint {
+                rejected.insert(patch_index);
+                diagnostics.push(workflow_diagnostic(
+                    "translation.stale_candidate",
+                    "Patch fingerprint no longer matches the current catalog entry.",
+                    Some(patch.id.clone()),
+                ));
+                continue;
+            }
+            if let Err(message) = validate_patch_translation(&current.source, &patch.translation) {
+                rejected.insert(patch_index);
+                diagnostics.push(workflow_diagnostic(
+                    "translation.shape_mismatch",
+                    message,
+                    Some(patch.id.clone()),
+                ));
+            }
+            if let Some(machine) = &patch.machine {
+                if let Err(message) = validate_machine_provenance(machine) {
+                    rejected.insert(patch_index);
+                    diagnostics.push(workflow_diagnostic(
+                        "translation.invalid_provenance",
+                        message,
+                        Some(patch.id.clone()),
+                    ));
+                }
+            }
+            if !rejected.contains(&patch_index) && patch_changes_candidate(&current, patch)? {
+                changed_patches.insert(patch_index);
+            }
+        }
+
+        if patch_indexes
+            .iter()
+            .all(|patch_index| !rejected.contains(patch_index))
+        {
+            for &patch_index in &patch_indexes {
+                apply_patch_to_po(&mut loaded.po, &request.patches[patch_index])?;
+            }
+            let po = ferrocat::stringify_po(&loaded.po, &SerializeOptions::default());
+            let content = render_target_catalog(
+                &po,
+                &request.config.source_locale,
+                &batch.locale,
+                loaded.format,
+                request.po.as_ref(),
+            )?;
+            prepared.push(PreparedCatalog {
+                path: loaded.path,
+                format: loaded.format,
+                locale: batch.locale,
+                changed: content != loaded.original,
+                content,
+            });
+        }
+    }
+
+    if !rejected.is_empty() {
+        diagnostics
+            .sort_by(|left, right| diagnostic_sort_key(left).cmp(&diagnostic_sort_key(right)));
+        let outcomes = request
+            .patches
+            .into_iter()
+            .enumerate()
+            .map(|(index, patch)| TranslationPatchOutcome {
+                id: patch.id,
+                status: if rejected.contains(&index) {
+                    TranslationPatchOutcomeStatus::Rejected
+                } else {
+                    TranslationPatchOutcomeStatus::NotApplied
+                },
+            })
+            .collect();
+        return Ok(TranslationPatchResult {
+            updated: false,
+            stats: TranslationPatchStats {
+                requested: requested_count,
+                ..TranslationPatchStats::default()
+            },
+            outcomes,
+            diagnostics,
+        });
+    }
+
+    let catalogs_updated = prepared.iter().filter(|catalog| catalog.changed).count();
+    for catalog in prepared.iter().filter(|catalog| catalog.changed) {
+        atomic_replace_catalog(catalog, &request.config.source_locale, request.po.as_ref())?;
+    }
+    let outcomes = request
+        .patches
+        .into_iter()
+        .enumerate()
+        .map(|(index, patch)| TranslationPatchOutcome {
+            id: patch.id,
+            status: if changed_patches.contains(&index) {
+                TranslationPatchOutcomeStatus::Applied
+            } else {
+                TranslationPatchOutcomeStatus::Unchanged
+            },
+        })
+        .collect();
+
+    Ok(TranslationPatchResult {
+        updated: catalogs_updated > 0,
+        stats: TranslationPatchStats {
+            requested: requested_count,
+            applied: changed_patches.len(),
+            unchanged: requested_count - changed_patches.len(),
+            catalogs_updated,
+        },
+        outcomes,
+        diagnostics,
+    })
+}
+
+fn default_max_origins() -> usize {
+    DEFAULT_MAX_ORIGINS
+}
+
+fn selected_locales(config: &CatalogArtifactConfig, requested: &[String]) -> Vec<String> {
+    let mut locales = if requested.is_empty() {
+        config
+            .locales
+            .iter()
+            .filter(|locale| locale.as_str() != config.source_locale)
+            .cloned()
+            .collect::<Vec<_>>()
+    } else {
+        requested
+            .iter()
+            .filter(|locale| config.locales.contains(locale))
+            .cloned()
+            .collect::<Vec<_>>()
+    };
+    locales.sort();
+    locales.dedup();
+    locales
+}
+
+fn load_catalog(
+    config: &CatalogArtifactConfig,
+    catalog: &CatalogConfig,
+    locale: &str,
+) -> PalamedesResult<LoadedCatalog> {
+    let path = resolve_catalog_path(config, catalog, locale);
+    let original = fs::read_to_string(&path).map_err(|source| PalamedesError::ReadFile {
+        path: path.clone(),
+        source,
+    })?;
+    let parsed = parse_catalog(
+        ParseCatalogOptions::new(&original, &config.source_locale)
+            .with_locale(locale)
+            .with_mode(catalog.format.ferrocat_mode()),
+    )?;
+    let mut messages = BTreeMap::new();
+    let mut ambiguous_messages = BTreeSet::new();
+    for message in parsed.messages {
+        let key = message.key();
+        if messages.insert(key.clone(), message).is_some() {
+            ambiguous_messages.insert(key);
+        }
+    }
+    let po = catalog_as_po(&original, &config.source_locale, locale, catalog.format)?;
+    Ok(LoadedCatalog {
+        scope: catalog.path.clone(),
+        locale: locale.to_owned(),
+        path,
+        format: catalog.format,
+        original,
+        po,
+        messages,
+        ambiguous_messages,
+    })
+}
+
+fn catalog_as_po(
+    content: &str,
+    source_locale: &str,
+    locale: &str,
+    format: PalamedesCatalogFormat,
+) -> PalamedesResult<PoFile> {
+    let po = match format {
+        PalamedesCatalogFormat::Po => content.to_owned(),
+        PalamedesCatalogFormat::Fcl => {
+            convert_catalog(
+                ConvertCatalogOptions::new(
+                    content,
+                    source_locale,
+                    CatalogMode::IcuFcl,
+                    CatalogMode::IcuPo,
+                )
+                .with_locale(locale),
+            )?
+            .content
+        }
+    };
+    Ok(ferrocat::parse_po(&po)?)
+}
+
+fn build_candidate(
+    loaded: &LoadedCatalog,
+    key: &CatalogMessageKey,
+    message: &CatalogMessage,
+    max_origins: usize,
+) -> TranslationCandidate {
+    let raw = find_po_item(&loaded.po, key);
+    let source = project_source(&message.msgid);
+    let translation = project_translation(message, &source);
+    let review = TranslationReviewState {
+        translated: value_is_translated(&translation),
+        fuzzy: raw.is_some_and(|item| item.flags.iter().any(|flag| flag == "fuzzy")),
+        obsolete: message.obsolete.is_some(),
+    };
+    let comments = raw.map_or_else(
+        || message.comments.clone(),
+        |item| item.extracted_comments.iter().cloned().collect(),
+    );
+    let origins = message
+        .origin
+        .iter()
+        .take(max_origins)
+        .map(|origin| TranslationWorkflowOrigin {
+            file: origin.file.clone(),
+            scope: origin.scope.clone(),
+        })
+        .collect();
+    let id = TranslationCandidateId {
+        catalog: loaded.scope.clone(),
+        locale: loaded.locale.clone(),
+        message: key.msgid.clone(),
+        context: key.msgctxt.clone(),
+    };
+    let mut candidate = TranslationCandidate {
+        id,
+        target_path: loaded.path.to_string_lossy().into_owned(),
+        format: loaded.format,
+        source,
+        translation,
+        comments,
+        origins,
+        review,
+        machine: message.machine.clone().map(MachineMetadata::from),
+        fingerprint: String::new(),
+    };
+    candidate.fingerprint = candidate_fingerprint(&candidate);
+    candidate
+}
+
+fn project_source(message: &str) -> TranslationValue {
+    project_icu_plural(message).unwrap_or_else(|| TranslationValue::Singular {
+        value: message.to_owned(),
+    })
+}
+
+fn project_translation(message: &CatalogMessage, source: &TranslationValue) -> TranslationValue {
+    match message.effective_translation() {
+        EffectiveTranslationRef::Singular(value) => {
+            if matches!(source, TranslationValue::Plural { .. }) {
+                if value.is_empty() {
+                    return empty_plural_like(source);
+                }
+                if let Some(projected) = project_icu_plural(value) {
+                    return projected;
+                }
+            }
+            TranslationValue::Singular {
+                value: value.to_owned(),
+            }
+        }
+        EffectiveTranslationRef::Plural(values) => match &message.translation {
+            TranslationShape::Plural { variable, .. } => TranslationValue::Plural {
+                variable: variable.clone(),
+                plural_kind: TranslationPluralKind::Cardinal,
+                offset: 0,
+                values: values.clone(),
+            },
+            TranslationShape::Singular { .. } => TranslationValue::Singular {
+                value: String::new(),
+            },
+        },
+    }
+}
+
+fn project_icu_plural(value: &str) -> Option<TranslationValue> {
+    let parsed = parse_icu(value).ok()?;
+    let [IcuNode::Plural {
+        name,
+        kind,
+        offset,
+        options,
+    }] = parsed.nodes.as_slice()
+    else {
+        return None;
+    };
+    let values = options
+        .iter()
+        .map(|option| {
+            (
+                option.selector.clone(),
+                stringify_icu(&IcuMessage {
+                    nodes: option.value.clone(),
+                }),
+            )
+        })
+        .collect();
+    Some(TranslationValue::Plural {
+        variable: name.clone(),
+        plural_kind: match kind {
+            IcuPluralKind::Cardinal => TranslationPluralKind::Cardinal,
+            IcuPluralKind::Ordinal => TranslationPluralKind::Ordinal,
+        },
+        offset: *offset,
+        values,
+    })
+}
+
+fn empty_plural_like(source: &TranslationValue) -> TranslationValue {
+    match source {
+        TranslationValue::Plural {
+            variable,
+            plural_kind,
+            offset,
+            values,
+        } => TranslationValue::Plural {
+            variable: variable.clone(),
+            plural_kind: *plural_kind,
+            offset: *offset,
+            values: values
+                .keys()
+                .map(|key| (key.clone(), String::new()))
+                .collect(),
+        },
+        TranslationValue::Singular { .. } => TranslationValue::Singular {
+            value: String::new(),
+        },
+    }
+}
+
+fn is_translated(message: &CatalogMessage) -> bool {
+    match message.effective_translation() {
+        EffectiveTranslationRef::Singular(value) => !value.is_empty(),
+        EffectiveTranslationRef::Plural(values) => {
+            !values.is_empty() && values.values().all(|value| !value.is_empty())
+        }
+    }
+}
+
+fn value_is_translated(value: &TranslationValue) -> bool {
+    match value {
+        TranslationValue::Singular { value } => !value.is_empty(),
+        TranslationValue::Plural { values, .. } => {
+            !values.is_empty() && values.values().all(|value| !value.is_empty())
+        }
+    }
+}
+
+fn candidate_fingerprint(candidate: &TranslationCandidate) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(CANDIDATE_FINGERPRINT_NAMESPACE);
+    hash_json(&mut hasher, &candidate.id);
+    hash_json(&mut hasher, &candidate.source);
+    hash_json(&mut hasher, &candidate.translation);
+    hash_json(&mut hasher, &candidate.comments);
+    hash_json(&mut hasher, &candidate.origins);
+    hash_json(&mut hasher, &candidate.review);
+    hash_json(&mut hasher, &candidate.machine);
+    let digest = hasher.finalize();
+    digest[..16]
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+fn hash_json<T: Serialize>(hasher: &mut Sha256, value: &T) {
+    let bytes = serde_json::to_vec(value).expect("translation fingerprint payload is serializable");
+    hasher.update((bytes.len() as u64).to_be_bytes());
+    hasher.update(bytes);
+}
+
+fn validate_patch_translation(
+    source: &TranslationValue,
+    translation: &TranslationValue,
+) -> Result<(), &'static str> {
+    match (source, translation) {
+        (TranslationValue::Singular { .. }, TranslationValue::Singular { value }) => {
+            if value.is_empty() {
+                Err("Completed singular translations must not be empty.")
+            } else {
+                Ok(())
+            }
+        }
+        (
+            TranslationValue::Plural {
+                variable: source_variable,
+                plural_kind: source_kind,
+                offset: source_offset,
+                values: source_values,
+            },
+            TranslationValue::Plural {
+                variable,
+                plural_kind,
+                offset,
+                values,
+            },
+        ) => {
+            if variable != source_variable || plural_kind != source_kind || offset != source_offset
+            {
+                return Err("Plural variable, kind, and offset must match the source candidate.");
+            }
+            if values.keys().ne(source_values.keys()) {
+                return Err(
+                    "Plural translation selectors must exactly match the source candidate.",
+                );
+            }
+            if values.values().any(String::is_empty) {
+                return Err("Completed plural translation branches must not be empty.");
+            }
+            Ok(())
+        }
+        _ => Err("Translation shape must match the source candidate."),
+    }
+}
+
+fn validate_machine_provenance(machine: &TranslationMachineProvenance) -> Result<(), &'static str> {
+    if let Some(ai) = &machine.ai {
+        if ai.model.trim().is_empty() {
+            return Err("AI model must not be empty.");
+        }
+        if ai
+            .confidence
+            .is_some_and(|confidence| !(0.0..=1.0).contains(&confidence))
+        {
+            return Err("AI confidence must be between 0 and 1.");
+        }
+    }
+    Ok(())
+}
+
+fn patch_changes_candidate(
+    candidate: &TranslationCandidate,
+    patch: &TranslationPatch,
+) -> PalamedesResult<bool> {
+    if candidate.translation != patch.translation {
+        return Ok(true);
+    }
+    let expected_machine = match &patch.machine {
+        Some(machine) => {
+            let rendered = render_translation_value(&patch.translation)?;
+            Some(MachineMetadata {
+                lock: machine_translation_hash(EffectiveTranslationRef::Singular(&rendered)),
+                ai: machine.ai.clone(),
+            })
+        }
+        None => None,
+    };
+    Ok(candidate.machine != expected_machine)
+}
+
+fn apply_patch_to_po(po: &mut PoFile, patch: &TranslationPatch) -> PalamedesResult<()> {
+    let matches = po
+        .items
+        .iter()
+        .enumerate()
+        .filter(|(_, item)| item.msgid == patch.id.message && item.msgctxt == patch.id.context)
+        .map(|(index, _)| index)
+        .collect::<Vec<_>>();
+    let [index] = matches.as_slice() else {
+        return Err(ferrocat::ApiError::Conflict(format!(
+            "catalog mutation identity {:?} with context {:?} is missing or ambiguous",
+            patch.id.message, patch.id.context
+        ))
+        .into());
+    };
+    let item = &mut po.items[*index];
+    let rendered = render_translation_value(&patch.translation)?;
+    item.msgstr = MsgStr::Singular(rendered.clone());
+    item.msgid_plural = None;
+    item.metadata = std::mem::take(&mut item.metadata)
+        .into_iter()
+        .filter(|(key, _)| key != "lock" && key != "ai")
+        .collect();
+    if let Some(machine) = &patch.machine {
+        let lock = machine_translation_hash(EffectiveTranslationRef::Singular(&rendered));
+        item.metadata.push(("lock".to_owned(), lock));
+        if let Some(ai) = &machine.ai {
+            let descriptor = match ai.confidence {
+                Some(confidence) => format!("{}:{confidence}", ai.model),
+                None => ai.model.clone(),
+            };
+            item.metadata.push(("ai".to_owned(), descriptor));
+        }
+    }
+    Ok(())
+}
+
+fn render_translation_value(value: &TranslationValue) -> PalamedesResult<String> {
+    match value {
+        TranslationValue::Singular { value } => Ok(value.clone()),
+        TranslationValue::Plural {
+            variable,
+            plural_kind,
+            offset,
+            values,
+        } => {
+            let options = values
+                .iter()
+                .map(|(selector, value)| {
+                    let value = parse_plural_branch(variable, *plural_kind, value)?;
+                    Ok(IcuOption {
+                        selector: selector.clone(),
+                        value,
+                    })
+                })
+                .collect::<Result<Vec<_>, ferrocat_icu::IcuParseError>>()?;
+            Ok(stringify_icu(&IcuMessage {
+                nodes: vec![IcuNode::Plural {
+                    name: variable.clone(),
+                    kind: match plural_kind {
+                        TranslationPluralKind::Cardinal => IcuPluralKind::Cardinal,
+                        TranslationPluralKind::Ordinal => IcuPluralKind::Ordinal,
+                    },
+                    offset: *offset,
+                    options,
+                }],
+            }))
+        }
+    }
+}
+
+fn parse_plural_branch(
+    variable: &str,
+    plural_kind: TranslationPluralKind,
+    value: &str,
+) -> Result<Vec<IcuNode>, ferrocat_icu::IcuParseError> {
+    let formatter = match plural_kind {
+        TranslationPluralKind::Cardinal => "plural",
+        TranslationPluralKind::Ordinal => "selectordinal",
+    };
+    let wrapped = format!("{{{variable}, {formatter}, other {{{value}}}}}");
+    let parsed = parse_icu(&wrapped)?;
+    let [IcuNode::Plural { options, .. }] = parsed.nodes.as_slice() else {
+        unreachable!("the generated plural wrapper always parses to one plural node");
+    };
+    Ok(options[0].value.clone())
+}
+
+fn render_target_catalog(
+    po_content: &str,
+    source_locale: &str,
+    locale: &str,
+    format: PalamedesCatalogFormat,
+    po_options: Option<&PoOutputOptions>,
+) -> PalamedesResult<String> {
+    let target_mode = match format {
+        PalamedesCatalogFormat::Po => CatalogMode::IcuPo,
+        PalamedesCatalogFormat::Fcl => CatalogMode::IcuFcl,
+    };
+    Ok(convert_catalog(
+        ConvertCatalogOptions::new(po_content, source_locale, CatalogMode::IcuPo, target_mode)
+            .with_locale(locale)
+            .with_po_serialize_options(po_serialize_options(po_options)),
+    )?
+    .content)
+}
+
+fn atomic_replace_catalog(
+    catalog: &PreparedCatalog,
+    source_locale: &str,
+    po: Option<&PoOutputOptions>,
+) -> PalamedesResult<()> {
+    let mut temporary =
+        tempfile::NamedTempFile::new().map_err(|source| PalamedesError::WriteFile {
+            path: catalog.path.clone(),
+            source,
+        })?;
+    temporary
+        .write_all(catalog.content.as_bytes())
+        .map_err(|source| PalamedesError::WriteFile {
+            path: catalog.path.clone(),
+            source,
+        })?;
+    temporary
+        .flush()
+        .map_err(|source| PalamedesError::WriteFile {
+            path: catalog.path.clone(),
+            source,
+        })?;
+    let format = match catalog.format {
+        PalamedesCatalogFormat::Po => FerrocatCatalogFileFormat::Po,
+        PalamedesCatalogFormat::Fcl => FerrocatCatalogFileFormat::Fcl,
+    };
+    convert_catalog_file(
+        ConvertCatalogFileOptions::new(temporary.path(), &catalog.path, source_locale)
+            .with_source_format(format)
+            .with_target_format(format)
+            .with_locale(&catalog.locale)
+            .with_po_serialize_options(po_serialize_options(po)),
+    )?;
+    Ok(())
+}
+
+fn find_po_item<'a>(po: &'a PoFile, key: &CatalogMessageKey) -> Option<&'a PoItem> {
+    po.items
+        .iter()
+        .find(|item| item.msgid == key.msgid && item.msgctxt == key.msgctxt)
+}
+
+fn workflow_diagnostic(
+    code: &str,
+    message: impl Into<String>,
+    id: Option<TranslationCandidateId>,
+) -> TranslationWorkflowDiagnostic {
+    TranslationWorkflowDiagnostic {
+        code: code.to_owned(),
+        message: message.into(),
+        id,
+    }
+}
+
+fn diagnostic_sort_key(
+    diagnostic: &TranslationWorkflowDiagnostic,
+) -> (&str, Option<&TranslationCandidateId>) {
+    (&diagnostic.code, diagnostic.id.as_ref())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::path::Path;
+
+    use ferrocat::{
+        convert_catalog, machine_translation_hash, parse_catalog, parse_po, CatalogMode,
+        ConvertCatalogOptions, EffectiveTranslationRef, ParseCatalogOptions,
+    };
+
+    use super::{
+        apply_translation_patches, list_translation_candidates, TranslationCandidate,
+        TranslationCandidateId, TranslationCandidateRequest, TranslationMachineProvenance,
+        TranslationPatch, TranslationPatchOutcomeStatus, TranslationPatchRequest,
+        TranslationPluralKind, TranslationValue,
+    };
+    use crate::{CatalogArtifactConfig, CatalogConfig, PalamedesCatalogFormat};
+
+    const FIXTURE: &str = include_str!("../fixtures/translation-workflow.de.po");
+
+    #[test]
+    fn enumerates_missing_and_explicit_candidates_across_catalogs_and_locales() {
+        let fixture = tempfile::tempdir().expect("fixture directory");
+        write_catalog_matrix(fixture.path());
+        let result = list_translation_candidates(&TranslationCandidateRequest {
+            config: config(fixture.path()),
+            locales: Vec::new(),
+            targets: Vec::new(),
+            max_origins: 1,
+        })
+        .expect("enumerate missing candidates");
+
+        assert!(result.diagnostics.is_empty());
+        assert_eq!(result.candidates.len(), 12);
+        assert!(result
+            .candidates
+            .windows(2)
+            .all(|pair| pair[0].id <= pair[1].id));
+        let plural = result
+            .candidates
+            .iter()
+            .find(|candidate| candidate.id.message.starts_with("{count, plural"))
+            .expect("plural candidate");
+        assert!(matches!(
+            &plural.source,
+            TranslationValue::Plural {
+                variable,
+                plural_kind: TranslationPluralKind::Cardinal,
+                offset: 0,
+                values,
+            } if variable == "count" && values.keys().cloned().collect::<Vec<_>>() == ["one", "other"]
+        ));
+        assert!(matches!(
+            &plural.translation,
+            TranslationValue::Plural { values, .. }
+                if values.values().all(String::is_empty)
+        ));
+        let hello = result
+            .candidates
+            .iter()
+            .find(|candidate| {
+                candidate.id.catalog == "messages/{locale}"
+                    && candidate.id.locale == "de"
+                    && candidate.id.message == "Hello"
+            })
+            .expect("German PO candidate");
+        assert_eq!(hello.comments, ["Greeting shown on the home page"]);
+        assert_eq!(hello.origins.len(), 1, "origins are bounded by the request");
+        assert!(!result.candidates.iter().any(|candidate| {
+            candidate.id.message == "Open" && candidate.id.context.as_deref() == Some("adjective")
+        }));
+        assert!(!result
+            .candidates
+            .iter()
+            .any(|candidate| candidate.id.message == "Old"));
+
+        let review_id = id("messages/{locale}", "de", "Review me", None);
+        let obsolete_id = id("messages/{locale}", "de", "Old", None);
+        let machine_id = id("messages/{locale}", "de", "Machine", None);
+        let explicit = list_translation_candidates(&TranslationCandidateRequest {
+            config: config(fixture.path()),
+            locales: vec!["de".to_owned()],
+            targets: vec![review_id, obsolete_id, machine_id],
+            max_origins: 8,
+        })
+        .expect("enumerate explicit candidates");
+        assert!(explicit.diagnostics.is_empty());
+        assert_eq!(explicit.candidates.len(), 3);
+        assert!(candidate(&explicit.candidates, "Review me").review.fuzzy);
+        assert!(candidate(&explicit.candidates, "Old").review.obsolete);
+        let machine = candidate(&explicit.candidates, "Machine")
+            .machine
+            .as_ref()
+            .expect("native machine metadata");
+        assert_eq!(
+            machine.ai.as_ref().map(|ai| ai.model.as_str()),
+            Some("example/model")
+        );
+    }
+
+    #[test]
+    fn applies_singular_and_plural_po_patches_without_losing_unrelated_state() {
+        let fixture = tempfile::tempdir().expect("fixture directory");
+        write_po_fixture(&fixture.path().join("messages/de.po"), "de");
+        let ids = [
+            id("messages/{locale}", "de", "Hello", None),
+            id(
+                "messages/{locale}",
+                "de",
+                "{count, plural, one {# file} other {# files}}",
+                None,
+            ),
+        ];
+        let listed = list_translation_candidates(&TranslationCandidateRequest {
+            config: po_config(fixture.path()),
+            locales: vec!["de".to_owned()],
+            targets: ids.to_vec(),
+            max_origins: 8,
+        })
+        .expect("list patch candidates");
+        let hello = candidate(&listed.candidates, "Hello");
+        let plural = candidate(
+            &listed.candidates,
+            "{count, plural, one {# file} other {# files}}",
+        );
+        let result = apply_translation_patches(TranslationPatchRequest {
+            config: po_config(fixture.path()),
+            po: None,
+            patches: vec![
+                TranslationPatch {
+                    id: hello.id.clone(),
+                    fingerprint: hello.fingerprint.clone(),
+                    translation: TranslationValue::Singular {
+                        value: "Hallo".to_owned(),
+                    },
+                    machine: Some(TranslationMachineProvenance {
+                        ai: Some(crate::AiProvenance {
+                            model: "example/new".to_owned(),
+                            confidence: Some(0.9),
+                        }),
+                    }),
+                },
+                TranslationPatch {
+                    id: plural.id.clone(),
+                    fingerprint: plural.fingerprint.clone(),
+                    translation: TranslationValue::Plural {
+                        variable: "count".to_owned(),
+                        plural_kind: TranslationPluralKind::Cardinal,
+                        offset: 0,
+                        values: [
+                            ("one".to_owned(), "# Datei".to_owned()),
+                            ("other".to_owned(), "# Dateien".to_owned()),
+                        ]
+                        .into_iter()
+                        .collect(),
+                    },
+                    machine: None,
+                },
+            ],
+        })
+        .expect("apply PO patches");
+
+        assert!(result.updated);
+        assert_eq!(result.stats.applied, 2);
+        assert_eq!(result.stats.catalogs_updated, 1);
+        assert!(result.diagnostics.is_empty());
+        assert!(result
+            .outcomes
+            .iter()
+            .all(|outcome| outcome.status == TranslationPatchOutcomeStatus::Applied));
+
+        let path = fixture.path().join("messages/de.po");
+        let output = fs::read_to_string(&path).expect("read patched PO");
+        assert!(output.contains("\"X-Custom: keep-me\\n\""));
+        let raw = parse_po(&output).expect("parse patched PO");
+        let hello = raw.items.iter().find(|item| item.msgid == "Hello").unwrap();
+        assert_eq!(hello.msgstr.first(), Some("Hallo"));
+        assert!(hello
+            .references
+            .iter()
+            .any(|origin| origin == "src/home.tsx#HomePage"));
+        assert!(hello.metadata.iter().any(|(key, _)| key == "lock"));
+        assert!(hello
+            .metadata
+            .iter()
+            .any(|(key, value)| key == "ai" && value == "example/new:0.9"));
+        let plural = raw
+            .items
+            .iter()
+            .find(|item| item.msgid.starts_with("{count, plural"))
+            .unwrap();
+        assert_eq!(
+            plural.msgstr.first(),
+            Some("{count, plural, one {# Datei} other {# Dateien}}")
+        );
+        let review = raw
+            .items
+            .iter()
+            .find(|item| item.msgid == "Review me")
+            .unwrap();
+        assert!(review.flags.iter().any(|flag| flag == "fuzzy"));
+        assert!(review.flags.iter().any(|flag| flag == "x-custom"));
+        assert_eq!(
+            review.comments.first().map(String::as_str),
+            Some("Translator-owned review note")
+        );
+        assert!(raw
+            .items
+            .iter()
+            .any(|item| item.msgid == "Old" && item.obsolete));
+        assert_eq!(
+            raw.items
+                .iter()
+                .find(|item| item.msgctxt.as_deref() == Some("adjective"))
+                .and_then(|item| item.msgstr.first()),
+            Some("Offen")
+        );
+
+        let parsed = parse_catalog(
+            ParseCatalogOptions::new(&output, "en")
+                .with_locale("de")
+                .with_mode(CatalogMode::IcuPo),
+        )
+        .expect("semantic parse");
+        let hello = parsed
+            .messages
+            .iter()
+            .find(|message| message.msgid == "Hello")
+            .unwrap();
+        assert_eq!(
+            hello
+                .machine
+                .as_ref()
+                .and_then(|metadata| metadata.ai.as_ref())
+                .map(|ai| ai.model.as_str()),
+            Some("example/new")
+        );
+    }
+
+    #[test]
+    fn applies_fcl_patches_and_supports_incremental_batches() {
+        let fixture = tempfile::tempdir().expect("fixture directory");
+        write_fcl_fixture(&fixture.path().join("features/de.fcl"), "de");
+        let targets = vec![
+            id("features/{locale}", "de", "Hello", None),
+            id("features/{locale}", "de", "Open", Some("verb")),
+        ];
+        let listed = list_translation_candidates(&TranslationCandidateRequest {
+            config: fcl_config(fixture.path()),
+            locales: vec!["de".to_owned()],
+            targets,
+            max_origins: 8,
+        })
+        .expect("list FCL candidates");
+        let hello = candidate(&listed.candidates, "Hello").clone();
+        let open = listed
+            .candidates
+            .iter()
+            .find(|candidate| candidate.id.context.as_deref() == Some("verb"))
+            .unwrap()
+            .clone();
+
+        let first = apply_translation_patches(TranslationPatchRequest {
+            config: fcl_config(fixture.path()),
+            po: None,
+            patches: vec![singular_patch(&open, "Öffnen")],
+        })
+        .expect("apply first incremental batch");
+        assert!(first.updated);
+        let second = apply_translation_patches(TranslationPatchRequest {
+            config: fcl_config(fixture.path()),
+            po: None,
+            patches: vec![singular_patch(&hello, "Hallo")],
+        })
+        .expect("unrelated candidate fingerprint remains valid");
+        assert!(second.updated);
+        assert!(second.diagnostics.is_empty());
+
+        let output =
+            fs::read_to_string(fixture.path().join("features/de.fcl")).expect("read patched FCL");
+        assert!(output.starts_with("%FCL1"));
+        assert!(output.contains("Hello\t\tHallo"));
+        assert!(output.contains("Open\tverb\tÖffnen"));
+        assert!(output.contains("\tc=Greeting shown on the home page"));
+        assert!(output.contains("Review me\t\tBitte prüfen"));
+        assert!(output.contains("\tf=fuzzy\tf=x-custom"));
+    }
+
+    #[test]
+    fn rejects_duplicate_unknown_and_stale_patches_without_writing() {
+        let fixture = tempfile::tempdir().expect("fixture directory");
+        let path = fixture.path().join("messages/de.po");
+        write_po_fixture(&path, "de");
+        let listed = list_translation_candidates(&TranslationCandidateRequest {
+            config: po_config(fixture.path()),
+            locales: vec!["de".to_owned()],
+            targets: vec![id("messages/{locale}", "de", "Hello", None)],
+            max_origins: 8,
+        })
+        .expect("list candidate");
+        let hello = candidate(&listed.candidates, "Hello").clone();
+        let before = fs::read_to_string(&path).expect("read before duplicate batch");
+        let duplicate = apply_translation_patches(TranslationPatchRequest {
+            config: po_config(fixture.path()),
+            po: None,
+            patches: vec![
+                singular_patch(&hello, "Hallo"),
+                singular_patch(&hello, "Servus"),
+            ],
+        })
+        .expect("reject duplicate batch");
+        assert!(!duplicate.updated);
+        assert!(duplicate
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "translation.duplicate_patch"));
+        assert_eq!(fs::read_to_string(&path).unwrap(), before);
+
+        let unknown = TranslationPatch {
+            id: id("messages/{locale}", "de", "Unknown", None),
+            fingerprint: "unknown".to_owned(),
+            translation: TranslationValue::Singular {
+                value: "Unbekannt".to_owned(),
+            },
+            machine: None,
+        };
+        let atomic = apply_translation_patches(TranslationPatchRequest {
+            config: po_config(fixture.path()),
+            po: None,
+            patches: vec![singular_patch(&hello, "Hallo"), unknown],
+        })
+        .expect("reject unknown message batch");
+        assert!(!atomic.updated);
+        assert!(atomic
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "translation.unknown_message"));
+        assert_eq!(fs::read_to_string(&path).unwrap(), before);
+
+        fs::write(
+            &path,
+            before.replace(
+                "msgid \"Hello\"\nmsgstr \"\"",
+                "msgid \"Hello\"\nmsgstr \"Extern\"",
+            ),
+        )
+        .expect("external candidate edit");
+        let externally_changed = fs::read_to_string(&path).unwrap();
+        let stale = apply_translation_patches(TranslationPatchRequest {
+            config: po_config(fixture.path()),
+            po: None,
+            patches: vec![singular_patch(&hello, "Hallo")],
+        })
+        .expect("reject stale candidate");
+        assert!(!stale.updated);
+        assert!(stale
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "translation.stale_candidate"));
+        assert_eq!(fs::read_to_string(&path).unwrap(), externally_changed);
+    }
+
+    #[test]
+    fn reports_ambiguous_po_identities_as_structured_diagnostics() {
+        let fixture = tempfile::tempdir().expect("fixture directory");
+        let path = fixture.path().join("messages/de.po");
+        write_po_fixture(&path, "de");
+        let content = fs::read_to_string(&path).expect("read fixture");
+        fs::write(
+            &path,
+            format!("{content}\n#~ msgid \"Hello\"\n#~ msgstr \"Historisch\"\n"),
+        )
+        .expect("write ambiguous fixture");
+        let target = id("messages/{locale}", "de", "Hello", None);
+        let listed = list_translation_candidates(&TranslationCandidateRequest {
+            config: po_config(fixture.path()),
+            locales: vec!["de".to_owned()],
+            targets: vec![target.clone()],
+            max_origins: 8,
+        })
+        .expect("list ambiguous identity");
+        assert!(listed.candidates.is_empty());
+        assert_eq!(listed.diagnostics.len(), 1);
+        assert_eq!(listed.diagnostics[0].code, "translation.ambiguous_message");
+
+        let before = fs::read_to_string(&path).expect("read before rejected patch");
+        let result = apply_translation_patches(TranslationPatchRequest {
+            config: po_config(fixture.path()),
+            po: None,
+            patches: vec![TranslationPatch {
+                id: target,
+                fingerprint: "cannot-be-unambiguous".to_owned(),
+                translation: TranslationValue::Singular {
+                    value: "Hallo".to_owned(),
+                },
+                machine: None,
+            }],
+        })
+        .expect("reject ambiguous patch");
+        assert!(!result.updated);
+        assert_eq!(
+            result.outcomes[0].status,
+            TranslationPatchOutcomeStatus::Rejected
+        );
+        assert!(result
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "translation.ambiguous_message"));
+        assert_eq!(fs::read_to_string(&path).unwrap(), before);
+    }
+
+    fn config(root: &Path) -> CatalogArtifactConfig {
+        CatalogArtifactConfig {
+            root_dir: root.to_string_lossy().into_owned(),
+            locales: vec!["en".to_owned(), "de".to_owned(), "fr".to_owned()],
+            source_locale: "en".to_owned(),
+            fallback_locales: None,
+            pseudo_locale: None,
+            catalogs: vec![
+                CatalogConfig {
+                    path: "messages/{locale}".to_owned(),
+                    format: PalamedesCatalogFormat::Po,
+                },
+                CatalogConfig {
+                    path: "features/{locale}".to_owned(),
+                    format: PalamedesCatalogFormat::Fcl,
+                },
+            ],
+        }
+    }
+
+    fn po_config(root: &Path) -> CatalogArtifactConfig {
+        let mut config = config(root);
+        config.locales = vec!["en".to_owned(), "de".to_owned()];
+        config.catalogs.truncate(1);
+        config
+    }
+
+    fn fcl_config(root: &Path) -> CatalogArtifactConfig {
+        let mut config = config(root);
+        config.locales = vec!["en".to_owned(), "de".to_owned()];
+        config.catalogs.remove(0);
+        config
+    }
+
+    fn write_catalog_matrix(root: &Path) {
+        for locale in ["de", "fr"] {
+            write_po_fixture(&root.join(format!("messages/{locale}.po")), locale);
+            write_fcl_fixture(&root.join(format!("features/{locale}.fcl")), locale);
+        }
+    }
+
+    fn write_po_fixture(path: &Path, locale: &str) {
+        fs::create_dir_all(path.parent().unwrap()).expect("catalog parent");
+        let lock = machine_translation_hash(EffectiveTranslationRef::Singular("Maschinell"));
+        let content = FIXTURE
+            .replace("{{LOCK}}", &lock)
+            .replace("Language: de", &format!("Language: {locale}"));
+        fs::write(path, content).expect("write PO fixture");
+    }
+
+    fn write_fcl_fixture(path: &Path, locale: &str) {
+        let temporary = path.with_extension("po");
+        write_po_fixture(&temporary, locale);
+        let po = fs::read_to_string(&temporary).expect("read PO fixture");
+        let fcl = convert_catalog(
+            ConvertCatalogOptions::new(&po, "en", CatalogMode::IcuPo, CatalogMode::IcuFcl)
+                .with_locale(locale),
+        )
+        .expect("convert fixture to FCL")
+        .content;
+        fs::write(path, fcl).expect("write FCL fixture");
+        fs::remove_file(temporary).expect("remove temporary PO fixture");
+    }
+
+    fn id(
+        catalog: &str,
+        locale: &str,
+        message: &str,
+        context: Option<&str>,
+    ) -> TranslationCandidateId {
+        TranslationCandidateId {
+            catalog: catalog.to_owned(),
+            locale: locale.to_owned(),
+            message: message.to_owned(),
+            context: context.map(str::to_owned),
+        }
+    }
+
+    fn candidate<'a>(
+        candidates: &'a [TranslationCandidate],
+        message: &str,
+    ) -> &'a TranslationCandidate {
+        candidates
+            .iter()
+            .find(|candidate| candidate.id.message == message)
+            .unwrap_or_else(|| panic!("missing candidate {message}"))
+    }
+
+    fn singular_patch(candidate: &TranslationCandidate, value: &str) -> TranslationPatch {
+        TranslationPatch {
+            id: candidate.id.clone(),
+            fingerprint: candidate.fingerprint.clone(),
+            translation: TranslationValue::Singular {
+                value: value.to_owned(),
+            },
+            machine: None,
+        }
+    }
+}

--- a/docs/translation-candidate-patches.md
+++ b/docs/translation-candidate-patches.md
@@ -1,0 +1,124 @@
+# Translation Candidates and Patches
+
+Palamedes Core exposes a provider-neutral boundary for finding local translation
+work and writing completed translations back to repository-owned catalogs. The
+API is available from Rust and through `@palamedes/core-node`.
+
+It deliberately does not choose a translation provider, authenticate remote
+requests, build prompts, or decide whether a translation is linguistically
+acceptable. A CLI, editor, hosted workflow, or local script can own those
+choices while sharing the same catalog semantics.
+
+## Enumerating candidates
+
+`listTranslationCandidates()` scans every configured non-source locale by
+default and returns active entries whose target value is missing. Pass
+`targets` to select exact translated, fuzzy, or obsolete entries for a re-run or
+review instead.
+
+Every candidate includes:
+
+- a stable identity consisting of catalog scope, locale, source message, and
+  optional context;
+- a resolved target path and storage format;
+- singular content or structured top-level ICU plural branches;
+- extracted comments and a bounded origin list;
+- translated, fuzzy, and obsolete state;
+- native Ferrocat machine provenance when present; and
+- a per-entry fingerprint for optimistic concurrency control.
+
+The fingerprint covers the candidate's source, current target, relevant
+metadata, and review state. An unrelated entry can therefore be written in an
+earlier incremental batch without invalidating the remaining candidates.
+
+## Applying completed translations
+
+`applyTranslationPatches()` validates the complete request before writing any
+catalog. Unknown or ambiguous catalogs, unknown messages, duplicate identities,
+stale fingerprints, shape mismatches, and invalid provenance are returned as
+structured diagnostics. A rejected validation batch leaves every original
+catalog unchanged.
+
+On success, Palamedes preserves unrelated translations, comments, origins,
+flags, obsolete entries, and PO headers. Each changed PO or FCL file is replaced
+atomically through Ferrocat's format-aware writer. A batch spanning several
+files has per-file atomicity; it is not a filesystem transaction across files.
+
+Applying a patch does not clear `fuzzy` or other review flags automatically.
+That is workflow policy and remains the caller's responsibility.
+
+## Provider-neutral TypeScript example
+
+```ts
+import {
+  applyTranslationPatches,
+  listTranslationCandidates,
+  type CatalogArtifactConfig,
+  type TranslationPatch,
+} from "@palamedes/core-node"
+
+declare function completedSingular(source: string): string
+declare function completedPluralBranch(selector: string, source: string): string
+
+const config: CatalogArtifactConfig = {
+  rootDir: process.cwd(),
+  sourceLocale: "en",
+  locales: ["en", "de"],
+  catalogs: [
+    {
+      path: "src/locales/{locale}/messages",
+      include: ["src"],
+    },
+  ],
+}
+
+const { candidates, diagnostics } = listTranslationCandidates({
+  config,
+  locales: ["de"],
+  maxOrigins: 5,
+})
+
+if (diagnostics.length > 0) {
+  throw new Error(diagnostics.map(({ message }) => message).join("\n"))
+}
+
+// A provider, translation memory, editor, or human review step can produce
+// these completed values. Core only validates and persists them.
+const patches: TranslationPatch[] = candidates.map((candidate) => ({
+  id: candidate.id,
+  fingerprint: candidate.fingerprint,
+  translation:
+    candidate.source.kind === "singular"
+      ? { kind: "singular", value: completedSingular(candidate.source.value) }
+      : {
+          ...candidate.source,
+          values: Object.fromEntries(
+            Object.entries(candidate.source.values).map(([selector, source]) => [
+              selector,
+              completedPluralBranch(selector, source),
+            ])
+          ),
+        },
+}))
+
+const result = applyTranslationPatches({ config, patches })
+
+if (result.diagnostics.length > 0) {
+  // Re-enumerate stale candidates before retrying them.
+  console.error(result.diagnostics)
+}
+```
+
+When a machine produced a value, a patch can add native provenance without
+supplying its integrity lock. Core computes the lock from the completed value:
+
+```ts
+const patch: TranslationPatch = {
+  id: candidate.id,
+  fingerprint: candidate.fingerprint,
+  translation: { kind: "singular", value: "Zur Kasse" },
+  machine: {
+    ai: { model: "example/model", confidence: 0.92 },
+  },
+}
+```

--- a/docs/translation-module-boundaries.md
+++ b/docs/translation-module-boundaries.md
@@ -158,6 +158,10 @@ The first public or semi-public Core surface should include:
 The purpose is not to freeze every field forever. The purpose is to keep the
 rewrite from losing the behavior downstream workflows already rely on.
 
+The first public implementation of `translation_candidates`, including its
+provider-neutral patch boundary, is documented in
+[Translation Candidates and Patches](./translation-candidate-patches.md).
+
 ## Boundary rules
 
 These modules belong in Core only while they remain:

--- a/docs/translation-workflow-surface.md
+++ b/docs/translation-workflow-surface.md
@@ -6,6 +6,9 @@ Palamedes+.
 
 For the first concrete module split, see [Translation Module Boundaries](./translation-module-boundaries.md).
 
+The implemented candidate-enumeration and atomic writeback contract is documented in
+[Translation Candidates and Patches](./translation-candidate-patches.md).
+
 ## Purpose
 
 Palamedes should make it unnecessary for downstream translation products to

--- a/packages/core-node/src/generated/palamedes-node-types.ts
+++ b/packages/core-node/src/generated/palamedes-node-types.ts
@@ -74,6 +74,89 @@ export interface CatalogParseResult {
   messages: Array<ParsedCatalogMessage>;
   diagnostics: Array<CatalogDiagnostic>;
 }
+export interface TranslationCandidateId {
+  catalog: string;
+  locale: string;
+  message: string;
+  context?: string;
+}
+export interface TranslationCandidateRequest {
+  config: CatalogArtifactConfig;
+  locales?: Array<string>;
+  targets?: Array<TranslationCandidateId>;
+  maxOrigins?: number;
+}
+export type TranslationValueKind = "Singular" | "Plural"
+export type TranslationPluralKind = "Cardinal" | "Ordinal"
+export interface TranslationValue {
+  kind: TranslationValueKind;
+  value?: string;
+  variable?: string;
+  pluralKind?: TranslationPluralKind;
+  offset?: number;
+  values?: Record<string, string>;
+}
+export interface TranslationWorkflowOrigin {
+  file: string;
+  scope?: string;
+}
+export interface TranslationReviewState {
+  translated: boolean;
+  fuzzy: boolean;
+  obsolete: boolean;
+}
+export interface TranslationCandidate {
+  id: TranslationCandidateId;
+  targetPath: string;
+  format: CatalogConfigFormat;
+  source: TranslationValue;
+  translation: TranslationValue;
+  comments: Array<string>;
+  origins: Array<TranslationWorkflowOrigin>;
+  review: TranslationReviewState;
+  machine?: MachineMetadata;
+  fingerprint: string;
+}
+export interface TranslationWorkflowDiagnostic {
+  code: string;
+  message: string;
+  id?: TranslationCandidateId;
+}
+export interface TranslationCandidateResult {
+  candidates: Array<TranslationCandidate>;
+  diagnostics: Array<TranslationWorkflowDiagnostic>;
+}
+export interface TranslationMachineProvenance {
+  ai?: AiProvenance;
+}
+export interface TranslationPatch {
+  id: TranslationCandidateId;
+  fingerprint: string;
+  translation: TranslationValue;
+  machine?: TranslationMachineProvenance;
+}
+export interface TranslationPatchRequest {
+  config: CatalogArtifactConfig;
+  patches: Array<TranslationPatch>;
+  po?: PoOutputOptions;
+}
+export type TranslationPatchOutcomeStatus = "Applied" | "Unchanged" | "Rejected" | "NotApplied"
+export interface TranslationPatchOutcome {
+  id: TranslationCandidateId;
+  status: TranslationPatchOutcomeStatus;
+}
+export interface TranslationPatchStats {
+  requested: number;
+  applied: number;
+  unchanged: number;
+  catalogsUpdated: number;
+}
+export interface TranslationPatchResult {
+  updated: boolean;
+  stats: TranslationPatchStats;
+  outcomes: Array<TranslationPatchOutcome>;
+  diagnostics: Array<TranslationWorkflowDiagnostic>;
+}
 export interface CatalogCombineInput {
   content: string;
   label?: string;
@@ -440,6 +523,8 @@ export interface NativeTransformResult {
 export interface NativeBindings {
   updateCatalogFile(request: CatalogUpdateRequest): CatalogUpdateResult;
   parseCatalog(request: CatalogParseRequest): CatalogParseResult;
+  listTranslationCandidates(request: TranslationCandidateRequest): TranslationCandidateResult;
+  applyTranslationPatches(request: TranslationPatchRequest): TranslationPatchResult;
   auditCatalogs(request: CatalogAuditRequest): CatalogAuditResult;
   deriveMessageMetadata(message: string, context?: string | undefined | null): MessageMetadata;
   normalizeMessageMetadata(input: MessageMetadataInput): MessageMetadata;

--- a/packages/core-node/src/index.test.ts
+++ b/packages/core-node/src/index.test.ts
@@ -7,10 +7,12 @@ import { afterEach, describe, expect, it } from "vitest"
 import {
   analyzeMdxNative,
   analyzeSourceNative,
+  applyTranslationPatches,
   compileCatalogArtifact,
   compileCatalogModule,
   extractMessagesNative,
   getNativeInfo,
+  listTranslationCandidates,
   parsePo,
   renderCatalogModule,
   transformMacrosNative,
@@ -159,6 +161,81 @@ msgstr "Oeffnen"
       long,
       "Zebra",
     ])
+  })
+
+  it("enumerates and atomically applies typed translation patches", async () => {
+    const rootDir = await createTempDir()
+    const catalogDir = path.join(rootDir, "locales", "de")
+    const targetPath = path.join(catalogDir, "messages.po")
+    await mkdir(catalogDir, { recursive: true })
+    await writeFile(
+      targetPath,
+      `msgid ""
+msgstr ""
+"Language: de\\n"
+
+#. Home greeting
+#: src/home.tsx#HomePage
+msgid "Hello"
+msgstr ""
+
+msgid "{count, plural, one {# file} other {# files}}"
+msgstr ""
+`
+    )
+    const config = {
+      rootDir,
+      locales: ["en", "de"],
+      sourceLocale: "en",
+      catalogs: [{ path: "locales/{locale}/messages", include: ["src"] }],
+    }
+    const listed = listTranslationCandidates({ config })
+    const hello = listed.candidates.find((candidate) => candidate.id.message === "Hello")
+    const plural = listed.candidates.find((candidate) => candidate.source.kind === "plural")
+
+    expect(listed.diagnostics).toStrictEqual([])
+    expect(hello).toMatchObject({
+      source: { kind: "singular", value: "Hello" },
+      review: { translated: false, fuzzy: false, obsolete: false },
+      origins: [{ file: "src/home.tsx", scope: "HomePage" }],
+    })
+    expect(plural?.source).toMatchObject({
+      kind: "plural",
+      variable: "count",
+      values: { one: "# file", other: "# files" },
+    })
+    if (!hello || !plural || plural.source.kind !== "plural") {
+      throw new Error("Expected singular and plural translation candidates")
+    }
+
+    const applied = applyTranslationPatches({
+      config,
+      patches: [
+        {
+          id: hello.id,
+          fingerprint: hello.fingerprint,
+          translation: { kind: "singular", value: "Hallo" },
+        },
+        {
+          id: plural.id,
+          fingerprint: plural.fingerprint,
+          translation: {
+            ...plural.source,
+            values: { one: "# Datei", other: "# Dateien" },
+          },
+        },
+      ],
+    })
+
+    expect(applied).toMatchObject({
+      updated: true,
+      stats: { requested: 2, applied: 2, catalogsUpdated: 1 },
+      outcomes: [{ status: "applied" }, { status: "applied" }],
+      diagnostics: [],
+    })
+    const output = await readFile(targetPath, "utf8")
+    expect(output).toContain('msgstr "Hallo"')
+    expect(output).toContain("{count, plural, one {# Datei} other {# Dateien}}")
   })
 
   it("maps native transform results into JavaScript strings and source maps", () => {

--- a/packages/core-node/src/index.ts
+++ b/packages/core-node/src/index.ts
@@ -64,6 +64,15 @@ import type {
   ParsedCatalogMessage as GeneratedParsedCatalogMessage,
   ParsedPoFile as GeneratedParsedPoFile,
   ParsedPoItem as GeneratedParsedPoItem,
+  TranslationCandidate as GeneratedTranslationCandidate,
+  TranslationCandidateId as GeneratedTranslationCandidateId,
+  TranslationCandidateRequest as GeneratedTranslationCandidateRequest,
+  TranslationCandidateResult as GeneratedTranslationCandidateResult,
+  TranslationPatch as GeneratedTranslationPatch,
+  TranslationPatchOutcome as GeneratedTranslationPatchOutcome,
+  TranslationPatchRequest as GeneratedTranslationPatchRequest,
+  TranslationPatchResult as GeneratedTranslationPatchResult,
+  TranslationValue as GeneratedTranslationValue,
 } from "./generated/palamedes-node-types"
 
 export type NativeInfo = GeneratedNativeInfo
@@ -90,6 +99,78 @@ export type CatalogUpdateResult = Omit<GeneratedCatalogUpdateResult, "diagnostic
 }
 export type CatalogParseResult = Omit<GeneratedCatalogParseResult, "diagnostics"> & {
   diagnostics: CatalogDiagnostic[]
+}
+export type TranslationCandidateId = GeneratedTranslationCandidateId
+export type TranslationPluralKind = "cardinal" | "ordinal"
+export type TranslationValue =
+  | { kind: "singular"; value: string }
+  | {
+      kind: "plural"
+      variable: string
+      pluralKind: TranslationPluralKind
+      offset: number
+      values: Record<string, string>
+    }
+export type TranslationWorkflowOrigin = {
+  file: string
+  scope?: string
+}
+export type TranslationReviewState = {
+  translated: boolean
+  fuzzy: boolean
+  obsolete: boolean
+}
+export type TranslationCandidate = Omit<
+  GeneratedTranslationCandidate,
+  "format" | "source" | "translation" | "origins"
+> & {
+  format: CatalogConfigFormat
+  source: TranslationValue
+  translation: TranslationValue
+  origins: TranslationWorkflowOrigin[]
+}
+export type TranslationWorkflowDiagnostic = {
+  code: string
+  message: string
+  id?: TranslationCandidateId
+}
+export type TranslationCandidateRequest = {
+  config: CatalogArtifactConfig
+  locales?: string[]
+  targets?: TranslationCandidateId[]
+  maxOrigins?: number
+}
+export type TranslationCandidateResult = {
+  candidates: TranslationCandidate[]
+  diagnostics: TranslationWorkflowDiagnostic[]
+}
+export type TranslationMachineProvenance = {
+  ai?: {
+    model: string
+    confidence?: number
+  }
+}
+export type TranslationPatch = {
+  id: TranslationCandidateId
+  fingerprint: string
+  translation: TranslationValue
+  machine?: TranslationMachineProvenance
+}
+export type TranslationPatchRequest = {
+  config: CatalogArtifactConfig
+  patches: TranslationPatch[]
+  po?: PoOutputOptions
+}
+export type TranslationPatchOutcomeStatus = "applied" | "unchanged" | "rejected" | "notApplied"
+export type TranslationPatchOutcome = Omit<GeneratedTranslationPatchOutcome, "status"> & {
+  status: TranslationPatchOutcomeStatus
+}
+export type TranslationPatchResult = Omit<
+  GeneratedTranslationPatchResult,
+  "outcomes" | "diagnostics"
+> & {
+  outcomes: TranslationPatchOutcome[]
+  diagnostics: TranslationWorkflowDiagnostic[]
 }
 export type CatalogAuditDiagnostic = Omit<GeneratedCatalogAuditDiagnostic, "severity"> & {
   severity: CatalogDiagnosticSeverity
@@ -253,6 +334,8 @@ type NativeCatalogArtifactSelectedRequest = GeneratedCatalogArtifactSelectedRequ
 type NativeCatalogModuleRequest = GeneratedCatalogModuleRequest
 type NativeCatalogUpdateRequest = GeneratedCatalogUpdateRequest
 type NativeCatalogParseRequest = GeneratedCatalogParseRequest
+type NativeTranslationCandidateRequest = GeneratedTranslationCandidateRequest
+type NativeTranslationPatchRequest = GeneratedTranslationPatchRequest
 
 function detectLinuxLibc(): "gnu" | "musl" | null {
   if (process.platform !== "linux") {
@@ -386,6 +469,120 @@ export function parseCatalog(request: CatalogParseRequest): CatalogParseResult {
   return {
     ...result,
     diagnostics: mapCatalogDiagnostics(result.diagnostics),
+  }
+}
+
+export function listTranslationCandidates(
+  request: TranslationCandidateRequest
+): TranslationCandidateResult {
+  const nativeRequest: NativeTranslationCandidateRequest = {
+    config: toNativeArtifactConfig(request.config),
+    locales: request.locales,
+    targets: request.targets,
+    maxOrigins: request.maxOrigins,
+  }
+  const result: GeneratedTranslationCandidateResult =
+    native.listTranslationCandidates(nativeRequest)
+  return {
+    candidates: result.candidates.map(fromNativeTranslationCandidate),
+    diagnostics: result.diagnostics,
+  }
+}
+
+export function applyTranslationPatches(request: TranslationPatchRequest): TranslationPatchResult {
+  const nativeRequest: NativeTranslationPatchRequest = {
+    config: toNativeArtifactConfig(request.config),
+    patches: request.patches.map(toNativeTranslationPatch),
+    po: toNativePoOptions(request.po),
+  }
+  const result: GeneratedTranslationPatchResult = native.applyTranslationPatches(nativeRequest)
+  return {
+    ...result,
+    outcomes: result.outcomes.map((outcome) => ({
+      ...outcome,
+      status: fromNativeTranslationPatchOutcomeStatus(outcome.status),
+    })),
+    diagnostics: result.diagnostics,
+  }
+}
+
+function fromNativeTranslationCandidate(
+  candidate: GeneratedTranslationCandidate
+): TranslationCandidate {
+  return {
+    ...candidate,
+    format: fromNativeFileFormat(candidate.format),
+    source: fromNativeTranslationValue(candidate.source),
+    translation: fromNativeTranslationValue(candidate.translation),
+  }
+}
+
+function fromNativeTranslationValue(value: GeneratedTranslationValue): TranslationValue {
+  switch (value.kind) {
+    case "Singular": {
+      if (value.value === undefined) {
+        throw new TypeError("Native singular translation value is missing `value`.")
+      }
+      return { kind: "singular", value: value.value }
+    }
+    case "Plural": {
+      if (
+        value.variable === undefined ||
+        value.pluralKind === undefined ||
+        value.offset === undefined ||
+        value.values === undefined
+      ) {
+        throw new TypeError("Native plural translation value is incomplete.")
+      }
+      return {
+        kind: "plural",
+        variable: value.variable,
+        pluralKind: value.pluralKind === "Cardinal" ? "cardinal" : "ordinal",
+        offset: value.offset,
+        values: value.values,
+      }
+    }
+  }
+}
+
+function toNativeTranslationPatch(patch: TranslationPatch): GeneratedTranslationPatch {
+  return {
+    id: patch.id,
+    fingerprint: patch.fingerprint,
+    translation: toNativeTranslationValue(patch.translation),
+    machine: patch.machine,
+  }
+}
+
+function toNativeTranslationValue(value: TranslationValue): GeneratedTranslationValue {
+  switch (value.kind) {
+    case "singular": {
+      return { kind: "Singular", value: value.value }
+    }
+    case "plural": {
+      return {
+        kind: "Plural",
+        variable: value.variable,
+        pluralKind: value.pluralKind === "cardinal" ? "Cardinal" : "Ordinal",
+        offset: value.offset,
+        values: value.values,
+      }
+    }
+  }
+}
+
+function fromNativeTranslationPatchOutcomeStatus(
+  status: GeneratedTranslationPatchOutcome["status"]
+): TranslationPatchOutcomeStatus {
+  switch (status) {
+    case "Applied":
+      return "applied"
+    case "Unchanged":
+      return "unchanged"
+    case "Rejected":
+      return "rejected"
+    case "NotApplied":
+      return "notApplied"
   }
 }
 


### PR DESCRIPTION
## Summary

- expose format-neutral Rust APIs to enumerate translation candidates and apply validated patches across configured PO and FCL catalogs
- use stable candidate identities and per-candidate fingerprints so incremental or stale batches are handled deterministically
- preserve catalog metadata while supporting singular/plural ICU values, structured diagnostics, per-file atomic writes, and optional machine-translation provenance
- expose ergonomic Node/TypeScript bindings, end-to-end coverage, fixtures, and provider-neutral workflow documentation

## Why

Issue #525 needs a stable core contract that translation providers and automation can consume without parsing or rewriting catalog formats themselves. This keeps catalog semantics in Ferrocat/Palamedes and gives external workflows a safe candidate/patch boundary.

## Developer impact

Consumers can now call `listTranslationCandidates` to obtain missing or explicitly selected work and submit `applyTranslationPatches` batches. Invalid, duplicate, ambiguous, unknown, or stale work is rejected with structured diagnostics before a catalog file is replaced.

## Validation

- `CI=true CARGO_NET_OFFLINE=true pnpm --config.verify-deps-before-run=false agent:check`
- full workspace build, release-set and published-type checks
- format and lint checks
- JavaScript/TypeScript tests and type checks
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked` (including 5 translation workflow tests)

Closes #525