### PR TITLE
fix(cli): add deletion-aware three-way catalog merge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -333,9 +333,9 @@ checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "ferrocat"
-version = "3.3.0"
+version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dbbee8180d6dd69406136e56aeb33292054393f8299266e369905bc850c2f0f"
+checksum = "65e24238a7e7464d91c58a3f68327ca71742727fdd29dc1a6c8369a2f2216772"
 dependencies = [
  "ferrocat-icu",
  "ferrocat-po",
@@ -343,9 +343,9 @@ dependencies = [
 
 [[package]]
 name = "ferrocat-icu"
-version = "3.3.0"
+version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e56fc963d6da2e3dc3804202d52f48ce1049daa3e8b785845f305fdca8e4201b"
+checksum = "a05e08c426188954709de42f6a5483253d7da6fa6350e0c7135ca777d4964e8f"
 dependencies = [
  "memchr",
  "serde",
@@ -353,9 +353,9 @@ dependencies = [
 
 [[package]]
 name = "ferrocat-po"
-version = "3.3.0"
+version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1543ac3b8874b658f2ac11737c42fa3610ed8ce2ceb288025adc722702562fd6"
+checksum = "0e8f57272ccb10e82e41669c3d24bb6a85968f42d462583d8eac95fffc3e37ad"
 dependencies = [
  "ferrocat-icu",
  "icu_locale",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,10 @@ license = "MIT"
 repository = "https://github.com/sebastian-software/palamedes"
 rust-version = "1.95"
 
+[profile.release]
+# Native npm packages ship the release artifacts, not their debug symbols.
+strip = "symbols"
+
 [workspace.lints.rust]
 future_incompatible = "warn"
 unused_must_use = "warn"

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ driver:
 
 ```bash
 git config merge.palamedes-catalog.driver \
-  'pmds catalog merge --format=po --conflict-strategy=use-first --output %A --path %P %A %B'
+  'pmds catalog merge-driver %O %A %B %A --path %P --format=po --conflict-strategy=use-first'
 ```
 
 For the full copy-paste path, including `.po` loading and the first translated

--- a/crates/palamedes-cli/src/cli.rs
+++ b/crates/palamedes-cli/src/cli.rs
@@ -55,6 +55,7 @@ impl Cli {
             Command::Report(options) => execute(options, &context).map(|()| 0),
             Command::Catalog(catalog) => match &catalog.command {
                 CatalogSubcommand::Merge(options) => execute(options, &context).map(|()| 0),
+                CatalogSubcommand::MergeDriver(options) => execute(options, &context).map(|()| 0),
                 CatalogSubcommand::Convert(options) => execute(options, &context).map(|()| 0),
             },
             Command::Version => execute(&VersionCommand, &context).map(|()| 0),

--- a/crates/palamedes-cli/src/commands/catalog/merge.rs
+++ b/crates/palamedes-cli/src/commands/catalog/merge.rs
@@ -1,11 +1,13 @@
 //! `pmds catalog merge` — semantic catalog merge, usable as a Git merge driver.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::process::Command as ProcessCommand;
 
 use clap::{Args, ValueEnum};
 use palamedes::{
-    combine_catalog_files, CatalogConflictStrategy, CatalogFileCombineRequest,
-    CatalogFileCombineResult, CatalogFileFormat,
+    combine_catalog_files, merge_catalog_files_three_way, CatalogConflictStrategy,
+    CatalogFileCombineRequest, CatalogFileCombineResult, CatalogFileFormat,
+    CatalogFileThreeWayMergeRequest,
 };
 
 use crate::command::{Command, Context};
@@ -14,7 +16,7 @@ use crate::error::CliError;
 
 #[derive(Debug, Args)]
 pub struct MergeOptions {
-    /// Input catalog files in precedence order.
+    /// Two current catalog files, ordered as ours and theirs when `--base` is set.
     #[arg(required = true)]
     inputs: Vec<PathBuf>,
     /// Output catalog path.
@@ -26,7 +28,7 @@ pub struct MergeOptions {
     /// Catalog format.
     #[arg(long)]
     format: Option<MergeFormat>,
-    /// Ancestor catalog path supplied by Git merge drivers.
+    /// Common ancestor catalog path for a deletion-aware three-way merge.
     #[arg(long)]
     base: Option<PathBuf>,
     /// Catalog conflict strategy.
@@ -45,6 +47,40 @@ pub struct MergeOptions {
     path: Option<PathBuf>,
 }
 
+#[derive(Debug, Args)]
+pub struct MergeDriverOptions {
+    /// Common ancestor supplied by Git as `%O`.
+    ancestor: PathBuf,
+    /// Git's `%A` file (stage 2 during conflicts).
+    current: PathBuf,
+    /// Git's `%B` file (stage 3 during conflicts).
+    other: PathBuf,
+    /// Output catalog, normally `%A`.
+    output: PathBuf,
+    /// Real catalog pathname supplied by Git as `%P`.
+    #[arg(long)]
+    path: PathBuf,
+    /// Path to a Palamedes config file.
+    #[arg(short, long)]
+    config: Option<PathBuf>,
+    /// Catalog format.
+    #[arg(long)]
+    format: Option<MergeFormat>,
+    /// Catalog conflict strategy. `use-first` always means the logical branch
+    /// being merged or rebased, even though Git swaps `%A`/`%B` during rebase.
+    #[arg(long, default_value = "use-first")]
+    conflict_strategy: MergeConflictStrategy,
+    /// Source locale for catalog semantics.
+    #[arg(long)]
+    source_locale: Option<String>,
+    /// Locale of the merged catalog.
+    #[arg(long)]
+    locale: Option<String>,
+    /// Git operation role mapping. `auto` detects an active rebase.
+    #[arg(long, default_value = "auto")]
+    operation: GitMergeOperation,
+}
+
 #[derive(Clone, Copy, Debug, ValueEnum)]
 enum MergeFormat {
     Po,
@@ -56,6 +92,13 @@ enum MergeConflictStrategy {
     UseFirst,
     UseLast,
     Error,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+enum GitMergeOperation {
+    Auto,
+    Merge,
+    Rebase,
 }
 
 impl Command for MergeOptions {
@@ -96,27 +139,32 @@ impl Command for MergeOptions {
                 .map(Into::into)
         });
 
-        let mut input_paths = self.inputs.clone();
-        if let Some(base) = &self.base {
-            input_paths.push(base.clone());
+        let format = self.format.map(MergeFormat::core);
+        let conflict_strategy = self.conflict_strategy.core();
+        match &self.base {
+            Some(base) => Ok(merge_catalog_files_three_way(
+                CatalogFileThreeWayMergeRequest {
+                    ancestor_path: base.clone(),
+                    ours_path: self.inputs[0].clone(),
+                    theirs_path: self.inputs[1].clone(),
+                    output_path: self.output.clone(),
+                    format,
+                    source_locale,
+                    locale: self.locale.clone(),
+                    conflict_strategy,
+                    po,
+                },
+            )?),
+            None => Ok(combine_catalog_files(CatalogFileCombineRequest {
+                input_paths: self.inputs.clone(),
+                output_path: self.output.clone(),
+                format,
+                source_locale,
+                locale: self.locale.clone(),
+                conflict_strategy,
+                po,
+            })?),
         }
-
-        Ok(combine_catalog_files(CatalogFileCombineRequest {
-            input_paths,
-            output_path: self.output.clone(),
-            format: self.format.map(|format| match format {
-                MergeFormat::Po => CatalogFileFormat::Po,
-                MergeFormat::Fcl => CatalogFileFormat::Fcl,
-            }),
-            source_locale,
-            locale: self.locale.clone(),
-            conflict_strategy: match self.conflict_strategy {
-                MergeConflictStrategy::UseFirst => CatalogConflictStrategy::UseFirst,
-                MergeConflictStrategy::UseLast => CatalogConflictStrategy::UseLast,
-                MergeConflictStrategy::Error => CatalogConflictStrategy::Error,
-            },
-            po,
-        })?)
     }
 
     /// The merged catalog file is the result. Git merge drivers run inside
@@ -124,5 +172,107 @@ impl Command for MergeOptions {
     /// so a successful merge stays silent and the exit code carries the answer.
     fn render(&self, _output: &Self::Output) -> Result<(), CliError> {
         Ok(())
+    }
+}
+
+impl Command for MergeDriverOptions {
+    type Output = CatalogFileCombineResult;
+
+    fn run(&self, context: &Context) -> Result<Self::Output, CliError> {
+        let (ours, theirs) = self.logical_sides();
+        MergeOptions {
+            inputs: vec![ours.to_path_buf(), theirs.to_path_buf()],
+            output: self.output.clone(),
+            config: self.config.clone(),
+            format: self.format,
+            base: Some(self.ancestor.clone()),
+            conflict_strategy: self.conflict_strategy,
+            source_locale: self.source_locale.clone(),
+            locale: self.locale.clone(),
+            path: Some(self.path.clone()),
+        }
+        .run(context)
+    }
+
+    fn render(&self, _output: &Self::Output) -> Result<(), CliError> {
+        Ok(())
+    }
+}
+
+impl MergeDriverOptions {
+    fn logical_sides(&self) -> (&Path, &Path) {
+        match self.resolved_operation() {
+            GitMergeOperation::Rebase => (&self.other, &self.current),
+            GitMergeOperation::Merge | GitMergeOperation::Auto => (&self.current, &self.other),
+        }
+    }
+
+    fn resolved_operation(&self) -> GitMergeOperation {
+        match self.operation {
+            GitMergeOperation::Auto if git_path_exists("rebase-merge") => GitMergeOperation::Rebase,
+            GitMergeOperation::Auto if git_path_exists("rebase-apply") => GitMergeOperation::Rebase,
+            GitMergeOperation::Auto => GitMergeOperation::Merge,
+            operation => operation,
+        }
+    }
+}
+
+impl MergeFormat {
+    fn core(self) -> CatalogFileFormat {
+        match self {
+            Self::Po => CatalogFileFormat::Po,
+            Self::Fcl => CatalogFileFormat::Fcl,
+        }
+    }
+}
+
+impl MergeConflictStrategy {
+    fn core(self) -> CatalogConflictStrategy {
+        match self {
+            Self::UseFirst => CatalogConflictStrategy::UseFirst,
+            Self::UseLast => CatalogConflictStrategy::UseLast,
+            Self::Error => CatalogConflictStrategy::Error,
+        }
+    }
+}
+
+fn git_path_exists(name: &str) -> bool {
+    let Ok(output) = ProcessCommand::new("git")
+        .args(["rev-parse", "--git-path", name])
+        .output()
+    else {
+        return false;
+    };
+    if !output.status.success() {
+        return false;
+    }
+    let path = String::from_utf8_lossy(&output.stdout);
+    Path::new(path.trim()).exists()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{GitMergeOperation, MergeConflictStrategy, MergeDriverOptions};
+    use std::path::PathBuf;
+
+    #[test]
+    fn explicit_rebase_mapping_keeps_the_rebased_branch_first() {
+        let options = MergeDriverOptions {
+            ancestor: PathBuf::from("base"),
+            current: PathBuf::from("upstream"),
+            other: PathBuf::from("rebased-branch"),
+            output: PathBuf::from("upstream"),
+            path: PathBuf::from("messages.po"),
+            config: None,
+            format: None,
+            conflict_strategy: MergeConflictStrategy::UseFirst,
+            source_locale: Some("en".to_owned()),
+            locale: Some("de".to_owned()),
+            operation: GitMergeOperation::Rebase,
+        };
+
+        let (ours, theirs) = options.logical_sides();
+        assert_eq!(ours, PathBuf::from("rebased-branch"));
+        assert_eq!(theirs, PathBuf::from("upstream"));
     }
 }

--- a/crates/palamedes-cli/src/commands/catalog/mod.rs
+++ b/crates/palamedes-cli/src/commands/catalog/mod.rs
@@ -6,7 +6,7 @@ pub mod convert;
 pub mod merge;
 
 use convert::ConvertOptions;
-use merge::MergeOptions;
+use merge::{MergeDriverOptions, MergeOptions};
 
 #[derive(Debug, Args)]
 pub struct CatalogCommand {
@@ -16,8 +16,10 @@ pub struct CatalogCommand {
 
 #[derive(Debug, Subcommand)]
 pub enum CatalogSubcommand {
-    /// Merge two catalog files with semantic use-first behavior.
+    /// Merge two current catalogs, optionally against an explicit ancestor.
     Merge(MergeOptions),
+    /// Run as a deletion-aware Git merge driver with merge/rebase role mapping.
+    MergeDriver(MergeDriverOptions),
     /// Convert configured PO catalogs to another Palamedes storage format.
     Convert(ConvertOptions),
 }

--- a/crates/palamedes-cli/tests/catalog_merge.rs
+++ b/crates/palamedes-cli/tests/catalog_merge.rs
@@ -1,0 +1,155 @@
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[test]
+fn base_only_entry_deleted_from_both_sides_stays_deleted() {
+    let fixture = fixture_dir("catalog-three-way-delete");
+    fs::create_dir_all(&fixture).expect("create fixture");
+    let base = fixture.join("base.po");
+    let ours = fixture.join("ours.po");
+    let theirs = fixture.join("theirs.po");
+    let output = fixture.join("merged.po");
+    fs::write(&base, "msgid \"Removed on both sides\"\nmsgstr \"Alt\"\n").expect("write base");
+    fs::write(&ours, "").expect("write ours");
+    fs::write(&theirs, "").expect("write theirs");
+
+    let result = Command::new(env!("CARGO_BIN_EXE_pmds"))
+        .args([
+            "catalog",
+            "merge",
+            ours.to_str().expect("ours path"),
+            theirs.to_str().expect("theirs path"),
+            "--base",
+            base.to_str().expect("base path"),
+            "--output",
+            output.to_str().expect("output path"),
+            "--format",
+            "po",
+            "--source-locale",
+            "en",
+            "--locale",
+            "de",
+        ])
+        .output()
+        .expect("run catalog merge");
+
+    assert!(result.status.success(), "{result:?}");
+    let merged = fs::read_to_string(&output).expect("read merged catalog");
+    assert!(!merged.contains("Removed on both sides"), "{merged}");
+
+    fs::remove_dir_all(fixture).expect("cleanup fixture");
+}
+
+#[test]
+fn merge_driver_use_first_keeps_the_current_branch_during_merge() {
+    let fixture = fixture_dir("catalog-driver-merge");
+    initialize_git_fixture(&fixture);
+
+    git(&fixture, &["checkout", "-b", "feature"]);
+    write_translation(&fixture, "Feature");
+    commit_all(&fixture, "feature translation");
+    git(&fixture, &["checkout", "main"]);
+    write_translation(&fixture, "Main");
+    commit_all(&fixture, "main translation");
+
+    git(&fixture, &["merge", "feature"]);
+    assert_translation(&fixture, "Main");
+
+    fs::remove_dir_all(fixture).expect("cleanup fixture");
+}
+
+#[test]
+fn merge_driver_use_first_keeps_the_rebased_branch_during_rebase() {
+    let fixture = fixture_dir("catalog-driver-rebase");
+    initialize_git_fixture(&fixture);
+
+    git(&fixture, &["checkout", "-b", "feature"]);
+    write_translation(&fixture, "Feature");
+    commit_all(&fixture, "feature translation");
+    git(&fixture, &["checkout", "main"]);
+    write_translation(&fixture, "Upstream");
+    commit_all(&fixture, "upstream translation");
+    git(&fixture, &["checkout", "feature"]);
+
+    git(&fixture, &["rebase", "main"]);
+    assert_translation(&fixture, "Feature");
+
+    fs::remove_dir_all(fixture).expect("cleanup fixture");
+}
+
+fn initialize_git_fixture(fixture: &std::path::Path) {
+    fs::create_dir_all(fixture).expect("create git fixture");
+    git(fixture, &["init", "-b", "main"]);
+    git(fixture, &["config", "user.name", "Palamedes Test"]);
+    git(
+        fixture,
+        &["config", "user.email", "palamedes@example.invalid"],
+    );
+    git(fixture, &["config", "commit.gpgsign", "false"]);
+    let driver = format!(
+        "'{}' catalog merge-driver %O %A %B %A --path %P --format po --source-locale en --locale de --conflict-strategy use-first",
+        env!("CARGO_BIN_EXE_pmds").replace('\'', "'\\''")
+    );
+    git(
+        fixture,
+        &["config", "merge.palamedes-catalog.driver", &driver],
+    );
+    fs::write(
+        fixture.join(".gitattributes"),
+        "messages.po merge=palamedes-catalog\n",
+    )
+    .expect("write attributes");
+    write_translation(fixture, "Base");
+    commit_all(fixture, "base catalog");
+}
+
+fn write_translation(fixture: &std::path::Path, translation: &str) {
+    fs::write(
+        fixture.join("messages.po"),
+        format!(
+            "msgid \"\"\nmsgstr \"\"\n\"Language: de\\n\"\n\nmsgid \"Hello\"\nmsgstr \"{translation}\"\n"
+        ),
+    )
+    .expect("write catalog");
+}
+
+fn assert_translation(fixture: &std::path::Path, translation: &str) {
+    let content = fs::read_to_string(fixture.join("messages.po")).expect("read catalog");
+    assert!(
+        content.contains(&format!("msgstr \"{translation}\"")),
+        "{content}"
+    );
+}
+
+fn commit_all(fixture: &std::path::Path, message: &str) {
+    git(fixture, &["add", "."]);
+    git(fixture, &["commit", "-m", message]);
+}
+
+fn git(fixture: &std::path::Path, arguments: &[&str]) -> std::process::Output {
+    let output = Command::new("git")
+        .args(arguments)
+        .current_dir(fixture)
+        .output()
+        .expect("run git");
+    assert!(
+        output.status.success(),
+        "git {arguments:?} failed:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    output
+}
+
+fn fixture_dir(name: &str) -> PathBuf {
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time")
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "palamedes-cli-{name}-{}-{stamp}",
+        std::process::id()
+    ))
+}

--- a/crates/palamedes-node/src/catalog.rs
+++ b/crates/palamedes-node/src/catalog.rs
@@ -292,6 +292,18 @@ pub struct CatalogCombineResult {
     pub diagnostics: Vec<CatalogDiagnostic>,
 }
 
+#[napi(object)]
+pub struct CatalogThreeWayMergeRequest {
+    pub ancestor: CatalogCombineInput,
+    pub ours: CatalogCombineInput,
+    pub theirs: CatalogCombineInput,
+    pub format: CatalogFileFormat,
+    pub source_locale: String,
+    pub locale: Option<String>,
+    pub conflict_strategy: Option<CatalogConflictStrategy>,
+    pub po: Option<PoOutputOptions>,
+}
+
 #[napi(string_enum)]
 pub enum CatalogFileFormat {
     Po,
@@ -315,6 +327,19 @@ pub struct CatalogFileCombineResult {
     pub format: CatalogFileFormat,
     pub stats: CatalogCombineStats,
     pub diagnostics: Vec<CatalogDiagnostic>,
+}
+
+#[napi(object)]
+pub struct CatalogFileThreeWayMergeRequest {
+    pub ancestor_path: String,
+    pub ours_path: String,
+    pub theirs_path: String,
+    pub output_path: String,
+    pub format: Option<CatalogFileFormat>,
+    pub source_locale: String,
+    pub locale: Option<String>,
+    pub conflict_strategy: Option<CatalogConflictStrategy>,
+    pub po: Option<PoOutputOptions>,
 }
 
 #[napi(string_enum)]
@@ -1063,6 +1088,23 @@ impl TryFrom<CatalogCombineRequest> for palamedes::CatalogCombineRequest {
     }
 }
 
+impl From<CatalogThreeWayMergeRequest> for palamedes::CatalogThreeWayMergeRequest {
+    fn from(value: CatalogThreeWayMergeRequest) -> Self {
+        Self {
+            ancestor: value.ancestor.into(),
+            ours: value.ours.into(),
+            theirs: value.theirs.into(),
+            format: value.format.into(),
+            source_locale: value.source_locale,
+            locale: value.locale,
+            conflict_strategy: value
+                .conflict_strategy
+                .map_or(palamedes::CatalogConflictStrategy::UseFirst, Into::into),
+            po: value.po.map(Into::into),
+        }
+    }
+}
+
 impl TryFrom<palamedes::CatalogCombineStats> for CatalogCombineStats {
     type Error = napi::Error;
 
@@ -1122,6 +1164,24 @@ impl From<CatalogFileCombineRequest> for palamedes::CatalogFileCombineRequest {
             input_paths: value.input_paths.into_iter().map(PathBuf::from).collect(),
             output_path: PathBuf::from(value.output_path),
             format: value.format.map(palamedes::CatalogFileFormat::from),
+            source_locale: value.source_locale,
+            locale: value.locale,
+            conflict_strategy: value
+                .conflict_strategy
+                .map_or(palamedes::CatalogConflictStrategy::UseFirst, Into::into),
+            po: value.po.map(Into::into),
+        }
+    }
+}
+
+impl From<CatalogFileThreeWayMergeRequest> for palamedes::CatalogFileThreeWayMergeRequest {
+    fn from(value: CatalogFileThreeWayMergeRequest) -> Self {
+        Self {
+            ancestor_path: PathBuf::from(value.ancestor_path),
+            ours_path: PathBuf::from(value.ours_path),
+            theirs_path: PathBuf::from(value.theirs_path),
+            output_path: PathBuf::from(value.output_path),
+            format: value.format.map(Into::into),
             source_locale: value.source_locale,
             locale: value.locale,
             conflict_strategy: value
@@ -1734,6 +1794,37 @@ pub fn combine_catalog_files(
     request: CatalogFileCombineRequest,
 ) -> Result<CatalogFileCombineResult> {
     palamedes::combine_catalog_files(request.into())
+        .map_err(to_napi_error)
+        .and_then(CatalogFileCombineResult::try_from)
+}
+
+#[napi]
+#[allow(clippy::needless_pass_by_value)]
+/// Merges explicit ancestor, ours, and theirs catalog contents.
+///
+/// # Errors
+///
+/// Returns an error for invalid catalogs or rejected translation and
+/// modify/delete conflicts.
+pub fn merge_catalogs_three_way(
+    request: CatalogThreeWayMergeRequest,
+) -> Result<CatalogCombineResult> {
+    palamedes::merge_catalogs_three_way(request.into())
+        .map_err(to_napi_error)
+        .and_then(CatalogCombineResult::try_from)
+}
+
+#[napi]
+#[allow(clippy::needless_pass_by_value)]
+/// Merges explicit ancestor, ours, and theirs files and atomically replaces the output.
+///
+/// # Errors
+///
+/// Returns an error for I/O failures, invalid catalogs, or rejected conflicts.
+pub fn merge_catalog_files_three_way(
+    request: CatalogFileThreeWayMergeRequest,
+) -> Result<CatalogFileCombineResult> {
+    palamedes::merge_catalog_files_three_way(request.into())
         .map_err(to_napi_error)
         .and_then(CatalogFileCombineResult::try_from)
 }

--- a/crates/palamedes/Cargo.toml
+++ b/crates/palamedes/Cargo.toml
@@ -8,9 +8,9 @@ rust-version.workspace = true
 description = "Rust core for Palamedes."
 
 [dependencies]
-ferrocat = "=3.3.0"
-ferrocat-icu = "=3.3.0"
-ferrocat-po = "=3.3.0"
+ferrocat = "=3.4.2"
+ferrocat-icu = "=3.4.2"
+ferrocat-po = "=3.4.2"
 ferromark = { version = "=0.7.0", features = ["mdx"] }
 oxc_allocator = "0.143.0"
 oxc_ast = "0.143.0"

--- a/crates/palamedes/src/catalog_three_way.rs
+++ b/crates/palamedes/src/catalog_three_way.rs
@@ -1,0 +1,468 @@
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use ferrocat::{
+    merge_catalogs_three_way as ferrocat_merge_catalogs_three_way,
+    CatalogCombineInput as FerrocatCombineInput, CatalogMode, MergeCatalogsThreeWayOptions,
+    OrderBy,
+};
+
+use crate::catalog_combine::{
+    CatalogCombineInput, CatalogCombineResult, CatalogConflictStrategy, CatalogFileCombineResult,
+    CatalogFileFormat,
+};
+use crate::catalog_update::{po_serialize_options, PoOutputOptions};
+use crate::error::{PalamedesError, PalamedesResult};
+
+pub use ferrocat::CatalogMergeSide;
+
+/// Stable Ferrocat diagnostic code for a modify/delete conflict resolved by policy.
+pub const CATALOG_MODIFY_DELETE_RESOLVED: &str =
+    ferrocat::po::diagnostic_codes::combine::MODIFY_DELETE_RESOLVED;
+
+/// Explicit ancestor/ours/theirs request for an in-memory catalog merge.
+#[derive(Debug)]
+pub struct CatalogThreeWayMergeRequest {
+    /// Common ancestor catalog.
+    pub ancestor: CatalogCombineInput,
+    /// Current-side catalog. This side wins with [`CatalogConflictStrategy::UseFirst`].
+    pub ours: CatalogCombineInput,
+    /// Incoming-side catalog. This side wins with [`CatalogConflictStrategy::UseLast`].
+    pub theirs: CatalogCombineInput,
+    /// Catalog format used to parse and render all three roles.
+    pub format: CatalogFileFormat,
+    /// Source locale used for source-side semantics and validation.
+    pub source_locale: String,
+    /// Locale of the merged catalog.
+    pub locale: Option<String>,
+    /// Strategy for resolving translation and modify/delete conflicts.
+    pub conflict_strategy: CatalogConflictStrategy,
+    /// Optional PO-specific output controls.
+    pub po: Option<PoOutputOptions>,
+}
+
+/// Explicit ancestor/ours/theirs request for an atomic file merge.
+#[derive(Debug)]
+pub struct CatalogFileThreeWayMergeRequest {
+    /// Common ancestor catalog path.
+    pub ancestor_path: PathBuf,
+    /// Current-side catalog path. This side wins with `use-first`.
+    pub ours_path: PathBuf,
+    /// Incoming-side catalog path. This side wins with `use-last`.
+    pub theirs_path: PathBuf,
+    /// Output path replaced only after parsing and merging succeed.
+    pub output_path: PathBuf,
+    /// Optional explicit format. When absent, it is inferred from every path.
+    pub format: Option<CatalogFileFormat>,
+    /// Source locale used for source-side semantics and validation.
+    pub source_locale: String,
+    /// Locale of the merged catalog.
+    pub locale: Option<String>,
+    /// Strategy for resolving translation and modify/delete conflicts.
+    pub conflict_strategy: CatalogConflictStrategy,
+    /// Optional PO-specific output controls.
+    pub po: Option<PoOutputOptions>,
+}
+
+/// Merges an ancestor and two current catalogs with deletion-aware semantics.
+///
+/// Message identity is the source message plus optional gettext context. An
+/// entry deleted from both sides stays deleted. A one-sided deletion also wins
+/// when the other side still matches the ancestor. Modify/delete and
+/// independently modified translation conflicts follow `conflict_strategy`.
+/// Ferrocat owns entry selection, conflict resolution, metadata ownership, and
+/// rendering. Palamedes only adapts its owned request types to that API.
+///
+/// # Examples
+///
+/// ```rust
+/// use palamedes::{
+///     merge_catalogs_three_way, CatalogCombineInput, CatalogConflictStrategy,
+///     CatalogFileFormat, CatalogThreeWayMergeRequest,
+/// };
+///
+/// let input = |content: &str, label: &str| CatalogCombineInput {
+///     content: content.to_owned(),
+///     label: Some(label.to_owned()),
+/// };
+/// let result = merge_catalogs_three_way(CatalogThreeWayMergeRequest {
+///     ancestor: input("msgid \"Removed\"\nmsgstr \"Alt\"\n", "base"),
+///     ours: input("", "ours"),
+///     theirs: input("", "theirs"),
+///     format: CatalogFileFormat::Po,
+///     source_locale: "en".to_owned(),
+///     locale: Some("de".to_owned()),
+///     conflict_strategy: CatalogConflictStrategy::UseFirst,
+///     po: None,
+/// })?;
+/// assert!(!result.content.contains("Removed"));
+/// # Ok::<(), palamedes::PalamedesError>(())
+/// ```
+///
+/// # Errors
+///
+/// Returns an error when a catalog cannot be parsed or rendered, when the
+/// roles use incompatible content, or when `error` rejects a translation or
+/// modify/delete conflict.
+pub fn merge_catalogs_three_way(
+    request: CatalogThreeWayMergeRequest,
+) -> PalamedesResult<CatalogCombineResult> {
+    let mode = request.format.mode();
+    let ancestor = FerrocatCombineInput {
+        content: &request.ancestor.content,
+        label: request.ancestor.label.as_deref().or(Some("ancestor")),
+    };
+    let ours = FerrocatCombineInput {
+        content: &request.ours.content,
+        label: request.ours.label.as_deref().or(Some("ours")),
+    };
+    let theirs = FerrocatCombineInput {
+        content: &request.theirs.content,
+        label: request.theirs.label.as_deref().or(Some("theirs")),
+    };
+    let mut options =
+        MergeCatalogsThreeWayOptions::new(ancestor, ours, theirs, &request.source_locale)
+            .with_mode(mode)
+            .with_conflict_strategy(request.conflict_strategy)
+            .with_order_by(OrderBy::Msgid)
+            .with_include_origins(true)
+            .with_po_serialize_options(po_serialize_options(request.po.as_ref()));
+    if let Some(locale) = request.locale.as_deref() {
+        options = options.with_locale(locale);
+    }
+
+    ferrocat_merge_catalogs_three_way(options).map_err(PalamedesError::from)
+}
+
+/// Merges three catalog files and atomically replaces the output on success.
+///
+/// Every input is read and parsed before the output path is touched. This also
+/// holds when the output path aliases `ours_path`, as it does for Git drivers.
+///
+/// # Errors
+///
+/// Returns an error when paths cannot be read, formats disagree, parsing or
+/// merging fails, or the final atomic replacement cannot be completed.
+pub fn merge_catalog_files_three_way(
+    request: CatalogFileThreeWayMergeRequest,
+) -> PalamedesResult<CatalogFileCombineResult> {
+    let format = match request.format {
+        Some(format) => format,
+        None => infer_file_format(&[
+            &request.ancestor_path,
+            &request.ours_path,
+            &request.theirs_path,
+            &request.output_path,
+        ])?,
+    };
+    let ancestor = read_catalog(&request.ancestor_path)?;
+    let ours = read_catalog(&request.ours_path)?;
+    let theirs = read_catalog(&request.theirs_path)?;
+    let result = merge_catalogs_three_way(CatalogThreeWayMergeRequest {
+        ancestor: CatalogCombineInput {
+            content: ancestor,
+            label: Some(request.ancestor_path.display().to_string()),
+        },
+        ours: CatalogCombineInput {
+            content: ours,
+            label: Some(request.ours_path.display().to_string()),
+        },
+        theirs: CatalogCombineInput {
+            content: theirs,
+            label: Some(request.theirs_path.display().to_string()),
+        },
+        format,
+        source_locale: request.source_locale,
+        locale: request.locale,
+        conflict_strategy: request.conflict_strategy,
+        po: request.po,
+    })?;
+    atomic_replace(&request.output_path, result.content.as_bytes())?;
+
+    Ok(CatalogFileCombineResult {
+        output_path: request.output_path,
+        format,
+        stats: result.stats,
+        diagnostics: result.diagnostics,
+    })
+}
+
+impl CatalogFileFormat {
+    fn mode(self) -> CatalogMode {
+        match self {
+            Self::Po => CatalogMode::IcuPo,
+            Self::Fcl => CatalogMode::IcuFcl,
+        }
+    }
+}
+
+fn infer_file_format(paths: &[&Path]) -> PalamedesResult<CatalogFileFormat> {
+    let mut inferred = None;
+    for path in paths {
+        let format = match ferrocat::CatalogFileFormat::infer_from_path(path)? {
+            ferrocat::CatalogFileFormat::Po => CatalogFileFormat::Po,
+            ferrocat::CatalogFileFormat::Fcl => CatalogFileFormat::Fcl,
+            _ => {
+                return Err(PalamedesError::UnsupportedCatalogFileFormat {
+                    format: path.display().to_string(),
+                });
+            }
+        };
+        if let Some(expected) = inferred {
+            if expected != format {
+                return Err(PalamedesError::from(ferrocat::ApiError::InvalidArguments(
+                    format!(
+                        "catalog path `{}` uses {format:?}, but the merge uses {expected:?}",
+                        path.display()
+                    ),
+                )));
+            }
+        } else {
+            inferred = Some(format);
+        }
+    }
+    inferred.ok_or(PalamedesError::InvalidCatalogFileCombineInputCount { count: 0 })
+}
+
+fn read_catalog(path: &Path) -> PalamedesResult<String> {
+    fs::read_to_string(path).map_err(|source| PalamedesError::ReadFile {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+fn atomic_replace(path: &Path, content: &[u8]) -> PalamedesResult<()> {
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let mut temporary =
+        tempfile::NamedTempFile::new_in(parent).map_err(|source| PalamedesError::WriteFile {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    temporary
+        .write_all(content)
+        .and_then(|()| temporary.flush())
+        .map_err(|source| PalamedesError::WriteFile {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    temporary
+        .persist(path)
+        .map_err(|error| PalamedesError::WriteFile {
+            path: path.to_path_buf(),
+            source: error.error,
+        })?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use super::{
+        merge_catalog_files_three_way, merge_catalogs_three_way, CatalogFileThreeWayMergeRequest,
+        CatalogThreeWayMergeRequest, CATALOG_MODIFY_DELETE_RESOLVED,
+    };
+    use crate::{
+        CatalogCombineInput, CatalogConflictStrategy, CatalogFileFormat, CatalogMergeSide,
+        PalamedesError,
+    };
+
+    #[test]
+    fn preserves_deletions_and_keeps_entries_new_on_either_side() {
+        let result = merge_po(
+            concat!(
+                "msgid \"Deleted by both\"\nmsgstr \"Alt\"\n\n",
+                "msgid \"Deleted by theirs\"\nmsgstr \"Alt\"\n",
+            ),
+            concat!(
+                "msgid \"Deleted by theirs\"\nmsgstr \"Alt\"\n\n",
+                "msgid \"New ours\"\nmsgstr \"Unser\"\n",
+            ),
+            "msgid \"New theirs\"\nmsgstr \"Ihr\"\n",
+            CatalogConflictStrategy::UseFirst,
+        )
+        .expect("three-way merge");
+
+        assert!(!result.content.contains("Deleted by both"));
+        assert!(!result.content.contains("Deleted by theirs"));
+        assert!(result.content.contains("New ours"));
+        assert!(result.content.contains("New theirs"));
+    }
+
+    #[test]
+    fn unchanged_side_does_not_conflict_with_a_changed_translation() {
+        let result = merge_po(
+            "msgid \"Hello\"\nmsgstr \"Alt\"\n",
+            "msgid \"Hello\"\nmsgstr \"Alt\"\n",
+            "msgid \"Hello\"\nmsgstr \"Neu\"\n",
+            CatalogConflictStrategy::Error,
+        )
+        .expect("one-sided change");
+
+        assert!(result.content.contains("msgstr \"Neu\""));
+        assert_eq!(result.stats.conflicts_resolved, 0);
+    }
+
+    #[test]
+    fn modify_delete_conflicts_follow_the_selected_side() {
+        let base = "msgid \"Hello\"\nmsgstr \"Alt\"\n";
+        let ours = "msgid \"Hello\"\nmsgstr \"Neu\"\n";
+
+        let use_first =
+            merge_po(base, ours, "", CatalogConflictStrategy::UseFirst).expect("use first");
+        assert!(use_first.content.contains("msgstr \"Neu\""));
+        assert!(use_first
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == CATALOG_MODIFY_DELETE_RESOLVED));
+
+        let use_last =
+            merge_po(base, ours, "", CatalogConflictStrategy::UseLast).expect("use last");
+        assert!(!use_last.content.contains("msgid \"Hello\""));
+
+        let error =
+            merge_po(base, ours, "", CatalogConflictStrategy::Error).expect_err("error strategy");
+        assert!(matches!(
+            error,
+            PalamedesError::CatalogApi(ferrocat::ApiError::ModifyDeleteConflict {
+                modified_side: CatalogMergeSide::Ours,
+                deleted_side: CatalogMergeSide::Theirs,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn fcl_uses_the_same_deletion_semantics() {
+        let result = merge_catalogs_three_way(CatalogThreeWayMergeRequest {
+            ancestor: input("%FCL1\tsource=en\tlocale=de\nRemoved\t\tAlt\n", "base"),
+            ours: input("%FCL1\tsource=en\tlocale=de\nNew ours\t\tUnser\n", "ours"),
+            theirs: input("%FCL1\tsource=en\tlocale=de\nNew theirs\t\tIhr\n", "theirs"),
+            format: CatalogFileFormat::Fcl,
+            source_locale: "en".to_owned(),
+            locale: Some("de".to_owned()),
+            conflict_strategy: CatalogConflictStrategy::UseFirst,
+            po: None,
+        })
+        .expect("FCL three-way merge");
+
+        assert!(!result.content.contains("Removed"));
+        assert!(result.content.contains("New ours\t\tUnser"));
+        assert!(result.content.contains("New theirs\t\tIhr"));
+    }
+
+    #[test]
+    fn po_three_way_output_honors_requested_line_breaks() {
+        let long = "A deliberately long translated catalog value that should remain on one line when PO folding is disabled.";
+        let content = format!("msgid \"Long\"\nmsgstr \"{long}\"\n");
+        let result = merge_catalogs_three_way(CatalogThreeWayMergeRequest {
+            ancestor: input(&content, "base"),
+            ours: input(&content, "ours"),
+            theirs: input(&content, "theirs"),
+            format: CatalogFileFormat::Po,
+            source_locale: "en".to_owned(),
+            locale: Some("de".to_owned()),
+            conflict_strategy: CatalogConflictStrategy::UseFirst,
+            po: Some(crate::PoOutputOptions {
+                line_breaks: crate::PoLineBreaks::Off,
+            }),
+        })
+        .expect("unfolded merge");
+
+        assert!(result
+            .content
+            .lines()
+            .any(|line| line == format!("msgstr \"{long}\"")));
+    }
+
+    #[test]
+    fn file_parse_failure_leaves_existing_output_unchanged() {
+        let fixture = tempfile::tempdir().expect("fixture");
+        let base = fixture.path().join("base.po");
+        let ours = fixture.path().join("ours.po");
+        let theirs = fixture.path().join("theirs.po");
+        let output = fixture.path().join("merged.po");
+        fs::write(&base, "msgid \"Hello\"\nmsgstr \"Alt\"\n").expect("base");
+        fs::write(&ours, "invalid").expect("ours");
+        fs::write(&theirs, "").expect("theirs");
+        fs::write(&output, "unchanged").expect("output");
+
+        merge_catalog_files_three_way(CatalogFileThreeWayMergeRequest {
+            ancestor_path: base,
+            ours_path: ours,
+            theirs_path: theirs,
+            output_path: output.clone(),
+            format: Some(CatalogFileFormat::Po),
+            source_locale: "en".to_owned(),
+            locale: Some("de".to_owned()),
+            conflict_strategy: CatalogConflictStrategy::UseFirst,
+            po: None,
+        })
+        .expect_err("invalid PO");
+
+        assert_eq!(
+            fs::read_to_string(output).expect("read output"),
+            "unchanged"
+        );
+    }
+
+    #[test]
+    fn file_merge_conflict_leaves_existing_output_unchanged() {
+        let fixture = tempfile::tempdir().expect("fixture");
+        let base = fixture.path().join("base.po");
+        let ours = fixture.path().join("ours.po");
+        let theirs = fixture.path().join("theirs.po");
+        let output = fixture.path().join("merged.po");
+        fs::write(&base, "msgid \"Hello\"\nmsgstr \"Alt\"\n").expect("base");
+        fs::write(&ours, "msgid \"Hello\"\nmsgstr \"Unser\"\n").expect("ours");
+        fs::write(&theirs, "msgid \"Hello\"\nmsgstr \"Ihr\"\n").expect("theirs");
+        fs::write(&output, "unchanged").expect("output");
+
+        merge_catalog_files_three_way(CatalogFileThreeWayMergeRequest {
+            ancestor_path: base,
+            ours_path: ours,
+            theirs_path: theirs,
+            output_path: output.clone(),
+            format: Some(CatalogFileFormat::Po),
+            source_locale: "en".to_owned(),
+            locale: Some("de".to_owned()),
+            conflict_strategy: CatalogConflictStrategy::Error,
+            po: None,
+        })
+        .expect_err("translation conflict");
+
+        assert_eq!(
+            fs::read_to_string(output).expect("read output"),
+            "unchanged"
+        );
+    }
+
+    fn merge_po(
+        ancestor: &str,
+        ours: &str,
+        theirs: &str,
+        conflict_strategy: CatalogConflictStrategy,
+    ) -> crate::PalamedesResult<crate::CatalogCombineResult> {
+        merge_catalogs_three_way(CatalogThreeWayMergeRequest {
+            ancestor: input(ancestor, "base"),
+            ours: input(ours, "ours"),
+            theirs: input(theirs, "theirs"),
+            format: CatalogFileFormat::Po,
+            source_locale: "en".to_owned(),
+            locale: Some("de".to_owned()),
+            conflict_strategy,
+            po: None,
+        })
+    }
+
+    fn input(content: &str, label: &str) -> CatalogCombineInput {
+        CatalogCombineInput {
+            content: content.to_owned(),
+            label: Some(label.to_owned()),
+        }
+    }
+}

--- a/crates/palamedes/src/lib.rs
+++ b/crates/palamedes/src/lib.rs
@@ -23,6 +23,7 @@ mod catalog_audit;
 mod catalog_combine;
 mod catalog_convert;
 mod catalog_coverage;
+mod catalog_three_way;
 mod catalog_update;
 mod choice;
 mod descriptor;
@@ -69,6 +70,10 @@ pub use catalog_convert::{
 pub use catalog_coverage::{
     measure_catalog_coverage, CatalogCoverageRequest, CatalogCoverageResult,
     CatalogLocaleCoverageResult,
+};
+pub use catalog_three_way::{
+    merge_catalog_files_three_way, merge_catalogs_three_way, CatalogFileThreeWayMergeRequest,
+    CatalogMergeSide, CatalogThreeWayMergeRequest, CATALOG_MODIFY_DELETE_RESOLVED,
 };
 pub use catalog_update::{
     parse_catalog, update_catalog_file, AiProvenance, CatalogOriginMetadata, CatalogParseRequest,
@@ -122,7 +127,7 @@ pub use translation_candidates::{
 };
 
 /// Published `ferrocat` version used by the Rust core.
-pub const FERROCAT_VERSION: &str = "3.3.0";
+pub const FERROCAT_VERSION: &str = "3.4.2";
 
 /// Version metadata for the loaded native core.
 #[derive(Debug, Serialize)]

--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -11,6 +11,7 @@ commands.
 - `pmds audit`
 - `pmds report`
 - `pmds catalog merge`
+- `pmds catalog merge-driver`
 - `pmds catalog convert`
 - `pmds version`
 

--- a/docs/api/core-node.md
+++ b/docs/api/core-node.md
@@ -15,6 +15,8 @@ core. Most apps use it indirectly through the CLI and plugins.
 - `validateMessageMetadata(input)`
 - `combineCatalogs(request)`
 - `combineCatalogFiles(request)`
+- `mergeCatalogsThreeWay(request)`
+- `mergeCatalogFilesThreeWay(request)`
 - `compileCatalogArtifact(config, resourcePath)`
 - `compileCatalogArtifactSelected(config, resourcePath, compiledIds)`
 - `compileCatalogModule(config, resourcePath, options)`

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -176,11 +176,27 @@ Git merge-driver workflows.
 
 ```bash
 pmds catalog merge ours.po theirs.po --output merged.po
-pmds catalog merge %A %B --base %O --output %A --path %P --format po --conflict-strategy use-first
+pmds catalog merge ours.po theirs.po --base base.po --output merged.po
+pmds catalog merge-driver %O %A %B %A --path %P --format po --conflict-strategy use-first
 pmds catalog merge ours.fcl theirs.fcl --output merged.fcl --format fcl
 ```
 
-`pmds catalog merge` requires exactly two input catalogs in precedence order.
+`pmds catalog merge` requires exactly two current input catalogs. Without
+`--base`, they are combined in precedence order. With `--base`, the command
+performs a deletion-aware three-way merge with explicit ancestor, ours (first
+input), and theirs (second input) roles:
+
+- an entry absent from both current sides stays deleted;
+- a deletion wins when the other side is unchanged from the ancestor;
+- an entry modified on one side and deleted on the other follows
+  `--conflict-strategy` and emits `combine.modify_delete_resolved` when resolved;
+- entries newly added on either side are retained; and
+- an entry changed on only one side is accepted without a translation conflict.
+
+`use-first` selects ours and `use-last` selects theirs for translation and
+modify/delete conflicts. `error` rejects the merge. Parse errors and rejected
+conflicts leave the output file unchanged. PO and FCL use the same identity and
+deletion rules; identity is the source message plus optional gettext context.
 
 Merged PO catalogs are written in the same order and shape as an extraction
 produces, so a resolved conflict does not land as a fully re-sorted file that
@@ -196,11 +212,34 @@ Options:
 | `--output <path>`                | Required output path.                                            |
 | `-c, --config <path>`            | Use a specific config file when inferring `source-locale`.       |
 | `--format <format>`              | `po` or `fcl`. Inferred from paths when omitted.                 |
-| `--base <path>`                  | Optional ancestor catalog path supplied by Git merge drivers.    |
+| `--base <path>`                  | Optional common ancestor for a three-way merge.                  |
 | `--conflict-strategy <strategy>` | `use-first`, `use-last`, or `error`. Default: `use-first`.       |
 | `--source-locale <locale>`       | Source locale for catalog semantics. Defaults to config or `en`. |
 | `--locale <locale>`              | Locale of the merged catalog.                                    |
 | `--path <path>`                  | Real catalog pathname; pass `%P` in a Git merge driver.          |
+
+### Git merge driver
+
+Use `catalog merge-driver` for Git instead of reconstructing role handling in
+a wrapper script:
+
+```bash
+git config merge.palamedes-catalog.driver \
+  'pmds catalog merge-driver %O %A %B %A --path %P --format po --conflict-strategy use-first'
+git config merge.palamedes-catalog-fcl.driver \
+  'pmds catalog merge-driver %O %A %B %A --path %P --format fcl --conflict-strategy use-first'
+```
+
+During a normal merge, Git's `%A` is logical ours and `%B` is theirs. During a
+rebase, Git internally assigns the upstream side to `%A` and the commit being
+replayed to `%B`. `merge-driver` detects the active rebase and swaps those
+inputs before calling the Core API, so `use-first` consistently means “the
+branch being merged or rebased wins.” Use `--operation merge` or
+`--operation rebase` to override auto-detection in unusual Git orchestration.
+
+The positional arguments are ancestor (`%O`), Git current file (`%A`), Git
+other file (`%B`), and output (`%A`). `--path %P` selects the real configured
+catalog so its PO formatting options are applied to the output.
 
 ## `pmds catalog convert`
 

--- a/docs/migrations/1.0.0.md
+++ b/docs/migrations/1.0.0.md
@@ -69,11 +69,11 @@ Use PO and FCL drivers instead:
 ```bash
 git config merge.palamedes-catalog.name "Palamedes catalog merge"
 git config merge.palamedes-catalog.driver \
-  'pmds catalog merge --format=po --conflict-strategy=use-first --base %O --output %A %A %B'
+  'pmds catalog merge-driver %O %A %B %A --path %P --format=po --conflict-strategy=use-first'
 
 git config merge.palamedes-catalog-fcl.name "Palamedes FCL catalog merge"
 git config merge.palamedes-catalog-fcl.driver \
-  'pmds catalog merge --format=fcl --conflict-strategy=use-first --base %O --output %A %A %B'
+  'pmds catalog merge-driver %O %A %B %A --path %P --format=fcl --conflict-strategy=use-first'
 ```
 
 ## Converting PO To FCL

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -172,14 +172,16 @@ locale is below the threshold.
 
 ### Catalog Merge
 
-`pmds catalog merge` combines catalog files. When inputs
-contain the same semantic identity, `--conflict-strategy` controls how
-translator-facing conflicts are handled; messages that only exist in the second
-input are added.
+`pmds catalog merge` combines two current catalog files. Supplying `--base`
+activates a true ancestor/ours/theirs merge: deletions are preserved, a
+one-sided deletion beats an unchanged opposite side, and modify/delete cases
+follow `--conflict-strategy`. New entries from either side remain in the
+result. PO and FCL both identify entries by source message plus optional
+gettext context.
 
 ```bash
-pnpm exec pmds catalog merge --format=po --conflict-strategy=use-first --base %O --output %A %A %B
-pnpm exec pmds catalog merge --format=fcl --conflict-strategy=use-first --base %O --output %A %A %B
+pnpm exec pmds catalog merge ours.po theirs.po --base base.po --output merged.po
+pnpm exec pmds catalog merge ours.fcl theirs.fcl --base base.fcl --output merged.fcl
 ```
 
 `--format` can be omitted when all input and output extensions are supported
@@ -194,13 +196,21 @@ For Git merge-driver usage:
 
 ```bash
 git config merge.palamedes-catalog.driver \
-  'pmds catalog merge --format=po --conflict-strategy=use-first --base %O --output %A %A %B'
+  'pmds catalog merge-driver %O %A %B %A --path %P --format=po --conflict-strategy=use-first'
 git config merge.palamedes-catalog-fcl.driver \
-  'pmds catalog merge --format=fcl --conflict-strategy=use-first --base %O --output %A %A %B'
+  'pmds catalog merge-driver %O %A %B %A --path %P --format=fcl --conflict-strategy=use-first'
 ```
 
 `--source-locale` is optional. The command uses an explicit value first, then
 the configured Palamedes config when available, then `en`.
+
+`merge-driver` maps Git's roles explicitly. In a normal merge, `%A` is ours.
+During a rebase Git reverses the logical branch roles, so the command detects
+the rebase and makes `%B` logical ours. Therefore `use-first` always favors the
+branch being merged or rebased. `use-last` favors the incoming or upstream
+side, while `error` rejects translation and modify/delete conflicts without
+changing `%A`. A resolved modify/delete conflict emits the stable Ferrocat
+diagnostic code `combine.modify_delete_resolved` through the Core API.
 
 ## Configuration
 

--- a/packages/core-node/README.md
+++ b/packages/core-node/README.md
@@ -53,6 +53,7 @@ the musl package while glibc distributions use the GNU package.
 import {
   combineCatalogFiles,
   getNativeInfo,
+  mergeCatalogFilesThreeWay,
   parsePo,
   updateCatalogFile,
 } from "@palamedes/core-node"
@@ -77,6 +78,15 @@ combineCatalogFiles({
   format: "po",
   sourceLocale: "en",
 })
+mergeCatalogFilesThreeWay({
+  ancestorPath: "git/base/de.po",
+  oursPath: "src/locales/de.po",
+  theirsPath: "incoming/de.po",
+  outputPath: "src/locales/de.po",
+  format: "po",
+  sourceLocale: "en",
+  conflictStrategy: "useFirst",
+})
 combineCatalogFiles({
   inputPaths: ["src/locales/de.fcl", "incoming/de.fcl"],
   outputPath: "src/locales/de.fcl",
@@ -100,6 +110,8 @@ console.log(po.headers.Language)
 - `validateMessageMetadata(input)`
 - `combineCatalogs(request)`
 - `combineCatalogFiles(request)`
+- `mergeCatalogsThreeWay(request)`
+- `mergeCatalogFilesThreeWay(request)`
 - `compileCatalogArtifact(config, resourcePath)`
 - `compileCatalogArtifactSelected(config, resourcePath, compiledIds)`
 - `compileCatalogModule(config, resourcePath, options)`

--- a/packages/core-node/src/generated/palamedes-node-types.ts
+++ b/packages/core-node/src/generated/palamedes-node-types.ts
@@ -188,6 +188,16 @@ export interface CatalogCombineResult {
   stats: CatalogCombineStats;
   diagnostics: Array<CatalogDiagnostic>;
 }
+export interface CatalogThreeWayMergeRequest {
+  ancestor: CatalogCombineInput;
+  ours: CatalogCombineInput;
+  theirs: CatalogCombineInput;
+  format: CatalogFileFormat;
+  sourceLocale: string;
+  locale?: string;
+  conflictStrategy?: CatalogConflictStrategy;
+  po?: PoOutputOptions;
+}
 export type CatalogFileFormat = "Po" | "Fcl"
 export interface CatalogFileCombineRequest {
   inputPaths: Array<string>;
@@ -203,6 +213,17 @@ export interface CatalogFileCombineResult {
   format: CatalogFileFormat;
   stats: CatalogCombineStats;
   diagnostics: Array<CatalogDiagnostic>;
+}
+export interface CatalogFileThreeWayMergeRequest {
+  ancestorPath: string;
+  oursPath: string;
+  theirsPath: string;
+  outputPath: string;
+  format?: CatalogFileFormat;
+  sourceLocale: string;
+  locale?: string;
+  conflictStrategy?: CatalogConflictStrategy;
+  po?: PoOutputOptions;
 }
 export type CatalogDiagnosticSeverity = "Info" | "Warning" | "Error"
 export interface CatalogDiagnosticSourceKey {
@@ -531,6 +552,8 @@ export interface NativeBindings {
   validateMessageMetadata(input: MessageMetadataInput): MessageMetadataValidationReport;
   combineCatalogs(request: CatalogCombineRequest): CatalogCombineResult;
   combineCatalogFiles(request: CatalogFileCombineRequest): CatalogFileCombineResult;
+  mergeCatalogsThreeWay(request: CatalogThreeWayMergeRequest): CatalogCombineResult;
+  mergeCatalogFilesThreeWay(request: CatalogFileThreeWayMergeRequest): CatalogFileCombineResult;
   compileCatalogArtifact(request: CatalogArtifactRequest): CatalogArtifactResult;
   compileCatalogModule(request: CatalogModuleRequest): CatalogModuleResult;
   compileCatalogArtifactSelected(request: CatalogArtifactSelectedRequest): CatalogArtifactResult;

--- a/packages/core-node/src/index.test.ts
+++ b/packages/core-node/src/index.test.ts
@@ -13,6 +13,8 @@ import {
   extractMessagesNative,
   getNativeInfo,
   listTranslationCandidates,
+  mergeCatalogFilesThreeWay,
+  mergeCatalogsThreeWay,
   parsePo,
   renderCatalogModule,
   transformMacrosNative,
@@ -161,6 +163,58 @@ msgstr "Oeffnen"
       long,
       "Zebra",
     ])
+  })
+
+  it("performs deletion-aware three-way catalog merges across the NAPI boundary", async () => {
+    const catalog = (entries: string) => `msgid ""
+msgstr ""
+"Language: de\\n"
+
+${entries}`
+    const ancestor = catalog(`msgid "Removed"
+msgstr "Alt"
+`)
+    const ours = catalog(`msgid "New ours"
+msgstr "Unser"
+`)
+    const theirs = catalog(`msgid "New theirs"
+msgstr "Ihr"
+`)
+    const merged = mergeCatalogsThreeWay({
+      ancestor: { content: ancestor, label: "base" },
+      ours: { content: ours, label: "ours" },
+      theirs: { content: theirs, label: "theirs" },
+      format: "po",
+      sourceLocale: "en",
+      locale: "de",
+    })
+
+    expect(merged.content).not.toContain('msgid "Removed"')
+    expect(merged.content).toContain('msgid "New ours"')
+    expect(merged.content).toContain('msgid "New theirs"')
+
+    const rootDir = await createTempDir()
+    const ancestorPath = path.join(rootDir, "ancestor.po")
+    const oursPath = path.join(rootDir, "ours.po")
+    const theirsPath = path.join(rootDir, "theirs.po")
+    const outputPath = path.join(rootDir, "merged.po")
+    await Promise.all([
+      writeFile(ancestorPath, ancestor),
+      writeFile(oursPath, ours),
+      writeFile(theirsPath, theirs),
+    ])
+
+    const fileResult = mergeCatalogFilesThreeWay({
+      ancestorPath,
+      oursPath,
+      theirsPath,
+      outputPath,
+      sourceLocale: "en",
+      locale: "de",
+    })
+
+    expect(fileResult.format).toBe("po")
+    expect(await readFile(outputPath, "utf8")).toBe(merged.content)
   })
 
   it("enumerates and atomically applies typed translation patches", async () => {

--- a/packages/core-node/src/index.ts
+++ b/packages/core-node/src/index.ts
@@ -11,6 +11,8 @@ import type {
   CatalogFileCombineResult as GeneratedCatalogFileCombineResult,
   CatalogCombineRequest as GeneratedCatalogCombineRequest,
   CatalogCombineResult as GeneratedCatalogCombineResult,
+  CatalogThreeWayMergeRequest as GeneratedCatalogThreeWayMergeRequest,
+  CatalogFileThreeWayMergeRequest as GeneratedCatalogFileThreeWayMergeRequest,
   CatalogArtifactCatalogConfig as GeneratedCatalogArtifactCatalogConfig,
   CatalogArtifactConfig as GeneratedCatalogArtifactConfig,
   CatalogArtifactDiagnostic as GeneratedCatalogArtifactDiagnostic,
@@ -196,6 +198,16 @@ export type CatalogCombineResult = Omit<GeneratedCatalogCombineResult, "diagnost
   diagnostics: CatalogDiagnostic[]
 }
 export type CatalogFileFormat = "po" | "fcl"
+export type CatalogThreeWayMergeRequest = {
+  ancestor: CatalogCombineInput
+  ours: CatalogCombineInput
+  theirs: CatalogCombineInput
+  format: CatalogFileFormat
+  sourceLocale: string
+  locale?: string
+  conflictStrategy?: CatalogConflictStrategy
+  po?: PoOutputOptions
+}
 export type CatalogConfigFormat = CatalogFileFormat
 export type PoLineBreaks = "auto" | "off"
 export type PoOutputOptions = {
@@ -223,6 +235,17 @@ export type CatalogFileCombineResult = Omit<
 > & {
   format: CatalogFileFormat
   diagnostics: CatalogDiagnostic[]
+}
+export type CatalogFileThreeWayMergeRequest = {
+  ancestorPath: string
+  oursPath: string
+  theirsPath: string
+  outputPath: string
+  format?: CatalogFileFormat
+  sourceLocale: string
+  locale?: string
+  conflictStrategy?: CatalogConflictStrategy
+  po?: PoOutputOptions
 }
 export type CatalogAuditOptions = {
   locales?: string[]
@@ -329,6 +352,8 @@ type NativeBindings = GeneratedNativeBindings
 type NativeCatalogAuditRequest = GeneratedCatalogAuditRequest
 type NativeCatalogCombineRequest = GeneratedCatalogCombineRequest
 type NativeCatalogFileCombineRequest = GeneratedCatalogFileCombineRequest
+type NativeCatalogThreeWayMergeRequest = GeneratedCatalogThreeWayMergeRequest
+type NativeCatalogFileThreeWayMergeRequest = GeneratedCatalogFileThreeWayMergeRequest
 type NativeCatalogArtifactRequest = GeneratedCatalogArtifactRequest
 type NativeCatalogArtifactSelectedRequest = GeneratedCatalogArtifactSelectedRequest
 type NativeCatalogModuleRequest = GeneratedCatalogModuleRequest
@@ -644,6 +669,25 @@ export function combineCatalogFiles(request: CatalogFileCombineRequest): Catalog
   }
 }
 
+export function mergeCatalogsThreeWay(request: CatalogThreeWayMergeRequest): CatalogCombineResult {
+  const result = native.mergeCatalogsThreeWay(toNativeThreeWayMergeRequest(request))
+  return {
+    ...result,
+    diagnostics: mapCatalogDiagnostics(result.diagnostics),
+  }
+}
+
+export function mergeCatalogFilesThreeWay(
+  request: CatalogFileThreeWayMergeRequest
+): CatalogFileCombineResult {
+  const result = native.mergeCatalogFilesThreeWay(toNativeFileThreeWayMergeRequest(request))
+  return {
+    ...result,
+    format: fromNativeFileFormat(result.format),
+    diagnostics: mapCatalogDiagnostics(result.diagnostics),
+  }
+}
+
 function toNativeCombineRequest(request: CatalogCombineRequest): NativeCatalogCombineRequest {
   return {
     inputs: request.inputs,
@@ -654,6 +698,23 @@ function toNativeCombineRequest(request: CatalogCombineRequest): NativeCatalogCo
       : undefined,
     selection: request.selection ? toNativeSelection(request.selection) : undefined,
     includeObsolete: request.includeObsolete,
+  }
+}
+
+function toNativeThreeWayMergeRequest(
+  request: CatalogThreeWayMergeRequest
+): NativeCatalogThreeWayMergeRequest {
+  return {
+    ancestor: request.ancestor,
+    ours: request.ours,
+    theirs: request.theirs,
+    format: toNativeFileFormat(request.format),
+    sourceLocale: request.sourceLocale,
+    locale: request.locale,
+    conflictStrategy: request.conflictStrategy
+      ? toNativeConflictStrategy(request.conflictStrategy)
+      : undefined,
+    po: toNativePoOptions(request.po),
   }
 }
 
@@ -678,6 +739,24 @@ function toNativeFileCombineRequest(
 ): NativeCatalogFileCombineRequest {
   return {
     inputPaths: request.inputPaths,
+    outputPath: request.outputPath,
+    format: request.format ? toNativeFileFormat(request.format) : undefined,
+    sourceLocale: request.sourceLocale,
+    locale: request.locale,
+    conflictStrategy: request.conflictStrategy
+      ? toNativeConflictStrategy(request.conflictStrategy)
+      : undefined,
+    po: toNativePoOptions(request.po),
+  }
+}
+
+function toNativeFileThreeWayMergeRequest(
+  request: CatalogFileThreeWayMergeRequest
+): NativeCatalogFileThreeWayMergeRequest {
+  return {
+    ancestorPath: request.ancestorPath,
+    oursPath: request.oursPath,
+    theirsPath: request.theirsPath,
     outputPath: request.outputPath,
     format: request.format ? toNativeFileFormat(request.format) : undefined,
     sourceLocale: request.sourceLocale,


### PR DESCRIPTION
## Summary

- upgrade the Ferrocat crate family from 3.3.0 to 3.4.2
- delegate host-neutral ancestor/ours/theirs semantics to `ferrocat::merge_catalogs_three_way` instead of duplicating entry selection, conflict resolution, metadata ownership, and rendering in Palamedes
- expose explicit three-way Rust and Core Node APIs while keeping atomic file replacement in Palamedes
- make `pmds catalog merge --base` deletion-aware and add `catalog merge-driver` with stable logical role mapping for normal merges and rebases
- document the new CLI, diagnostic, and Core Node contracts
- strip debug symbols from shipped release artifacts so the new functionality stays comfortably within the native package size budget

The generic catalog semantics and PO/FCL golden fixtures are owned and tested upstream in [Ferrocat #292](https://github.com/sebastian-software/ferrocat/pull/292), released in [Ferrocat 3.4.2](https://github.com/sebastian-software/ferrocat/releases/tag/ferrocat-v3.4.2). Palamedes now tests its consumer contract, Git integration, N-API mapping, and transactional file boundary.

## Issue

Closes #523.

## Validation

- `env RUSTUP_TOOLCHAIN=1.95 pnpm agent:check`
- `pnpm build:site`
- `pnpm --filter @palamedes/site typecheck`
- `env RUSTUP_TOOLCHAIN=1.95 pnpm check:binary-size`
- `cargo +1.95 test -p palamedes-cli --test catalog_merge --locked`
- `pnpm --filter @palamedes/core-node test`

With release debug symbols stripped, the local release binary is 6.27 MB against the 9.50 MB limit (3.23 MB spare).

## Follow-up

None. The only intentionally upstream evidence is the detailed catalog-semantic golden matrix in Ferrocat; Palamedes retains focused adapter and process-level coverage.