### PR TITLE
fix(core): fingerprint complete translation origins

### DIFF
--- a/crates/palamedes-node/src/catalog.rs
+++ b/crates/palamedes-node/src/catalog.rs
@@ -796,7 +796,10 @@ impl TryFrom<TranslationCandidateRequest> for palamedes::TranslationCandidateReq
                 .into_iter()
                 .map(palamedes::TranslationCandidateId::from)
                 .collect(),
-            max_origins: value.max_origins.map_or(8, |limit| limit as usize),
+            max_origins: value.max_origins.map_or(
+                palamedes::DEFAULT_TRANSLATION_CANDIDATE_MAX_ORIGINS,
+                |limit| limit as usize,
+            ),
         })
     }
 }

--- a/crates/palamedes/src/lib.rs
+++ b/crates/palamedes/src/lib.rs
@@ -124,6 +124,7 @@ pub use translation_candidates::{
     TranslationPatchOutcomeStatus, TranslationPatchRequest, TranslationPatchResult,
     TranslationPatchStats, TranslationPluralKind, TranslationReviewState, TranslationValue,
     TranslationWorkflowDiagnostic, TranslationWorkflowOrigin,
+    DEFAULT_TRANSLATION_CANDIDATE_MAX_ORIGINS,
 };
 
 /// Published `ferrocat` version used by the Rust core.

--- a/crates/palamedes/src/translation_candidates.rs
+++ b/crates/palamedes/src/translation_candidates.rs
@@ -97,7 +97,7 @@ pub struct TranslationCandidate {
 }
 
 /// Source origin exposed to translation workflow consumers.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TranslationWorkflowOrigin {
     /// Source filename.
@@ -694,7 +694,7 @@ fn build_candidate(
         || message.comments.clone(),
         |item| item.extracted_comments.iter().cloned().collect(),
     );
