### PR TITLE
fix(site): build TypeDoc packages before conversion

### DIFF
--- a/site/scripts/prebuild-content.mjs
+++ b/site/scripts/prebuild-content.mjs
@@ -1,5 +1,6 @@
 import { copyFile, mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises"
 import { existsSync } from "node:fs"
+import { spawnSync } from "node:child_process"
 import { dirname, extname, join, posix, relative, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 
@@ -11,6 +12,8 @@ const routesRoot = join(siteRoot, "app/routes")
 const publicRoot = join(siteRoot, "public")
 const repoUrl = "https://github.com/sebastian-software/palamedes"
 const pendingAssetCopies = []
+
+buildTypedocPackages()
 
 const generatedDirs = [
   join(routesRoot, "api-reference"),
@@ -59,6 +62,29 @@ await writeContentStats(adrs)
 console.log(
   `prebuild-content: generated ${docs.length} docs, ${adrs.length} ADRs, ${posts.length} posts, and TypeDoc API routes`
 )
+
+function buildTypedocPackages() {
+  const filters = typedocPackages().flatMap(({ packageDir }) => [
+    "--filter",
+    `./packages/${packageDir}`,
+  ])
+  const pnpm = process.platform === "win32" ? "pnpm.cmd" : "pnpm"
+
+  console.log("prebuild-content: building TypeDoc workspace packages")
+  const result = spawnSync(pnpm, ["--recursive", ...filters, "build"], {
+    cwd: repoRoot,
+    stdio: "inherit",
+  })
+
+  if (result.error) {
+    throw new Error("Could not start the TypeDoc workspace package build", {
+      cause: result.error,
+    })
+  }
+  if (result.status !== 0) {
+    throw new Error(`TypeDoc workspace package build failed with status ${result.status}`)
+  }
+}
 
 /*
  * Derives the stat-tile numbers (ADR count, example matrix shape) from the

--- a/site/tsconfig.typedoc.json
+++ b/site/tsconfig.typedoc.json
@@ -1,7 +1,6 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": "..",
     "ignoreDeprecations": "6.0",
     "jsx": "react-jsx",
     "jsxImportSource": "react",
@@ -9,28 +8,7 @@
     "moduleResolution": "Bundler",
     "noEmit": true,
     "rootDir": "..",
-    "types": ["node"],
-    "paths": {
-      "@palamedes/cli": ["packages/cli/src/index.ts"],
-      "@palamedes/config": ["packages/config/src/index.ts"],
-      "@palamedes/core": ["packages/core/src/index.ts"],
-      "@palamedes/core/compiled": ["packages/core/src/compiled.ts"],
-      "@palamedes/core/locale": ["packages/core/src/locale.ts"],
-      "@palamedes/core/macro": ["packages/core/src/macro.ts"],
-      "@palamedes/core-node": ["packages/core-node/src/index.ts"],
-      "@palamedes/extractor": ["packages/extractor/src/index.ts"],
-      "@palamedes/next-plugin": ["packages/next-plugin/src/index.ts"],
-      "@palamedes/react": ["packages/react/src/index.tsx"],
-      "@palamedes/react/client": ["packages/react/src/client.tsx"],
-      "@palamedes/react/macro": ["packages/react/src/macro.ts"],
-      "@palamedes/runtime": ["packages/runtime/src/index.ts"],
-      "@palamedes/runtime/server": ["packages/runtime/src/server.ts"],
-      "@palamedes/solid": ["packages/solid/src/index.tsx"],
-      "@palamedes/solid/macro": ["packages/solid/src/macro.ts"],
-      "@palamedes/transform": ["packages/transform/src/index.ts"],
-      "@palamedes/transform/catalog-loader": ["packages/transform/src/catalogLoader.ts"],
-      "@palamedes/vite-plugin": ["packages/vite-plugin/src/index.ts"]
-    }
+    "types": ["node"]
   },
   "include": ["../packages/*/src/**/*"],
   "exclude": ["../packages/**/*.test.ts", "../packages/**/*.test.tsx"]


### PR DESCRIPTION
## What this changes

This is an alternative to #549.

Before TypeDoc conversion, the site prebuild now builds the workspace packages already listed by `typedocPackages()`. pnpm runs those 11 package builds in topological order, so their normal `package.json#exports` targets and declaration files exist when TypeDoc resolves cross-package imports.

The TypeDoc-specific `baseUrl` and hand-maintained `paths` mirror are removed completely.

## Why

The Pages workflow installs the workspace and builds the site without first building the packages. pnpm links the workspace package directories, but TypeScript still follows each package's public exports, which point to `dist`. The missing output caused TypeDoc to fail on newly added public subpaths and required aliases such as `@palamedes/core/compiled` and `@palamedes/next-plugin/server-function-entry` to be duplicated in the site tsconfig.

Building the documented package graph first keeps package exports as the single module-resolution contract. Adding another exported subpath no longer requires a matching TypeDoc alias.

## Impact

- Site build and site typecheck remain self-contained from a fresh install.
- TypeDoc resolves the same public export surface that package consumers use.
- The package selection has one source of truth: `typedocPackages()`.
- Native platform packages are not selected; only the 11 documented packages are built.

## Validation

- Confirmed there were no `packages/*/dist` directories before the first site build.
- `pnpm build:site`
- `pnpm --filter @palamedes/site typecheck`
- `pnpm format:check -- site/scripts/prebuild-content.mjs site/tsconfig.typedoc.json`
- `pnpm lint`
- `git diff --check`
