### PR TITLE
feat(cli): add non-mutating extraction checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,13 @@ declare module "*.po" {
 pnpm exec pmds extract
 ```
 
+Keep generated PO and FCL catalogs synchronized in CI without rewriting the
+workspace:
+
+```bash
+pnpm exec pmds extract --check --json
+```
+
 For semantic catalog conflict handling, Palamedes can also act as a Git merge
 driver:
 

--- a/crates/palamedes-cli/src/commands/extract/mod.rs
+++ b/crates/palamedes-cli/src/commands/extract/mod.rs
@@ -13,12 +13,12 @@ use std::time::Instant;
 
 use clap::Args;
 use palamedes::{
-    extract_catalog_messages_cached, update_catalog_file, CatalogUpdateMessage,
-    CatalogUpdateRequest, ExtractCache, ExtractCatalogFileFailure,
+    extract_catalog_messages_cached, preview_catalog_file_update, update_catalog_file,
+    CatalogUpdateMessage, CatalogUpdateRequest, ExtractCache, ExtractCatalogFileFailure,
 };
 use serde::Serialize;
 
-use crate::command::{Command, Context};
+use crate::command::{render_json, Command, Context};
 use crate::config::{ConfigCatalog, LoadedConfig};
 use crate::error::CliError;
 use cache::{load_extract_cache, persist_extract_cache};
@@ -37,6 +37,12 @@ pub struct ExtractOptions {
     /// Watch for file changes.
     #[arg(short, long)]
     watch: bool,
+    /// Verify that extraction would leave every configured catalog unchanged.
+    #[arg(long, conflicts_with = "watch")]
+    check: bool,
+    /// Print the extraction check as one JSON document.
+    #[arg(long, requires = "check")]
+    json: bool,
     /// Remove obsolete messages whose obsolete-since marker is older than the
     /// 30-day grace period; undated entries are kept (use --force-clean to
     /// remove everything immediately).
@@ -58,26 +64,153 @@ pub struct ExtractOptions {
 }
 
 impl Command for ExtractOptions {
-    type Output = ();
+    type Output = ExtractOutput;
 
     fn run(&self, context: &Context) -> Result<Self::Output, CliError> {
+        let result = self.run_configured(context);
+        if self.check {
+            return match result {
+                Ok(output) => Ok(output),
+                Err(error) => Ok(ExtractOutput::Check(ExtractCheckReport::error(
+                    error.to_string(),
+                ))),
+            };
+        }
+        result
+    }
+
+    fn render(&self, output: &Self::Output) -> Result<(), CliError> {
+        let ExtractOutput::Check(report) = output else {
+            return Ok(());
+        };
+        if self.json {
+            return render_json(report);
+        }
+        report.render_human();
+        Ok(())
+    }
+
+    fn verdict(&self, output: &Self::Output) -> Result<(), CliError> {
+        let ExtractOutput::Check(report) = output else {
+            return Ok(());
+        };
+        match report.status {
+            ExtractCheckStatus::Clean => Ok(()),
+            ExtractCheckStatus::Drift => Err(CliError::CatalogDrift {
+                catalogs: report.catalogs.len(),
+            }),
+            ExtractCheckStatus::Error => Err(CliError::ExtractionCheckFailed {
+                message: report
+                    .error
+                    .as_ref()
+                    .map(|error| error.message.clone())
+                    .unwrap_or_else(|| "Catalog extraction check failed.".to_owned()),
+            }),
+        }
+    }
+}
+
+impl ExtractOptions {
+    fn run_configured(&self, context: &Context) -> Result<ExtractOutput, CliError> {
         let config = context.load_config(self.config.as_deref())?;
         if self.verbose {
             eprintln!("Config loaded from {}", config.config_path.display());
         }
 
         if self.watch {
-            run_watch_mode(&config, self)
+            run_watch_mode(&config, self)?;
+            Ok(ExtractOutput::Completed)
         } else {
             run_extraction(&config, self)
         }
     }
+}
 
-    /// Extraction reports as it goes — one summary line per pass, so watch mode
-    /// reports every rebuild rather than only the last one — and has nothing
-    /// left to render once the run is over.
-    fn render(&self, _output: &Self::Output) -> Result<(), CliError> {
-        Ok(())
+#[derive(Debug)]
+pub enum ExtractOutput {
+    Completed,
+    Check(ExtractCheckReport),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+enum ExtractCheckStatus {
+    Clean,
+    Drift,
+    Error,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExtractCheckReport {
+    status: ExtractCheckStatus,
+    catalogs: Vec<CatalogDrift>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<ExtractCheckError>,
+}
+
+impl ExtractCheckReport {
+    fn from_catalogs(mut catalogs: Vec<CatalogDrift>) -> Self {
+        catalogs.sort();
+        Self {
+            status: if catalogs.is_empty() {
+                ExtractCheckStatus::Clean
+            } else {
+                ExtractCheckStatus::Drift
+            },
+            catalogs,
+            error: None,
+        }
+    }
+
+    fn error(message: String) -> Self {
+        Self {
+            status: ExtractCheckStatus::Error,
+            catalogs: Vec::new(),
+            error: Some(ExtractCheckError { message }),
+        }
+    }
+
+    fn render_human(&self) {
+        match self.status {
+            ExtractCheckStatus::Clean => println!("✓ Catalogs are up to date."),
+            ExtractCheckStatus::Drift => {
+                println!("Catalog drift detected:");
+                for catalog in &self.catalogs {
+                    println!("  {} {}", catalog.change.human_verb(), catalog.path);
+                }
+            }
+            ExtractCheckStatus::Error => {}
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ExtractCheckError {
+    message: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CatalogDrift {
+    path: String,
+    change: CatalogChangeKind,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(rename_all = "camelCase")]
+enum CatalogChangeKind {
+    Created,
+    Modified,
+}
+
+impl CatalogChangeKind {
+    fn human_verb(self) -> &'static str {
+        match self {
+            Self::Created => "create",
+            Self::Modified => "modify",
+        }
     }
 }
 
@@ -102,7 +235,10 @@ struct TimingReport {
     total_files: usize,
 }
 
-fn run_extraction(config: &LoadedConfig, options: &ExtractOptions) -> Result<(), CliError> {
+fn run_extraction(
+    config: &LoadedConfig,
+    options: &ExtractOptions,
+) -> Result<ExtractOutput, CliError> {
     let mut cache = load_extract_cache(config, options);
     let result = run_extraction_with_cache(config, options, &mut cache);
     persist_extract_cache(config, options, &mut cache);
@@ -113,7 +249,7 @@ fn run_extraction_with_cache(
     config: &LoadedConfig,
     options: &ExtractOptions,
     cache: &mut ExtractCache,
-) -> Result<(), CliError> {
+) -> Result<ExtractOutput, CliError> {
     let started_at = Instant::now();
     let mut total_glob_ms = 0;
     let mut total_extract_ms = 0;
@@ -187,8 +323,19 @@ fn run_extraction_with_cache(
             write_jobs.push((catalog, &result.messages, locale.as_str()));
         }
     }
-    write_catalogs(&write_jobs, config, options)?;
+    let operation = if options.check {
+        CatalogOperation::Preview
+    } else {
+        CatalogOperation::Write
+    };
+    let drift = process_catalogs(&write_jobs, config, options, operation)?;
     let total_write_ms = write_started_at.elapsed().as_millis();
+
+    if options.check {
+        return Ok(ExtractOutput::Check(ExtractCheckReport::from_catalogs(
+            drift,
+        )));
+    }
 
     let total_ms = started_at.elapsed().as_millis();
     println!("✓ Extracted {total_messages} messages from {total_files} files ({total_ms}ms)");
@@ -206,7 +353,7 @@ fn run_extraction_with_cache(
         println!("{TIMING_MARKER}{}", serde_json::to_string(&report)?);
     }
 
-    Ok(())
+    Ok(ExtractOutput::Completed)
 }
 
 fn extract_from_catalog(
@@ -226,7 +373,7 @@ fn extract_from_catalog(
 
     if files.is_empty() {
         eprintln!(
-            "Warning: catalog '{}' matched no source files (include: {}); writing an empty catalog.",
+            "Warning: catalog '{}' matched no source files (include: {}); projecting an empty catalog.",
             catalog.path,
             catalog.include.join(", ")
         );
@@ -264,12 +411,11 @@ fn extract_from_catalog(
 }
 
 /*
- * Each (catalog, locale) write is independent work against a distinct target
- * file, so the jobs run concurrently. That overlaps the CPU-bound
- * parse/merge/serialize work in ferrocat across locales and — just as
- * important on macOS, where `File::sync_all` issues an F_FULLFSYNC barrier
- * per written catalog and its directory — the per-file durability stalls that
- * dominate the write phase for small catalogs.
+ * Each (catalog, locale) projection is independent work against a distinct
+ * target file, so writes and previews run concurrently. That overlaps the
+ * CPU-bound parse/merge/serialize work in ferrocat across locales and — for
+ * writes on macOS — the per-file durability stalls that dominate the write
+ * phase for small catalogs.
  *
  * Outcomes are collected per job and reported in job order afterwards, so
  * verbose output and the first error stay deterministic regardless of how the
@@ -277,23 +423,37 @@ fn extract_from_catalog(
  * attempted when an earlier one fails; the first failure in job order is the
  * one returned.
  */
-fn write_catalogs(
+#[derive(Clone, Copy)]
+enum CatalogOperation {
+    Write,
+    Preview,
+}
+
+struct CatalogJobOutcome {
+    lines: Vec<String>,
+    drift: Option<CatalogDrift>,
+}
+
+fn process_catalogs(
     write_jobs: &[(&ConfigCatalog, &Vec<CatalogUpdateMessage>, &str)],
     config: &LoadedConfig,
     options: &ExtractOptions,
-) -> Result<(), CliError> {
+    operation: CatalogOperation,
+) -> Result<Vec<CatalogDrift>, CliError> {
     let worker_count = write_jobs.len().min(
         std::thread::available_parallelism()
             .map(std::num::NonZeroUsize::get)
             .unwrap_or(1),
     );
 
-    let mut outcomes: Vec<Option<Result<Vec<String>, CliError>>> = Vec::new();
+    let mut outcomes: Vec<Option<Result<CatalogJobOutcome, CliError>>> = Vec::new();
     outcomes.resize_with(write_jobs.len(), || None);
 
     if worker_count <= 1 {
         for (outcome, (catalog, messages, locale)) in outcomes.iter_mut().zip(write_jobs) {
-            *outcome = Some(write_catalog(catalog, locale, messages, config, options));
+            *outcome = Some(process_catalog(
+                catalog, locale, messages, config, options, operation,
+            ));
         }
     } else {
         let collected = std::thread::scope(|scope| {
@@ -308,7 +468,9 @@ fn write_catalogs(
                             .map(|(index, (catalog, messages, locale))| {
                                 (
                                     index,
-                                    write_catalog(catalog, locale, messages, config, options),
+                                    process_catalog(
+                                        catalog, locale, messages, config, options, operation,
+                                    ),
                                 )
                             })
                             .collect::<Vec<_>>()
@@ -325,33 +487,31 @@ fn write_catalogs(
         }
     }
 
+    let mut drift = Vec::new();
     for outcome in outcomes {
-        let lines = outcome.expect("every write job produces an outcome")?;
-        for line in lines {
+        let outcome = outcome.expect("every catalog job produces an outcome")?;
+        for line in outcome.lines {
             eprintln!("{line}");
         }
+        if let Some(catalog) = outcome.drift {
+            drift.push(catalog);
+        }
     }
-    Ok(())
+    Ok(drift)
 }
 
-fn write_catalog(
+fn process_catalog(
     catalog: &ConfigCatalog,
     locale: &str,
     messages: &[CatalogUpdateMessage],
     config: &LoadedConfig,
     options: &ExtractOptions,
-) -> Result<Vec<String>, CliError> {
+    operation: CatalogOperation,
+) -> Result<CatalogJobOutcome, CliError> {
     let catalog_path = config
         .resolve_catalog_path(&catalog.path, locale)
         .with_extension(catalog.format.extension());
-    if let Some(parent) = catalog_path.parent() {
-        fs::create_dir_all(parent).map_err(|source| CliError::Io {
-            path: parent.to_path_buf(),
-            source,
-        })?;
-    }
-
-    let result = update_catalog_file(CatalogUpdateRequest {
+    let request = CatalogUpdateRequest {
         target_path: catalog_path.to_string_lossy().into_owned(),
         locale: locale.to_owned(),
         source_locale: config.source_locale.clone(),
@@ -360,20 +520,65 @@ fn write_catalog(
         format: catalog.format,
         po: catalog.po.clone().map(Into::into),
         messages: messages.to_vec(),
-    })?;
+    };
 
     let mut lines = Vec::new();
-    if options.verbose {
-        lines.push(format!("  -> {}", catalog_path.display()));
-        for diagnostic in result.diagnostics {
-            lines.push(format!(
-                "Warning: {}: {}",
-                diagnostic.code, diagnostic.message
-            ));
+    let drift = match operation {
+        CatalogOperation::Write => {
+            if let Some(parent) = catalog_path.parent() {
+                fs::create_dir_all(parent).map_err(|source| CliError::Io {
+                    path: parent.to_path_buf(),
+                    source,
+                })?;
+            }
+            let result = update_catalog_file(request)?;
+            if options.verbose {
+                lines.push(format!("  -> {}", catalog_path.display()));
+                for diagnostic in result.diagnostics {
+                    lines.push(format!(
+                        "Warning: {}: {}",
+                        diagnostic.code, diagnostic.message
+                    ));
+                }
+            }
+            None
         }
-    }
+        CatalogOperation::Preview => {
+            let result = preview_catalog_file_update(request)?;
+            if options.verbose {
+                lines.push(format!("  -> checked {}", catalog_path.display()));
+                for diagnostic in result.diagnostics {
+                    lines.push(format!(
+                        "Warning: {}: {}",
+                        diagnostic.code, diagnostic.message
+                    ));
+                }
+            }
+            let change = if result.created {
+                Some(CatalogChangeKind::Created)
+            } else if result.updated {
+                Some(CatalogChangeKind::Modified)
+            } else {
+                None
+            };
+            change.map(|change| CatalogDrift {
+                path: stable_catalog_path(&catalog_path, &config.root_dir),
+                change,
+            })
+        }
+    };
 
-    Ok(lines)
+    Ok(CatalogJobOutcome { lines, drift })
+}
+
+fn stable_catalog_path(path: &Path, root: &Path) -> String {
+    let relative = path.strip_prefix(root).unwrap_or(path);
+    let value = relative.to_string_lossy();
+    if std::path::MAIN_SEPARATOR == '\\' {
+        value.replace('\\', "/")
+    } else {
+        value.into_owned()
+    }
 }
 
 #[cfg(test)]

--- a/crates/palamedes-cli/src/commands/extract/test_support.rs
+++ b/crates/palamedes-cli/src/commands/extract/test_support.rs
@@ -12,6 +12,8 @@ pub(super) fn extract_options() -> ExtractOptions {
     ExtractOptions {
         config: None,
         watch: false,
+        check: false,
+        json: false,
         clean: false,
         force_clean: false,
         threads: None,

--- a/crates/palamedes-cli/src/commands/extract/watch.rs
+++ b/crates/palamedes-cli/src/commands/extract/watch.rs
@@ -227,7 +227,7 @@ fn run_watch_extraction(
     let result = run_extraction_with_cache(config, options, cache);
     persist_extract_cache(config, options, cache);
     match result {
-        Ok(()) => Ok(()),
+        Ok(_) => Ok(()),
         Err(error) => {
             eprintln!("Warning: {error} Continuing to watch for changes.");
             Ok(())

--- a/crates/palamedes-cli/src/error.rs
+++ b/crates/palamedes-cli/src/error.rs
@@ -6,6 +6,9 @@ use thiserror::Error;
 
 use crate::config::ConfigError;
 
+/// Exit status used when `extract --check` finds catalog drift.
+pub const CATALOG_DRIFT_EXIT_CODE: u8 = 3;
+
 #[derive(Debug, Error)]
 pub enum CliError {
     #[error(transparent)]
@@ -48,6 +51,10 @@ pub enum CliError {
     CompletenessBelowThreshold { threshold: String, locales: String },
     #[error("Extraction failed for {failures} source file(s); catalogs were not updated.")]
     ExtractionFailed { failures: usize },
+    #[error("Catalog extraction check found drift in {catalogs} catalog file(s).")]
+    CatalogDrift { catalogs: usize },
+    #[error("{message}")]
+    ExtractionCheckFailed { message: String },
     #[error("Source lint failed with {errors} error diagnostic(s).")]
     LintFailedOnError { errors: usize },
     #[error("Source lint failed with {errors} error(s) and {warnings} warning(s).")]
@@ -62,4 +69,14 @@ pub enum CliError {
     },
     #[error("Could not watch source files: {0}")]
     Watch(#[from] notify::Error),
+}
+
+impl CliError {
+    /// Process status for this failure.
+    pub fn exit_code(&self) -> u8 {
+        match self {
+            Self::CatalogDrift { .. } => CATALOG_DRIFT_EXIT_CODE,
+            _ => 1,
+        }
+    }
 }

--- a/crates/palamedes-cli/src/main.rs
+++ b/crates/palamedes-cli/src/main.rs
@@ -20,7 +20,7 @@ fn main() -> ExitCode {
         Ok(code) => ExitCode::from(code),
         Err(error) => {
             eprintln!("Error: {error}");
-            ExitCode::FAILURE
+            ExitCode::from(error.exit_code())
         }
     }
 }

--- a/crates/palamedes-cli/tests/extract_check.rs
+++ b/crates/palamedes-cli/tests/extract_check.rs
@@ -1,0 +1,319 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use serde_json::{json, Value};
+
+#[test]
+fn reports_po_and_fcl_drift_without_mutating_catalogs() {
+    let fixture = fixture_dir("po-fcl-drift");
+    write_project(
+        &fixture,
+        r#"locales: [de]
+source-locale: de
+extract-cache: true
+catalogs:
+  - path: locales/{locale}/messages
+    format: po
+    include: [src]
+  - path: catalogs/{locale}/messages
+    format: fcl
+    include: [src]
+"#,
+        &["Alpha", "Removed"],
+    );
+    let initial = pmds(&fixture, &["extract", "--no-cache"]);
+    assert!(initial.status.success(), "{initial:?}");
+
+    let po = fixture.join("locales/de/messages.po");
+    let fcl = fixture.join("catalogs/de/messages.fcl");
+    let fixed_mtime = UNIX_EPOCH + Duration::from_secs(1_000_000);
+    for path in [&po, &fcl] {
+        fs::File::options()
+            .write(true)
+            .open(path)
+            .expect("open catalog")
+            .set_modified(fixed_mtime)
+            .expect("set catalog mtime");
+    }
+    let po_before = fs::read(&po).expect("read PO before check");
+    let fcl_before = fs::read(&fcl).expect("read FCL before check");
+
+    write_source(&fixture, &["Alpha changed", "Added"]);
+    let cold = pmds(&fixture, &["extract", "--check", "--json", "--no-cache"]);
+    assert_eq!(cold.status.code(), Some(3), "{cold:?}");
+    let expected = json!({
+        "status": "drift",
+        "catalogs": [
+            { "path": "catalogs/de/messages.fcl", "change": "modified" },
+            { "path": "locales/de/messages.po", "change": "modified" }
+        ]
+    });
+    assert_eq!(json_stdout(&cold), expected);
+    assert!(
+        String::from_utf8_lossy(&cold.stderr)
+            .contains("Catalog extraction check found drift in 2 catalog file(s)"),
+        "{cold:?}"
+    );
+    assert_catalog_unchanged(&po, &po_before, fixed_mtime);
+    assert_catalog_unchanged(&fcl, &fcl_before, fixed_mtime);
+
+    age_file(&fixture.join("src/messages.ts"));
+    let cached = pmds(&fixture, &["extract", "--check", "--json"]);
+    let warm = pmds(&fixture, &["extract", "--check", "--json"]);
+    assert_eq!(cached.status.code(), Some(3), "{cached:?}");
+    assert_eq!(warm.status.code(), Some(3), "{warm:?}");
+    assert_eq!(cold.stdout, cached.stdout);
+    assert_eq!(cached.stdout, warm.stdout);
+    assert!(fixture.join(".palamedes/extract-cache.json").exists());
+    assert_catalog_unchanged(&po, &po_before, fixed_mtime);
+    assert_catalog_unchanged(&fcl, &fcl_before, fixed_mtime);
+
+    let update = pmds(&fixture, &["extract", "--no-cache"]);
+    assert!(update.status.success(), "{update:?}");
+    let clean_mtime = UNIX_EPOCH + Duration::from_secs(2_000_000);
+    let po_clean = fs::read(&po).expect("read clean PO");
+    let fcl_clean = fs::read(&fcl).expect("read clean FCL");
+    for path in [&po, &fcl] {
+        fs::File::options()
+            .write(true)
+            .open(path)
+            .expect("open clean catalog")
+            .set_modified(clean_mtime)
+            .expect("set clean catalog mtime");
+    }
+    let clean = pmds(&fixture, &["extract", "--check", "--json", "--no-cache"]);
+    assert!(clean.status.success(), "{clean:?}");
+    assert_eq!(
+        json_stdout(&clean),
+        json!({ "status": "clean", "catalogs": [] })
+    );
+    assert_catalog_unchanged(&po, &po_clean, clean_mtime);
+    assert_catalog_unchanged(&fcl, &fcl_clean, clean_mtime);
+
+    fs::remove_dir_all(fixture).expect("cleanup fixture");
+}
+
+#[test]
+fn reports_missing_catalog_as_created_without_creating_parent_directories() {
+    let fixture = fixture_dir("created");
+    write_project(
+        &fixture,
+        r#"locales: [de]
+source-locale: de
+extract-cache: false
+catalogs:
+  - path: generated/deep/{locale}/messages
+    format: po
+    include: [src]
+"#,
+        &["Hello"],
+    );
+
+    let output = pmds(&fixture, &["extract", "--check", "--json"]);
+
+    assert_eq!(output.status.code(), Some(3), "{output:?}");
+    assert_eq!(
+        json_stdout(&output),
+        json!({
+            "status": "drift",
+            "catalogs": [
+                { "path": "generated/deep/de/messages.po", "change": "created" }
+            ]
+        })
+    );
+    let human = pmds(&fixture, &["extract", "--check"]);
+    assert_eq!(human.status.code(), Some(3), "{human:?}");
+    assert_eq!(
+        String::from_utf8_lossy(&human.stdout),
+        "Catalog drift detected:\n  create generated/deep/de/messages.po\n"
+    );
+    assert!(!fixture.join("generated").exists());
+    assert!(
+        !fixture.join(".git").exists(),
+        "fixture intentionally runs outside Git"
+    );
+
+    fs::remove_dir_all(fixture).expect("cleanup fixture");
+}
+
+#[test]
+fn detects_formatting_only_drift_without_rewriting_the_catalog() {
+    let fixture = fixture_dir("formatting");
+    write_project(
+        &fixture,
+        r#"locales: [de]
+source-locale: de
+extract-cache: false
+catalogs:
+  - path: locales/{locale}/messages
+    format: po
+    include: [src]
+"#,
+        &["Hello"],
+    );
+    assert!(pmds(&fixture, &["extract"]).status.success());
+    let catalog = fixture.join("locales/de/messages.po");
+    let mut noncanonical = fs::read_to_string(&catalog).expect("read catalog");
+    noncanonical.push('\n');
+    fs::write(&catalog, &noncanonical).expect("write formatting drift");
+
+    let output = pmds(&fixture, &["extract", "--check", "--json"]);
+
+    assert_eq!(output.status.code(), Some(3), "{output:?}");
+    assert_eq!(
+        json_stdout(&output)["catalogs"],
+        json!([{ "path": "locales/de/messages.po", "change": "modified" }])
+    );
+    assert_eq!(
+        fs::read_to_string(&catalog).expect("read after check"),
+        noncanonical
+    );
+
+    fs::remove_dir_all(fixture).expect("cleanup fixture");
+}
+
+#[test]
+fn force_clean_check_previews_obsolete_removal_without_applying_it() {
+    let fixture = fixture_dir("force-clean");
+    write_project(
+        &fixture,
+        r#"locales: [de]
+source-locale: de
+extract-cache: false
+catalogs:
+  - path: locales/{locale}/messages
+    format: po
+    include: [src]
+"#,
+        &["Removed"],
+    );
+    assert!(pmds(&fixture, &["extract"]).status.success());
+    let catalog = fixture.join("locales/de/messages.po");
+    let before = fs::read_to_string(&catalog).expect("read catalog");
+    write_source(&fixture, &[]);
+
+    let check = pmds(&fixture, &["extract", "--check", "--json", "--force-clean"]);
+
+    assert_eq!(check.status.code(), Some(3), "{check:?}");
+    assert_eq!(
+        fs::read_to_string(&catalog).expect("read after check"),
+        before
+    );
+    let apply = pmds(&fixture, &["extract", "--force-clean"]);
+    assert!(apply.status.success(), "{apply:?}");
+    assert!(!fs::read_to_string(&catalog)
+        .expect("read after cleanup")
+        .contains("Removed"));
+
+    fs::remove_dir_all(fixture).expect("cleanup fixture");
+}
+
+#[test]
+fn json_distinguishes_execution_errors_and_clap_rejects_invalid_combinations() {
+    let fixture = fixture_dir("errors");
+    fs::create_dir_all(&fixture).expect("create fixture");
+
+    let failure = pmds(&fixture, &["extract", "--check", "--json"]);
+    assert_eq!(failure.status.code(), Some(1), "{failure:?}");
+    let report = json_stdout(&failure);
+    assert_eq!(report["status"], "error");
+    assert_eq!(report["catalogs"], json!([]));
+    assert!(
+        report["error"]["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("Could not find a Palamedes config")),
+        "{report}"
+    );
+
+    let watch = pmds(&fixture, &["extract", "--check", "--watch"]);
+    assert_eq!(watch.status.code(), Some(2), "{watch:?}");
+    assert!(
+        String::from_utf8_lossy(&watch.stderr).contains("cannot be used with '--watch'"),
+        "{watch:?}"
+    );
+    let json_without_check = pmds(&fixture, &["extract", "--json"]);
+    assert_eq!(
+        json_without_check.status.code(),
+        Some(2),
+        "{json_without_check:?}"
+    );
+    assert!(
+        String::from_utf8_lossy(&json_without_check.stderr)
+            .contains("the following required arguments were not provided"),
+        "{json_without_check:?}"
+    );
+
+    fs::remove_dir_all(fixture).expect("cleanup fixture");
+}
+
+fn write_project(root: &Path, config: &str, messages: &[&str]) {
+    fs::create_dir_all(root.join("src")).expect("create source directory");
+    fs::write(root.join("palamedes.yaml"), config).expect("write config");
+    write_source(root, messages);
+}
+
+fn write_source(root: &Path, messages: &[&str]) {
+    let calls = messages
+        .iter()
+        .map(|message| format!("t`{message}`"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    fs::write(
+        root.join("src/messages.ts"),
+        format!(
+            "import {{ t }} from \"@palamedes/core/macro\";\nexport function messages() {{ return [{calls}]; }}\n"
+        ),
+    )
+    .expect("write source");
+}
+
+fn pmds(root: &Path, arguments: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_pmds"))
+        .args(arguments)
+        .current_dir(root)
+        .output()
+        .expect("run pmds")
+}
+
+fn json_stdout(output: &Output) -> Value {
+    serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "parse JSON stdout: {error}\nstdout: {}\nstderr: {}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        )
+    })
+}
+
+fn assert_catalog_unchanged(path: &Path, expected: &[u8], modified: SystemTime) {
+    assert_eq!(fs::read(path).expect("read catalog after check"), expected);
+    assert_eq!(
+        fs::metadata(path)
+            .expect("catalog metadata")
+            .modified()
+            .expect("catalog mtime"),
+        modified
+    );
+}
+
+fn age_file(path: &Path) {
+    fs::File::options()
+        .write(true)
+        .open(path)
+        .expect("open source")
+        .set_modified(SystemTime::now() - Duration::from_secs(10))
+        .expect("age source");
+}
+
+fn fixture_dir(name: &str) -> PathBuf {
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time")
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "palamedes-cli-extract-check-{name}-{}-{stamp}",
+        std::process::id()
+    ))
+}

--- a/crates/palamedes/src/catalog_update.rs
+++ b/crates/palamedes/src/catalog_update.rs
@@ -5,11 +5,11 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use crate::diagnostic::CatalogDiagnostic;
 use crate::error::{PalamedesError, PalamedesResult};
 use ferrocat::{
-    parse_catalog as ferrocat_parse_catalog, update_catalog_file as ferrocat_update_catalog_file,
-    ApiError, CatalogOrigin, CatalogStats, CatalogUpdateInput, CatalogUpdateResult,
-    EffectiveTranslationRef, ObsoleteStrategy, ParseCatalogOptions, ParsedCatalog,
-    PlaceholderCommentMode, RenderOptions, SerializeOptions, SourceExtractedMessage,
-    UpdateCatalogFileOptions, UpdateCatalogOptions,
+    parse_catalog as ferrocat_parse_catalog, update_catalog as ferrocat_update_catalog,
+    update_catalog_file as ferrocat_update_catalog_file, ApiError, CatalogOrigin, CatalogStats,
+    CatalogUpdateInput, CatalogUpdateResult, EffectiveTranslationRef, ObsoleteStrategy,
+    ParseCatalogOptions, ParsedCatalog, PlaceholderCommentMode, RenderOptions, SerializeOptions,
+    SourceExtractedMessage, UpdateCatalogFileOptions, UpdateCatalogOptions,
 };
 use ferrocat::{AiProvenance as FerrocatAiProvenance, MachineMetadata as FerrocatMachineMetadata};
 use serde::{Deserialize, Serialize};
@@ -132,6 +132,22 @@ pub struct CatalogUpdateResponse {
     pub diagnostics: Vec<CatalogDiagnostic>,
 }
 
+/// Non-mutating result of rendering the update a catalog file would receive.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CatalogUpdatePreview {
+    /// Whether the target catalog does not exist and would be created.
+    pub created: bool,
+    /// Whether the rendered content differs from the current target content.
+    pub updated: bool,
+    /// Complete catalog content that a file update would write.
+    pub content: String,
+    /// Aggregate update statistics.
+    pub stats: CatalogUpdateStats,
+    /// Diagnostics emitted while rendering the update.
+    pub diagnostics: Vec<CatalogDiagnostic>,
+}
+
 /// Aggregate statistics from a catalog update.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -240,6 +256,27 @@ pub fn update_catalog_file(
     update_catalog_file_source_first(request)
 }
 
+/// Renders the update for a catalog file without creating or changing it.
+///
+/// This uses the same source-first projection, cleanup policy, compatibility
+/// handling, and Ferrocat rendering options as [`update_catalog_file`].
+///
+/// # Errors
+///
+/// Returns an error when the target file cannot be read, when Ferrocat rejects
+/// the projected messages, or when any extracted message is empty.
+pub fn preview_catalog_file_update(
+    request: CatalogUpdateRequest,
+) -> PalamedesResult<CatalogUpdatePreview> {
+    let target_path = validated_target_path(&request.target_path)?;
+    let existing = read_optional_catalog(&target_path)?;
+    let result = update_catalog_source_first(
+        request,
+        CatalogUpdateDestination::Preview(existing.as_deref()),
+    )?;
+    Ok(public_preview_result(result))
+}
+
 /// Parses a catalog file into the public semantic result shape.
 ///
 /// # Errors
@@ -263,16 +300,33 @@ pub fn parse_catalog(request: &CatalogParseRequest) -> PalamedesResult<CatalogPa
 }
 
 fn update_catalog_file_source_first(
-    mut request: CatalogUpdateRequest,
+    request: CatalogUpdateRequest,
 ) -> PalamedesResult<CatalogUpdateResponse> {
-    let target_path = PathBuf::from(&request.target_path);
-    if target_path.as_os_str().is_empty() {
-        return Err(PalamedesError::from(ApiError::InvalidArguments(
-            "target_path must not be empty".to_owned(),
-        )));
-    }
+    let target_path = validated_target_path(&request.target_path)?;
+    let result =
+        update_catalog_source_first(request, CatalogUpdateDestination::File(&target_path))?;
+    Ok(public_update_result(result))
+}
+
+#[derive(Clone, Copy)]
+enum CatalogUpdateDestination<'a> {
+    File(&'a Path),
+    Preview(Option<&'a str>),
+}
+
+fn update_catalog_source_first(
+    mut request: CatalogUpdateRequest,
+    destination: CatalogUpdateDestination<'_>,
+) -> PalamedesResult<CatalogUpdateResult> {
     validate_po_options(request.format, request.po.as_ref())?;
-    preserve_existing_po_apostrophe_identities(&mut request, &target_path)?;
+    match destination {
+        CatalogUpdateDestination::File(target_path) => {
+            preserve_existing_po_apostrophe_identities(&mut request, target_path)?;
+        }
+        CatalogUpdateDestination::Preview(existing) => {
+            preserve_existing_po_apostrophe_identities_from_content(&mut request, existing)?;
+        }
+    }
     let custom_header_attributes =
         BTreeMap::from([("X-Generator".to_owned(), "palamedes".to_owned())]);
     let input = CatalogUpdateInput::SourceFirst(
@@ -301,30 +355,58 @@ fn update_catalog_file_source_first(
             .with_custom_header_attributes(&custom_header_attributes)
             .with_po_serialize_options(po_serialize_options(request.po.as_ref()));
     }
-    let update_options = UpdateCatalogOptions::new(&request.source_locale, input)
+    let mut update_options = UpdateCatalogOptions::new(&request.source_locale, input)
         .with_locale(&request.locale)
         .with_mode(request.format.ferrocat_mode())
         .with_obsolete_strategy(obsolete_strategy)
         .with_overwrite_source_translations(true)
         .with_render(render)
         .with_now(&now);
-    /*
-     * Catalog files are repository-owned, regenerable artifacts, so the write
-     * skips Ferrocat's per-file durability barriers (File::sync_all is
-     * F_FULLFSYNC on macOS and was the dominant fixed cost of the write phase
-     * there). The rename stays atomic; after a crash the worst case is an old
-     * or missing catalog that the next extract rewrites.
-     */
-    let file_options = UpdateCatalogFileOptions::new(
-        &target_path,
-        &request.source_locale,
-        CatalogUpdateInput::default(),
-    )
-    .with_options(update_options)
-    .with_durability(ferrocat::WriteDurability::Rename);
-    let result = ferrocat_update_catalog_file(file_options).map_err(PalamedesError::from)?;
+    match destination {
+        CatalogUpdateDestination::File(target_path) => {
+            /*
+             * Catalog files are repository-owned, regenerable artifacts, so
+             * the write skips Ferrocat's per-file durability barriers
+             * (File::sync_all is F_FULLFSYNC on macOS and was the dominant
+             * fixed cost of the write phase there). The rename stays atomic;
+             * after a crash the worst case is an old or missing catalog that
+             * the next extract rewrites.
+             */
+            let file_options = UpdateCatalogFileOptions::new(
+                target_path,
+                &request.source_locale,
+                CatalogUpdateInput::default(),
+            )
+            .with_options(update_options)
+            .with_durability(ferrocat::WriteDurability::Rename);
+            ferrocat_update_catalog_file(file_options).map_err(PalamedesError::from)
+        }
+        CatalogUpdateDestination::Preview(existing) => {
+            update_options.existing = existing;
+            ferrocat_update_catalog(update_options).map_err(PalamedesError::from)
+        }
+    }
+}
 
-    Ok(public_update_result(result))
+fn validated_target_path(value: &str) -> PalamedesResult<PathBuf> {
+    let target_path = PathBuf::from(value);
+    if target_path.as_os_str().is_empty() {
+        return Err(PalamedesError::from(ApiError::InvalidArguments(
+            "target_path must not be empty".to_owned(),
+        )));
+    }
+    Ok(target_path)
+}
+
+fn read_optional_catalog(target_path: &Path) -> PalamedesResult<Option<String>> {
+    match std::fs::read_to_string(target_path) {
+        Ok(content) => Ok(Some(content)),
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(source) => Err(PalamedesError::ReadFile {
+            path: target_path.to_path_buf(),
+            source,
+        }),
+    }
 }
 
 /// Keeps a translated PO entry attached when an extractor upgrade only changes
@@ -351,22 +433,33 @@ fn preserve_existing_po_apostrophe_identities(
         return Ok(());
     }
 
-    let content = match std::fs::read_to_string(target_path) {
-        Ok(content) => content,
-        Err(source) if source.kind() == std::io::ErrorKind::NotFound => return Ok(()),
-        Err(source) => {
-            return Err(PalamedesError::ReadFile {
-                path: target_path.to_path_buf(),
-                source,
-            });
-        }
+    let content = read_optional_catalog(target_path)?;
+    preserve_existing_po_apostrophe_identities_from_content(request, content.as_deref())
+}
+
+fn preserve_existing_po_apostrophe_identities_from_content(
+    request: &mut CatalogUpdateRequest,
+    content: Option<&str>,
+) -> PalamedesResult<()> {
+    if request.format != super::catalog_artifact::PalamedesCatalogFormat::Po {
+        return Ok(());
+    }
+    if !request
+        .messages
+        .iter()
+        .any(|message| message.message.contains('\''))
+    {
+        return Ok(());
+    }
+    let Some(content) = content.filter(|content| !content.is_empty()) else {
+        return Ok(());
     };
-    if content.is_empty() || request.messages.is_empty() {
+    if request.messages.is_empty() {
         return Ok(());
     }
 
     let parsed = ferrocat_parse_catalog(
-        ParseCatalogOptions::new(&content, &request.source_locale)
+        ParseCatalogOptions::new(content, &request.source_locale)
             .with_locale(&request.locale)
             .with_mode(request.format.ferrocat_mode()),
     )
@@ -497,6 +590,20 @@ fn public_update_result(result: CatalogUpdateResult) -> CatalogUpdateResponse {
     }
 }
 
+fn public_preview_result(result: CatalogUpdateResult) -> CatalogUpdatePreview {
+    CatalogUpdatePreview {
+        created: result.created,
+        updated: result.updated,
+        content: result.content,
+        stats: public_stats(&result.stats),
+        diagnostics: result
+            .diagnostics
+            .into_iter()
+            .map(CatalogDiagnostic::from)
+            .collect(),
+    }
+}
+
 fn public_parse_result(parsed: ParsedCatalog) -> CatalogParseResult {
     CatalogParseResult {
         locale: parsed.locale,
@@ -614,8 +721,9 @@ mod tests {
     use std::collections::BTreeMap;
 
     use super::{
-        parse_catalog, update_catalog_file, CatalogParseRequest, CatalogUpdateMessage,
-        CatalogUpdateOrigin, CatalogUpdateRequest, PoLineBreaks, PoOutputOptions,
+        parse_catalog, preview_catalog_file_update, update_catalog_file, CatalogParseRequest,
+        CatalogUpdateMessage, CatalogUpdateOrigin, CatalogUpdateRequest, PoLineBreaks,
+        PoOutputOptions,
     };
     use crate::parse_po;
     use ferrocat::{machine_translation_hash, EffectiveTranslationRef};
@@ -1075,6 +1183,72 @@ msgstr "Zebra""#;
         let po = parse_po(&std::fs::read_to_string(&path).expect("read output")).expect("parse po");
         assert_eq!(po.items.len(), 1);
         assert_eq!(po.items[0].msgid, "Hello");
+    }
+
+    #[test]
+    fn previews_the_exact_file_update_without_changing_the_target() {
+        let path = temp_file("preview-existing");
+        std::fs::write(
+            &path,
+            concat!(
+                "msgid \"Hello\"\n",
+                "msgstr \"Hallo\"\n\n",
+                "msgid \"Old\"\n",
+                "msgstr \"Alt\"\n",
+            ),
+        )
+        .expect("write existing");
+        let before = std::fs::read(&path).expect("read existing bytes");
+        let request = || CatalogUpdateRequest {
+            target_path: path.clone(),
+            locale: "de".to_owned(),
+            source_locale: "en".to_owned(),
+            clean: false,
+            force_clean: false,
+            format: crate::PalamedesCatalogFormat::Po,
+            po: None,
+            messages: vec![
+                message("Hello", None, "src/App.tsx"),
+                message("New", None, "src/New.tsx"),
+            ],
+        };
+
+        let preview = preview_catalog_file_update(request()).expect("preview");
+
+        assert!(!preview.created);
+        assert!(preview.updated);
+        assert!(preview.content.contains("msgstr \"Hallo\""));
+        assert!(preview.content.contains("msgid \"New\""));
+        assert_eq!(std::fs::read(&path).expect("read after preview"), before);
+
+        update_catalog_file(request()).expect("apply update");
+        assert_eq!(
+            std::fs::read_to_string(&path).expect("read applied update"),
+            preview.content
+        );
+    }
+
+    #[test]
+    fn previews_a_missing_catalog_without_creating_it() {
+        let path = temp_file_with_extension("preview-created", "fcl");
+        let _ = std::fs::remove_file(&path);
+
+        let preview = preview_catalog_file_update(CatalogUpdateRequest {
+            target_path: path.clone(),
+            locale: "de".to_owned(),
+            source_locale: "en".to_owned(),
+            clean: false,
+            force_clean: false,
+            format: crate::PalamedesCatalogFormat::Fcl,
+            po: None,
+            messages: vec![message("Hello", None, "src/App.tsx")],
+        })
+        .expect("preview");
+
+        assert!(preview.created);
+        assert!(preview.updated);
+        assert!(preview.content.starts_with("%FCL1"));
+        assert!(!std::path::Path::new(&path).exists());
     }
 
     #[test]

--- a/crates/palamedes/src/lib.rs
+++ b/crates/palamedes/src/lib.rs
@@ -76,10 +76,10 @@ pub use catalog_three_way::{
     CatalogMergeSide, CatalogThreeWayMergeRequest, CATALOG_MODIFY_DELETE_RESOLVED,
 };
 pub use catalog_update::{
-    parse_catalog, update_catalog_file, AiProvenance, CatalogOriginMetadata, CatalogParseRequest,
-    CatalogParseResult, CatalogUpdateMessage, CatalogUpdateOrigin, CatalogUpdateRequest,
-    CatalogUpdateResponse, CatalogUpdateStats, MachineMetadata, ParsedCatalogMessage, PoLineBreaks,
-    PoOutputOptions,
+    parse_catalog, preview_catalog_file_update, update_catalog_file, AiProvenance,
+    CatalogOriginMetadata, CatalogParseRequest, CatalogParseResult, CatalogUpdateMessage,
+    CatalogUpdateOrigin, CatalogUpdatePreview, CatalogUpdateRequest, CatalogUpdateResponse,
+    CatalogUpdateStats, MachineMetadata, ParsedCatalogMessage, PoLineBreaks, PoOutputOptions,
 };
 pub use diagnostic::{CatalogDiagnostic, CatalogDiagnosticSeverity, CatalogDiagnosticSourceKey};
 pub use error::{PalamedesError, PalamedesResult};

--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -6,7 +6,7 @@ commands.
 
 ## Commands
 
-- `pmds extract`
+- `pmds extract` (`--check` verifies catalog drift without rewriting files)
 - `pmds lint`
 - `pmds audit`
 - `pmds report`

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -32,6 +32,8 @@ pmds extract
 pmds extract --config ./palamedes.yaml
 pmds extract --clean
 pmds extract --force-clean
+pmds extract --check
+pmds extract --check --json
 pmds extract --watch
 pmds extract --verbose
 ```
@@ -44,9 +46,46 @@ Options:
 | `-w, --watch`         | Re-run extraction on file changes (debounced). Fatal authoring errors are printed and watching continues; the config file is watched and reloaded on change. |
 | `--clean`             | Remove obsolete entries with `obsolete-since` at least 30 days old; keep undated obsolete entries.                                                           |
 | `--force-clean`       | Remove all obsolete entries immediately, including undated entries.                                                                                          |
+| `--check`             | Exit unsuccessfully when extraction would create or modify a catalog, without writing catalog files. Cannot be combined with `--watch`.                      |
+| `--json`              | With `--check`, print one deterministic result document.                                                                                                     |
 | `--threads <COUNT>`   | Worker threads for the parallel extraction pass. Overrides `extract-threads` in the config; defaults to `4`; `1` runs serial.                                |
 | `--no-cache`          | Ignore and do not write the extraction cache in `.palamedes/`. Use for a cold run; the cache is on by default.                                               |
 | `-v, --verbose`       | Print verbose extraction details.                                                                                                                            |
+
+`--check` runs the normal source discovery, extraction, catalog projection,
+obsolete-entry policy, metadata generation, and PO/FCL serialization in memory.
+It compares the exact resulting bytes with each configured catalog. Catalog
+files, missing catalog directories, and catalog modification times remain
+unchanged. The source-analysis cache may still be populated; add `--no-cache`
+when the entire check must avoid cache writes.
+
+`--clean` and `--force-clean` keep their normal meaning in check mode. If both
+are present, `--force-clean` wins. Because regular extraction does not delete
+catalog files, the current catalog change kinds are `created` and `modified`;
+cleanup flags remove obsolete entries inside the projected file.
+
+JSON paths are relative to the configuration root when possible, use `/` as
+the separator, and are sorted deterministically:
+
+```json
+{
+  "status": "drift",
+  "catalogs": [
+    { "path": "catalogs/de/messages.fcl", "change": "modified" },
+    { "path": "locales/de/messages.po", "change": "created" }
+  ]
+}
+```
+
+A clean result uses `{ "status": "clean", "catalogs": [] }`. An extraction
+or configuration failure uses status `error`, an empty `catalogs` array, and
+`error.message`. Exit code `0` means clean, `1` means the check could not run,
+`2` is reserved by Clap for invalid command-line usage, and `3` means catalog
+drift. A minimal CI check is:
+
+```bash
+pnpm exec pmds extract --check --json
+```
 
 ## `pmds lint`
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -15,6 +15,7 @@ configuration, plugin dispatch, output, and exit codes.
 Use `@palamedes/cli` when you want:
 
 - a supported extraction command for Palamedes projects
+- a non-mutating catalog drift check for CI
 - structured catalog audits in CI
 - watch mode during development
 - a clean way to update `.po` catalogs in CI, with opt-in `.fcl` storage
@@ -73,6 +74,8 @@ pnpm exec pmds extract
 pnpm exec pmds extract --watch
 pnpm exec pmds extract --clean
 pnpm exec pmds extract --force-clean
+pnpm exec pmds extract --check
+pnpm exec pmds extract --check --json
 pnpm exec pmds extract --config ./palamedes.yaml
 pnpm exec pmds extract --threads 1
 pnpm exec pmds extract --no-cache
@@ -101,6 +104,17 @@ must fail CI; the default continues to fail only on errors.
 `pmds lint` is non-mutating and checks Palamedes authoring across the same
 configured sources as extraction. It supports stable human and JSON output,
 configured rule levels, code-specific line suppressions, and CI thresholds.
+
+`pmds extract --check` projects configured PO and FCL catalogs through the
+same extraction and serialization path without changing catalog files or
+creating missing catalog directories. Add `--json` for deterministic CI
+output. Exit code `0` means clean, `1` means extraction or configuration
+failed, `2` means invalid CLI usage, and `3` means catalog drift. The extraction
+cache may still be updated unless `--no-cache` is present.
+
+```bash
+pnpm exec pmds extract --check --json
+```
 
 `pmds catalog convert` preserves translator comments, obsolete state, and
 review markers such as `fuzzy` when converting PO catalogs to FCL.


### PR DESCRIPTION
## Summary

- add non-mutating pmds extract --check and deterministic --json output
- preview PO and FCL catalogs through the same Ferrocat projection path without changing catalog files or missing directories
- define stable exit codes, cache and cleanup behavior, and reject incompatible watch usage
- document the CI contract and cover clean, created, modified, formatting, obsolete, cache, outside-Git, and error cases

## Exit codes

- 0: catalogs are clean
- 1: extraction or configuration failed
- 2: invalid CLI usage (Clap)
- 3: catalog drift

## Validation

- pnpm agent:check
- pnpm build:site
- cargo test -p palamedes-cli --test extract_check --locked

Closes #524