### PR TITLE
fix(core-node): catch panics at N-API boundary

### DIFF
--- a/crates/palamedes-node/src/catalog.rs
+++ b/crates/palamedes-node/src/catalog.rs
@@ -1655,7 +1655,7 @@ impl From<palamedes::CatalogArtifactResult> for CatalogArtifactResult {
     }
 }
 
-#[napi]
+#[napi(catch_unwind)]
 #[allow(clippy::needless_pass_by_value)]
 /// Updates a PO catalog file from source-first extracted messages.
 ///
@@ -1669,7 +1669,7 @@ pub fn update_catalog_file(request: CatalogUpdateRequest) -> Result<CatalogUpdat
         .and_then(CatalogUpdateResult::try_from)
 }
 
-#[napi]
+#[napi(catch_unwind)]
 #[allow(clippy::needless_pass_by_value)]
 /// Parses a PO catalog file into the public semantic catalog shape.
 ///
@@ -1684,7 +1684,7 @@ pub fn parse_catalog(request: CatalogParseRequest) -> Result<CatalogParseResult>
         .map_err(to_napi_error)
 }
 
-#[napi]
+#[napi(catch_unwind)]
 #[allow(clippy::needless_pass_by_value)]
 /// Enumerates provider-neutral translation candidates across configured catalogs.
 ///
@@ -1700,7 +1700,7 @@ pub fn list_translation_candidates(
         .map_err(to_napi_error)
 }
 
-#[napi]
+#[napi(catch_unwind)]
 #[allow(clippy::needless_pass_by_value)]
 /// Validates and atomically applies provider-neutral translation patches.
 ///
@@ -1716,7 +1716,7 @@ pub fn apply_translation_patches(
         .and_then(TranslationPatchResult::try_from)
 }
 
-#[napi]
+#[napi(catch_unwind)]
 #[allow(clippy::needless_pass_by_value)]
 /// Audits configured catalogs with Ferrocat catalog QA checks.
 ///
@@ -1731,7 +1731,7 @@ pub fn audit_catalogs(request: CatalogAuditRequest) -> Result<CatalogAuditResult
         .and_then(CatalogAuditResult::try_from)
 }
 
-#[napi]
+#[napi(catch_unwind)]
 #[allow(clippy::needless_pass_by_value)]
 /// Derives normalized semantic metadata from an ICU MessageFormat v1 message.
 ///
@@ -1747,7 +1747,7 @@ pub fn derive_message_metadata(
         .map_err(to_napi_error)
 }
 
-#[napi]
+#[napi(catch_unwind)]
 #[allow(clippy::needless_pass_by_value)]
 /// Normalizes progressive semantic metadata into canonical object form.
 ///
@@ -1760,14 +1760,14 @@ pub fn normalize_message_metadata(input: MessageMetadataInput) -> Result<Message
         .map_err(to_napi_error)
 }
 
-#[napi]
+#[napi(catch_unwind)]
 #[allow(clippy::needless_pass_by_value)]
 /// Validates progressive semantic metadata against its `msgid`.
 pub fn validate_message_metadata(input: MessageMetadataInput) -> MessageMetadataValidationReport {
     palamedes::validate_message_metadata(input.into()).into()
 }
 
-#[napi]
+#[napi(catch_unwind)]
 #[allow(clippy::needless_pass_by_value)]
 /// Combines multiple catalog contents into one deterministic catalog.
 ///
@@ -1782,7 +1782,7 @@ pub fn combine_catalogs(request: CatalogCombineRequest) -> Result<CatalogCombine
         .and_then(CatalogCombineResult::try_from)
 }
 
-#[napi]
+#[napi(catch_unwind)]
 #[allow(clippy::needless_pass_by_value)]
 /// Combines exactly two catalog files and replaces the output after a successful combine.
 ///
@@ -1798,7 +1798,7 @@ pub fn combine_catalog_files(
         .and_then(CatalogFileCombineResult::try_from)
 }
 
