### PR TITLE
fix(site): resolve next plugin server function subpaths for TypeDoc

### DIFF
--- a/site/tsconfig.typedoc.json
+++ b/site/tsconfig.typedoc.json
@@ -20,6 +20,12 @@
       "@palamedes/core-node": ["packages/core-node/src/index.ts"],
       "@palamedes/extractor": ["packages/extractor/src/index.ts"],
       "@palamedes/next-plugin": ["packages/next-plugin/src/index.ts"],
+      "@palamedes/next-plugin/server-function-entry": [
+        "packages/next-plugin/src/server-function-entry.ts"
+      ],
+      "@palamedes/next-plugin/server-function-initializer": [
+        "packages/next-plugin/src/server-function-initializer.ts"
+      ],
       "@palamedes/react": ["packages/react/src/index.tsx"],
       "@palamedes/react/client": ["packages/react/src/client.tsx"],
       "@palamedes/react/macro": ["packages/react/src/macro.ts"],


### PR DESCRIPTION
## What this fixes

The current `Deploy Site` workflow is failing during the Ardo/TypeDoc prebuild step because TypeDoc reads `packages/next-plugin/src/index.ts` from source and then reaches `packages/next-plugin/src/server-function-initializer.ts`, which imports the package's own server-function subpath:

```ts
@palamedes/next-plugin/server-function-entry
```

That package self-reference is intentional: the Next plugin aliases that public subpath to the consuming app's `palamedes.server` module at runtime. The site TypeDoc config, however, did not map those internal public subpaths while converting source.

This PR adds the missing TypeDoc path aliases for the Next plugin server-function subpaths, preserving runtime behavior while making source conversion resolve them during the site build.

## Validation

- `corepack pnpm --filter @palamedes/next-plugin build`
- `corepack pnpm --filter @palamedes/core build`
- `corepack pnpm --filter @palamedes/runtime build`
- `corepack pnpm --filter @palamedes/next-plugin exec tsc --noEmit -p tsconfig.json`
- `corepack pnpm build:site`
- `corepack pnpm format:check -- packages/next-plugin/src/server-function-initializer.ts packages/next-plugin/src/server-function-initializer.test.ts`

I also verified the originally attempted source-relative import locally, but it broke the Next server-function alias path in CI. This revision deliberately keeps the package self-reference and fixes only the TypeDoc resolution context.