-    let all_origins = message
+    let mut all_origins = message
         .origin
         .iter()
         .map(|origin| TranslationWorkflowOrigin {
@@ -702,6 +702,8 @@ fn build_candidate(
             scope: origin.scope.clone(),
         })
         .collect::<Vec<_>>();
+    all_origins.sort();
+    all_origins.dedup();
     let id = TranslationCandidateId {
         catalog: loaded.scope.clone(),
         locale: loaded.locale.clone(),
@@ -1344,14 +1346,22 @@ mod tests {
     }
 
     #[test]
-    fn fingerprints_complete_origins_while_returning_the_requested_origin_limit() {
+    fn canonicalizes_complete_origins_for_fingerprints_and_response_limits() {
         let fixture = tempfile::tempdir().expect("fixture directory");
         let path = fixture.path().join("messages/de.po");
         write_po_fixture(&path, "de");
-        let origins = (1..=10)
+        let canonical_origins = (1..=10)
             .map(|index| format!("#: src/origin-{index}.tsx#Origin{index}"))
             .collect::<Vec<_>>()
             .join("\n");
+        let origins = format!(
+            "{}\n#: src/origin-1.tsx#Origin1",
+            (1..=10)
+                .rev()
+                .map(|index| format!("#: src/origin-{index}.tsx#Origin{index}"))
+                .collect::<Vec<_>>()
+                .join("\n")
+        );
         let content = fs::read_to_string(&path).expect("read fixture");
         let expanded_content = content.replace(
             "#: src/home.tsx#HomePage\n#: src/shared.ts#formatGreeting",
@@ -1381,6 +1391,26 @@ mod tests {
         assert_eq!(expanded.origins.len(), 6);
         assert_eq!(limited.fingerprint, expanded.fingerprint);
 
+        fs::write(
+            &path,
+            content.replace(
+                "#: src/home.tsx#HomePage\n#: src/shared.ts#formatGreeting",
+                &canonical_origins,
+            ),
+        )
+        .expect("rewrite origins in canonical order without duplicates");
+        let rewritten = list_translation_candidates(&TranslationCandidateRequest {
+            config: po_config(fixture.path()),
+            locales: vec!["de".to_owned()],
+            targets: vec![target.clone()],
+            max_origins: 2,
+        })
+        .expect("list candidate after equivalent origin rewrite");
+        let rewritten = candidate(&rewritten.candidates, "Hello");
+        assert_eq!(limited.origins, rewritten.origins);
+        assert_eq!(limited.fingerprint, rewritten.fingerprint);
+
+        fs::write(&path, &expanded_content).expect("restore expanded origins");
         fs::write(
             &path,
             expanded_content.replace("Origin10", "UpdatedOrigin10"),

--- a/crates/palamedes/src/translation_candidates.rs
+++ b/crates/palamedes/src/translation_candidates.rs
@@ -20,8 +20,12 @@ use crate::{
     PoOutputOptions,
 };
 
-const DEFAULT_MAX_ORIGINS: usize = 8;
-const CANDIDATE_FINGERPRINT_NAMESPACE: &[u8] = b"palamedes:translation-candidate:v1";
+/// Default maximum number of origins returned for each translation candidate.
+pub const DEFAULT_TRANSLATION_CANDIDATE_MAX_ORIGINS: usize = 8;
+
+// v2 fingerprints include every origin, rather than the response's bounded origin list.
+// Candidates listed by v1 builds must be listed again before they can be patched.
+const CANDIDATE_FINGERPRINT_NAMESPACE: &[u8] = b"palamedes:translation-candidate:v2";
 
 /// Stable catalog and message identity used by translation workflow APIs.
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, PartialOrd, Ord, Serialize)]
@@ -589,7 +593,7 @@ pub fn apply_translation_patches(
 }
 
 fn default_max_origins() -> usize {
-    DEFAULT_MAX_ORIGINS
+    DEFAULT_TRANSLATION_CANDIDATE_MAX_ORIGINS
 }
 
 fn selected_locales(config: &CatalogArtifactConfig, requested: &[String]) -> Vec<String> {
@@ -690,15 +694,14 @@ fn build_candidate(
         || message.comments.clone(),
         |item| item.extracted_comments.iter().cloned().collect(),
     );
-    let origins = message
+    let all_origins = message
         .origin
         .iter()
-        .take(max_origins)
         .map(|origin| TranslationWorkflowOrigin {
             file: origin.file.clone(),
             scope: origin.scope.clone(),
         })
-        .collect();
+        .collect::<Vec<_>>();
     let id = TranslationCandidateId {
         catalog: loaded.scope.clone(),
         locale: loaded.locale.clone(),
@@ -712,12 +715,12 @@ fn build_candidate(
         source,
         translation,
         comments,
-        origins,
+        origins: all_origins.iter().take(max_origins).cloned().collect(),
         review,
         machine: message.machine.clone().map(MachineMetadata::from),
         fingerprint: String::new(),
     };
-    candidate.fingerprint = candidate_fingerprint(&candidate);
+    candidate.fingerprint = candidate_fingerprint(&candidate, &all_origins);
     candidate
 }
 
@@ -829,14 +832,17 @@ fn value_is_translated(value: &TranslationValue) -> bool {
     }
 }
 
-fn candidate_fingerprint(candidate: &TranslationCandidate) -> String {
+fn candidate_fingerprint(
+    candidate: &TranslationCandidate,
+    all_origins: &[TranslationWorkflowOrigin],
+) -> String {
     let mut hasher = Sha256::new();
     hasher.update(CANDIDATE_FINGERPRINT_NAMESPACE);
     hash_json(&mut hasher, &candidate.id);
     hash_json(&mut hasher, &candidate.source);
     hash_json(&mut hasher, &candidate.translation);
     hash_json(&mut hasher, &candidate.comments);
-    hash_json(&mut hasher, &candidate.origins);
+    hash_json(&mut hasher, all_origins);
     hash_json(&mut hasher, &candidate.review);
     hash_json(&mut hasher, &candidate.machine);
     let digest = hasher.finalize();
@@ -846,7 +852,7 @@ fn candidate_fingerprint(candidate: &TranslationCandidate) -> String {
         .collect()
 }
 
-fn hash_json<T: Serialize>(hasher: &mut Sha256, value: &T) {
+fn hash_json<T: Serialize + ?Sized>(hasher: &mut Sha256, value: &T) {
     let bytes = serde_json::to_vec(value).expect("translation fingerprint payload is serializable");
     hasher.update((bytes.len() as u64).to_be_bytes());
     hasher.update(bytes);
@@ -1335,6 +1341,72 @@ mod tests {
                 .map(|ai| ai.model.as_str()),
             Some("example/new")
         );
+    }
+
+    #[test]
+    fn fingerprints_complete_origins_while_returning_the_requested_origin_limit() {
+        let fixture = tempfile::tempdir().expect("fixture directory");
+        let path = fixture.path().join("messages/de.po");
+        write_po_fixture(&path, "de");
+        let origins = (1..=10)
+            .map(|index| format!("#: src/origin-{index}.tsx#Origin{index}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let content = fs::read_to_string(&path).expect("read fixture");
+        let expanded_content = content.replace(
+            "#: src/home.tsx#HomePage\n#: src/shared.ts#formatGreeting",
+            &origins,
+        );
+        fs::write(&path, &expanded_content).expect("write expanded origins");
+
+        let target = id("messages/{locale}", "de", "Hello", None);
+        let two_origins = list_translation_candidates(&TranslationCandidateRequest {
+            config: po_config(fixture.path()),
+            locales: vec!["de".to_owned()],
+            targets: vec![target.clone()],
+            max_origins: 2,
+        })
+        .expect("list candidate with two origins");
+        let six_origins = list_translation_candidates(&TranslationCandidateRequest {
+            config: po_config(fixture.path()),
+            locales: vec!["de".to_owned()],
+            targets: vec![target.clone()],
+            max_origins: 6,
+        })
+        .expect("list candidate with six origins");
+        let limited = candidate(&two_origins.candidates, "Hello");
+        let expanded = candidate(&six_origins.candidates, "Hello");
+
+        assert_eq!(limited.origins.len(), 2);
+        assert_eq!(expanded.origins.len(), 6);
+        assert_eq!(limited.fingerprint, expanded.fingerprint);
+
+        fs::write(
+            &path,
+            expanded_content.replace("Origin10", "UpdatedOrigin10"),
+        )
+        .expect("change an origin outside the response limit");
+        let changed = list_translation_candidates(&TranslationCandidateRequest {
+            config: po_config(fixture.path()),
+            locales: vec!["de".to_owned()],
+            targets: vec![target],
+            max_origins: 2,
+        })
+        .expect("list candidate after an origin change");
+        assert_ne!(
+            limited.fingerprint,
+            candidate(&changed.candidates, "Hello").fingerprint
+        );
+        fs::write(&path, expanded_content).expect("restore unchanged catalog");
+
+        let result = apply_translation_patches(TranslationPatchRequest {
+            config: po_config(fixture.path()),
+            po: None,
+            patches: vec![singular_patch(limited, "Hallo")],
+        })
+        .expect("apply candidate listed with truncated origins");
+        assert!(result.updated);
+        assert!(result.diagnostics.is_empty());
     }
 
     #[test]

--- a/docs/translation-candidate-patches.md
+++ b/docs/translation-candidate-patches.md
@@ -27,9 +27,14 @@ Every candidate includes:
 - native Ferrocat machine provenance when present; and
 - a per-entry fingerprint for optimistic concurrency control.
 
-The fingerprint covers the candidate's source, current target, relevant
-metadata, and review state. An unrelated entry can therefore be written in an
-earlier incremental batch without invalidating the remaining candidates.
+The fingerprint covers the candidate's source, current target, complete origin
+state, relevant metadata, and review state. The `maxOrigins` response limit
+only affects the displayed origin list, never the fingerprint. An unrelated
+entry can therefore be written in an earlier incremental batch without
+invalidating the remaining candidates.
+
+Fingerprint payload changes are versioned. When upgrading across a fingerprint
+version, discard in-flight candidates and list them again before patching.
 
 ## Applying completed translations
 

--- a/packages/core-node/src/index.test.ts
+++ b/packages/core-node/src/index.test.ts
@@ -292,6 +292,64 @@ msgstr ""
     expect(output).toContain("{count, plural, one {# Datei} other {# Dateien}}")
   })
 
+  it("patches candidates listed with truncated origins using a stable fingerprint", async () => {
+    const rootDir = await createTempDir()
+    const catalogDir = path.join(rootDir, "locales", "de")
+    const targetPath = path.join(catalogDir, "messages.po")
+    const origins = Array.from(
+      { length: 10 },
+      (_, index) => `#: src/origin-${index + 1}.tsx#Origin${index + 1}`
+    ).join("\n")
+    await mkdir(catalogDir, { recursive: true })
+    await writeFile(
+      targetPath,
+      `msgid ""
+msgstr ""
+"Language: de\\n"
+
+${origins}
+msgid "Hello"
+msgstr ""
+`
+    )
+    const config = {
+      rootDir,
+      locales: ["en", "de"],
+      sourceLocale: "en",
+      catalogs: [{ path: "locales/{locale}/messages", include: ["src"] }],
+    }
+
+    const twoOrigins = listTranslationCandidates({ config, maxOrigins: 2 })
+    const sixOrigins = listTranslationCandidates({ config, maxOrigins: 6 })
+    const limited = twoOrigins.candidates.find((candidate) => candidate.id.message === "Hello")
+    const expanded = sixOrigins.candidates.find((candidate) => candidate.id.message === "Hello")
+
+    expect(limited?.origins).toHaveLength(2)
+    expect(expanded?.origins).toHaveLength(6)
+    expect(limited?.fingerprint).toBe(expanded?.fingerprint)
+    if (!limited) {
+      throw new Error("Expected candidate listed with truncated origins")
+    }
+
+    const applied = applyTranslationPatches({
+      config,
+      patches: [
+        {
+          id: limited.id,
+          fingerprint: limited.fingerprint,
+          translation: { kind: "singular", value: "Hallo" },
+        },
+      ],
+    })
+
+    expect(applied).toMatchObject({
+      updated: true,
+      stats: { requested: 1, applied: 1, catalogsUpdated: 1 },
+      outcomes: [{ status: "applied" }],
+      diagnostics: [],
+    })
+  })
+
   it("maps native transform results into JavaScript strings and source maps", () => {
     const source = `import { t } from "@palamedes/core/macro";
 function message(name) {

--- a/packages/core-node/src/index.test.ts
+++ b/packages/core-node/src/index.test.ts
@@ -296,14 +296,16 @@ msgstr ""
     const rootDir = await createTempDir()
     const catalogDir = path.join(rootDir, "locales", "de")
     const targetPath = path.join(catalogDir, "messages.po")
-    const origins = Array.from(
+    const canonicalOrigins = Array.from(
       { length: 10 },
       (_, index) => `#: src/origin-${index + 1}.tsx#Origin${index + 1}`
     ).join("\n")
+    const origins = `${Array.from(
+      { length: 10 },
+      (_, index) => `#: src/origin-${10 - index}.tsx#Origin${10 - index}`
+    ).join("\n")}\n#: src/origin-1.tsx#Origin1`
     await mkdir(catalogDir, { recursive: true })
-    await writeFile(
-      targetPath,
-      `msgid ""
+    const catalog = `msgid ""
 msgstr ""
 "Language: de\\n"
 
@@ -311,7 +313,7 @@ ${origins}
 msgid "Hello"
 msgstr ""
 `
-    )
+    await writeFile(targetPath, catalog)
     const config = {
       rootDir,
       locales: ["en", "de"],
@@ -327,6 +329,12 @@ msgstr ""
     expect(limited?.origins).toHaveLength(2)
     expect(expanded?.origins).toHaveLength(6)
     expect(limited?.fingerprint).toBe(expanded?.fingerprint)
+    await writeFile(targetPath, catalog.replace(origins, canonicalOrigins))
+    const rewritten = listTranslationCandidates({ config, maxOrigins: 2 }).candidates.find(
+      (candidate) => candidate.id.message === "Hello"
+    )
+    expect(rewritten?.origins).toStrictEqual(limited?.origins)
+    expect(rewritten?.fingerprint).toBe(limited?.fingerprint)
     if (!limited) {
       throw new Error("Expected candidate listed with truncated origins")
     }


### PR DESCRIPTION
## Summary

- hash complete catalog origin state rather than the bounded candidate response list
- share the core default origin limit with the Node binding
- cover truncated candidate patching in Rust and core-node, and document the v2 fingerprint relist requirement

## Issue

Closes #568

## Validation

- `rustup run 1.95 cargo test --workspace --locked`
- `rustup run 1.95 cargo clippy --workspace --all-targets --locked -- -D warnings`
- `pnpm build`
- `pnpm check-types`
- `pnpm format:check`
- `pnpm lint`
- `pnpm --filter @palamedes/core-node test`

## Follow-up

None.