-#[napi]
+#[napi(catch_unwind)]
 #[allow(clippy::needless_pass_by_value)]
 /// Merges explicit ancestor, ours, and theirs catalog contents.
 ///
@@ -1814,7 +1814,7 @@ pub fn merge_catalogs_three_way(
         .and_then(CatalogCombineResult::try_from)
 }
 
-#[napi]
+#[napi(catch_unwind)]
 #[allow(clippy::needless_pass_by_value)]
 /// Merges explicit ancestor, ours, and theirs files and atomically replaces the output.
 ///
@@ -1829,7 +1829,7 @@ pub fn merge_catalog_files_three_way(
         .and_then(CatalogFileCombineResult::try_from)
 }
 
-#[napi]
+#[napi(catch_unwind)]
 #[allow(clippy::needless_pass_by_value)]
 /// Compiles a full host-neutral catalog artifact for a requested locale.
 ///
@@ -1844,7 +1844,7 @@ pub fn compile_catalog_artifact(request: CatalogArtifactRequest) -> Result<Catal
         .map_err(to_napi_error)
 }
 
-#[napi]
+#[napi(catch_unwind)]
 #[allow(clippy::needless_pass_by_value)]
 /// Compiles a catalog and renders the JavaScript module consumed by bundlers.
 ///
@@ -1884,7 +1884,7 @@ pub fn compile_catalog_module(request: CatalogModuleRequest) -> Result<CatalogMo
     create_catalog_module_result(artifact, &render_options)
 }
 
-#[napi]
+#[napi(catch_unwind)]
 #[allow(clippy::needless_pass_by_value)]
 /// Compiles a selected subset of runtime IDs for a requested locale.
 ///
@@ -1968,7 +1968,7 @@ fn create_catalog_module_result(
     })
 }
 
-#[napi]
+#[napi(catch_unwind)]
 #[allow(clippy::needless_pass_by_value)]
 /// Renders catalog messages as the executable JavaScript module consumed by bundlers.
 ///

--- a/crates/palamedes-node/src/extract.rs
+++ b/crates/palamedes-node/src/extract.rs
@@ -102,7 +102,7 @@ impl TryFrom<palamedes::ExtractCatalogMessagesResult> for ExtractCatalogMessages
     }
 }
 
-#[napi]
+#[napi(catch_unwind)]
 #[allow(clippy::needless_pass_by_value)]
 /// Extracts source-first messages from a JavaScript, TypeScript, or MDX module.
 ///
@@ -126,7 +126,7 @@ pub fn extract_messages(
         })
 }
 
-#[napi]
+#[napi(catch_unwind)]
 #[allow(clippy::needless_pass_by_value)]
 /// Extracts and aggregates source-first catalog update messages from files.
 ///

--- a/crates/palamedes-node/src/lib.rs
+++ b/crates/palamedes-node/src/lib.rs
@@ -30,7 +30,7 @@ mod tests {
             let unguarded_exports = napi_attributes(&source)
                 .into_iter()
                 .filter(|(_, attribute)| {
-                    !is_object_or_enum_annotation(attribute) && !attribute.contains("catch_unwind")
+                    !is_object_or_enum_annotation(attribute) && !has_catch_unwind_option(attribute)
                 })
                 .map(|(line, _)| line)
                 .collect::<Vec<_>>();
@@ -56,6 +56,7 @@ mod tests {
             vec![(1, "#[napi(js_name = \"exported\")]".to_owned())]
         );
         assert!(!is_object_or_enum_annotation(&attributes[0].1));
+        assert!(!has_catch_unwind_option(&attributes[0].1));
     }
 
     #[test]
