### PR TITLE
fix(next-example): reload after cookie locale switch

### DIFF
--- a/examples/nextjs-cookie/AGENTS.md
+++ b/examples/nextjs-cookie/AGENTS.md
@@ -1,0 +1,9 @@
+<!-- BEGIN:nextjs-agent-rules -->
+
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
+<!-- END:nextjs-agent-rules -->

--- a/examples/nextjs-cookie/CLAUDE.md
+++ b/examples/nextjs-cookie/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/examples/nextjs-cookie/scripts/rsc-scope-production.test.mjs
+++ b/examples/nextjs-cookie/scripts/rsc-scope-production.test.mjs
@@ -227,6 +227,111 @@ async function assertClientGraphSplitting() {
   }
 }
 
+async function assertLocaleSwitchThenClientNavigation() {
+  const executablePath = [
+    process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE,
+    "/opt/pw-browsers/chromium",
+    "/usr/bin/google-chrome",
+    "/usr/bin/google-chrome-stable",
+    "/usr/bin/chromium",
+    "/usr/bin/chromium-browser",
+    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+    "/Applications/Chromium.app/Contents/MacOS/Chromium",
+  ].find((candidate) => candidate && existsSync(candidate))
+  const browser = await chromium.launch(executablePath ? { executablePath } : undefined)
+
+  try {
+    const context = await browser.newContext({
+      extraHTTPHeaders: { "accept-language": "en" },
+      locale: "en",
+    })
+    const page = await context.newPage()
+    const errors = []
+    const chunkResponses = []
+
+    page.on("console", (message) => {
+      if (message.type() !== "error") return
+
+      const text = message.text()
+      if (text.startsWith("Failed to load resource: the server responded with a status of 404")) {
+        return
+      }
+      errors.push(`console: ${text}`)
+    })
+    page.on("pageerror", (error) => errors.push(`page: ${error.message}`))
+    page.on("requestfailed", (request) => {
+      const failure = request.failure()?.errorText ?? "unknown"
+      if (failure !== "net::ERR_ABORTED" || request.url().includes("/_next/static/")) {
+        errors.push(`request: ${request.url()} (${failure})`)
+      }
+    })
+    page.on("response", (response) => {
+      const url = response.url()
+      if (response.status() >= 400 && url.includes("/_next/static/")) {
+        errors.push(`response: ${url} (${response.status()})`)
+      }
+      if (!url.includes("/_next/static/") || !url.endsWith(".js")) return
+      chunkResponses.push(
+        response
+          .body()
+          .then((body) => ({ source: body.toString("utf8"), url }))
+          .catch(() => ({ source: "", url }))
+      )
+    })
+
+    await page.goto(baseUrl)
+    await page.getByTestId("client-ready").waitFor({ state: "attached" })
+
+    const navigation = page.waitForNavigation({ waitUntil: "domcontentloaded", timeout: 15_000 })
+    await page.getByTestId("locale-switch-de").click({ noWaitAfter: true })
+    await navigation
+    await page.getByTestId("client-ready").waitFor({ state: "attached" })
+    await page.waitForLoadState("networkidle")
+
+    assert.equal(await page.locator("html").getAttribute("lang"), "de")
+    assert.equal((await page.getByTestId("server-locale-value").textContent())?.trim(), "Deutsch")
+    assert.equal((await page.locator(".ticket .cta").textContent())?.trim(), "In den Warenkorb")
+    assert.equal((await page.locator("body").innerText()).includes("Add to cart"), false)
+
+    const responseCountBeforeClientNavigation = chunkResponses.length
+    await page.getByTestId("open-lazy-client-probe").evaluate((button) => button.click())
+    await page.getByTestId("lazy-client-message").waitFor()
+    await page.waitForLoadState("networkidle")
+
+    assert.equal(
+      await page.getByTestId("lazy-client-message").textContent(),
+      "Erst nach Client-Navigation geladen",
+      "locale switch followed by client navigation rendered the wrong message fragment"
+    )
+    const navigationChunks = await Promise.all(
+      chunkResponses.slice(responseCountBeforeClientNavigation)
+    )
+    const navigationSource = navigationChunks.map(({ source }) => source).join("\n")
+    assert(
+      navigationSource.includes("Erst nach Client-Navigation geladen"),
+      "locale switch followed by client navigation did not request the German message fragment"
+    )
+    for (const inactiveFragment of [
+      "Loaded only after client navigation",
+      "Cargado solo después de la navegación del cliente",
+    ]) {
+      assert.equal(
+        navigationSource.includes(inactiveFragment),
+        false,
+        `locale switch followed by client navigation requested inactive fragment ${JSON.stringify(inactiveFragment)}`
+      )
+    }
+    assert.deepEqual(
+      errors,
+      [],
+      "locale switch followed by client navigation caused browser errors"
+    )
+    await context.close()
+  } finally {
+    await browser.close()
+  }
+}
+
 const server = spawn(process.execPath, [nextCli, "start", "--port", String(port)], {
   cwd: new URL("..", import.meta.url),
   env: { ...process.env, NODE_ENV: "production" },
@@ -255,8 +360,9 @@ try {
     )
   )
   await assertClientGraphSplitting()
+  await assertLocaleSwitchThenClientNavigation()
   console.log(
-    "Next.js production scopes stayed request-local and client requests followed locale × route graphs"
+    "Next.js production scopes stayed request-local and client requests followed locale × route graphs after a document locale switch"
   )
 } catch (error) {
   console.error(serverOutput)

--- a/examples/nextjs-cookie/src/components/LocaleSwitcher.tsx
+++ b/examples/nextjs-cookie/src/components/LocaleSwitcher.tsx
@@ -22,6 +22,9 @@ export function LocaleSwitcher({ locale }: LocaleSwitcherProps) {
   function handleLocaleChange(nextLocale: Locale) {
     startTransition(async () => {
       await setLocaleAction(nextLocale)
+      // Locale is document bootstrap state. Start a new document only after the
+      // server action has persisted the cookie so server and client agree.
+      window.location.assign("/")
     })
   }
 

--- a/tests/examples-browser/examples.browser.test.js
+++ b/tests/examples-browser/examples.browser.test.js
@@ -162,21 +162,22 @@ test("matrix example browser contract", async () => {
   await captureScreenshot(page, example, "initial")
 
   if (example.strategy === "cookie") {
+    const navigation = page.waitForNavigation({ waitUntil: "domcontentloaded", timeout: 15_000 })
     await page
       .getByTestId("locale-switch-de")
       .click({ force: true, noWaitAfter: true, timeout: 15_000 })
+    await navigation
 
-    try {
-      await expect.poll(() => currentServerLocale(page), { timeout: 2500 }).toContain("Deutsch")
-    } catch {
-      await page.reload({ waitUntil: "domcontentloaded" })
-      await expect.poll(() => currentServerLocale(page)).toContain("Deutsch")
-    }
-
-    await page.reload({ waitUntil: "domcontentloaded" })
+    await expect.poll(() => page.locator("html").getAttribute("lang")).toBe("de")
     await expect.poll(() => currentServerLocale(page)).toContain("Deutsch")
 
     await waitForClientReady(page)
+    if (example.id === "nextjs-cookie") {
+      await expect.poll(() => page.locator(".ticket .cta").textContent()).toBe("In den Warenkorb")
+      await expect
+        .poll(async () => (await page.locator("body").innerText()).includes("Add to cart"))
+        .toBe(false)
+    }
     await page.evaluate(() => {
       document.querySelector('[data-testid="server-proof-trigger"]')?.click()
     })


### PR DESCRIPTION
## Summary

- Navigate to a fresh document after the Next.js cookie locale action persists the locale.
- Make the shared browser contract require that navigation and prove the Next.js document has no mixed English/German client state.
- Exercise a locale switch followed by client navigation in the production RSC message-splitting test.

## Issue

Closes #572

## Validation

- `pnpm --filter @palamedes/example-nextjs-cookie exec tsc --noEmit -p tsconfig.json`
- `pnpm exec oxfmt --check examples/nextjs-cookie/src/components/LocaleSwitcher.tsx examples/nextjs-cookie/scripts/rsc-scope-production.test.mjs tests/examples-browser/examples.browser.test.js`
- `pnpm exec eslint --max-warnings=0 examples/nextjs-cookie/src/components/LocaleSwitcher.tsx examples/nextjs-cookie/scripts/rsc-scope-production.test.mjs tests/examples-browser/examples.browser.test.js`
- `pnpm --filter @palamedes/example-nextjs-cookie test:rsc-scope`
- `pnpm --filter @palamedes/example-nextjs-cookie test:rsc-scope:webpack`
- `pnpm --filter @palamedes/example-nextjs-cookie test:message-splitting:development`
- `pnpm verify:examples:browser -- --id nextjs-cookie`

## Follow-up

None.
