### PR TITLE
fix(examples): scope server i18n per request

### DIFF
--- a/examples/react-router-cookie/app/entry.server.tsx
+++ b/examples/react-router-cookie/app/entry.server.tsx
@@ -7,7 +7,12 @@ import { isbot } from "isbot"
 import type { RenderToPipeableStreamOptions } from "react-dom/server"
 import { renderToPipeableStream } from "react-dom/server"
 import { resolveLocaleFromRequest } from "~/lib/i18n"
-import { getLocaleBinding, type LocaleBinding } from "~/lib/i18n.server"
+import {
+  createServerI18n,
+  getLocaleBinding,
+  serverI18nScope,
+  type LocaleBinding,
+} from "~/lib/i18n.server"
 
 export const streamTimeout = 5000
 
@@ -90,65 +95,70 @@ export default function handleRequest(
     })
   }
 
-  return new Promise((resolve, reject) => {
-    let shellRendered = false
-    const userAgent = request.headers.get("user-agent")
+  const locale = resolveLocaleFromRequest(request).locale
+  return serverI18nScope.run(
+    createServerI18n(locale),
+    () =>
+      new Promise((resolve, reject) => {
+        let shellRendered = false
+        const userAgent = request.headers.get("user-agent")
 
-    // Ensure requests from bots and SPA Mode renders wait for all content to load before responding
-    // https://react.dev/reference/react-dom/server/renderToPipeableStream#waiting-for-all-content-to-load-for-crawlers-and-static-generation
-    const readyOption: keyof RenderToPipeableStreamOptions =
-      (userAgent && isbot(userAgent)) || routerContext.isSpaMode ? "onAllReady" : "onShellReady"
+        // Ensure requests from bots and SPA Mode renders wait for all content to load before responding
+        // https://react.dev/reference/react-dom/server/renderToPipeableStream#waiting-for-all-content-to-load-for-crawlers-and-static-generation
+        const readyOption: keyof RenderToPipeableStreamOptions =
+          (userAgent && isbot(userAgent)) || routerContext.isSpaMode ? "onAllReady" : "onShellReady"
 
-    // Abort the rendering stream after the `streamTimeout` so it has time to
-    // flush down the rejected boundaries
-    let timeoutId: ReturnType<typeof setTimeout> | undefined = setTimeout(
-      () => abort(),
-      streamTimeout + 1000
-    )
+        // Abort the rendering stream after the `streamTimeout` so it has time to
+        // flush down the rejected boundaries
+        let timeoutId: ReturnType<typeof setTimeout> | undefined = setTimeout(
+          () => abort(),
+          streamTimeout + 1000
+        )
 
-    const { pipe, abort } = renderToPipeableStream(
-      <ServerRouter context={routerContext} url={request.url} />,
-      {
-        [readyOption]() {
-          shellRendered = true
-          const body = new PassThrough({
-            final(callback) {
-              // Clear the timeout to prevent retaining the closure and memory leak
-              clearTimeout(timeoutId)
-              timeoutId = undefined
-              callback()
+        const { pipe, abort } = renderToPipeableStream(
+          <ServerRouter context={routerContext} url={request.url} />,
+          {
+            [readyOption]() {
+              shellRendered = true
+              const body = new PassThrough({
+                final(callback) {
+                  // Clear the timeout to prevent retaining the closure and memory leak
+                  clearTimeout(timeoutId)
+                  timeoutId = undefined
+                  callback()
+                },
+              })
+              const stream = createReadableStreamFromReadable(body)
+
+              responseHeaders.set("Content-Type", "text/html")
+
+              const injector = createLocaleBindingInjector(
+                getLocaleBinding(resolveLocaleFromRequest(request).locale)
+              )
+              injector.pipe(body)
+              pipe(injector)
+
+              resolve(
+                new Response(stream, {
+                  headers: responseHeaders,
+                  status: responseStatusCode,
+                })
+              )
             },
-          })
-          const stream = createReadableStreamFromReadable(body)
-
-          responseHeaders.set("Content-Type", "text/html")
-
-          const injector = createLocaleBindingInjector(
-            getLocaleBinding(resolveLocaleFromRequest(request).locale)
-          )
-          injector.pipe(body)
-          pipe(injector)
-
-          resolve(
-            new Response(stream, {
-              headers: responseHeaders,
-              status: responseStatusCode,
-            })
-          )
-        },
-        onShellError(error: unknown) {
-          reject(error)
-        },
-        onError(error: unknown) {
-          responseStatusCode = 500
-          // Log streaming rendering errors from inside the shell.  Don't log
-          // errors encountered during initial shell rendering since they'll
-          // reject and get logged in handleDocumentRequest.
-          if (shellRendered) {
-            console.error(error)
+            onShellError(error: unknown) {
+              reject(error)
+            },
+            onError(error: unknown) {
+              responseStatusCode = 500
+              // Log streaming rendering errors from inside the shell.  Don't log
+              // errors encountered during initial shell rendering since they'll
+              // reject and get logged in handleDocumentRequest.
+              if (shellRendered) {
+                console.error(error)
+              }
+            },
           }
-        },
-      }
-    )
-  })
+        )
+      })
+  )
 }

--- a/examples/react-router-cookie/app/entry.server.tsx
+++ b/examples/react-router-cookie/app/entry.server.tsx
@@ -6,7 +6,10 @@ import { ServerRouter } from "react-router"
 import { isbot } from "isbot"
 import type { RenderToPipeableStreamOptions } from "react-dom/server"
 import { renderToPipeableStream } from "react-dom/server"
-import { waitForServerI18nTestBarrier } from "@palamedes/runtime/server/test"
+import {
+  markServerI18nTestBarrierReached,
+  waitForServerI18nTestBarrier,
+} from "@palamedes/runtime/server/test"
 import { resolveLocaleFromRequest } from "~/lib/i18n"
 import {
   createServerI18n,
@@ -99,6 +102,7 @@ export default function handleRequest(
   const locale = resolveLocaleFromRequest(request).locale
   return serverI18nScope.run(createServerI18n(locale), async () => {
     await waitForServerI18nTestBarrier(request)
+    markServerI18nTestBarrierReached(request, responseHeaders)
     return new Promise((resolve, reject) => {
       let shellRendered = false
       const userAgent = request.headers.get("user-agent")

--- a/examples/react-router-cookie/app/entry.server.tsx
+++ b/examples/react-router-cookie/app/entry.server.tsx
@@ -6,6 +6,7 @@ import { ServerRouter } from "react-router"
 import { isbot } from "isbot"
 import type { RenderToPipeableStreamOptions } from "react-dom/server"
 import { renderToPipeableStream } from "react-dom/server"
+import { waitForServerI18nTestBarrier } from "@palamedes/runtime/server/test"
 import { resolveLocaleFromRequest } from "~/lib/i18n"
 import {
   createServerI18n,
@@ -96,69 +97,68 @@ export default function handleRequest(
   }
 
   const locale = resolveLocaleFromRequest(request).locale
-  return serverI18nScope.run(
-    createServerI18n(locale),
-    () =>
-      new Promise((resolve, reject) => {
-        let shellRendered = false
-        const userAgent = request.headers.get("user-agent")
+  return serverI18nScope.run(createServerI18n(locale), async () => {
+    await waitForServerI18nTestBarrier(request)
+    return new Promise((resolve, reject) => {
+      let shellRendered = false
+      const userAgent = request.headers.get("user-agent")
 
-        // Ensure requests from bots and SPA Mode renders wait for all content to load before responding
-        // https://react.dev/reference/react-dom/server/renderToPipeableStream#waiting-for-all-content-to-load-for-crawlers-and-static-generation
-        const readyOption: keyof RenderToPipeableStreamOptions =
-          (userAgent && isbot(userAgent)) || routerContext.isSpaMode ? "onAllReady" : "onShellReady"
+      // Ensure requests from bots and SPA Mode renders wait for all content to load before responding
+      // https://react.dev/reference/react-dom/server/renderToPipeableStream#waiting-for-all-content-to-load-for-crawlers-and-static-generation
+      const readyOption: keyof RenderToPipeableStreamOptions =
+        (userAgent && isbot(userAgent)) || routerContext.isSpaMode ? "onAllReady" : "onShellReady"
 
-        // Abort the rendering stream after the `streamTimeout` so it has time to
-        // flush down the rejected boundaries
-        let timeoutId: ReturnType<typeof setTimeout> | undefined = setTimeout(
-          () => abort(),
-          streamTimeout + 1000
-        )
+      // Abort the rendering stream after the `streamTimeout` so it has time to
+      // flush down the rejected boundaries
+      let timeoutId: ReturnType<typeof setTimeout> | undefined = setTimeout(
+        () => abort(),
+        streamTimeout + 1000
+      )
 
-        const { pipe, abort } = renderToPipeableStream(
-          <ServerRouter context={routerContext} url={request.url} />,
-          {
-            [readyOption]() {
-              shellRendered = true
-              const body = new PassThrough({
-                final(callback) {
-                  // Clear the timeout to prevent retaining the closure and memory leak
-                  clearTimeout(timeoutId)
-                  timeoutId = undefined
-                  callback()
-                },
+      const { pipe, abort } = renderToPipeableStream(
+        <ServerRouter context={routerContext} url={request.url} />,
+        {
+          [readyOption]() {
+            shellRendered = true
+            const body = new PassThrough({
+              final(callback) {
+                // Clear the timeout to prevent retaining the closure and memory leak
+                clearTimeout(timeoutId)
+                timeoutId = undefined
+                callback()
+              },
+            })
+            const stream = createReadableStreamFromReadable(body)
+
+            responseHeaders.set("Content-Type", "text/html")
+
+            const injector = createLocaleBindingInjector(
+              getLocaleBinding(resolveLocaleFromRequest(request).locale)
+            )
+            injector.pipe(body)
+            pipe(injector)
+
+            resolve(
+              new Response(stream, {
+                headers: responseHeaders,
+                status: responseStatusCode,
               })
-              const stream = createReadableStreamFromReadable(body)
-
-              responseHeaders.set("Content-Type", "text/html")
-
-              const injector = createLocaleBindingInjector(
-                getLocaleBinding(resolveLocaleFromRequest(request).locale)
-              )
-              injector.pipe(body)
-              pipe(injector)
-
-              resolve(
-                new Response(stream, {
-                  headers: responseHeaders,
-                  status: responseStatusCode,
-                })
-              )
-            },
-            onShellError(error: unknown) {
-              reject(error)
-            },
-            onError(error: unknown) {
-              responseStatusCode = 500
-              // Log streaming rendering errors from inside the shell.  Don't log
-              // errors encountered during initial shell rendering since they'll
-              // reject and get logged in handleDocumentRequest.
-              if (shellRendered) {
-                console.error(error)
-              }
-            },
-          }
-        )
-      })
-  )
+            )
+          },
+          onShellError(error: unknown) {
+            reject(error)
+          },
+          onError(error: unknown) {
+            responseStatusCode = 500
+            // Log streaming rendering errors from inside the shell.  Don't log
+            // errors encountered during initial shell rendering since they'll
+            // reject and get logged in handleDocumentRequest.
+            if (shellRendered) {
+              console.error(error)
+            }
+          },
+        }
+      )
+    })
+  })
 }

--- a/examples/react-router-cookie/app/lib/i18n.server.ts
+++ b/examples/react-router-cookie/app/lib/i18n.server.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs"
 import path from "node:path"
 import type { CompiledCatalogMessages } from "@palamedes/core/compiled"
-import { setServerI18nGetter } from "@palamedes/runtime"
+import { createServerI18nScope } from "@palamedes/runtime/server"
 import { messages as enMessages } from "../locales/en.po"
 import { messages as deMessages } from "../locales/de.po"
 import { messages as esMessages } from "../locales/es.po"
@@ -16,12 +16,17 @@ const CATALOGS: Record<Locale, CompiledCatalogMessages> = {
   es: esMessages,
 }
 
-export function activateServerI18n(locale: Locale) {
+export const serverI18nScope = createServerI18nScope<ReturnType<typeof createExampleI18n>>()
+
+export function createServerI18n(locale: Locale) {
   const i18n = createExampleI18n()
   i18n.load(locale, CATALOGS[locale])
   i18n.activate(locale)
-  setServerI18nGetter(() => i18n)
   return i18n
+}
+
+export function activateServerI18n(locale: Locale) {
+  return serverI18nScope.activate(createServerI18n(locale))
 }
 
 // Import-map locale binding: the production client resolves its per-route

--- a/examples/react-router-route/app/entry.server.tsx
+++ b/examples/react-router-route/app/entry.server.tsx
@@ -5,7 +5,10 @@ import type { EntryContext, RouterContextProvider } from "react-router"
 import { ServerRouter } from "react-router"
 import type { RenderToPipeableStreamOptions } from "react-dom/server"
 import { renderToPipeableStream } from "react-dom/server"
-import { waitForServerI18nTestBarrier } from "@palamedes/runtime/server/test"
+import {
+  markServerI18nTestBarrierReached,
+  waitForServerI18nTestBarrier,
+} from "@palamedes/runtime/server/test"
 import { createServerI18n, resolveLocaleFromRequest } from "~/lib/i18n"
 import { serverI18nScope } from "~/lib/i18n.server"
 
@@ -19,12 +22,16 @@ export default function handleRequest(
   _loadContext: RouterContextProvider
 ) {
   if (request.method.toUpperCase() === "HEAD") {
-    return new Response(null, { status: responseStatusCode, headers: responseHeaders })
+    return new Response(null, {
+      status: responseStatusCode,
+      headers: responseHeaders,
+    })
   }
 
   const i18n = createServerI18n(resolveLocaleFromRequest(request))
   return serverI18nScope.run(i18n, async () => {
     await waitForServerI18nTestBarrier(request)
+    markServerI18nTestBarrierReached(request, responseHeaders)
     return new Promise((resolve, reject) => {
       let shellRendered = false
       const userAgent = request.headers.get("user-agent")

--- a/examples/react-router-route/app/entry.server.tsx
+++ b/examples/react-router-route/app/entry.server.tsx
@@ -5,6 +5,7 @@ import type { EntryContext, RouterContextProvider } from "react-router"
 import { ServerRouter } from "react-router"
 import type { RenderToPipeableStreamOptions } from "react-dom/server"
 import { renderToPipeableStream } from "react-dom/server"
+import { waitForServerI18nTestBarrier } from "@palamedes/runtime/server/test"
 import { createServerI18n, resolveLocaleFromRequest } from "~/lib/i18n"
 import { serverI18nScope } from "~/lib/i18n.server"
 
@@ -22,48 +23,47 @@ export default function handleRequest(
   }
 
   const i18n = createServerI18n(resolveLocaleFromRequest(request))
-  return serverI18nScope.run(
-    i18n,
-    () =>
-      new Promise((resolve, reject) => {
-        let shellRendered = false
-        const userAgent = request.headers.get("user-agent")
-        const readyOption: keyof RenderToPipeableStreamOptions =
-          (userAgent && isbot(userAgent)) || routerContext.isSpaMode ? "onAllReady" : "onShellReady"
-        let timeoutId: ReturnType<typeof setTimeout> | undefined = setTimeout(
-          () => abort(),
-          streamTimeout + 1000
-        )
-        const { pipe, abort } = renderToPipeableStream(
-          <ServerRouter context={routerContext} url={request.url} />,
-          {
-            [readyOption]() {
-              shellRendered = true
-              const body = new PassThrough({
-                final(callback) {
-                  clearTimeout(timeoutId)
-                  timeoutId = undefined
-                  callback()
-                },
+  return serverI18nScope.run(i18n, async () => {
+    await waitForServerI18nTestBarrier(request)
+    return new Promise((resolve, reject) => {
+      let shellRendered = false
+      const userAgent = request.headers.get("user-agent")
+      const readyOption: keyof RenderToPipeableStreamOptions =
+        (userAgent && isbot(userAgent)) || routerContext.isSpaMode ? "onAllReady" : "onShellReady"
+      let timeoutId: ReturnType<typeof setTimeout> | undefined = setTimeout(
+        () => abort(),
+        streamTimeout + 1000
+      )
+      const { pipe, abort } = renderToPipeableStream(
+        <ServerRouter context={routerContext} url={request.url} />,
+        {
+          [readyOption]() {
+            shellRendered = true
+            const body = new PassThrough({
+              final(callback) {
+                clearTimeout(timeoutId)
+                timeoutId = undefined
+                callback()
+              },
+            })
+            responseHeaders.set("Content-Type", "text/html")
+            pipe(body)
+            resolve(
+              new Response(createReadableStreamFromReadable(body), {
+                headers: responseHeaders,
+                status: responseStatusCode,
               })
-              responseHeaders.set("Content-Type", "text/html")
-              pipe(body)
-              resolve(
-                new Response(createReadableStreamFromReadable(body), {
-                  headers: responseHeaders,
-                  status: responseStatusCode,
-                })
-              )
-            },
-            onShellError(error: unknown) {
-              reject(error)
-            },
-            onError(error: unknown) {
-              responseStatusCode = 500
-              if (shellRendered) console.error(error)
-            },
-          }
-        )
-      })
-  )
+            )
+          },
+          onShellError(error: unknown) {
+            reject(error)
+          },
+          onError(error: unknown) {
+            responseStatusCode = 500
+            if (shellRendered) console.error(error)
+          },
+        }
+      )
+    })
+  })
 }

--- a/examples/react-router-route/app/entry.server.tsx
+++ b/examples/react-router-route/app/entry.server.tsx
@@ -1,0 +1,69 @@
+import { PassThrough } from "node:stream"
+import { createReadableStreamFromReadable } from "@react-router/node"
+import { isbot } from "isbot"
+import type { EntryContext, RouterContextProvider } from "react-router"
+import { ServerRouter } from "react-router"
+import type { RenderToPipeableStreamOptions } from "react-dom/server"
+import { renderToPipeableStream } from "react-dom/server"
+import { createServerI18n, resolveLocaleFromRequest } from "~/lib/i18n"
+import { serverI18nScope } from "~/lib/i18n.server"
+
+export const streamTimeout = 5000
+
+export default function handleRequest(
+  request: Request,
+  responseStatusCode: number,
+  responseHeaders: Headers,
+  routerContext: EntryContext,
+  _loadContext: RouterContextProvider
+) {
+  if (request.method.toUpperCase() === "HEAD") {
+    return new Response(null, { status: responseStatusCode, headers: responseHeaders })
+  }
+
+  const i18n = createServerI18n(resolveLocaleFromRequest(request))
+  return serverI18nScope.run(
+    i18n,
+    () =>
+      new Promise((resolve, reject) => {
+        let shellRendered = false
+        const userAgent = request.headers.get("user-agent")
+        const readyOption: keyof RenderToPipeableStreamOptions =
+          (userAgent && isbot(userAgent)) || routerContext.isSpaMode ? "onAllReady" : "onShellReady"
+        let timeoutId: ReturnType<typeof setTimeout> | undefined = setTimeout(
+          () => abort(),
+          streamTimeout + 1000
+        )
+        const { pipe, abort } = renderToPipeableStream(
+          <ServerRouter context={routerContext} url={request.url} />,
+          {
+            [readyOption]() {
+              shellRendered = true
+              const body = new PassThrough({
+                final(callback) {
+                  clearTimeout(timeoutId)
+                  timeoutId = undefined
+                  callback()
+                },
+              })
+              responseHeaders.set("Content-Type", "text/html")
+              pipe(body)
+              resolve(
+                new Response(createReadableStreamFromReadable(body), {
+                  headers: responseHeaders,
+                  status: responseStatusCode,
+                })
+              )
+            },
+            onShellError(error: unknown) {
+              reject(error)
+            },
+            onError(error: unknown) {
+              responseStatusCode = 500
+              if (shellRendered) console.error(error)
+            },
+          }
+        )
+      })
+  )
+}

--- a/examples/react-router-route/app/lib/i18n.server.ts
+++ b/examples/react-router-route/app/lib/i18n.server.ts
@@ -1,0 +1,4 @@
+import { createServerI18nScope } from "@palamedes/runtime/server"
+import type { createExampleI18n } from "./i18n"
+
+export const serverI18nScope = createServerI18nScope<ReturnType<typeof createExampleI18n>>()

--- a/examples/react-router-route/app/lib/i18n.ts
+++ b/examples/react-router-route/app/lib/i18n.ts
@@ -1,6 +1,6 @@
 import { createI18n } from "@palamedes/core"
 import type { CompiledCatalogMessages } from "@palamedes/core/compiled"
-import { setClientI18n, setServerI18nGetter } from "@palamedes/runtime"
+import { activateServerI18n as activateScopedServerI18n, setClientI18n } from "@palamedes/runtime"
 import { defineLocaleControls } from "@palamedes/core/locale"
 import { messages as enMessages } from "../locales/en.po"
 import { messages as deMessages } from "../locales/de.po"
@@ -48,12 +48,15 @@ export function createExampleI18n() {
   return createI18n()
 }
 
-export function activateServerI18n(locale: Locale) {
+export function createServerI18n(locale: Locale) {
   const i18n = createExampleI18n()
   i18n.load(locale, loadMessages(locale))
   i18n.activate(locale)
-  setServerI18nGetter(() => i18n)
   return i18n
+}
+
+export function activateServerI18n(locale: Locale) {
+  return activateScopedServerI18n(createServerI18n(locale))
 }
 
 const clientI18n = createExampleI18n()

--- a/examples/react-router-subdomain/app/entry.server.tsx
+++ b/examples/react-router-subdomain/app/entry.server.tsx
@@ -5,7 +5,10 @@ import type { EntryContext, RouterContextProvider } from "react-router"
 import { ServerRouter } from "react-router"
 import type { RenderToPipeableStreamOptions } from "react-dom/server"
 import { renderToPipeableStream } from "react-dom/server"
-import { waitForServerI18nTestBarrier } from "@palamedes/runtime/server/test"
+import {
+  markServerI18nTestBarrierReached,
+  waitForServerI18nTestBarrier,
+} from "@palamedes/runtime/server/test"
 import { createServerI18n, resolveLocaleFromRequest } from "~/lib/i18n"
 import { serverI18nScope } from "~/lib/i18n.server"
 
@@ -19,12 +22,16 @@ export default function handleRequest(
   _loadContext: RouterContextProvider
 ) {
   if (request.method.toUpperCase() === "HEAD") {
-    return new Response(null, { status: responseStatusCode, headers: responseHeaders })
+    return new Response(null, {
+      status: responseStatusCode,
+      headers: responseHeaders,
+    })
   }
 
   const i18n = createServerI18n(resolveLocaleFromRequest(request))
   return serverI18nScope.run(i18n, async () => {
     await waitForServerI18nTestBarrier(request)
+    markServerI18nTestBarrierReached(request, responseHeaders)
     return new Promise((resolve, reject) => {
       let shellRendered = false
       const userAgent = request.headers.get("user-agent")

--- a/examples/react-router-subdomain/app/entry.server.tsx
+++ b/examples/react-router-subdomain/app/entry.server.tsx
@@ -5,6 +5,7 @@ import type { EntryContext, RouterContextProvider } from "react-router"
 import { ServerRouter } from "react-router"
 import type { RenderToPipeableStreamOptions } from "react-dom/server"
 import { renderToPipeableStream } from "react-dom/server"
+import { waitForServerI18nTestBarrier } from "@palamedes/runtime/server/test"
 import { createServerI18n, resolveLocaleFromRequest } from "~/lib/i18n"
 import { serverI18nScope } from "~/lib/i18n.server"
 
@@ -22,48 +23,47 @@ export default function handleRequest(
   }
 
   const i18n = createServerI18n(resolveLocaleFromRequest(request))
-  return serverI18nScope.run(
-    i18n,
-    () =>
-      new Promise((resolve, reject) => {
-        let shellRendered = false
-        const userAgent = request.headers.get("user-agent")
-        const readyOption: keyof RenderToPipeableStreamOptions =
-          (userAgent && isbot(userAgent)) || routerContext.isSpaMode ? "onAllReady" : "onShellReady"
-        let timeoutId: ReturnType<typeof setTimeout> | undefined = setTimeout(
-          () => abort(),
-          streamTimeout + 1000
-        )
-        const { pipe, abort } = renderToPipeableStream(
-          <ServerRouter context={routerContext} url={request.url} />,
-          {
-            [readyOption]() {
-              shellRendered = true
-              const body = new PassThrough({
-                final(callback) {
-                  clearTimeout(timeoutId)
-                  timeoutId = undefined
-                  callback()
-                },
+  return serverI18nScope.run(i18n, async () => {
+    await waitForServerI18nTestBarrier(request)
+    return new Promise((resolve, reject) => {
+      let shellRendered = false
+      const userAgent = request.headers.get("user-agent")
+      const readyOption: keyof RenderToPipeableStreamOptions =
+        (userAgent && isbot(userAgent)) || routerContext.isSpaMode ? "onAllReady" : "onShellReady"
+      let timeoutId: ReturnType<typeof setTimeout> | undefined = setTimeout(
+        () => abort(),
+        streamTimeout + 1000
+      )
+      const { pipe, abort } = renderToPipeableStream(
+        <ServerRouter context={routerContext} url={request.url} />,
+        {
+          [readyOption]() {
+            shellRendered = true
+            const body = new PassThrough({
+              final(callback) {
+                clearTimeout(timeoutId)
+                timeoutId = undefined
+                callback()
+              },
+            })
+            responseHeaders.set("Content-Type", "text/html")
+            pipe(body)
+            resolve(
+              new Response(createReadableStreamFromReadable(body), {
+                headers: responseHeaders,
+                status: responseStatusCode,
               })
-              responseHeaders.set("Content-Type", "text/html")
-              pipe(body)
-              resolve(
-                new Response(createReadableStreamFromReadable(body), {
-                  headers: responseHeaders,
-                  status: responseStatusCode,
-                })
-              )
-            },
-            onShellError(error: unknown) {
-              reject(error)
-            },
-            onError(error: unknown) {
-              responseStatusCode = 500
-              if (shellRendered) console.error(error)
-            },
-          }
-        )
-      })
-  )
+            )
+          },
+          onShellError(error: unknown) {
+            reject(error)
+          },
+          onError(error: unknown) {
+            responseStatusCode = 500
+            if (shellRendered) console.error(error)
+          },
+        }
+      )
+    })
+  })
 }

--- a/examples/react-router-subdomain/app/entry.server.tsx
+++ b/examples/react-router-subdomain/app/entry.server.tsx
@@ -1,0 +1,69 @@
+import { PassThrough } from "node:stream"
+import { createReadableStreamFromReadable } from "@react-router/node"
+import { isbot } from "isbot"
+import type { EntryContext, RouterContextProvider } from "react-router"
+import { ServerRouter } from "react-router"
+import type { RenderToPipeableStreamOptions } from "react-dom/server"
+import { renderToPipeableStream } from "react-dom/server"
+import { createServerI18n, resolveLocaleFromRequest } from "~/lib/i18n"
+import { serverI18nScope } from "~/lib/i18n.server"
+
+export const streamTimeout = 5000
+
+export default function handleRequest(
+  request: Request,
+  responseStatusCode: number,
+  responseHeaders: Headers,
+  routerContext: EntryContext,
+  _loadContext: RouterContextProvider
+) {
+  if (request.method.toUpperCase() === "HEAD") {
+    return new Response(null, { status: responseStatusCode, headers: responseHeaders })
+  }
+
+  const i18n = createServerI18n(resolveLocaleFromRequest(request))
+  return serverI18nScope.run(
+    i18n,
+    () =>
+      new Promise((resolve, reject) => {
+        let shellRendered = false
+        const userAgent = request.headers.get("user-agent")
+        const readyOption: keyof RenderToPipeableStreamOptions =
+          (userAgent && isbot(userAgent)) || routerContext.isSpaMode ? "onAllReady" : "onShellReady"
+        let timeoutId: ReturnType<typeof setTimeout> | undefined = setTimeout(
+          () => abort(),
+          streamTimeout + 1000
+        )
+        const { pipe, abort } = renderToPipeableStream(
+          <ServerRouter context={routerContext} url={request.url} />,
+          {
+            [readyOption]() {
+              shellRendered = true
+              const body = new PassThrough({
+                final(callback) {
+                  clearTimeout(timeoutId)
+                  timeoutId = undefined
+                  callback()
+                },
+              })
+              responseHeaders.set("Content-Type", "text/html")
+              pipe(body)
+              resolve(
+                new Response(createReadableStreamFromReadable(body), {
+                  headers: responseHeaders,
+                  status: responseStatusCode,
+                })
+              )
+            },
+            onShellError(error: unknown) {
+              reject(error)
+            },
+            onError(error: unknown) {
+              responseStatusCode = 500
+              if (shellRendered) console.error(error)
+            },
+          }
+        )
+      })
+  )
+}

--- a/examples/react-router-subdomain/app/lib/i18n.server.ts
+++ b/examples/react-router-subdomain/app/lib/i18n.server.ts
@@ -1,0 +1,4 @@
+import { createServerI18nScope } from "@palamedes/runtime/server"
+import type { createExampleI18n } from "./i18n"
+
+export const serverI18nScope = createServerI18nScope<ReturnType<typeof createExampleI18n>>()

--- a/examples/react-router-subdomain/app/lib/i18n.ts
+++ b/examples/react-router-subdomain/app/lib/i18n.ts
@@ -1,6 +1,6 @@
 import { createI18n } from "@palamedes/core"
 import type { CompiledCatalogMessages } from "@palamedes/core/compiled"
-import { setClientI18n, setServerI18nGetter } from "@palamedes/runtime"
+import { activateServerI18n as activateScopedServerI18n, setClientI18n } from "@palamedes/runtime"
 import { defineLocaleControls } from "@palamedes/core/locale"
 import { messages as enMessages } from "../locales/en.po"
 import { messages as deMessages } from "../locales/de.po"
@@ -46,12 +46,15 @@ export function createExampleI18n() {
   return createI18n()
 }
 
-export function activateServerI18n(locale: Locale) {
+export function createServerI18n(locale: Locale) {
   const i18n = createExampleI18n()
   i18n.load(locale, loadMessages(locale))
   i18n.activate(locale)
-  setServerI18nGetter(() => i18n)
   return i18n
+}
+
+export function activateServerI18n(locale: Locale) {
+  return activateScopedServerI18n(createServerI18n(locale))
 }
 
 const clientI18n = createExampleI18n()

--- a/examples/react-router-tld/app/entry.server.tsx
+++ b/examples/react-router-tld/app/entry.server.tsx
@@ -5,7 +5,10 @@ import type { EntryContext, RouterContextProvider } from "react-router"
 import { ServerRouter } from "react-router"
 import type { RenderToPipeableStreamOptions } from "react-dom/server"
 import { renderToPipeableStream } from "react-dom/server"
-import { waitForServerI18nTestBarrier } from "@palamedes/runtime/server/test"
+import {
+  markServerI18nTestBarrierReached,
+  waitForServerI18nTestBarrier,
+} from "@palamedes/runtime/server/test"
 import { createServerI18n, resolveLocaleFromRequest } from "~/lib/i18n"
 import { serverI18nScope } from "~/lib/i18n.server"
 
@@ -19,12 +22,16 @@ export default function handleRequest(
   _loadContext: RouterContextProvider
 ) {
   if (request.method.toUpperCase() === "HEAD") {
-    return new Response(null, { status: responseStatusCode, headers: responseHeaders })
+    return new Response(null, {
+      status: responseStatusCode,
+      headers: responseHeaders,
+    })
   }
 
   const i18n = createServerI18n(resolveLocaleFromRequest(request))
   return serverI18nScope.run(i18n, async () => {
     await waitForServerI18nTestBarrier(request)
+    markServerI18nTestBarrierReached(request, responseHeaders)
     return new Promise((resolve, reject) => {
       let shellRendered = false
       const userAgent = request.headers.get("user-agent")

--- a/examples/react-router-tld/app/entry.server.tsx
+++ b/examples/react-router-tld/app/entry.server.tsx
@@ -5,6 +5,7 @@ import type { EntryContext, RouterContextProvider } from "react-router"
 import { ServerRouter } from "react-router"
 import type { RenderToPipeableStreamOptions } from "react-dom/server"
 import { renderToPipeableStream } from "react-dom/server"
+import { waitForServerI18nTestBarrier } from "@palamedes/runtime/server/test"
 import { createServerI18n, resolveLocaleFromRequest } from "~/lib/i18n"
 import { serverI18nScope } from "~/lib/i18n.server"
 
@@ -22,48 +23,47 @@ export default function handleRequest(
   }
 
   const i18n = createServerI18n(resolveLocaleFromRequest(request))
-  return serverI18nScope.run(
-    i18n,
-    () =>
-      new Promise((resolve, reject) => {
-        let shellRendered = false
-        const userAgent = request.headers.get("user-agent")
-        const readyOption: keyof RenderToPipeableStreamOptions =
-          (userAgent && isbot(userAgent)) || routerContext.isSpaMode ? "onAllReady" : "onShellReady"
-        let timeoutId: ReturnType<typeof setTimeout> | undefined = setTimeout(
-          () => abort(),
-          streamTimeout + 1000
-        )
-        const { pipe, abort } = renderToPipeableStream(
-          <ServerRouter context={routerContext} url={request.url} />,
-          {
-            [readyOption]() {
-              shellRendered = true
-              const body = new PassThrough({
-                final(callback) {
-                  clearTimeout(timeoutId)
-                  timeoutId = undefined
-                  callback()
-                },
+  return serverI18nScope.run(i18n, async () => {
+    await waitForServerI18nTestBarrier(request)
+    return new Promise((resolve, reject) => {
+      let shellRendered = false
+      const userAgent = request.headers.get("user-agent")
+      const readyOption: keyof RenderToPipeableStreamOptions =
+        (userAgent && isbot(userAgent)) || routerContext.isSpaMode ? "onAllReady" : "onShellReady"
+      let timeoutId: ReturnType<typeof setTimeout> | undefined = setTimeout(
+        () => abort(),
+        streamTimeout + 1000
+      )
+      const { pipe, abort } = renderToPipeableStream(
+        <ServerRouter context={routerContext} url={request.url} />,
+        {
+          [readyOption]() {
+            shellRendered = true
+            const body = new PassThrough({
+              final(callback) {
+                clearTimeout(timeoutId)
+                timeoutId = undefined
+                callback()
+              },
+            })
+            responseHeaders.set("Content-Type", "text/html")
+            pipe(body)
+            resolve(
+              new Response(createReadableStreamFromReadable(body), {
+                headers: responseHeaders,
+                status: responseStatusCode,
               })
-              responseHeaders.set("Content-Type", "text/html")
-              pipe(body)
-              resolve(
-                new Response(createReadableStreamFromReadable(body), {
-                  headers: responseHeaders,
-                  status: responseStatusCode,
-                })
-              )
-            },
-            onShellError(error: unknown) {
-              reject(error)
-            },
-            onError(error: unknown) {
-              responseStatusCode = 500
-              if (shellRendered) console.error(error)
-            },
-          }
-        )
-      })
-  )
+            )
+          },
+          onShellError(error: unknown) {
+            reject(error)
+          },
+          onError(error: unknown) {
+            responseStatusCode = 500
+            if (shellRendered) console.error(error)
+          },
+        }
+      )
+    })
+  })
 }

--- a/examples/react-router-tld/app/entry.server.tsx
+++ b/examples/react-router-tld/app/entry.server.tsx
@@ -1,0 +1,69 @@
+import { PassThrough } from "node:stream"
+import { createReadableStreamFromReadable } from "@react-router/node"
+import { isbot } from "isbot"
+import type { EntryContext, RouterContextProvider } from "react-router"
+import { ServerRouter } from "react-router"
+import type { RenderToPipeableStreamOptions } from "react-dom/server"
+import { renderToPipeableStream } from "react-dom/server"
+import { createServerI18n, resolveLocaleFromRequest } from "~/lib/i18n"
+import { serverI18nScope } from "~/lib/i18n.server"
+
+export const streamTimeout = 5000
+
+export default function handleRequest(
+  request: Request,
+  responseStatusCode: number,
+  responseHeaders: Headers,
+  routerContext: EntryContext,
+  _loadContext: RouterContextProvider
+) {
+  if (request.method.toUpperCase() === "HEAD") {
+    return new Response(null, { status: responseStatusCode, headers: responseHeaders })
+  }
+
+  const i18n = createServerI18n(resolveLocaleFromRequest(request))
+  return serverI18nScope.run(
+    i18n,
+    () =>
+      new Promise((resolve, reject) => {
+        let shellRendered = false
+        const userAgent = request.headers.get("user-agent")
+        const readyOption: keyof RenderToPipeableStreamOptions =
+          (userAgent && isbot(userAgent)) || routerContext.isSpaMode ? "onAllReady" : "onShellReady"
+        let timeoutId: ReturnType<typeof setTimeout> | undefined = setTimeout(
+          () => abort(),
+          streamTimeout + 1000
+        )
+        const { pipe, abort } = renderToPipeableStream(
+          <ServerRouter context={routerContext} url={request.url} />,
+          {
+            [readyOption]() {
+              shellRendered = true
+              const body = new PassThrough({
+                final(callback) {
+                  clearTimeout(timeoutId)
+                  timeoutId = undefined
+                  callback()
+                },
+              })
+              responseHeaders.set("Content-Type", "text/html")
+              pipe(body)
+              resolve(
+                new Response(createReadableStreamFromReadable(body), {
+                  headers: responseHeaders,
+                  status: responseStatusCode,
+                })
+              )
+            },
+            onShellError(error: unknown) {
+              reject(error)
+            },
+            onError(error: unknown) {
+              responseStatusCode = 500
+              if (shellRendered) console.error(error)
+            },
+          }
+        )
+      })
+  )
+}

--- a/examples/react-router-tld/app/lib/i18n.server.ts
+++ b/examples/react-router-tld/app/lib/i18n.server.ts
@@ -1,0 +1,4 @@
+import { createServerI18nScope } from "@palamedes/runtime/server"
+import type { createExampleI18n } from "./i18n"
+
+export const serverI18nScope = createServerI18nScope<ReturnType<typeof createExampleI18n>>()

--- a/examples/react-router-tld/app/lib/i18n.ts
+++ b/examples/react-router-tld/app/lib/i18n.ts
@@ -1,6 +1,6 @@
 import { createI18n } from "@palamedes/core"
 import type { CompiledCatalogMessages } from "@palamedes/core/compiled"
-import { setClientI18n, setServerI18nGetter } from "@palamedes/runtime"
+import { activateServerI18n as activateScopedServerI18n, setClientI18n } from "@palamedes/runtime"
 import { defineLocaleControls } from "@palamedes/core/locale"
 import { messages as enMessages } from "../locales/en.po"
 import { messages as deMessages } from "../locales/de.po"
@@ -51,12 +51,15 @@ export function createExampleI18n() {
   return createI18n()
 }
 
-export function activateServerI18n(locale: Locale) {
+export function createServerI18n(locale: Locale) {
   const i18n = createExampleI18n()
   i18n.load(locale, loadMessages(locale))
   i18n.activate(locale)
-  setServerI18nGetter(() => i18n)
   return i18n
+}
+
+export function activateServerI18n(locale: Locale) {
+  return activateScopedServerI18n(createServerI18n(locale))
 }
 
 const clientI18n = createExampleI18n()

--- a/examples/solidstart-cookie/src/entry-server.tsx
+++ b/examples/solidstart-cookie/src/entry-server.tsx
@@ -1,29 +1,19 @@
 import { createHandler, StartServer } from "@solidjs/start/server"
-import { createServerI18n, serverI18nScope } from "./lib/i18n.server"
-import { locales } from "./lib/i18n"
 
-export default createHandler((context) => {
-  const { locale } = locales.resolve({
-    strategy: "cookie",
-    acceptLanguageHeader: context.request.headers.get("accept-language"),
-    cookieHeader: context.request.headers.get("cookie"),
-  })
-  serverI18nScope.activate(createServerI18n(locale))
-  return (
-    <StartServer
-      document={({ assets, children, scripts }) => (
-        <html lang="en">
-          <head>
-            <meta charset="utf-8" />
-            <meta content="width=device-width, initial-scale=1" name="viewport" />
-            {assets}
-          </head>
-          <body>
-            <div id="app">{children}</div>
-            {scripts}
-          </body>
-        </html>
-      )}
-    />
-  )
-})
+export default createHandler(() => (
+  <StartServer
+    document={({ assets, children, scripts }) => (
+      <html lang="en">
+        <head>
+          <meta charset="utf-8" />
+          <meta content="width=device-width, initial-scale=1" name="viewport" />
+          {assets}
+        </head>
+        <body>
+          <div id="app">{children}</div>
+          {scripts}
+        </body>
+      </html>
+    )}
+  />
+))

--- a/examples/solidstart-cookie/src/entry-server.tsx
+++ b/examples/solidstart-cookie/src/entry-server.tsx
@@ -1,19 +1,29 @@
 import { createHandler, StartServer } from "@solidjs/start/server"
+import { createServerI18n, serverI18nScope } from "./lib/i18n.server"
+import { locales } from "./lib/i18n"
 
-export default createHandler(() => (
-  <StartServer
-    document={({ assets, children, scripts }) => (
-      <html lang="en">
-        <head>
-          <meta charset="utf-8" />
-          <meta content="width=device-width, initial-scale=1" name="viewport" />
-          {assets}
-        </head>
-        <body>
-          <div id="app">{children}</div>
-          {scripts}
-        </body>
-      </html>
-    )}
-  />
-))
+export default createHandler((context) => {
+  const { locale } = locales.resolve({
+    strategy: "cookie",
+    acceptLanguageHeader: context.request.headers.get("accept-language"),
+    cookieHeader: context.request.headers.get("cookie"),
+  })
+  serverI18nScope.activate(createServerI18n(locale))
+  return (
+    <StartServer
+      document={({ assets, children, scripts }) => (
+        <html lang="en">
+          <head>
+            <meta charset="utf-8" />
+            <meta content="width=device-width, initial-scale=1" name="viewport" />
+            {assets}
+          </head>
+          <body>
+            <div id="app">{children}</div>
+            {scripts}
+          </body>
+        </html>
+      )}
+    />
+  )
+})

--- a/examples/solidstart-cookie/src/lib/i18n.server.ts
+++ b/examples/solidstart-cookie/src/lib/i18n.server.ts
@@ -1,13 +1,17 @@
-import { setServerI18nGetter } from "@palamedes/runtime"
+import { createServerI18nScope } from "@palamedes/runtime/server"
 import { createExampleI18n, loadMessages, type Locale } from "./i18n"
 
-export async function activateServerI18n(locale: Locale) {
+export const serverI18nScope = createServerI18nScope<ReturnType<typeof createExampleI18n>>()
+
+export function createServerI18n(locale: Locale) {
   const i18n = createExampleI18n()
-  const messages = await loadMessages(locale)
+  const messages = loadMessages(locale)
 
   i18n.load(locale, messages)
   i18n.activate(locale)
-  setServerI18nGetter(() => i18n)
-
   return i18n
+}
+
+export function activateServerI18n(locale: Locale) {
+  return serverI18nScope.activate(createServerI18n(locale))
 }

--- a/examples/solidstart-cookie/src/middleware.ts
+++ b/examples/solidstart-cookie/src/middleware.ts
@@ -1,0 +1,16 @@
+import { createMiddleware } from "@solidjs/start/middleware"
+import { waitForServerI18nTestBarrier } from "@palamedes/runtime/server/test"
+import { createServerI18n, serverI18nScope } from "./lib/i18n.server"
+import { locales } from "./lib/i18n"
+
+export default createMiddleware({
+  async onRequest(event) {
+    const { locale } = locales.resolve({
+      strategy: "cookie",
+      acceptLanguageHeader: event.request.headers.get("accept-language"),
+      cookieHeader: event.request.headers.get("cookie"),
+    })
+    serverI18nScope.activate(createServerI18n(locale))
+    await waitForServerI18nTestBarrier(event.request)
+  },
+})

--- a/examples/solidstart-cookie/src/middleware.ts
+++ b/examples/solidstart-cookie/src/middleware.ts
@@ -1,16 +1,23 @@
 import { createMiddleware } from "@solidjs/start/middleware"
-import { waitForServerI18nTestBarrier } from "@palamedes/runtime/server/test"
+import {
+  markServerI18nTestBarrierReached,
+  waitForServerI18nTestBarrier,
+} from "@palamedes/runtime/server/test"
 import { createServerI18n, serverI18nScope } from "./lib/i18n.server"
 import { locales } from "./lib/i18n"
 
-export default createMiddleware({
-  async onRequest(event) {
+export default createMiddleware([
+  async (event, next) => {
+    const request = event.req
     const { locale } = locales.resolve({
       strategy: "cookie",
-      acceptLanguageHeader: event.request.headers.get("accept-language"),
-      cookieHeader: event.request.headers.get("cookie"),
+      acceptLanguageHeader: request.headers.get("accept-language"),
+      cookieHeader: request.headers.get("cookie"),
     })
-    serverI18nScope.activate(createServerI18n(locale))
-    await waitForServerI18nTestBarrier(event.request)
+    return serverI18nScope.run(createServerI18n(locale), async () => {
+      await waitForServerI18nTestBarrier(request)
+      markServerI18nTestBarrierReached(request, event.res.headers)
+      return next()
+    })
   },
-})
+])

--- a/examples/solidstart-cookie/vite.config.ts
+++ b/examples/solidstart-cookie/vite.config.ts
@@ -4,5 +4,9 @@ import { solidStart } from "@solidjs/start/config"
 import { palamedes } from "@palamedes/vite-plugin"
 
 export default defineConfig({
-  plugins: [palamedes({ framework: "solid" }), solidStart(), nitro()],
+  plugins: [
+    palamedes({ framework: "solid" }),
+    solidStart({ middleware: "src/middleware.ts" }),
+    nitro(),
+  ],
 })

--- a/examples/solidstart-route/src/entry-server.tsx
+++ b/examples/solidstart-route/src/entry-server.tsx
@@ -1,19 +1,27 @@
 import { createHandler, StartServer } from "@solidjs/start/server"
+import { createServerI18n, serverI18nScope } from "./lib/i18n.server"
+import { normalizeLocale } from "./lib/i18n"
 
-export default createHandler(() => (
-  <StartServer
-    document={({ assets, children, scripts }) => (
-      <html lang="en">
-        <head>
-          <meta charset="utf-8" />
-          <meta content="width=device-width, initial-scale=1" name="viewport" />
-          {assets}
-        </head>
-        <body>
-          <div id="app">{children}</div>
-          {scripts}
-        </body>
-      </html>
-    )}
-  />
-))
+export default createHandler((context) => {
+  const locale = normalizeLocale(
+    new URL(context.request.url).pathname.split("/").filter(Boolean)[0]
+  )
+  serverI18nScope.activate(createServerI18n(locale))
+  return (
+    <StartServer
+      document={({ assets, children, scripts }) => (
+        <html lang="en">
+          <head>
+            <meta charset="utf-8" />
+            <meta content="width=device-width, initial-scale=1" name="viewport" />
+            {assets}
+          </head>
+          <body>
+            <div id="app">{children}</div>
+            {scripts}
+          </body>
+        </html>
+      )}
+    />
+  )
+})

--- a/examples/solidstart-route/src/entry-server.tsx
+++ b/examples/solidstart-route/src/entry-server.tsx
@@ -1,27 +1,19 @@
 import { createHandler, StartServer } from "@solidjs/start/server"
-import { createServerI18n, serverI18nScope } from "./lib/i18n.server"
-import { normalizeLocale } from "./lib/i18n"
 
-export default createHandler((context) => {
-  const locale = normalizeLocale(
-    new URL(context.request.url).pathname.split("/").filter(Boolean)[0]
-  )
-  serverI18nScope.activate(createServerI18n(locale))
-  return (
-    <StartServer
-      document={({ assets, children, scripts }) => (
-        <html lang="en">
-          <head>
-            <meta charset="utf-8" />
-            <meta content="width=device-width, initial-scale=1" name="viewport" />
-            {assets}
-          </head>
-          <body>
-            <div id="app">{children}</div>
-            {scripts}
-          </body>
-        </html>
-      )}
-    />
-  )
-})
+export default createHandler(() => (
+  <StartServer
+    document={({ assets, children, scripts }) => (
+      <html lang="en">
+        <head>
+          <meta charset="utf-8" />
+          <meta content="width=device-width, initial-scale=1" name="viewport" />
+          {assets}
+        </head>
+        <body>
+          <div id="app">{children}</div>
+          {scripts}
+        </body>
+      </html>
+    )}
+  />
+))

--- a/examples/solidstart-route/src/lib/i18n.server.ts
+++ b/examples/solidstart-route/src/lib/i18n.server.ts
@@ -1,12 +1,16 @@
-import { setServerI18nGetter } from "@palamedes/runtime"
+import { createServerI18nScope } from "@palamedes/runtime/server"
 import { createExampleI18n, localeMessages, type Locale } from "./i18n"
 
-export function activateServerI18n(locale: Locale) {
+export const serverI18nScope = createServerI18nScope<ReturnType<typeof createExampleI18n>>()
+
+export function createServerI18n(locale: Locale) {
   const i18n = createExampleI18n()
 
   i18n.load(locale, localeMessages[locale])
   i18n.activate(locale)
-  setServerI18nGetter(() => i18n)
-
   return i18n
+}
+
+export function activateServerI18n(locale: Locale) {
+  return serverI18nScope.activate(createServerI18n(locale))
 }

--- a/examples/solidstart-route/src/middleware.ts
+++ b/examples/solidstart-route/src/middleware.ts
@@ -1,0 +1,14 @@
+import { createMiddleware } from "@solidjs/start/middleware"
+import { waitForServerI18nTestBarrier } from "@palamedes/runtime/server/test"
+import { createServerI18n, serverI18nScope } from "./lib/i18n.server"
+import { normalizeLocale } from "./lib/i18n"
+
+export default createMiddleware({
+  async onRequest(event) {
+    const locale = normalizeLocale(
+      new URL(event.request.url).pathname.split("/").filter(Boolean)[0]
+    )
+    serverI18nScope.activate(createServerI18n(locale))
+    await waitForServerI18nTestBarrier(event.request)
+  },
+})

--- a/examples/solidstart-route/src/middleware.ts
+++ b/examples/solidstart-route/src/middleware.ts
@@ -1,14 +1,19 @@
 import { createMiddleware } from "@solidjs/start/middleware"
-import { waitForServerI18nTestBarrier } from "@palamedes/runtime/server/test"
+import {
+  markServerI18nTestBarrierReached,
+  waitForServerI18nTestBarrier,
+} from "@palamedes/runtime/server/test"
 import { createServerI18n, serverI18nScope } from "./lib/i18n.server"
 import { normalizeLocale } from "./lib/i18n"
 
-export default createMiddleware({
-  async onRequest(event) {
-    const locale = normalizeLocale(
-      new URL(event.request.url).pathname.split("/").filter(Boolean)[0]
-    )
-    serverI18nScope.activate(createServerI18n(locale))
-    await waitForServerI18nTestBarrier(event.request)
+export default createMiddleware([
+  async (event, next) => {
+    const request = event.req
+    const locale = normalizeLocale(new URL(request.url).pathname.split("/").filter(Boolean)[0])
+    return serverI18nScope.run(createServerI18n(locale), async () => {
+      await waitForServerI18nTestBarrier(request)
+      markServerI18nTestBarrierReached(request, event.res.headers)
+      return next()
+    })
   },
-})
+])

--- a/examples/solidstart-route/vite.config.ts
+++ b/examples/solidstart-route/vite.config.ts
@@ -6,5 +6,9 @@ import { palamedes } from "@palamedes/vite-plugin"
 export default defineConfig({
   // Select Solid's component contract for compiled rich messages. Macro
   // lookups keep using the framework-neutral, hook-free runtime getter.
-  plugins: [palamedes({ framework: "solid" }), solidStart(), nitro()],
+  plugins: [
+    palamedes({ framework: "solid" }),
+    solidStart({ middleware: "src/middleware.ts" }),
+    nitro(),
+  ],
 })

--- a/examples/solidstart-subdomain/src/entry-server.tsx
+++ b/examples/solidstart-subdomain/src/entry-server.tsx
@@ -1,19 +1,29 @@
 import { createHandler, StartServer } from "@solidjs/start/server"
+import { createServerI18n, serverI18nScope } from "./lib/i18n.server"
+import { locales } from "./lib/i18n"
 
-export default createHandler(() => (
-  <StartServer
-    document={({ assets, children, scripts }) => (
-      <html lang="en">
-        <head>
-          <meta charset="utf-8" />
-          <meta content="width=device-width, initial-scale=1" name="viewport" />
-          {assets}
-        </head>
-        <body>
-          <div id="app">{children}</div>
-          {scripts}
-        </body>
-      </html>
-    )}
-  />
-))
+export default createHandler((context) => {
+  const { locale } = locales.resolve({
+    strategy: "subdomain",
+    acceptLanguageHeader: context.request.headers.get("accept-language"),
+    requestHost: context.request.headers.get("host"),
+  })
+  serverI18nScope.activate(createServerI18n(locale))
+  return (
+    <StartServer
+      document={({ assets, children, scripts }) => (
+        <html lang="en">
+          <head>
+            <meta charset="utf-8" />
+            <meta content="width=device-width, initial-scale=1" name="viewport" />
+            {assets}
+          </head>
+          <body>
+            <div id="app">{children}</div>
+            {scripts}
+          </body>
+        </html>
+      )}
+    />
+  )
+})

--- a/examples/solidstart-subdomain/src/entry-server.tsx
+++ b/examples/solidstart-subdomain/src/entry-server.tsx
@@ -1,29 +1,19 @@
 import { createHandler, StartServer } from "@solidjs/start/server"
-import { createServerI18n, serverI18nScope } from "./lib/i18n.server"
-import { locales } from "./lib/i18n"
 
-export default createHandler((context) => {
-  const { locale } = locales.resolve({
-    strategy: "subdomain",
-    acceptLanguageHeader: context.request.headers.get("accept-language"),
-    requestHost: context.request.headers.get("host"),
-  })
-  serverI18nScope.activate(createServerI18n(locale))
-  return (
-    <StartServer
-      document={({ assets, children, scripts }) => (
-        <html lang="en">
-          <head>
-            <meta charset="utf-8" />
-            <meta content="width=device-width, initial-scale=1" name="viewport" />
-            {assets}
-          </head>
-          <body>
-            <div id="app">{children}</div>
-            {scripts}
-          </body>
-        </html>
-      )}
-    />
-  )
-})
+export default createHandler(() => (
+  <StartServer
+    document={({ assets, children, scripts }) => (
+      <html lang="en">
+        <head>
+          <meta charset="utf-8" />
+          <meta content="width=device-width, initial-scale=1" name="viewport" />
+          {assets}
+        </head>
+        <body>
+          <div id="app">{children}</div>
+          {scripts}
+        </body>
+      </html>
+    )}
+  />
+))

--- a/examples/solidstart-subdomain/src/lib/i18n.server.ts
+++ b/examples/solidstart-subdomain/src/lib/i18n.server.ts
@@ -1,12 +1,16 @@
-import { setServerI18nGetter } from "@palamedes/runtime"
+import { createServerI18nScope } from "@palamedes/runtime/server"
 import { createExampleI18n, localeMessages, type Locale } from "./i18n"
 
-export function activateServerI18n(locale: Locale) {
+export const serverI18nScope = createServerI18nScope<ReturnType<typeof createExampleI18n>>()
+
+export function createServerI18n(locale: Locale) {
   const i18n = createExampleI18n()
 
   i18n.load(locale, localeMessages[locale])
   i18n.activate(locale)
-  setServerI18nGetter(() => i18n)
-
   return i18n
+}
+
+export function activateServerI18n(locale: Locale) {
+  return serverI18nScope.activate(createServerI18n(locale))
 }

--- a/examples/solidstart-subdomain/src/middleware.ts
+++ b/examples/solidstart-subdomain/src/middleware.ts
@@ -1,0 +1,16 @@
+import { createMiddleware } from "@solidjs/start/middleware"
+import { waitForServerI18nTestBarrier } from "@palamedes/runtime/server/test"
+import { createServerI18n, serverI18nScope } from "./lib/i18n.server"
+import { locales } from "./lib/i18n"
+
+export default createMiddleware({
+  async onRequest(event) {
+    const { locale } = locales.resolve({
+      strategy: "subdomain",
+      acceptLanguageHeader: event.request.headers.get("accept-language"),
+      requestHost: event.request.headers.get("host"),
+    })
+    serverI18nScope.activate(createServerI18n(locale))
+    await waitForServerI18nTestBarrier(event.request)
+  },
+})

--- a/examples/solidstart-subdomain/src/middleware.ts
+++ b/examples/solidstart-subdomain/src/middleware.ts
@@ -1,16 +1,23 @@
 import { createMiddleware } from "@solidjs/start/middleware"
-import { waitForServerI18nTestBarrier } from "@palamedes/runtime/server/test"
+import {
+  markServerI18nTestBarrierReached,
+  waitForServerI18nTestBarrier,
+} from "@palamedes/runtime/server/test"
 import { createServerI18n, serverI18nScope } from "./lib/i18n.server"
 import { locales } from "./lib/i18n"
 
-export default createMiddleware({
-  async onRequest(event) {
+export default createMiddleware([
+  async (event, next) => {
+    const request = event.req
     const { locale } = locales.resolve({
       strategy: "subdomain",
-      acceptLanguageHeader: event.request.headers.get("accept-language"),
-      requestHost: event.request.headers.get("host"),
+      acceptLanguageHeader: request.headers.get("accept-language"),
+      requestHost: request.headers.get("host"),
     })
-    serverI18nScope.activate(createServerI18n(locale))
-    await waitForServerI18nTestBarrier(event.request)
+    return serverI18nScope.run(createServerI18n(locale), async () => {
+      await waitForServerI18nTestBarrier(request)
+      markServerI18nTestBarrierReached(request, event.res.headers)
+      return next()
+    })
   },
-})
+])

--- a/examples/solidstart-subdomain/vite.config.ts
+++ b/examples/solidstart-subdomain/vite.config.ts
@@ -6,7 +6,11 @@ import { palamedes } from "@palamedes/vite-plugin"
 export default defineConfig({
   // Select Solid's component contract for compiled rich messages. Macro
   // lookups keep using the framework-neutral, hook-free runtime getter.
-  plugins: [palamedes({ framework: "solid" }), solidStart(), nitro()],
+  plugins: [
+    palamedes({ framework: "solid" }),
+    solidStart({ middleware: "src/middleware.ts" }),
+    nitro(),
+  ],
   // The subdomain strategy serves each locale from its own host label
   // (`de.lvh.me`, `en.lvh.me`, …). Allow those hosts plus the deployed
   // preview domain for the dev/preview servers, and pin the demo port.

--- a/examples/solidstart-tld/src/entry-server.tsx
+++ b/examples/solidstart-tld/src/entry-server.tsx
@@ -1,19 +1,29 @@
 import { createHandler, StartServer } from "@solidjs/start/server"
+import { createServerI18n, serverI18nScope } from "./lib/i18n.server"
+import { locales } from "./lib/i18n"
 
-export default createHandler(() => (
-  <StartServer
-    document={({ assets, children, scripts }) => (
-      <html lang="en">
-        <head>
-          <meta charset="utf-8" />
-          <meta content="width=device-width, initial-scale=1" name="viewport" />
-          {assets}
-        </head>
-        <body>
-          <div id="app">{children}</div>
-          {scripts}
-        </body>
-      </html>
-    )}
-  />
-))
+export default createHandler((context) => {
+  const { locale } = locales.resolve({
+    strategy: "tld",
+    acceptLanguageHeader: context.request.headers.get("accept-language"),
+    requestHost: context.request.headers.get("host"),
+  })
+  serverI18nScope.activate(createServerI18n(locale))
+  return (
+    <StartServer
+      document={({ assets, children, scripts }) => (
+        <html lang="en">
+          <head>
+            <meta charset="utf-8" />
+            <meta content="width=device-width, initial-scale=1" name="viewport" />
+            {assets}
+          </head>
+          <body>
+            <div id="app">{children}</div>
+            {scripts}
+          </body>
+        </html>
+      )}
+    />
+  )
+})

--- a/examples/solidstart-tld/src/entry-server.tsx
+++ b/examples/solidstart-tld/src/entry-server.tsx
@@ -1,29 +1,19 @@
 import { createHandler, StartServer } from "@solidjs/start/server"
-import { createServerI18n, serverI18nScope } from "./lib/i18n.server"
-import { locales } from "./lib/i18n"
 
-export default createHandler((context) => {
-  const { locale } = locales.resolve({
-    strategy: "tld",
-    acceptLanguageHeader: context.request.headers.get("accept-language"),
-    requestHost: context.request.headers.get("host"),
-  })
-  serverI18nScope.activate(createServerI18n(locale))
-  return (
-    <StartServer
-      document={({ assets, children, scripts }) => (
-        <html lang="en">
-          <head>
-            <meta charset="utf-8" />
-            <meta content="width=device-width, initial-scale=1" name="viewport" />
-            {assets}
-          </head>
-          <body>
-            <div id="app">{children}</div>
-            {scripts}
-          </body>
-        </html>
-      )}
-    />
-  )
-})
+export default createHandler(() => (
+  <StartServer
+    document={({ assets, children, scripts }) => (
+      <html lang="en">
+        <head>
+          <meta charset="utf-8" />
+          <meta content="width=device-width, initial-scale=1" name="viewport" />
+          {assets}
+        </head>
+        <body>
+          <div id="app">{children}</div>
+          {scripts}
+        </body>
+      </html>
+    )}
+  />
+))

--- a/examples/solidstart-tld/src/lib/i18n.server.ts
+++ b/examples/solidstart-tld/src/lib/i18n.server.ts
@@ -1,12 +1,16 @@
-import { setServerI18nGetter } from "@palamedes/runtime"
+import { createServerI18nScope } from "@palamedes/runtime/server"
 import { createExampleI18n, localeMessages, type Locale } from "./i18n"
 
-export function activateServerI18n(locale: Locale) {
+export const serverI18nScope = createServerI18nScope<ReturnType<typeof createExampleI18n>>()
+
+export function createServerI18n(locale: Locale) {
   const i18n = createExampleI18n()
 
   i18n.load(locale, localeMessages[locale])
   i18n.activate(locale)
-  setServerI18nGetter(() => i18n)
-
   return i18n
+}
+
+export function activateServerI18n(locale: Locale) {
+  return serverI18nScope.activate(createServerI18n(locale))
 }

--- a/examples/solidstart-tld/src/middleware.ts
+++ b/examples/solidstart-tld/src/middleware.ts
@@ -1,16 +1,23 @@
 import { createMiddleware } from "@solidjs/start/middleware"
-import { waitForServerI18nTestBarrier } from "@palamedes/runtime/server/test"
+import {
+  markServerI18nTestBarrierReached,
+  waitForServerI18nTestBarrier,
+} from "@palamedes/runtime/server/test"
 import { createServerI18n, serverI18nScope } from "./lib/i18n.server"
 import { locales } from "./lib/i18n"
 
-export default createMiddleware({
-  async onRequest(event) {
+export default createMiddleware([
+  async (event, next) => {
+    const request = event.req
     const { locale } = locales.resolve({
       strategy: "tld",
-      acceptLanguageHeader: event.request.headers.get("accept-language"),
-      requestHost: event.request.headers.get("host"),
+      acceptLanguageHeader: request.headers.get("accept-language"),
+      requestHost: request.headers.get("host"),
     })
-    serverI18nScope.activate(createServerI18n(locale))
-    await waitForServerI18nTestBarrier(event.request)
+    return serverI18nScope.run(createServerI18n(locale), async () => {
+      await waitForServerI18nTestBarrier(request)
+      markServerI18nTestBarrierReached(request, event.res.headers)
+      return next()
+    })
   },
-})
+])

--- a/examples/solidstart-tld/src/middleware.ts
+++ b/examples/solidstart-tld/src/middleware.ts
@@ -1,0 +1,16 @@
+import { createMiddleware } from "@solidjs/start/middleware"
+import { waitForServerI18nTestBarrier } from "@palamedes/runtime/server/test"
+import { createServerI18n, serverI18nScope } from "./lib/i18n.server"
+import { locales } from "./lib/i18n"
+
+export default createMiddleware({
+  async onRequest(event) {
+    const { locale } = locales.resolve({
+      strategy: "tld",
+      acceptLanguageHeader: event.request.headers.get("accept-language"),
+      requestHost: event.request.headers.get("host"),
+    })
+    serverI18nScope.activate(createServerI18n(locale))
+    await waitForServerI18nTestBarrier(event.request)
+  },
+})

--- a/examples/solidstart-tld/vite.config.ts
+++ b/examples/solidstart-tld/vite.config.ts
@@ -6,7 +6,11 @@ import { palamedes } from "@palamedes/vite-plugin"
 export default defineConfig({
   // Select Solid's component contract for compiled rich messages. Macro
   // lookups keep using the framework-neutral, hook-free runtime getter.
-  plugins: [palamedes({ framework: "solid" }), solidStart(), nitro()],
+  plugins: [
+    palamedes({ framework: "solid" }),
+    solidStart({ middleware: "src/middleware.ts" }),
+    nitro(),
+  ],
   // The TLD strategy serves each locale from its own top-level domain
   // (`example.de`, `example.fr`, …). Allow those hosts plus the deployed
   // preview domain for the dev/preview servers, and pin the demo port.

--- a/examples/tanstack-cookie/src/lib/i18n.server.ts
+++ b/examples/tanstack-cookie/src/lib/i18n.server.ts
@@ -1,13 +1,17 @@
-import { setServerI18nGetter } from "@palamedes/runtime"
+import { createServerI18nScope } from "@palamedes/runtime/server"
 import { createExampleI18n, loadMessages, type Locale } from "./i18n"
 
-export async function activateServerI18n(locale: Locale) {
+export const serverI18nScope = createServerI18nScope<ReturnType<typeof createExampleI18n>>()
+
+export async function createServerI18n(locale: Locale) {
   const i18n = createExampleI18n()
   const messages = await loadMessages(locale)
 
   i18n.load(locale, messages)
   i18n.activate(locale)
-  setServerI18nGetter(() => i18n)
-
   return i18n
+}
+
+export async function activateServerI18n(locale: Locale) {
+  return serverI18nScope.activate(await createServerI18n(locale))
 }

--- a/examples/tanstack-cookie/src/server.ts
+++ b/examples/tanstack-cookie/src/server.ts
@@ -1,0 +1,16 @@
+import { createStartHandler, defaultStreamHandler } from "@tanstack/react-start/server"
+import { createServerI18n, serverI18nScope } from "./lib/i18n.server"
+import { locales } from "./lib/i18n"
+
+const handler = createStartHandler(defaultStreamHandler)
+
+export default {
+  async fetch(request: Request, options?: never) {
+    const { locale } = locales.resolve({
+      strategy: "cookie",
+      acceptLanguageHeader: request.headers.get("accept-language"),
+      cookieHeader: request.headers.get("cookie"),
+    })
+    return serverI18nScope.run(await createServerI18n(locale), () => handler(request, options))
+  },
+}

--- a/examples/tanstack-cookie/src/server.ts
+++ b/examples/tanstack-cookie/src/server.ts
@@ -1,4 +1,5 @@
 import { createStartHandler, defaultStreamHandler } from "@tanstack/react-start/server"
+import { waitForServerI18nTestBarrier } from "@palamedes/runtime/server/test"
 import { createServerI18n, serverI18nScope } from "./lib/i18n.server"
 import { locales } from "./lib/i18n"
 
@@ -11,6 +12,9 @@ export default {
       acceptLanguageHeader: request.headers.get("accept-language"),
       cookieHeader: request.headers.get("cookie"),
     })
-    return serverI18nScope.run(await createServerI18n(locale), () => handler(request, options))
+    return serverI18nScope.run(await createServerI18n(locale), async () => {
+      await waitForServerI18nTestBarrier(request)
+      return handler(request, options)
+    })
   },
 }

--- a/examples/tanstack-cookie/src/server.ts
+++ b/examples/tanstack-cookie/src/server.ts
@@ -1,5 +1,8 @@
 import { createStartHandler, defaultStreamHandler } from "@tanstack/react-start/server"
-import { waitForServerI18nTestBarrier } from "@palamedes/runtime/server/test"
+import {
+  markServerI18nTestBarrierReached,
+  waitForServerI18nTestBarrier,
+} from "@palamedes/runtime/server/test"
 import { createServerI18n, serverI18nScope } from "./lib/i18n.server"
 import { locales } from "./lib/i18n"
 
@@ -14,7 +17,9 @@ export default {
     })
     return serverI18nScope.run(await createServerI18n(locale), async () => {
       await waitForServerI18nTestBarrier(request)
-      return handler(request, options)
+      const response = await handler(request, options)
+      markServerI18nTestBarrierReached(request, response.headers)
+      return response
     })
   },
 }

--- a/examples/tanstack-route/src/lib/i18n.server.ts
+++ b/examples/tanstack-route/src/lib/i18n.server.ts
@@ -1,12 +1,16 @@
-import { setServerI18nGetter } from "@palamedes/runtime"
+import { createServerI18nScope } from "@palamedes/runtime/server"
 import { createExampleI18n, localeMessages, type Locale } from "./i18n"
 
-export function activateServerI18n(locale: Locale) {
+export const serverI18nScope = createServerI18nScope<ReturnType<typeof createExampleI18n>>()
+
+export function createServerI18n(locale: Locale) {
   const i18n = createExampleI18n()
 
   i18n.load(locale, localeMessages[locale])
   i18n.activate(locale)
-  setServerI18nGetter(() => i18n)
-
   return i18n
+}
+
+export function activateServerI18n(locale: Locale) {
+  return serverI18nScope.activate(createServerI18n(locale))
 }

--- a/examples/tanstack-route/src/server.ts
+++ b/examples/tanstack-route/src/server.ts
@@ -1,0 +1,14 @@
+import { createStartHandler, defaultStreamHandler } from "@tanstack/react-start/server"
+import { createServerI18n, serverI18nScope } from "./lib/i18n.server"
+import { normalizeLocale } from "./lib/i18n"
+
+const handler = createStartHandler(defaultStreamHandler)
+
+export default {
+  fetch(request: Request, options?: never) {
+    const segment = new URL(request.url).pathname.split("/").filter(Boolean)[0]
+    return serverI18nScope.run(createServerI18n(normalizeLocale(segment)), () =>
+      handler(request, options)
+    )
+  },
+}

--- a/examples/tanstack-route/src/server.ts
+++ b/examples/tanstack-route/src/server.ts
@@ -1,4 +1,5 @@
 import { createStartHandler, defaultStreamHandler } from "@tanstack/react-start/server"
+import { waitForServerI18nTestBarrier } from "@palamedes/runtime/server/test"
 import { createServerI18n, serverI18nScope } from "./lib/i18n.server"
 import { normalizeLocale } from "./lib/i18n"
 
@@ -7,8 +8,9 @@ const handler = createStartHandler(defaultStreamHandler)
 export default {
   fetch(request: Request, options?: never) {
     const segment = new URL(request.url).pathname.split("/").filter(Boolean)[0]
-    return serverI18nScope.run(createServerI18n(normalizeLocale(segment)), () =>
-      handler(request, options)
-    )
+    return serverI18nScope.run(createServerI18n(normalizeLocale(segment)), async () => {
+      await waitForServerI18nTestBarrier(request)
+      return handler(request, options)
+    })
   },
 }

--- a/examples/tanstack-route/src/server.ts
+++ b/examples/tanstack-route/src/server.ts
@@ -1,5 +1,8 @@
 import { createStartHandler, defaultStreamHandler } from "@tanstack/react-start/server"
-import { waitForServerI18nTestBarrier } from "@palamedes/runtime/server/test"
+import {
+  markServerI18nTestBarrierReached,
+  waitForServerI18nTestBarrier,
+} from "@palamedes/runtime/server/test"
 import { createServerI18n, serverI18nScope } from "./lib/i18n.server"
 import { normalizeLocale } from "./lib/i18n"
 
@@ -10,7 +13,9 @@ export default {
     const segment = new URL(request.url).pathname.split("/").filter(Boolean)[0]
     return serverI18nScope.run(createServerI18n(normalizeLocale(segment)), async () => {
       await waitForServerI18nTestBarrier(request)
-      return handler(request, options)
+      const response = await handler(request, options)
+      markServerI18nTestBarrierReached(request, response.headers)
+      return response
     })
   },
 }

--- a/examples/tanstack-subdomain/src/lib/i18n.server.ts
+++ b/examples/tanstack-subdomain/src/lib/i18n.server.ts
@@ -1,12 +1,16 @@
-import { setServerI18nGetter } from "@palamedes/runtime"
+import { createServerI18nScope } from "@palamedes/runtime/server"
 import { createExampleI18n, localeMessages, type Locale } from "./i18n"
 
-export function activateServerI18n(locale: Locale) {
+export const serverI18nScope = createServerI18nScope<ReturnType<typeof createExampleI18n>>()
+
+export function createServerI18n(locale: Locale) {
   const i18n = createExampleI18n()
 
   i18n.load(locale, localeMessages[locale])
   i18n.activate(locale)
-  setServerI18nGetter(() => i18n)
-
   return i18n
+}
+
+export function activateServerI18n(locale: Locale) {
+  return serverI18nScope.activate(createServerI18n(locale))
 }

--- a/examples/tanstack-subdomain/src/server.ts
+++ b/examples/tanstack-subdomain/src/server.ts
@@ -1,4 +1,5 @@
 import { createStartHandler, defaultStreamHandler } from "@tanstack/react-start/server"
+import { waitForServerI18nTestBarrier } from "@palamedes/runtime/server/test"
 import { createServerI18n, serverI18nScope } from "./lib/i18n.server"
 import { locales } from "./lib/i18n"
 
@@ -11,6 +12,9 @@ export default {
       acceptLanguageHeader: request.headers.get("accept-language"),
       requestHost: request.headers.get("host"),
     })
-    return serverI18nScope.run(createServerI18n(locale), () => handler(request, options))
+    return serverI18nScope.run(createServerI18n(locale), async () => {
+      await waitForServerI18nTestBarrier(request)
+      return handler(request, options)
+    })
   },
 }

--- a/examples/tanstack-subdomain/src/server.ts
+++ b/examples/tanstack-subdomain/src/server.ts
@@ -1,0 +1,16 @@
+import { createStartHandler, defaultStreamHandler } from "@tanstack/react-start/server"
+import { createServerI18n, serverI18nScope } from "./lib/i18n.server"
+import { locales } from "./lib/i18n"
+
+const handler = createStartHandler(defaultStreamHandler)
+
+export default {
+  fetch(request: Request, options?: never) {
+    const { locale } = locales.resolve({
+      strategy: "subdomain",
+      acceptLanguageHeader: request.headers.get("accept-language"),
+      requestHost: request.headers.get("host"),
+    })
+    return serverI18nScope.run(createServerI18n(locale), () => handler(request, options))
+  },
+}

--- a/examples/tanstack-subdomain/src/server.ts
+++ b/examples/tanstack-subdomain/src/server.ts
@@ -1,5 +1,8 @@
 import { createStartHandler, defaultStreamHandler } from "@tanstack/react-start/server"
-import { waitForServerI18nTestBarrier } from "@palamedes/runtime/server/test"
+import {
+  markServerI18nTestBarrierReached,
+  waitForServerI18nTestBarrier,
+} from "@palamedes/runtime/server/test"
 import { createServerI18n, serverI18nScope } from "./lib/i18n.server"
 import { locales } from "./lib/i18n"
 
@@ -14,7 +17,9 @@ export default {
     })
     return serverI18nScope.run(createServerI18n(locale), async () => {
       await waitForServerI18nTestBarrier(request)
-      return handler(request, options)
+      const response = await handler(request, options)
+      markServerI18nTestBarrierReached(request, response.headers)
+      return response
     })
   },
 }

--- a/examples/tanstack-tld/src/lib/i18n.server.ts
+++ b/examples/tanstack-tld/src/lib/i18n.server.ts
@@ -1,12 +1,16 @@
-import { setServerI18nGetter } from "@palamedes/runtime"
+import { createServerI18nScope } from "@palamedes/runtime/server"
 import { createExampleI18n, localeMessages, type Locale } from "./i18n"
 
-export function activateServerI18n(locale: Locale) {
+export const serverI18nScope = createServerI18nScope<ReturnType<typeof createExampleI18n>>()
+
+export function createServerI18n(locale: Locale) {
   const i18n = createExampleI18n()
 
   i18n.load(locale, localeMessages[locale])
   i18n.activate(locale)
-  setServerI18nGetter(() => i18n)
-
   return i18n
+}
+
+export function activateServerI18n(locale: Locale) {
+  return serverI18nScope.activate(createServerI18n(locale))
 }

--- a/examples/tanstack-tld/src/server.ts
+++ b/examples/tanstack-tld/src/server.ts
@@ -1,0 +1,16 @@
+import { createStartHandler, defaultStreamHandler } from "@tanstack/react-start/server"
+import { createServerI18n, serverI18nScope } from "./lib/i18n.server"
+import { locales } from "./lib/i18n"
+
+const handler = createStartHandler(defaultStreamHandler)
+
+export default {
+  fetch(request: Request, options?: never) {
+    const { locale } = locales.resolve({
+      strategy: "tld",
+      acceptLanguageHeader: request.headers.get("accept-language"),
+      requestHost: request.headers.get("host"),
+    })
+    return serverI18nScope.run(createServerI18n(locale), () => handler(request, options))
+  },
+}

--- a/examples/tanstack-tld/src/server.ts
+++ b/examples/tanstack-tld/src/server.ts
@@ -1,4 +1,5 @@
 import { createStartHandler, defaultStreamHandler } from "@tanstack/react-start/server"
+import { waitForServerI18nTestBarrier } from "@palamedes/runtime/server/test"
 import { createServerI18n, serverI18nScope } from "./lib/i18n.server"
 import { locales } from "./lib/i18n"
 
@@ -11,6 +12,9 @@ export default {
       acceptLanguageHeader: request.headers.get("accept-language"),
       requestHost: request.headers.get("host"),
     })
-    return serverI18nScope.run(createServerI18n(locale), () => handler(request, options))
+    return serverI18nScope.run(createServerI18n(locale), async () => {
+      await waitForServerI18nTestBarrier(request)
+      return handler(request, options)
+    })
   },
 }

--- a/examples/tanstack-tld/src/server.ts
+++ b/examples/tanstack-tld/src/server.ts
@@ -1,5 +1,8 @@
 import { createStartHandler, defaultStreamHandler } from "@tanstack/react-start/server"
-import { waitForServerI18nTestBarrier } from "@palamedes/runtime/server/test"
+import {
+  markServerI18nTestBarrierReached,
+  waitForServerI18nTestBarrier,
+} from "@palamedes/runtime/server/test"
 import { createServerI18n, serverI18nScope } from "./lib/i18n.server"
 import { locales } from "./lib/i18n"
 
@@ -14,7 +17,9 @@ export default {
     })
     return serverI18nScope.run(createServerI18n(locale), async () => {
       await waitForServerI18nTestBarrier(request)
-      return handler(request, options)
+      const response = await handler(request, options)
+      markServerI18nTestBarrierReached(request, response.headers)
+      return response
     })
   },
 }

--- a/examples/waku-cookie/src/lib/i18n.ts
+++ b/examples/waku-cookie/src/lib/i18n.ts
@@ -1,6 +1,6 @@
 import { createI18n } from "@palamedes/core"
 import type { CompiledCatalogMessages } from "@palamedes/core/compiled"
-import { setClientI18n, setServerI18nGetter } from "@palamedes/runtime"
+import { activateServerI18n as activateScopedServerI18n, setClientI18n } from "@palamedes/runtime"
 import { defineLocaleControls } from "@palamedes/core/locale"
 import { messages as enMessages } from "../locales/en.po"
 import { messages as deMessages } from "../locales/de.po"
@@ -40,28 +40,24 @@ export function loadMessages(locale: Locale): CompiledCatalogMessages {
 
 const clientI18n = createI18n()
 
-export async function activateServerI18n(locale: Locale) {
+export async function createServerI18n(locale: Locale) {
   const i18n = createI18n()
   i18n.load(locale, loadMessages(locale))
   i18n.activate(locale)
-  setServerI18nGetter(() => i18n)
   return i18n
+}
+
+export async function activateServerI18n(locale: Locale) {
+  return activateScopedServerI18n(await createServerI18n(locale))
 }
 
 export function initializeClientI18n(locale: Locale) {
   clientI18n.load(locale, loadMessages(locale))
   clientI18n.activate(locale)
 
-  if (typeof window === "undefined") {
-    // "use client" components are still server-rendered for the initial HTML.
-    // That SSR pass runs in its own module instance where activateServerI18n was
-    // never called, so register this catalog as the server getter too — otherwise
-    // their <Trans> calls throw "No active server i18n instance" during SSR.
-    setServerI18nGetter(() => clientI18n)
-    return
+  if (typeof window !== "undefined") {
+    setClientI18n(clientI18n)
   }
-
-  setClientI18n(clientI18n)
 }
 
 if (typeof window !== "undefined") {

--- a/examples/waku-cookie/src/waku.server.ts
+++ b/examples/waku-cookie/src/waku.server.ts
@@ -1,7 +1,10 @@
 import { fsRouter } from "waku"
 import adapter from "waku/adapters/default"
 import { createServerI18nScope } from "@palamedes/runtime/server"
-import { waitForServerI18nTestBarrier } from "@palamedes/runtime/server/test"
+import {
+  markServerI18nTestBarrierReached,
+  waitForServerI18nTestBarrier,
+} from "@palamedes/runtime/server/test"
 import { createServerI18n, locales } from "./lib/i18n"
 
 // Glob keys must keep the `pages/` prefix so fsRouter's default `pagesDir: "pages"`
@@ -29,6 +32,7 @@ export default adapter(fsRouter(modules), {
       })
       return serverI18nScope.run(await createServerI18n(locale), async () => {
         await waitForServerI18nTestBarrier(request)
+        markServerI18nTestBarrierReached(request, context.res.headers)
         return next()
       })
     },

--- a/examples/waku-cookie/src/waku.server.ts
+++ b/examples/waku-cookie/src/waku.server.ts
@@ -1,5 +1,7 @@
 import { fsRouter } from "waku"
 import adapter from "waku/adapters/default"
+import { createServerI18nScope } from "@palamedes/runtime/server"
+import { createServerI18n, locales } from "./lib/i18n"
 
 // Glob keys must keep the `pages/` prefix so fsRouter's default `pagesDir: "pages"`
 // matches them. Globbing from `/src` and stripping the leading `/src/` yields
@@ -13,4 +15,18 @@ const modules = Object.fromEntries(
   ])
 )
 
-export default adapter(fsRouter(modules))
+const serverI18nScope = createServerI18nScope<Awaited<ReturnType<typeof createServerI18n>>>()
+
+export default adapter(fsRouter(modules), {
+  middlewareFns: [
+    () => async (context, next) => {
+      const request = context.req.raw
+      const { locale } = locales.resolve({
+        strategy: "cookie",
+        acceptLanguageHeader: request.headers.get("accept-language"),
+        cookieHeader: request.headers.get("cookie"),
+      })
+      return serverI18nScope.run(await createServerI18n(locale), () => next())
+    },
+  ],
+})

--- a/examples/waku-cookie/src/waku.server.ts
+++ b/examples/waku-cookie/src/waku.server.ts
@@ -1,6 +1,7 @@
 import { fsRouter } from "waku"
 import adapter from "waku/adapters/default"
 import { createServerI18nScope } from "@palamedes/runtime/server"
+import { waitForServerI18nTestBarrier } from "@palamedes/runtime/server/test"
 import { createServerI18n, locales } from "./lib/i18n"
 
 // Glob keys must keep the `pages/` prefix so fsRouter's default `pagesDir: "pages"`
@@ -26,7 +27,10 @@ export default adapter(fsRouter(modules), {
         acceptLanguageHeader: request.headers.get("accept-language"),
         cookieHeader: request.headers.get("cookie"),
       })
-      return serverI18nScope.run(await createServerI18n(locale), () => next())
+      return serverI18nScope.run(await createServerI18n(locale), async () => {
+        await waitForServerI18nTestBarrier(request)
+        return next()
+      })
     },
   ],
 })

--- a/examples/waku-route/src/lib/i18n.ts
+++ b/examples/waku-route/src/lib/i18n.ts
@@ -1,5 +1,5 @@
 import { createI18n } from "@palamedes/core"
-import { setClientI18n, setServerI18nGetter } from "@palamedes/runtime"
+import { activateServerI18n as activateScopedServerI18n, setClientI18n } from "@palamedes/runtime"
 import { defineLocaleControls } from "@palamedes/core/locale"
 import { messages as deMessages } from "../locales/de.po"
 import { messages as enMessages } from "../locales/en.po"
@@ -38,21 +38,22 @@ export function getLocaleLabel(locale: Locale) {
   return locales.label(locale)
 }
 
-export function activateServerI18n(locale: Locale) {
+export function createServerI18n(locale: Locale) {
   const i18n = createI18n()
   i18n.load(locale, localeMessages[locale])
   i18n.activate(locale)
-  setServerI18nGetter(() => i18n)
   return i18n
+}
+
+export function activateServerI18n(locale: Locale) {
+  return activateScopedServerI18n(createServerI18n(locale))
 }
 
 export function initializeClientI18n(locale: Locale) {
   clientI18n.load(locale, localeMessages[locale])
   clientI18n.activate(locale)
 
-  if (typeof window === "undefined") {
-    setServerI18nGetter(() => clientI18n)
-  } else {
+  if (typeof window !== "undefined") {
     setClientI18n(clientI18n)
   }
 

--- a/examples/waku-route/src/waku.server.ts
+++ b/examples/waku-route/src/waku.server.ts
@@ -1,7 +1,10 @@
 import { fsRouter } from "waku"
 import adapter from "waku/adapters/default"
 import { createServerI18nScope } from "@palamedes/runtime/server"
-import { waitForServerI18nTestBarrier } from "@palamedes/runtime/server/test"
+import {
+  markServerI18nTestBarrierReached,
+  waitForServerI18nTestBarrier,
+} from "@palamedes/runtime/server/test"
 import { createServerI18n, normalizeLocale } from "./lib/i18n"
 
 // Glob keys must keep the `pages/` prefix so fsRouter's default `pagesDir: "pages"`
@@ -24,6 +27,7 @@ export default adapter(fsRouter(modules), {
       const segment = new URL(context.req.raw.url).pathname.split("/").filter(Boolean)[0]
       return serverI18nScope.run(createServerI18n(normalizeLocale(segment)), async () => {
         await waitForServerI18nTestBarrier(context.req.raw)
+        markServerI18nTestBarrierReached(context.req.raw, context.res.headers)
         return next()
       })
     },

--- a/examples/waku-route/src/waku.server.ts
+++ b/examples/waku-route/src/waku.server.ts
@@ -1,5 +1,7 @@
 import { fsRouter } from "waku"
 import adapter from "waku/adapters/default"
+import { createServerI18nScope } from "@palamedes/runtime/server"
+import { createServerI18n, normalizeLocale } from "./lib/i18n"
 
 // Glob keys must keep the `pages/` prefix so fsRouter's default `pagesDir: "pages"`
 // matches them. Globbing from `/src` and stripping the leading `/src/` yields
@@ -13,4 +15,13 @@ const modules = Object.fromEntries(
   ])
 )
 
-export default adapter(fsRouter(modules))
+const serverI18nScope = createServerI18nScope<ReturnType<typeof createServerI18n>>()
+
+export default adapter(fsRouter(modules), {
+  middlewareFns: [
+    () => async (context, next) => {
+      const segment = new URL(context.req.raw.url).pathname.split("/").filter(Boolean)[0]
+      return serverI18nScope.run(createServerI18n(normalizeLocale(segment)), () => next())
+    },
+  ],
+})

--- a/examples/waku-route/src/waku.server.ts
+++ b/examples/waku-route/src/waku.server.ts
@@ -1,6 +1,7 @@
 import { fsRouter } from "waku"
 import adapter from "waku/adapters/default"
 import { createServerI18nScope } from "@palamedes/runtime/server"
+import { waitForServerI18nTestBarrier } from "@palamedes/runtime/server/test"
 import { createServerI18n, normalizeLocale } from "./lib/i18n"
 
 // Glob keys must keep the `pages/` prefix so fsRouter's default `pagesDir: "pages"`
@@ -21,7 +22,10 @@ export default adapter(fsRouter(modules), {
   middlewareFns: [
     () => async (context, next) => {
       const segment = new URL(context.req.raw.url).pathname.split("/").filter(Boolean)[0]
-      return serverI18nScope.run(createServerI18n(normalizeLocale(segment)), () => next())
+      return serverI18nScope.run(createServerI18n(normalizeLocale(segment)), async () => {
+        await waitForServerI18nTestBarrier(context.req.raw)
+        return next()
+      })
     },
   ],
 })

--- a/examples/waku-subdomain/src/lib/i18n.ts
+++ b/examples/waku-subdomain/src/lib/i18n.ts
@@ -1,5 +1,5 @@
 import { createI18n } from "@palamedes/core"
-import { setClientI18n, setServerI18nGetter } from "@palamedes/runtime"
+import { activateServerI18n as activateScopedServerI18n, setClientI18n } from "@palamedes/runtime"
 import { defineLocaleControls } from "@palamedes/core/locale"
 import { messages as deMessages } from "../locales/de.po"
 import { messages as enMessages } from "../locales/en.po"
@@ -36,21 +36,22 @@ export function getLocaleLabel(locale: Locale) {
   return locales.label(locale)
 }
 
-export function activateServerI18n(locale: Locale) {
+export function createServerI18n(locale: Locale) {
   const i18n = createI18n()
   i18n.load(locale, localeMessages[locale])
   i18n.activate(locale)
-  setServerI18nGetter(() => i18n)
   return i18n
+}
+
+export function activateServerI18n(locale: Locale) {
+  return activateScopedServerI18n(createServerI18n(locale))
 }
 
 export function initializeClientI18n(locale: Locale) {
   clientI18n.load(locale, localeMessages[locale])
   clientI18n.activate(locale)
 
-  if (typeof window === "undefined") {
-    setServerI18nGetter(() => clientI18n)
-  } else {
+  if (typeof window !== "undefined") {
     setClientI18n(clientI18n)
   }
 

--- a/examples/waku-subdomain/src/waku.server.ts
+++ b/examples/waku-subdomain/src/waku.server.ts
@@ -1,7 +1,10 @@
 import { fsRouter } from "waku"
 import adapter from "waku/adapters/default"
 import { createServerI18nScope } from "@palamedes/runtime/server"
-import { waitForServerI18nTestBarrier } from "@palamedes/runtime/server/test"
+import {
+  markServerI18nTestBarrierReached,
+  waitForServerI18nTestBarrier,
+} from "@palamedes/runtime/server/test"
 import { createServerI18n, locales } from "./lib/i18n"
 
 // Glob keys must keep the `pages/` prefix so fsRouter's default `pagesDir: "pages"`
@@ -29,6 +32,7 @@ export default adapter(fsRouter(modules), {
       })
       return serverI18nScope.run(createServerI18n(locale), async () => {
         await waitForServerI18nTestBarrier(request)
+        markServerI18nTestBarrierReached(request, context.res.headers)
         return next()
       })
     },

--- a/examples/waku-subdomain/src/waku.server.ts
+++ b/examples/waku-subdomain/src/waku.server.ts
@@ -1,5 +1,7 @@
 import { fsRouter } from "waku"
 import adapter from "waku/adapters/default"
+import { createServerI18nScope } from "@palamedes/runtime/server"
+import { createServerI18n, locales } from "./lib/i18n"
 
 // Glob keys must keep the `pages/` prefix so fsRouter's default `pagesDir: "pages"`
 // matches them. Globbing from `/src` and stripping the leading `/src/` yields
@@ -13,4 +15,18 @@ const modules = Object.fromEntries(
   ])
 )
 
-export default adapter(fsRouter(modules))
+const serverI18nScope = createServerI18nScope<ReturnType<typeof createServerI18n>>()
+
+export default adapter(fsRouter(modules), {
+  middlewareFns: [
+    () => async (context, next) => {
+      const request = context.req.raw
+      const { locale } = locales.resolve({
+        strategy: "subdomain",
+        acceptLanguageHeader: request.headers.get("accept-language"),
+        requestHost: request.headers.get("host"),
+      })
+      return serverI18nScope.run(createServerI18n(locale), () => next())
+    },
+  ],
+})

--- a/examples/waku-subdomain/src/waku.server.ts
+++ b/examples/waku-subdomain/src/waku.server.ts
@@ -1,6 +1,7 @@
 import { fsRouter } from "waku"
 import adapter from "waku/adapters/default"
 import { createServerI18nScope } from "@palamedes/runtime/server"
+import { waitForServerI18nTestBarrier } from "@palamedes/runtime/server/test"
 import { createServerI18n, locales } from "./lib/i18n"
 
 // Glob keys must keep the `pages/` prefix so fsRouter's default `pagesDir: "pages"`
@@ -26,7 +27,10 @@ export default adapter(fsRouter(modules), {
         acceptLanguageHeader: request.headers.get("accept-language"),
         requestHost: request.headers.get("host"),
       })
-      return serverI18nScope.run(createServerI18n(locale), () => next())
+      return serverI18nScope.run(createServerI18n(locale), async () => {
+        await waitForServerI18nTestBarrier(request)
+        return next()
+      })
     },
   ],
 })

--- a/examples/waku-tld/src/lib/i18n.ts
+++ b/examples/waku-tld/src/lib/i18n.ts
@@ -1,5 +1,5 @@
 import { createI18n } from "@palamedes/core"
-import { setClientI18n, setServerI18nGetter } from "@palamedes/runtime"
+import { activateServerI18n as activateScopedServerI18n, setClientI18n } from "@palamedes/runtime"
 import { defineLocaleControls } from "@palamedes/core/locale"
 import { messages as deMessages } from "../locales/de.po"
 import { messages as enMessages } from "../locales/en.po"
@@ -40,21 +40,22 @@ export function getLocaleLabel(locale: Locale) {
   return locales.label(locale)
 }
 
-export function activateServerI18n(locale: Locale) {
+export function createServerI18n(locale: Locale) {
   const i18n = createI18n()
   i18n.load(locale, localeMessages[locale])
   i18n.activate(locale)
-  setServerI18nGetter(() => i18n)
   return i18n
+}
+
+export function activateServerI18n(locale: Locale) {
+  return activateScopedServerI18n(createServerI18n(locale))
 }
 
 export function initializeClientI18n(locale: Locale) {
   clientI18n.load(locale, localeMessages[locale])
   clientI18n.activate(locale)
 
-  if (typeof window === "undefined") {
-    setServerI18nGetter(() => clientI18n)
-  } else {
+  if (typeof window !== "undefined") {
     setClientI18n(clientI18n)
   }
 

--- a/examples/waku-tld/src/waku.server.ts
+++ b/examples/waku-tld/src/waku.server.ts
@@ -1,5 +1,7 @@
 import { fsRouter } from "waku"
 import adapter from "waku/adapters/default"
+import { createServerI18nScope } from "@palamedes/runtime/server"
+import { createServerI18n, locales } from "./lib/i18n"
 
 // Glob keys must keep the `pages/` prefix so fsRouter's default `pagesDir: "pages"`
 // matches them. Globbing from `/src` and stripping the leading `/src/` yields
@@ -13,4 +15,18 @@ const modules = Object.fromEntries(
   ])
 )
 
-export default adapter(fsRouter(modules))
+const serverI18nScope = createServerI18nScope<ReturnType<typeof createServerI18n>>()
+
+export default adapter(fsRouter(modules), {
+  middlewareFns: [
+    () => async (context, next) => {
+      const request = context.req.raw
+      const { locale } = locales.resolve({
+        strategy: "tld",
+        acceptLanguageHeader: request.headers.get("accept-language"),
+        requestHost: request.headers.get("host"),
+      })
+      return serverI18nScope.run(createServerI18n(locale), () => next())
+    },
+  ],
+})

--- a/examples/waku-tld/src/waku.server.ts
+++ b/examples/waku-tld/src/waku.server.ts
@@ -1,7 +1,10 @@
 import { fsRouter } from "waku"
 import adapter from "waku/adapters/default"
 import { createServerI18nScope } from "@palamedes/runtime/server"
-import { waitForServerI18nTestBarrier } from "@palamedes/runtime/server/test"
+import {
+  markServerI18nTestBarrierReached,
+  waitForServerI18nTestBarrier,
+} from "@palamedes/runtime/server/test"
 import { createServerI18n, locales } from "./lib/i18n"
 
 // Glob keys must keep the `pages/` prefix so fsRouter's default `pagesDir: "pages"`
@@ -29,6 +32,7 @@ export default adapter(fsRouter(modules), {
       })
       return serverI18nScope.run(createServerI18n(locale), async () => {
         await waitForServerI18nTestBarrier(request)
+        markServerI18nTestBarrierReached(request, context.res.headers)
         return next()
       })
     },

--- a/examples/waku-tld/src/waku.server.ts
+++ b/examples/waku-tld/src/waku.server.ts
@@ -1,6 +1,7 @@
 import { fsRouter } from "waku"
 import adapter from "waku/adapters/default"
 import { createServerI18nScope } from "@palamedes/runtime/server"
+import { waitForServerI18nTestBarrier } from "@palamedes/runtime/server/test"
 import { createServerI18n, locales } from "./lib/i18n"
 
 // Glob keys must keep the `pages/` prefix so fsRouter's default `pagesDir: "pages"`
@@ -26,7 +27,10 @@ export default adapter(fsRouter(modules), {
         acceptLanguageHeader: request.headers.get("accept-language"),
         requestHost: request.headers.get("host"),
       })
-      return serverI18nScope.run(createServerI18n(locale), () => next())
+      return serverI18nScope.run(createServerI18n(locale), async () => {
+        await waitForServerI18nTestBarrier(request)
+        return next()
+      })
     },
   ],
 })

--- a/packages/runtime/build.config.ts
+++ b/packages/runtime/build.config.ts
@@ -1,7 +1,7 @@
 import { defineBuildConfig } from "unbuild"
 
 export default defineBuildConfig({
-  entries: ["./src/index", "./src/server", "./src/server-unavailable"],
+  entries: ["./src/index", "./src/server", "./src/server-test", "./src/server-unavailable"],
   declaration: true,
   failOnWarn: false,
   rollup: {

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -31,6 +31,21 @@
         "import": "./dist/server-unavailable.mjs",
         "require": "./dist/server-unavailable.cjs"
       }
+    },
+    "./server/test": {
+      "types": "./dist/server-test.d.ts",
+      "node": {
+        "import": "./dist/server-test.mjs",
+        "require": "./dist/server-test.cjs"
+      },
+      "browser": {
+        "import": "./dist/server-unavailable.mjs",
+        "require": "./dist/server-unavailable.cjs"
+      },
+      "default": {
+        "import": "./dist/server-unavailable.mjs",
+        "require": "./dist/server-unavailable.cjs"
+      }
     }
   },
   "main": "./dist/index.cjs",

--- a/packages/runtime/src/server-test.ts
+++ b/packages/runtime/src/server-test.ts
@@ -4,6 +4,7 @@
  */
 const TEST_BARRIER_ENV = "PALAMEDES_I18N_TEST_BARRIER"
 const TEST_BARRIER_HEADER = "x-palamedes-i18n-test-barrier"
+export const SERVER_I18N_TEST_BARRIER_REACHED_HEADER = "x-palamedes-i18n-test-barrier-reached"
 const TEST_BARRIER_TIMEOUT_MS = 5e3
 const TEST_BARRIERS_KEY = Symbol.for("palamedes.runtime.serverI18nTestBarriers")
 
@@ -28,6 +29,21 @@ function testBarriers(): Map<string, Barrier> {
   return barriers
 }
 
+function serverI18nTestBarrierId(request: Request): string | undefined {
+  if (process.env[TEST_BARRIER_ENV] !== "1") return
+  return request.headers.get(TEST_BARRIER_HEADER) ?? undefined
+}
+
+/**
+ * Adds a test-only response marker after a request has passed the rendezvous.
+ * The verifier requires this marker, so an adapter that does not register its
+ * barrier cannot produce a false-positive concurrency result.
+ */
+export function markServerI18nTestBarrierReached(request: Request, headers: Headers): void {
+  const barrierId = serverI18nTestBarrierId(request)
+  if (barrierId) headers.set(SERVER_I18N_TEST_BARRIER_REACHED_HEADER, barrierId)
+}
+
 /**
  * Wait for a matching request after its i18n scope has been activated and
  * before the framework begins rendering translations. This is deliberately
@@ -35,9 +51,7 @@ function testBarriers(): Map<string, Barrier> {
  * per-request header are required.
  */
 export function waitForServerI18nTestBarrier(request: Request): Promise<void> | undefined {
-  if (process.env[TEST_BARRIER_ENV] !== "1") return
-
-  const barrierId = request.headers.get(TEST_BARRIER_HEADER)
+  const barrierId = serverI18nTestBarrierId(request)
   if (!barrierId) return
 
   const barriers = testBarriers()

--- a/packages/runtime/src/server-test.ts
+++ b/packages/runtime/src/server-test.ts
@@ -1,0 +1,72 @@
+/**
+ * Test-only request rendezvous for proving server i18n isolation. It is inert
+ * unless the test runner explicitly enables it and sends the matching header.
+ */
+const TEST_BARRIER_ENV = "PALAMEDES_I18N_TEST_BARRIER"
+const TEST_BARRIER_HEADER = "x-palamedes-i18n-test-barrier"
+const TEST_BARRIER_TIMEOUT_MS = 5e3
+const TEST_BARRIERS_KEY = Symbol.for("palamedes.runtime.serverI18nTestBarriers")
+
+type Barrier = {
+  arrivals: number
+  reject(error: Error): void
+  resolve(): void
+  timeout: ReturnType<typeof setTimeout>
+}
+
+type TestBarrierState = typeof globalThis & {
+  [TEST_BARRIERS_KEY]?: Map<string, Barrier>
+}
+
+function testBarriers(): Map<string, Barrier> {
+  const state = globalThis as TestBarrierState
+  const existing = state[TEST_BARRIERS_KEY]
+  if (existing) return existing
+
+  const barriers = new Map<string, Barrier>()
+  state[TEST_BARRIERS_KEY] = barriers
+  return barriers
+}
+
+/**
+ * Wait for a matching request after its i18n scope has been activated and
+ * before the framework begins rendering translations. This is deliberately
+ * unreachable in normal servers: both the opt-in environment variable and a
+ * per-request header are required.
+ */
+export function waitForServerI18nTestBarrier(request: Request): Promise<void> | undefined {
+  if (process.env[TEST_BARRIER_ENV] !== "1") return
+
+  const barrierId = request.headers.get(TEST_BARRIER_HEADER)
+  if (!barrierId) return
+
+  const barriers = testBarriers()
+  const existing = barriers.get(barrierId)
+  if (existing) {
+    existing.arrivals += 1
+    if (existing.arrivals === 2) {
+      clearTimeout(existing.timeout)
+      barriers.delete(barrierId)
+      existing.resolve()
+    }
+    return new Promise((resolve) => queueMicrotask(resolve))
+  }
+
+  return new Promise((resolve, reject) => {
+    const barrier: Barrier = {
+      arrivals: 1,
+      reject,
+      resolve,
+      timeout: setTimeout(() => {
+        if (barriers.get(barrierId) !== barrier) return
+        barriers.delete(barrierId)
+        reject(
+          new Error(
+            `Timed out waiting for a second server i18n test request in barrier ${JSON.stringify(barrierId)}`
+          )
+        )
+      }, TEST_BARRIER_TIMEOUT_MS),
+    }
+    barriers.set(barrierId, barrier)
+  })
+}

--- a/packages/runtime/src/server.test.ts
+++ b/packages/runtime/src/server.test.ts
@@ -2,13 +2,27 @@ import { AsyncLocalStorage } from "node:async_hooks"
 
 import { describe, expect, it, afterEach, vi } from "vitest"
 
-import { type I18nInstance, getI18n, resetI18nRuntime } from "./index"
+import { type I18nInstance, getI18n, resetI18nRuntime, setServerI18nGetter } from "./index"
 import { createServerI18nScope } from "./server"
 
 function createTestI18n(locale = "en"): I18nInstance {
   return {
     locale,
     _: (message: string) => message,
+  }
+}
+
+function rendezvousAfterActivation() {
+  let arrivals = 0
+  let release!: () => void
+  const barrier = new Promise<void>((resolve) => {
+    release = resolve
+  })
+
+  return async () => {
+    arrivals += 1
+    if (arrivals === 2) release()
+    await barrier
   }
 }
 
@@ -169,6 +183,38 @@ describe("@palamedes/runtime/server", () => {
         expect(getI18n()).toBe(enI18n)
       }),
     ])
+  })
+
+  it("shows the legacy global getter leaking after two requests rendezvous", async () => {
+    const deI18n = createTestI18n("de")
+    const enI18n = createTestI18n("en")
+    const rendezvous = rendezvousAfterActivation()
+
+    async function render(i18n: I18nInstance) {
+      setServerI18nGetter(() => i18n)
+      await rendezvous()
+      await new Promise((resolve) => setTimeout(resolve, 0))
+      return getI18n().locale
+    }
+
+    await expect(Promise.all([render(deI18n), render(enI18n)])).resolves.toEqual(["en", "en"])
+  })
+
+  it("keeps scoped i18n instances isolated after the same rendezvous", async () => {
+    const scope = createServerI18nScope<I18nInstance>()
+    const deI18n = createTestI18n("de")
+    const enI18n = createTestI18n("en")
+    const rendezvous = rendezvousAfterActivation()
+
+    async function render(i18n: I18nInstance) {
+      return scope.run(i18n, async () => {
+        await rendezvous()
+        await new Promise((resolve) => setTimeout(resolve, 0))
+        return getI18n().locale
+      })
+    }
+
+    await expect(Promise.all([render(deI18n), render(enI18n)])).resolves.toEqual(["de", "en"])
   })
 
   it("keeps concurrent activated server contexts isolated", async () => {

--- a/scripts/example-matrix.mjs
+++ b/scripts/example-matrix.mjs
@@ -91,11 +91,9 @@ export const EXAMPLE_MATRIX = [
     cwd: path.join(ROOT, "examples/waku-cookie"),
     build: ["build"],
     start: ["start"],
-    // Waku (Vite RSC) ships a client-bootstrap shell over plain HTTP and streams
-    // the rendered markup via the RSC payload, so localized text never appears in
-    // the initial document. Node fetch+substring cannot see it; the browser tests
-    // (which deserialize the stream) cover this example instead. We still start the
-    // server here to confirm it boots and serves.
+    // The normal smoke pass only confirms that Waku boots. The verifier's
+    // deterministic i18n-concurrency pass below fetches the localized SSR/RSC
+    // response after both request scopes have rendezvoused.
     smokeChecks: [],
   },
   {
@@ -106,8 +104,8 @@ export const EXAMPLE_MATRIX = [
     cwd: path.join(ROOT, "examples/waku-route"),
     build: ["build"],
     start: ["start"],
-    // See waku-cookie: the RSC shell hides localized text from a plain fetch, so
-    // the Node smoke only confirms boot; browser tests cover the rendered output.
+    // See waku-cookie: the normal smoke only confirms boot; the deterministic
+    // i18n-concurrency pass asserts localized SSR/RSC output.
     smokeChecks: [],
   },
   {
@@ -342,8 +340,8 @@ export const EXAMPLE_MATRIX = [
     cwd: path.join(ROOT, "examples/waku-subdomain"),
     build: ["build"],
     start: ["start"],
-    // See waku-cookie/route: the RSC shell hides localized text from a plain
-    // fetch, so the Node smoke only confirms boot; browser tests cover output.
+    // See waku-cookie: the normal smoke only confirms boot; the deterministic
+    // i18n-concurrency pass asserts localized SSR/RSC output.
     smokeChecks: [],
   },
   {
@@ -456,8 +454,8 @@ export const EXAMPLE_MATRIX = [
     cwd: path.join(ROOT, "examples/waku-tld"),
     build: ["build"],
     start: ["start"],
-    // See waku-cookie/route/subdomain: the RSC shell hides localized text from a
-    // plain fetch, so the Node smoke only confirms boot; browser tests cover output.
+    // See waku-cookie: the normal smoke only confirms boot; the deterministic
+    // i18n-concurrency pass asserts localized SSR/RSC output.
     smokeChecks: [],
   },
   {

--- a/scripts/example-matrix.mjs
+++ b/scripts/example-matrix.mjs
@@ -55,6 +55,11 @@ export const EXAMPLE_MATRIX = [
         path: "/",
         substrings: ["Deutsch", "Plätze frei"],
       },
+      {
+        headers: { "accept-language": "en" },
+        path: "/",
+        substrings: ["English", "seats left"],
+      },
     ],
   },
   {
@@ -119,6 +124,11 @@ export const EXAMPLE_MATRIX = [
         path: "/",
         substrings: ["Deutsch", "Plätze frei"],
       },
+      {
+        headers: { "accept-language": "en" },
+        path: "/",
+        substrings: ["English", "seats left"],
+      },
     ],
   },
   {
@@ -171,6 +181,11 @@ export const EXAMPLE_MATRIX = [
         headers: { "accept-language": "de" },
         path: "/",
         substrings: ["Deutsch", "Plätze frei"],
+      },
+      {
+        headers: { "accept-language": "en" },
+        path: "/",
+        substrings: ["English", "seats left"],
       },
     ],
   },

--- a/scripts/verify-examples.mjs
+++ b/scripts/verify-examples.mjs
@@ -2,6 +2,8 @@ import { execFileSync, spawn } from "node:child_process"
 import http from "node:http"
 import { parseExampleArgs, selectExamples } from "./example-matrix.mjs"
 
+let barrierSequence = 0
+
 function runCommand({ args, cwd, env }) {
   return new Promise((resolve, reject) => {
     const child = spawn("pnpm", args, {
@@ -174,17 +176,73 @@ async function verifyExample(example) {
   const child = startCommand({
     args: example.start,
     cwd: example.cwd,
-    env: example.startEnv,
+    env: {
+      ...example.startEnv,
+      // The test barrier is inert without the per-request header below. Keeping
+      // it enabled for this short-lived verifier makes the overlap deterministic.
+      PALAMEDES_I18N_TEST_BARRIER: "1",
+    },
   })
 
   try {
     await waitForServer(example.port, example.strategy === "route" ? "/en" : "/")
 
     await Promise.all(example.smokeChecks.map((check) => verifySmokeCheck(example, check)))
+    if (["react-router", "solidstart", "tanstack", "waku"].includes(example.framework)) {
+      await verifyConcurrentServerI18n(example)
+    }
   } finally {
     await stopCommand(child)
     await ensurePortFree(example.port)
   }
+}
+
+function serverI18nConcurrencyChecks(example) {
+  const english = {
+    path: example.strategy === "route" ? "/en" : "/",
+    substrings: ["English", "seats left"],
+  }
+  const german = {
+    path: example.strategy === "route" ? "/de" : "/",
+    substrings: ["Deutsch", "Plätze frei"],
+  }
+
+  if (example.strategy === "cookie") {
+    return [
+      { ...english, headers: { "accept-language": "en" } },
+      { ...german, headers: { "accept-language": "de" } },
+    ]
+  }
+
+  if (example.strategy === "subdomain") {
+    return [
+      { ...english, headers: { host: `en.lvh.me:${example.port}` } },
+      { ...german, headers: { host: `de.lvh.me:${example.port}` } },
+    ]
+  }
+
+  if (example.strategy === "tld") {
+    return [
+      { ...english, headers: { host: `palamedes-i18n.com:${example.port}` } },
+      { ...german, headers: { host: `palamedes-i18n.de:${example.port}` } },
+    ]
+  }
+
+  return [english, german]
+}
+
+async function verifyConcurrentServerI18n(example) {
+  barrierSequence += 1
+  const barrierId = `${example.id}-${barrierSequence}`
+  const checks = serverI18nConcurrencyChecks(example).map((check) => ({
+    ...check,
+    headers: {
+      ...check.headers,
+      "x-palamedes-i18n-test-barrier": barrierId,
+    },
+  }))
+
+  await Promise.all(checks.map((check) => verifySmokeCheck(example, check)))
 }
 
 async function verifySmokeCheck(example, check) {

--- a/scripts/verify-examples.mjs
+++ b/scripts/verify-examples.mjs
@@ -180,19 +180,21 @@ async function verifyExample(example) {
   try {
     await waitForServer(example.port, example.strategy === "route" ? "/en" : "/")
 
-    for (const check of example.smokeChecks) {
-      const response = await requestText(example.port, check.path, check.headers)
-      for (const substring of check.substrings) {
-        if (!response.body.includes(substring)) {
-          throw new Error(
-            `Missing substring "${substring}" in ${example.id} response for ${check.path}`
-          )
-        }
-      }
-    }
+    await Promise.all(example.smokeChecks.map((check) => verifySmokeCheck(example, check)))
   } finally {
     await stopCommand(child)
     await ensurePortFree(example.port)
+  }
+}
+
+async function verifySmokeCheck(example, check) {
+  const response = await requestText(example.port, check.path, check.headers)
+  for (const substring of check.substrings) {
+    if (!response.body.includes(substring)) {
+      throw new Error(
+        `Missing substring "${substring}" in ${example.id} response for ${check.path}`
+      )
+    }
   }
 }
 

--- a/scripts/verify-examples.mjs
+++ b/scripts/verify-examples.mjs
@@ -3,6 +3,7 @@ import http from "node:http"
 import { parseExampleArgs, selectExamples } from "./example-matrix.mjs"
 
 let barrierSequence = 0
+const SERVER_I18N_TEST_BARRIER_REACHED_HEADER = "x-palamedes-i18n-test-barrier-reached"
 
 function runCommand({ args, cwd, env }) {
   return new Promise((resolve, reject) => {
@@ -236,6 +237,7 @@ async function verifyConcurrentServerI18n(example) {
   const barrierId = `${example.id}-${barrierSequence}`
   const checks = serverI18nConcurrencyChecks(example).map((check) => ({
     ...check,
+    expectedBarrierId: barrierId,
     headers: {
       ...check.headers,
       "x-palamedes-i18n-test-barrier": barrierId,
@@ -247,6 +249,16 @@ async function verifyConcurrentServerI18n(example) {
 
 async function verifySmokeCheck(example, check) {
   const response = await requestText(example.port, check.path, check.headers)
+  if (check.expectedBarrierId) {
+    const reachedBarrier = response.headers[SERVER_I18N_TEST_BARRIER_REACHED_HEADER]
+    const reachedBarrierIds = Array.isArray(reachedBarrier) ? reachedBarrier : [reachedBarrier]
+    if (!reachedBarrierIds.includes(check.expectedBarrierId)) {
+      throw new Error(
+        `${example.id} did not reach server i18n test barrier ${JSON.stringify(check.expectedBarrierId)}`
+      )
+    }
+  }
+
   for (const substring of check.substrings) {
     if (!response.body.includes(substring)) {
       throw new Error(


### PR DESCRIPTION
## Summary

Replace mutable process-global server i18n activation in the React Router, SolidStart, TanStack Start, and Waku locale examples with request-local `@palamedes/runtime/server` scopes.

Wrap each framework's SSR handler or render stream lifetime, while preserving the existing cookie, route, subdomain, and TLD locale negotiation behavior. The example smoke verifier now runs per-example locale checks in parallel, with additional cookie-locale checks to prevent regressions.

## Issue

Closes #573

## Validation

- `RUSTUP_TOOLCHAIN=1.95-aarch64-apple-darwin pnpm build`
- Framework production builds for React Router, TanStack Start, SolidStart, and Waku
- `pnpm verify:examples:smoke -- --framework react-router`
- `pnpm verify:examples:smoke -- --framework tanstack`
- `pnpm verify:examples:smoke -- --framework solidstart`
- `pnpm verify:examples:smoke -- --framework waku`
- `pnpm format:check`
- Targeted ESLint and Oxc lint on all changed source files
- `pnpm exec vitest run packages/runtime/src/server.test.ts`

## Follow-up

None.