@@ -69,6 +70,31 @@ mod tests {
         assert!(attributes
             .iter()
             .all(|(_, attribute)| is_object_or_enum_annotation(attribute)));
+    }
+
+    #[test]
+    fn napi_option_scan_ignores_string_and_comment_collisions() {
+        let unguarded_attributes = [
+            format!("#[{}]", r#"napi(js_name = "catch_unwind")"#),
+            format!("#[{}]", r#"napi(ts_return_type = "catch_unwind")"#),
+            format!("#[{}]", r##"napi(ts_return_type = r#"catch_unwind"#)"##),
+            format!("#[{}]", "napi(\njs_name = \"exported\", // catch_unwind\n)"),
+            format!("#[{}]", "napi(/* catch_unwind */ js_name = \"exported\")"),
+        ];
+
+        assert!(unguarded_attributes
+            .iter()
+            .all(|attribute| !has_catch_unwind_option(attribute)));
+    }
+
+    #[test]
+    fn napi_option_scan_recognizes_multiline_catch_unwind_option() {
+        let attribute = format!(
+            "#[{}]",
+            "napi(\njs_name = \"exported\",\n// Keep panics inside the N-API boundary.\ncatch_unwind,\nts_return_type = \"string\"\n)"
+        );
+
+        assert!(has_catch_unwind_option(&attribute));
     }
 
     fn rust_source_modules(dir: &Path) -> Vec<PathBuf> {
@@ -112,10 +138,168 @@ mod tests {
     }
 
     fn is_object_or_enum_annotation(attribute: &str) -> bool {
-        let normalized = attribute
-            .chars()
-            .filter(|character| !character.is_whitespace())
-            .collect::<String>();
-        normalized.starts_with("#[napi(object") || normalized.starts_with("#[napi(string_enum")
+        matches!(
+            napi_option_names(attribute).first().copied(),
+            Some("object" | "string_enum")
+        )
+    }
+
+    fn has_catch_unwind_option(attribute: &str) -> bool {
+        napi_option_names(attribute)
+            .into_iter()
+            .any(|option| option == "catch_unwind")
+    }
+
+    fn napi_option_names(attribute: &str) -> Vec<&str> {
+        let Some(options) = attribute
+            .strip_prefix("#[napi(")
+            .and_then(|attribute| attribute.strip_suffix(")]"))
+        else {
+            return Vec::new();
+        };
+
+        top_level_options(options)
+            .into_iter()
+            .filter_map(leading_identifier)
+            .collect()
+    }
+
+    fn top_level_options(options: &str) -> Vec<&str> {
+        let bytes = options.as_bytes();
+        let mut segments = Vec::new();
+        let mut start = 0;
+        let mut index = 0;
+        let mut depth = 0_usize;
+
+        while index < bytes.len() {
+            match bytes[index] {
+                b'/' if bytes.get(index + 1) == Some(&b'/') => {
+                    index = skip_line_comment(bytes, index + 2);
+                }
+                b'/' if bytes.get(index + 1) == Some(&b'*') => {
+                    index = skip_block_comment(bytes, index + 2);
+                }
+                b'"' => index = skip_quoted_string(bytes, index + 1),
+                b'r' => {
+                    if let Some(next) = skip_raw_string(bytes, index) {
+                        index = next;
+                    } else {
+                        index += 1;
+                    }
+                }
+                b'(' | b'[' | b'{' => {
+                    depth += 1;
+                    index += 1;
+                }
+                b')' | b']' | b'}' => {
+                    depth = depth.saturating_sub(1);
+                    index += 1;
+                }
+                b',' if depth == 0 => {
+                    segments.push(&options[start..index]);
+                    start = index + 1;
+                    index += 1;
+                }
+                _ => index += 1,
+            }
+        }
+
+        segments.push(&options[start..]);
+        segments
+    }
+
+    fn leading_identifier(option: &str) -> Option<&str> {
+        let bytes = option.as_bytes();
+        let mut index = 0;
+
+        loop {
+            while bytes.get(index).is_some_and(u8::is_ascii_whitespace) {
+                index += 1;
+            }
+            match (bytes.get(index), bytes.get(index + 1)) {
+                (Some(b'/'), Some(b'/')) => index = skip_line_comment(bytes, index + 2),
+                (Some(b'/'), Some(b'*')) => index = skip_block_comment(bytes, index + 2),
+                _ => break,
+            }
+        }
+
+        let start = index;
+        if !bytes
+            .get(index)
+            .is_some_and(|byte| byte.is_ascii_alphabetic() || *byte == b'_')
+        {
+            return None;
+        }
+        index += 1;
+        while bytes
+            .get(index)
+            .is_some_and(|byte| byte.is_ascii_alphanumeric() || *byte == b'_')
+        {
+            index += 1;
+        }
+        Some(&option[start..index])
+    }
+
+    fn skip_line_comment(bytes: &[u8], mut index: usize) -> usize {
+        while bytes.get(index).is_some_and(|byte| *byte != b'\n') {
+            index += 1;
+        }
+        index
+    }
+
+    fn skip_block_comment(bytes: &[u8], mut index: usize) -> usize {
+        let mut depth = 1;
+        while index < bytes.len() {
+            match (bytes.get(index), bytes.get(index + 1)) {
+                (Some(b'/'), Some(b'*')) => {
+                    depth += 1;
+                    index += 2;
+                }
+                (Some(b'*'), Some(b'/')) => {
+                    depth -= 1;
+                    index += 2;
+                    if depth == 0 {
+                        break;
+                    }
+                }
+                _ => index += 1,
+            }
+        }
+        index
+    }
+
+    fn skip_quoted_string(bytes: &[u8], mut index: usize) -> usize {
+        while index < bytes.len() {
+            match bytes[index] {
+                b'\\' => index += 2,
+                b'"' => return index + 1,
+                _ => index += 1,
+            }
+        }
+        index
+    }
+
+    fn skip_raw_string(bytes: &[u8], index: usize) -> Option<usize> {
+        let mut quote = index + 1;
+        while bytes.get(quote) == Some(&b'#') {
+            quote += 1;
+        }
+        if bytes.get(quote) != Some(&b'"') {
+            return None;
+        }
+
+        let hashes = quote - index - 1;
+        let mut cursor = quote + 1;
+        while cursor < bytes.len() {
+            if bytes[cursor] == b'"'
+                && bytes
+                    .get(cursor + 1..cursor + hashes + 1)
+                    .is_some_and(|suffix| suffix.iter().all(|byte| *byte == b'#'))
+            {
+                return Some(cursor + hashes + 1);
+            }
+            cursor += 1;
+        }
+        Some(cursor)
     }
 }

--- a/crates/palamedes-node/src/lib.rs
+++ b/crates/palamedes-node/src/lib.rs
@@ -13,3 +13,31 @@ pub use self::mdx::*;
 pub use self::po::*;
 pub use self::source::*;
 pub use self::transform::*;
+
+#[cfg(test)]
+mod tests {
+    const SYNC_NAPI_EXPORT_MODULES: [(&str, &str); 6] = [
+        ("catalog.rs", include_str!("catalog.rs")),
+        ("extract.rs", include_str!("extract.rs")),
+        ("mdx.rs", include_str!("mdx.rs")),
+        ("po.rs", include_str!("po.rs")),
+        ("source.rs", include_str!("source.rs")),
+        ("transform.rs", include_str!("transform.rs")),
+    ];
+
+    #[test]
+    fn every_sync_napi_export_enables_panic_catching() {
+        for (module, source) in SYNC_NAPI_EXPORT_MODULES {
+            let unguarded_exports = source
+                .lines()
+                .enumerate()
+                .filter_map(|(index, line)| (line.trim() == "#[napi]").then_some(index + 1))
+                .collect::<Vec<_>>();
+
+            assert!(
+                unguarded_exports.is_empty(),
+                "{module} has synchronous #[napi] exports without catch_unwind at lines {unguarded_exports:?}"
+            );
+        }
+    }
+}

--- a/crates/palamedes-node/src/lib.rs
+++ b/crates/palamedes-node/src/lib.rs
@@ -16,28 +16,106 @@ pub use self::transform::*;
 
 #[cfg(test)]
 mod tests {
-    const SYNC_NAPI_EXPORT_MODULES: [(&str, &str); 6] = [
-        ("catalog.rs", include_str!("catalog.rs")),
-        ("extract.rs", include_str!("extract.rs")),
-        ("mdx.rs", include_str!("mdx.rs")),
-        ("po.rs", include_str!("po.rs")),
-        ("source.rs", include_str!("source.rs")),
-        ("transform.rs", include_str!("transform.rs")),
-    ];
+    use std::{
+        fs,
+        path::{Path, PathBuf},
+    };
 
     #[test]
-    fn every_sync_napi_export_enables_panic_catching() {
-        for (module, source) in SYNC_NAPI_EXPORT_MODULES {
-            let unguarded_exports = source
-                .lines()
-                .enumerate()
-                .filter_map(|(index, line)| (line.trim() == "#[napi]").then_some(index + 1))
+    fn every_function_napi_export_enables_panic_catching() {
+        let source_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+
+        for module in rust_source_modules(&source_dir) {
+            let source = fs::read_to_string(&module).expect("read Rust source module");
+            let unguarded_exports = napi_attributes(&source)
+                .into_iter()
+                .filter(|(_, attribute)| {
+                    !is_object_or_enum_annotation(attribute) && !attribute.contains("catch_unwind")
+                })
+                .map(|(line, _)| line)
                 .collect::<Vec<_>>();
 
             assert!(
                 unguarded_exports.is_empty(),
-                "{module} has synchronous #[napi] exports without catch_unwind at lines {unguarded_exports:?}"
+                "{} has function-level #[napi] exports without catch_unwind at lines {unguarded_exports:?}",
+                module.display()
             );
         }
+    }
+
+    #[test]
+    fn napi_attribute_scan_detects_function_options() {
+        let source = format!(
+            "#[{}]\npub fn exported() {{}}",
+            "napi(js_name = \"exported\")"
+        );
+        let attributes = napi_attributes(&source);
+
+        assert_eq!(
+            attributes,
+            vec![(1, "#[napi(js_name = \"exported\")]".to_owned())]
+        );
+        assert!(!is_object_or_enum_annotation(&attributes[0].1));
+    }
+
+    #[test]
+    fn napi_attribute_scan_excludes_object_and_enum_annotations() {
+        let source = format!(
+            "#[{}]\npub struct Object {{}}\n#[{}]\npub enum Enum {{ Value }}",
+            "napi(object)", "napi(string_enum)"
+        );
+        let attributes = napi_attributes(&source);
+
+        assert!(attributes
+            .iter()
+            .all(|(_, attribute)| is_object_or_enum_annotation(attribute)));
+    }
+
+    fn rust_source_modules(dir: &Path) -> Vec<PathBuf> {
+        let mut modules = Vec::new();
+
+        for entry in fs::read_dir(dir).expect("read Rust source directory") {
+            let path = entry.expect("read Rust source entry").path();
+            if path.is_dir() {
+                modules.extend(rust_source_modules(&path));
+            } else if path.extension().is_some_and(|extension| extension == "rs") {
+                modules.push(path);
+            }
+        }
+
+        modules.sort();
+        modules
+    }
+
+    fn napi_attributes(source: &str) -> Vec<(usize, String)> {
+        let mut attributes = Vec::new();
+        let mut lines = source.lines().enumerate();
+
+        while let Some((index, line)) = lines.next() {
+            let trimmed = line.trim_start();
+            if !(trimmed == "#[napi]" || trimmed.starts_with("#[napi(")) {
+                continue;
+            }
+
+            let mut attribute = trimmed.to_owned();
+            while !attribute.trim_end().ends_with(']') {
+                let Some((_, continuation)) = lines.next() else {
+                    break;
+                };
+                attribute.push('\n');
+                attribute.push_str(continuation.trim());
+            }
+            attributes.push((index + 1, attribute));
+        }
+
+        attributes
+    }
+
+    fn is_object_or_enum_annotation(attribute: &str) -> bool {
+        let normalized = attribute
+            .chars()
+            .filter(|character| !character.is_whitespace())
+            .collect::<String>();
+        normalized.starts_with("#[napi(object") || normalized.starts_with("#[napi(string_enum")
     }
 }

--- a/crates/palamedes-node/src/mdx.rs
+++ b/crates/palamedes-node/src/mdx.rs
@@ -132,7 +132,7 @@ impl TryFrom<palamedes::MdxAnalysisResult> for NativeMdxAnalysisResult {
     }
 }
 
-#[napi]
+#[napi(catch_unwind)]
 #[allow(clippy::needless_pass_by_value)]
 /// Analyze and compile an MDX module through the native semantic pipeline.
 ///

--- a/crates/palamedes-node/src/po.rs
+++ b/crates/palamedes-node/src/po.rs
@@ -82,14 +82,14 @@ impl TryFrom<palamedes::JsPoFile> for ParsedPoFile {
     }
 }
 
-#[napi]
+#[napi(catch_unwind)]
 #[must_use]
 /// Returns the version metadata for the loaded native binding.
 pub fn get_native_info() -> NativeInfo {
     palamedes::get_native_info().into()
 }
 
-#[napi]
+#[napi(catch_unwind)]
 #[allow(clippy::needless_pass_by_value)]
 /// Parses raw PO source text into the public host-facing PO shape.
 ///

--- a/crates/palamedes-node/src/source.rs
+++ b/crates/palamedes-node/src/source.rs
@@ -150,7 +150,7 @@ impl TryFrom<NativeSourceAnalysisOptions> for palamedes::SourceAnalysisOptions {
     }
 }
 
-#[napi]
+#[napi(catch_unwind)]
 #[allow(clippy::needless_pass_by_value)]
 /// Analyze source-first messages and authoring diagnostics in one native pass.
 ///

--- a/crates/palamedes-node/src/transform.rs
+++ b/crates/palamedes-node/src/transform.rs
@@ -110,7 +110,7 @@ impl TryFrom<palamedes::NativeTransformResult> for NativeTransformResult {
     }
 }
 
-#[napi]
+#[napi(catch_unwind)]
 #[allow(clippy::needless_pass_by_value)]
 /// Transforms Lingui-style macros into Palamedes runtime calls.
 ///

--- a/packages/core-node/scripts/build-native.mjs
+++ b/packages/core-node/scripts/build-native.mjs
@@ -117,10 +117,11 @@ if (muslNodeAddon) {
   // needed. (The static-musl CLI *binary* keeps `+crt-static` and links fully
   // statically, which is why it builds fine on the glibc host.)
   //
-  // `panic=abort` is intentionally not forced here. napi-rs (`#[napi]`) wraps
-  // every `extern "C"` entry point in a panic guard, so panics are converted to
-  // JS errors and never unwind across the FFI boundary — matching the gnu,
-  // darwin, and win32 addons, which all build with the default unwind strategy.
+  // `panic=abort` is intentionally not forced here. Every synchronous export in
+  // `palamedes-node` opts into napi-rs's `#[napi(catch_unwind)]` guard, so Rust
+  // panics become catchable JavaScript errors instead of unwinding across the
+  // FFI boundary — matching the gnu, darwin, and win32 addons, which all build
+  // with the default unwind strategy.
   //
   // Prepend any inherited target rustflags so an externally provided value
   // (e.g. CI optimisation overrides) is preserved rather than dropped.


### PR DESCRIPTION
## Summary

- Opt every synchronous `palamedes-node` N-API export into `catch_unwind`.
- Add a regression test that rejects unguarded synchronous exports.
- Correct the native-build panic-safety comment.

## Issue

Closes #570

## Validation

- `rustup run 1.95-aarch64-apple-darwin cargo test -p palamedes-node --locked`
- `rustup run 1.95-aarch64-apple-darwin cargo clippy -p palamedes-node --all-targets --locked -- -D warnings`
- `pnpm format:check`
- `RUSTUP_TOOLCHAIN=1.95-aarch64-apple-darwin pnpm --filter @palamedes/core-node-darwin-arm64 build`
- `RUSTUP_TOOLCHAIN=1.95-aarch64-apple-darwin pnpm --filter @palamedes/core-node check-native-types`
- `pnpm --filter @palamedes/core-node build`
- `pnpm --filter @palamedes/core-node test`

## Follow-up

None.