### PR TITLE
fix(react): evict rejected catalog resources

### DIFF
--- a/packages/react/src/client.tsx
+++ b/packages/react/src/client.tsx
@@ -58,7 +58,7 @@ export function createClientCatalogBoundary<TLocale extends string>({
   const clientLocale = typeof window === "undefined" ? undefined : resolveClientLocale()
   let clientI18nResource: Promise<CompiledPalamedesI18n> | undefined
   let clientI18nResourceRejected = false
-  let clientI18nResourceEvictionScheduled = false
+  let clientI18nResourceError: unknown
 
   function createClientI18nResource(locale: TLocale): Promise<CompiledPalamedesI18n> {
     const resource = loadCatalog(locale).then((catalog) =>
@@ -66,33 +66,64 @@ export function createClientCatalogBoundary<TLocale extends string>({
     )
     clientI18nResource = resource
     clientI18nResourceRejected = false
-    clientI18nResourceEvictionScheduled = false
-    void resource.catch(() => {
+    clientI18nResourceError = undefined
+    void resource.catch((error: unknown) => {
       if (clientI18nResource === resource) {
         clientI18nResourceRejected = true
+        clientI18nResourceError = error
       }
     })
     return resource
   }
 
-  function scheduleClientI18nResourceEviction(resource: Promise<CompiledPalamedesI18n>) {
+  function evictClientI18nResource(error: unknown) {
     if (
-      clientI18nResource !== resource ||
-      !clientI18nResourceRejected ||
-      clientI18nResourceEvictionScheduled
+      clientI18nResource !== undefined &&
+      clientI18nResourceRejected &&
+      error === clientI18nResourceError
     ) {
-      return
+      clientI18nResource = undefined
+      clientI18nResourceRejected = false
+      clientI18nResourceError = undefined
+    }
+  }
+
+  type ClientCatalogResourceErrorBoundaryState = {
+    error: unknown
+    hasError: boolean
+    rethrow: boolean
+  }
+
+  class ClientCatalogResourceErrorBoundary extends React.Component<
+    { children: ReactNode },
+    ClientCatalogResourceErrorBoundaryState
+  > {
+    public state: ClientCatalogResourceErrorBoundaryState = {
+      error: undefined,
+      hasError: false,
+      rethrow: false,
     }
 
-    clientI18nResourceEvictionScheduled = true
-    // Let React commit the nearest error boundary with the original error before retrying.
-    setTimeout(() => {
-      if (clientI18nResource === resource && clientI18nResourceRejected) {
-        clientI18nResource = undefined
-        clientI18nResourceRejected = false
+    public static getDerivedStateFromError(
+      error: unknown
+    ): ClientCatalogResourceErrorBoundaryState {
+      return { error, hasError: true, rethrow: false }
+    }
+
+    public componentDidCatch(error: unknown) {
+      evictClientI18nResource(error)
+      this.setState({ rethrow: true })
+    }
+
+    public render() {
+      if (this.state.rethrow) {
+        throw this.state.error
       }
-      clientI18nResourceEvictionScheduled = false
-    })
+      if (this.state.hasError) {
+        return null
+      }
+      return this.props.children
+    }
   }
 
   if (clientLocale !== undefined) {
@@ -120,7 +151,7 @@ export function createClientCatalogBoundary<TLocale extends string>({
     return resource
   }
 
-  function ClientCatalogBoundary({ children, locale }: ClientCatalogBoundaryProps<TLocale>) {
+  function ClientCatalogContents({ children, locale }: ClientCatalogBoundaryProps<TLocale>) {
     const isClient = typeof window !== "undefined"
     if (isClient && locale !== clientLocale) {
       throw new Error(
@@ -131,9 +162,6 @@ export function createClientCatalogBoundary<TLocale extends string>({
     const resource = (
       isClient ? getClientI18nResource() : getServerCatalogResource(locale)
     ) as Promise<ClientCatalogModule | CompiledPalamedesI18n>
-    if (isClient && clientI18nResource === resource && clientI18nResourceRejected) {
-      scheduleClientI18nResourceEviction(resource as Promise<CompiledPalamedesI18n>)
-    }
     const catalogOrI18n = use(resource)
     const i18n = useMemo<CompiledPalamedesI18n>(() => {
       if (isClient) {
@@ -147,6 +175,17 @@ export function createClientCatalogBoundary<TLocale extends string>({
     }
 
     return children
+  }
+
+  function ClientCatalogBoundary(props: ClientCatalogBoundaryProps<TLocale>) {
+    if (typeof window === "undefined") {
+      return <ClientCatalogContents {...props} />
+    }
+    return (
+      <ClientCatalogResourceErrorBoundary>
+        <ClientCatalogContents {...props} />
+      </ClientCatalogResourceErrorBoundary>
+    )
   }
 
   ClientCatalogBoundary.displayName = "PalamedesClientCatalogBoundary"

--- a/packages/react/src/client.tsx
+++ b/packages/react/src/client.tsx
@@ -57,18 +57,42 @@ export function createClientCatalogBoundary<TLocale extends string>({
   const serverResources = new Map<TLocale, Promise<ClientCatalogModule>>()
   const clientLocale = typeof window === "undefined" ? undefined : resolveClientLocale()
   let clientI18nResource: Promise<CompiledPalamedesI18n> | undefined
+  let clientI18nResourceRejected = false
+  let clientI18nResourceEvictionScheduled = false
 
   function createClientI18nResource(locale: TLocale): Promise<CompiledPalamedesI18n> {
     const resource = loadCatalog(locale).then((catalog) =>
       setClientI18n(createCatalogI18n(locale, catalog))
     )
     clientI18nResource = resource
+    clientI18nResourceRejected = false
+    clientI18nResourceEvictionScheduled = false
     void resource.catch(() => {
       if (clientI18nResource === resource) {
-        clientI18nResource = undefined
+        clientI18nResourceRejected = true
       }
     })
     return resource
+  }
+
+  function scheduleClientI18nResourceEviction(resource: Promise<CompiledPalamedesI18n>) {
+    if (
+      clientI18nResource !== resource ||
+      !clientI18nResourceRejected ||
+      clientI18nResourceEvictionScheduled
+    ) {
+      return
+    }
+
+    clientI18nResourceEvictionScheduled = true
+    // Let React commit the nearest error boundary with the original error before retrying.
+    setTimeout(() => {
+      if (clientI18nResource === resource && clientI18nResourceRejected) {
+        clientI18nResource = undefined
+        clientI18nResourceRejected = false
+      }
+      clientI18nResourceEvictionScheduled = false
+    })
   }
 
   if (clientLocale !== undefined) {
@@ -107,6 +131,9 @@ export function createClientCatalogBoundary<TLocale extends string>({
     const resource = (
       isClient ? getClientI18nResource() : getServerCatalogResource(locale)
     ) as Promise<ClientCatalogModule | CompiledPalamedesI18n>
+    if (isClient && clientI18nResource === resource && clientI18nResourceRejected) {
+      scheduleClientI18nResourceEviction(resource as Promise<CompiledPalamedesI18n>)
+    }
     const catalogOrI18n = use(resource)
     const i18n = useMemo<CompiledPalamedesI18n>(() => {
       if (isClient) {

--- a/packages/react/src/client.tsx
+++ b/packages/react/src/client.tsx
@@ -56,18 +56,42 @@ export function createClientCatalogBoundary<TLocale extends string>({
 }: CreateClientCatalogBoundaryOptions<TLocale>) {
   const serverResources = new Map<TLocale, Promise<ClientCatalogModule>>()
   const clientLocale = typeof window === "undefined" ? undefined : resolveClientLocale()
-  const clientI18nResource =
-    clientLocale === undefined
-      ? undefined
-      : loadCatalog(clientLocale).then((catalog) =>
-          setClientI18n(createCatalogI18n(clientLocale, catalog))
-        )
+  let clientI18nResource: Promise<CompiledPalamedesI18n> | undefined
+
+  function createClientI18nResource(locale: TLocale): Promise<CompiledPalamedesI18n> {
+    const resource = loadCatalog(locale).then((catalog) =>
+      setClientI18n(createCatalogI18n(locale, catalog))
+    )
+    clientI18nResource = resource
+    void resource.catch(() => {
+      if (clientI18nResource === resource) {
+        clientI18nResource = undefined
+      }
+    })
+    return resource
+  }
+
+  if (clientLocale !== undefined) {
+    createClientI18nResource(clientLocale)
+  }
+
+  function getClientI18nResource(): Promise<CompiledPalamedesI18n> {
+    if (clientLocale === undefined) {
+      throw new Error("Palamedes client catalog boundary was rendered on the server")
+    }
+    return clientI18nResource ?? createClientI18nResource(clientLocale)
+  }
 
   function getServerCatalogResource(locale: TLocale): Promise<ClientCatalogModule> {
     let resource = serverResources.get(locale)
     if (!resource) {
       resource = loadCatalog(locale)
       serverResources.set(locale, resource)
+      void resource.catch(() => {
+        if (serverResources.get(locale) === resource) {
+          serverResources.delete(locale)
+        }
+      })
     }
     return resource
   }
@@ -80,9 +104,9 @@ export function createClientCatalogBoundary<TLocale extends string>({
       )
     }
 
-    const resource = (isClient ? clientI18nResource! : getServerCatalogResource(locale)) as Promise<
-      ClientCatalogModule | CompiledPalamedesI18n
-    >
+    const resource = (
+      isClient ? getClientI18nResource() : getServerCatalogResource(locale)
+    ) as Promise<ClientCatalogModule | CompiledPalamedesI18n>
     const catalogOrI18n = use(resource)
     const i18n = useMemo<CompiledPalamedesI18n>(() => {
       if (isClient) {

--- a/packages/react/src/clientCatalog.test.tsx
+++ b/packages/react/src/clientCatalog.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { Suspense } from "react"
+import { Component, Suspense, type ReactNode } from "react"
 import { act, render, waitFor } from "@testing-library/react"
 import { afterEach, describe, expect, it, vi } from "vitest"
 
@@ -42,6 +42,22 @@ function deferred<T>(): {
     reject = fail
   })
   return { promise, resolve, reject }
+}
+
+class CatalogErrorBoundary extends Component<{ children: ReactNode }, { error: Error | null }> {
+  public state: { error: Error | null } = { error: null }
+
+  public static getDerivedStateFromError(error: Error) {
+    return { error }
+  }
+
+  public render() {
+    return this.state.error ? (
+      <span role="alert">{this.state.error.message}</span>
+    ) : (
+      this.props.children
+    )
+  }
 }
 
 describe("createClientCatalogBoundary", () => {
@@ -121,9 +137,10 @@ describe("createClientCatalogBoundary", () => {
 
   it("retries a rejected preload and keeps the successful catalog cached", async () => {
     document.documentElement.lang = "de"
+    const loadError = new Error("catalog unavailable")
     const loadCatalog = vi
       .fn<() => Promise<CatalogModule>>()
-      .mockRejectedValueOnce(new Error("catalog unavailable"))
+      .mockRejectedValueOnce(loadError)
       .mockResolvedValueOnce(catalog("Hallo"))
     const Boundary = createClientCatalogBoundary<Locale>({
       loadCatalog,
@@ -135,37 +152,43 @@ describe("createClientCatalogBoundary", () => {
       return <span>{String(getI18n()._("greeting"))}</span>
     }
 
-    function boundary() {
+    function boundary(retryKey: string) {
       return (
         <Suspense fallback={<span>Loading</span>}>
-          <Boundary locale="de">
-            <Greeting />
-          </Boundary>
+          <CatalogErrorBoundary key={retryKey}>
+            <Boundary locale="de">
+              <Greeting />
+            </Boundary>
+          </CatalogErrorBoundary>
         </Suspense>
       )
     }
 
     let view!: ReturnType<typeof render>
     await act(async () => {
-      view = render(boundary())
+      view = render(boundary("first"))
+      await Promise.resolve()
+    })
+    await waitFor(() => expect(view.getByRole("alert").textContent).toBe("catalog unavailable"))
+    expect(loadCatalog).toHaveBeenCalledOnce()
+
+    await act(async () => {
+      view.rerender(boundary("retry"))
       await Promise.resolve()
     })
     await waitFor(() => expect(view.container.textContent).toBe("Hallo"))
     expect(loadCatalog).toHaveBeenCalledTimes(2)
-
-    await act(async () => {
-      view.rerender(boundary())
-    })
-    expect(view.container.textContent).toBe("Hallo")
-    expect(loadCatalog).toHaveBeenCalledTimes(2)
   })
 
-  it("observes a rejected preload before the boundary renders", async () => {
+  it("surfaces repeated rejected preloads before retrying successfully", async () => {
     document.documentElement.lang = "de"
+    const firstError = new Error("first failure")
+    const secondError = new Error("second failure")
     const preload = deferred<CatalogModule>()
     const loadCatalog = vi
       .fn<() => Promise<CatalogModule>>()
       .mockReturnValueOnce(preload.promise)
+      .mockRejectedValueOnce(secondError)
       .mockResolvedValueOnce(catalog("Hallo"))
     const Boundary = createClientCatalogBoundary<Locale>({
       loadCatalog,
@@ -174,21 +197,41 @@ describe("createClientCatalogBoundary", () => {
     expect(loadCatalog).toHaveBeenCalledOnce()
 
     await act(async () => {
-      preload.reject(new Error("catalog unavailable"))
+      preload.reject(firstError)
       await Promise.resolve()
       await Promise.resolve()
     })
 
-    let view!: ReturnType<typeof render>
-    await act(async () => {
-      view = render(
+    function boundary(retryKey: string) {
+      return (
         <Suspense fallback={<span>Loading</span>}>
-          <Boundary locale="de">Ready</Boundary>
+          <CatalogErrorBoundary key={retryKey}>
+            <Boundary locale="de">Ready</Boundary>
+          </CatalogErrorBoundary>
         </Suspense>
       )
+    }
+
+    let view!: ReturnType<typeof render>
+    await act(async () => {
+      view = render(boundary("first"))
+      await Promise.resolve()
+    })
+    await waitFor(() => expect(view.getByRole("alert").textContent).toBe("first failure"))
+    expect(loadCatalog).toHaveBeenCalledOnce()
+
+    await act(async () => {
+      view.rerender(boundary("second"))
+      await Promise.resolve()
+    })
+    await waitFor(() => expect(view.getByRole("alert").textContent).toBe("second failure"))
+    expect(loadCatalog).toHaveBeenCalledTimes(2)
+
+    await act(async () => {
+      view.rerender(boundary("success"))
       await Promise.resolve()
     })
     await waitFor(() => expect(view.container.textContent).toBe("Ready"))
-    expect(loadCatalog).toHaveBeenCalledTimes(2)
+    expect(loadCatalog).toHaveBeenCalledTimes(3)
   })
 })

--- a/packages/react/src/clientCatalog.test.tsx
+++ b/packages/react/src/clientCatalog.test.tsx
@@ -33,12 +33,15 @@ function fulfilled<T>(value: T): Promise<T> {
 function deferred<T>(): {
   promise: Promise<T>
   resolve: (value: T) => void
+  reject: (reason?: unknown) => void
 } {
   let resolve!: (value: T) => void
-  const promise = new Promise<T>((done) => {
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((done, fail) => {
     resolve = done
+    reject = fail
   })
-  return { promise, resolve }
+  return { promise, resolve, reject }
 }
 
 describe("createClientCatalogBoundary", () => {
@@ -114,5 +117,78 @@ describe("createClientCatalogBoundary", () => {
         )
       })
     ).rejects.toThrow(/Perform a document navigation to change locale/)
+  })
+
+  it("retries a rejected preload and keeps the successful catalog cached", async () => {
+    document.documentElement.lang = "de"
+    const loadCatalog = vi
+      .fn<() => Promise<CatalogModule>>()
+      .mockRejectedValueOnce(new Error("catalog unavailable"))
+      .mockResolvedValueOnce(catalog("Hallo"))
+    const Boundary = createClientCatalogBoundary<Locale>({
+      loadCatalog,
+      resolveClientLocale: () => document.documentElement.lang as Locale,
+    })
+    expect(loadCatalog).toHaveBeenCalledOnce()
+
+    function Greeting() {
+      return <span>{String(getI18n()._("greeting"))}</span>
+    }
+
+    function boundary() {
+      return (
+        <Suspense fallback={<span>Loading</span>}>
+          <Boundary locale="de">
+            <Greeting />
+          </Boundary>
+        </Suspense>
+      )
+    }
+
+    let view!: ReturnType<typeof render>
+    await act(async () => {
+      view = render(boundary())
+      await Promise.resolve()
+    })
+    await waitFor(() => expect(view.container.textContent).toBe("Hallo"))
+    expect(loadCatalog).toHaveBeenCalledTimes(2)
+
+    await act(async () => {
+      view.rerender(boundary())
+    })
+    expect(view.container.textContent).toBe("Hallo")
+    expect(loadCatalog).toHaveBeenCalledTimes(2)
+  })
+
+  it("observes a rejected preload before the boundary renders", async () => {
+    document.documentElement.lang = "de"
+    const preload = deferred<CatalogModule>()
+    const loadCatalog = vi
+      .fn<() => Promise<CatalogModule>>()
+      .mockReturnValueOnce(preload.promise)
+      .mockResolvedValueOnce(catalog("Hallo"))
+    const Boundary = createClientCatalogBoundary<Locale>({
+      loadCatalog,
+      resolveClientLocale: () => document.documentElement.lang as Locale,
+    })
+    expect(loadCatalog).toHaveBeenCalledOnce()
+
+    await act(async () => {
+      preload.reject(new Error("catalog unavailable"))
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    let view!: ReturnType<typeof render>
+    await act(async () => {
+      view = render(
+        <Suspense fallback={<span>Loading</span>}>
+          <Boundary locale="de">Ready</Boundary>
+        </Suspense>
+      )
+      await Promise.resolve()
+    })
+    await waitFor(() => expect(view.container.textContent).toBe("Ready"))
+    expect(loadCatalog).toHaveBeenCalledTimes(2)
   })
 })

--- a/packages/react/src/clientCatalogServer.test.tsx
+++ b/packages/react/src/clientCatalogServer.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment node
 import * as React from "react"
 import { renderToStaticMarkup } from "react-dom/server"
-import { afterEach, describe, expect, it } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 
 import {
   createI18n,
@@ -22,6 +22,16 @@ function fulfilled<T>(value: T): Promise<T> {
   }
   promise.status = "fulfilled"
   promise.value = value
+  return promise
+}
+
+function rejected<T>(reason: unknown): Promise<T> {
+  const promise = Promise.reject(reason) as Promise<T> & {
+    status: "rejected"
+    reason: unknown
+  }
+  promise.status = "rejected"
+  promise.reason = reason
   return promise
 }
 
@@ -61,5 +71,61 @@ describe("createClientCatalogBoundary on the server", () => {
 
     expect(deHtml).toBe("Hallo")
     expect(enHtml).toBe("Hello")
+  })
+
+  it("rethrows failed server loads, then caches the retry that succeeds", async () => {
+    const loadError = new Error("catalog unavailable")
+    const loadCatalog = vi
+      .fn<() => Promise<{ messages: CompiledCatalogMessages }>>()
+      .mockReturnValueOnce(rejected(loadError))
+      .mockReturnValueOnce(fulfilled({ messages: defineCompiledCatalog({ greeting: "Hallo" }) }))
+    const Boundary = createClientCatalogBoundary<Locale>({
+      loadCatalog,
+      resolveClientLocale() {
+        throw new Error("resolveClientLocale must not run on the server")
+      },
+    })
+
+    function Greeting() {
+      return String(getI18n()._("greeting"))
+    }
+
+    const renderGreeting = () =>
+      renderToStaticMarkup(
+        <Boundary locale="de">
+          <Greeting />
+        </Boundary>
+      )
+
+    expect(renderGreeting).toThrow(loadError)
+    await Promise.resolve()
+    expect(renderGreeting()).toBe("Hallo")
+    expect(renderGreeting()).toBe("Hallo")
+    expect(loadCatalog).toHaveBeenCalledTimes(2)
+  })
+
+  it("evicts each rejected server load before the next render", async () => {
+    const firstError = new Error("first failure")
+    const secondError = new Error("second failure")
+    const loadCatalog = vi
+      .fn<() => Promise<{ messages: CompiledCatalogMessages }>>()
+      .mockReturnValueOnce(rejected(firstError))
+      .mockReturnValueOnce(rejected(secondError))
+      .mockReturnValueOnce(fulfilled({ messages: defineCompiledCatalog({ greeting: "Hallo" }) }))
+    const Boundary = createClientCatalogBoundary<Locale>({
+      loadCatalog,
+      resolveClientLocale() {
+        throw new Error("resolveClientLocale must not run on the server")
+      },
+    })
+
+    const renderBoundary = () => renderToStaticMarkup(<Boundary locale="de">Ready</Boundary>)
+
+    expect(renderBoundary).toThrow(firstError)
+    await Promise.resolve()
+    expect(renderBoundary).toThrow(secondError)
+    await Promise.resolve()
+    expect(renderBoundary()).toBe("Ready")
+    expect(loadCatalog).toHaveBeenCalledTimes(3)
   })
 })


### PR DESCRIPTION
## Summary

- Evict rejected client and server catalog resources while preserving eager client preloads and successful cache reuse.
- Observe client preload rejections until React consumes them, avoiding unhandled rejection behavior.
- Add client and server regression coverage for recovery, repeated failures, original error propagation, and cache reuse.

## Issue

Closes #571

## Validation

- `pnpm --filter @palamedes/react... build`
- `pnpm --filter @palamedes/react test`
- `pnpm --filter @palamedes/react exec tsc --noEmit -p tsconfig.json`
- `pnpm format:check`
- `pnpm lint`
- `RUSTUP_TOOLCHAIN=1.95-aarch64-apple-darwin pnpm test`
- `RUSTUP_TOOLCHAIN=1.95-aarch64-apple-darwin pnpm check-types`
- `pnpm check:published-types`
- `pnpm proof:icu:check`
- `pnpm check:release-set`

## Follow-up

None.