### PR TITLE
fix(next-example): allow localhost dev origin for catalog test

### DIFF
--- a/examples/nextjs-cookie/next.config.mjs
+++ b/examples/nextjs-cookie/next.config.mjs
@@ -1,7 +1,9 @@
 import { withPalamedes } from "@palamedes/next-plugin"
 
 export default withPalamedes(
-  {},
+  {
+    allowedDevOrigins: ["127.0.0.1"],
+  },
   {
     messageSplitting: true,
     serverFunctions: true,


### PR DESCRIPTION
## What this fixes

The latest main CI runs fail on Ubuntu Node 24 in `Verify Next.js development catalog invalidation`.

Next 16 rejects the test browser requests from `127.0.0.1` unless that origin is explicitly allowed in development mode, and prints:

```txt
To allow this host in development, add it to "allowedDevOrigins" in next.config.js and restart the dev server:
  allowedDevOrigins: ['127.0.0.1']
```

The dev invalidation script intentionally drives the example through `http://127.0.0.1:4199`, so this PR adds that host to the example's Next config.

## Validation

- `corepack pnpm build`
- `corepack pnpm format:check -- examples/nextjs-cookie/next.config.mjs`

I also started `corepack pnpm --filter @palamedes/example-nextjs-cookie test:message-splitting:development`; the local Next dev server reached `GET / 200` without the CI's `allowedDevOrigins` warning after this change, but the script could not finish on this host because the Playwright Chromium browser binary is not installed locally.
