### PR TITLE
fix(cli+core): align audit verdict and locales

### DIFF
--- a/crates/palamedes-cli/src/commands/audit.rs
+++ b/crates/palamedes-cli/src/commands/audit.rs
@@ -4,7 +4,10 @@ use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 use clap::{Args, ValueEnum};
-use palamedes::{audit_catalogs, CatalogAuditDiagnostic, CatalogAuditRequest, CatalogAuditResult};
+use palamedes::{
+    audit_catalogs, CatalogAuditDiagnostic, CatalogAuditRequest, CatalogAuditResult,
+    CatalogAuditSummary,
+};
 
 use crate::command::{render_json, Command, Context};
 use crate::commands::normalize_locale_list;
@@ -50,39 +53,44 @@ impl Command for AuditOptions {
         if self.json {
             return render_json(output);
         }
-        print_audit_result(output);
+        print_audit_result(output, self.fail_on);
         Ok(())
     }
 
     fn verdict(&self, output: &Self::Output) -> Result<(), CliError> {
+        if !self.fail_on.should_fail(&output.summary) {
+            return Ok(());
+        }
+
         match self.fail_on {
-            FailOn::Info
-                if output.summary.errors > 0
-                    || output.summary.warnings > 0
-                    || output.summary.infos > 0 =>
-            {
-                Err(CliError::AuditFailedOnInfo {
-                    errors: output.summary.errors,
-                    warnings: output.summary.warnings,
-                    infos: output.summary.infos,
-                })
-            }
-            FailOn::Warning if output.summary.errors > 0 || output.summary.warnings > 0 => {
-                Err(CliError::AuditFailedOnWarning {
-                    errors: output.summary.errors,
-                    warnings: output.summary.warnings,
-                })
-            }
-            FailOn::Error if output.summary.errors > 0 => Err(CliError::AuditFailedOnError {
+            FailOn::Info => Err(CliError::AuditFailedOnInfo {
+                errors: output.summary.errors,
+                warnings: output.summary.warnings,
+                infos: output.summary.infos,
+            }),
+            FailOn::Warning => Err(CliError::AuditFailedOnWarning {
+                errors: output.summary.errors,
+                warnings: output.summary.warnings,
+            }),
+            FailOn::Error => Err(CliError::AuditFailedOnError {
                 errors: output.summary.errors,
             }),
-            _ => Ok(()),
         }
     }
 }
 
-fn print_audit_result(result: &CatalogAuditResult) {
-    let status = if result.summary.errors > 0 {
+impl FailOn {
+    fn should_fail(self, summary: &CatalogAuditSummary) -> bool {
+        match self {
+            Self::Info => summary.errors > 0 || summary.warnings > 0 || summary.infos > 0,
+            Self::Warning => summary.errors > 0 || summary.warnings > 0,
+            Self::Error => summary.errors > 0,
+        }
+    }
+}
+
+fn print_audit_result(result: &CatalogAuditResult, fail_on: FailOn) {
+    let status = if fail_on.should_fail(&result.summary) {
         "failed"
     } else {
         "passed"
@@ -121,5 +129,34 @@ fn print_audit_result(result: &CatalogAuditResult) {
                 println!("    Source: {}{}", source_key.message, context);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::FailOn;
+    use palamedes::CatalogAuditSummary;
+
+    #[test]
+    fn fail_on_thresholds_share_exact_severity_boundaries() {
+        let errors = CatalogAuditSummary {
+            errors: 1,
+            ..CatalogAuditSummary::default()
+        };
+        let warnings = CatalogAuditSummary {
+            warnings: 1,
+            ..CatalogAuditSummary::default()
+        };
+        let infos = CatalogAuditSummary {
+            infos: 1,
+            ..CatalogAuditSummary::default()
+        };
+
+        assert!(FailOn::Error.should_fail(&errors));
+        assert!(!FailOn::Error.should_fail(&warnings));
+        assert!(FailOn::Warning.should_fail(&warnings));
+        assert!(!FailOn::Warning.should_fail(&infos));
+        assert!(FailOn::Info.should_fail(&infos));
+        assert!(!FailOn::Info.should_fail(&CatalogAuditSummary::default()));
     }
 }

--- a/crates/palamedes-cli/tests/audit_exit.rs
+++ b/crates/palamedes-cli/tests/audit_exit.rs
@@ -4,8 +4,92 @@ use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 #[test]
-fn audit_info_threshold_fails_on_fuzzy_markers_without_changing_the_default() {
+fn audit_warning_threshold_prints_failed_status_and_exits_one() {
+    let fixture = fixture_dir("audit-warning-threshold");
+    write_config(&fixture);
+    write_catalogs(
+        &fixture,
+        "msgid \"Save\"\nmsgstr \"Save\"\n",
+        "msgid \"Save\"\nmsgstr \"Speichern\"\n\nmsgid \"Only target\"\nmsgstr \"Nur Ziel\"\n",
+    );
+
+    let default = audit(&fixture, &[]);
+    assert!(default.status.success(), "{default:?}");
+    assert!(String::from_utf8_lossy(&default.stdout)
+        .contains("Catalog audit passed: 0 error(s), 1 warning(s), 0 info"));
+
+    let fail_on_warning = audit(&fixture, &["--fail-on", "warning"]);
+    assert_eq!(
+        fail_on_warning.status.code(),
+        Some(1),
+        "{fail_on_warning:?}"
+    );
+    assert!(String::from_utf8_lossy(&fail_on_warning.stdout)
+        .contains("Catalog audit failed: 0 error(s), 1 warning(s), 0 info"));
+
+    fs::remove_dir_all(fixture).expect("cleanup");
+}
+
+#[test]
+fn audit_info_threshold_prints_failed_status_and_exits_one() {
     let fixture = fixture_dir("audit-info-threshold");
+    write_config(&fixture);
+    write_catalogs(
+        &fixture,
+        "msgid \"Save\"\nmsgstr \"Save\"\n",
+        "#, fuzzy\nmsgid \"Save\"\nmsgstr \"Speichern\"\n",
+    );
+
+    let default = audit(&fixture, &[]);
+    assert!(default.status.success(), "{default:?}");
+    assert!(String::from_utf8_lossy(&default.stdout)
+        .contains("Catalog audit passed: 0 error(s), 0 warning(s), 1 info"));
+
+    let fail_on_info = audit(&fixture, &["--fail-on", "info"]);
+    assert_eq!(fail_on_info.status.code(), Some(1), "{fail_on_info:?}");
+    assert!(
+        String::from_utf8_lossy(&fail_on_info.stdout)
+            .contains("Catalog audit failed: 0 error(s), 0 warning(s), 1 info"),
+        "{fail_on_info:?}"
+    );
+    assert!(
+        String::from_utf8_lossy(&fail_on_info.stderr)
+            .contains("Catalog audit failed with 0 error(s), 0 warning(s), and 1 info"),
+        "{fail_on_info:?}"
+    );
+
+    fs::remove_dir_all(fixture).expect("cleanup");
+}
+
+#[test]
+fn audit_json_output_remains_machine_readable_when_its_threshold_fails() {
+    let fixture = fixture_dir("audit-json-threshold");
+    write_config(&fixture);
+    write_catalogs(
+        &fixture,
+        "msgid \"Save\"\nmsgstr \"Save\"\n",
+        "msgid \"Save\"\nmsgstr \"Speichern\"\n\nmsgid \"Only target\"\nmsgstr \"Nur Ziel\"\n",
+    );
+
+    let output = audit(&fixture, &["--json", "--fail-on", "warning"]);
+    assert_eq!(output.status.code(), Some(1), "{output:?}");
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).expect("audit JSON");
+    assert_eq!(json["summary"]["warnings"], 1);
+    assert!(!String::from_utf8_lossy(&output.stdout).contains("Catalog audit"));
+
+    fs::remove_dir_all(fixture).expect("cleanup");
+}
+
+fn audit(cwd: &Path, arguments: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_pmds"))
+        .arg("audit")
+        .args(arguments)
+        .current_dir(cwd)
+        .output()
+        .expect("run pmds audit")
+}
+
+fn write_config(fixture: &Path) {
     fs::create_dir_all(fixture.join("locales/en")).expect("create source catalog dir");
     fs::create_dir_all(fixture.join("locales/de")).expect("create target catalog dir");
     fs::write(
@@ -18,42 +102,11 @@ catalogs:
 "#,
     )
     .expect("write config");
-    fs::write(
-        fixture.join("locales/en/messages.po"),
-        "msgid \"Save\"\nmsgstr \"Save\"\n",
-    )
-    .expect("write source catalog");
-    fs::write(
-        fixture.join("locales/de/messages.po"),
-        "#, fuzzy\nmsgid \"Save\"\nmsgstr \"Speichern\"\n",
-    )
-    .expect("write target catalog");
-
-    let default = audit(&fixture, &[]);
-    assert!(default.status.success(), "{default:?}");
-
-    let fail_on_info = audit(&fixture, &["--fail-on", "info"]);
-    assert_eq!(fail_on_info.status.code(), Some(1), "{fail_on_info:?}");
-    assert!(
-        String::from_utf8_lossy(&fail_on_info.stdout).contains("1 info"),
-        "{fail_on_info:?}"
-    );
-    assert!(
-        String::from_utf8_lossy(&fail_on_info.stderr)
-            .contains("Catalog audit failed with 0 error(s), 0 warning(s), and 1 info"),
-        "{fail_on_info:?}"
-    );
-
-    fs::remove_dir_all(fixture).expect("cleanup");
 }
 
-fn audit(cwd: &Path, arguments: &[&str]) -> std::process::Output {
-    Command::new(env!("CARGO_BIN_EXE_pmds"))
-        .arg("audit")
-        .args(arguments)
-        .current_dir(cwd)
-        .output()
-        .expect("run pmds audit")
+fn write_catalogs(fixture: &Path, source: &str, target: &str) {
+    fs::write(fixture.join("locales/en/messages.po"), source).expect("write source catalog");
+    fs::write(fixture.join("locales/de/messages.po"), target).expect("write target catalog");
 }
 
 fn fixture_dir(name: &str) -> PathBuf {

--- a/crates/palamedes/src/catalog_audit.rs
+++ b/crates/palamedes/src/catalog_audit.rs
@@ -353,20 +353,24 @@ impl CatalogAuditCheckOptions {
 }
 
 fn target_locales(config: &CatalogArtifactConfig, requested: &[String]) -> Vec<String> {
-    if requested.is_empty() {
-        return config
+    let mut locales = if requested.is_empty() {
+        config
             .locales
             .iter()
             .filter(|locale| locale.as_str() != config.source_locale)
             .cloned()
-            .collect();
-    }
+            .collect::<Vec<_>>()
+    } else {
+        requested
+            .iter()
+            .filter(|locale| locale.as_str() != config.source_locale)
+            .cloned()
+            .collect::<Vec<_>>()
+    };
 
-    requested
-        .iter()
-        .filter(|locale| locale.as_str() != config.source_locale)
-        .cloned()
-        .collect()
+    locales.sort();
+    locales.dedup();
+    locales
 }
 
 fn load_audit_catalogs(
@@ -561,6 +565,88 @@ msgstr "{name}, Eigentümer: {name}"
                 && diagnostic.message.contains("1 occurrence(s) in the source")
                 && diagnostic.message.contains("2 in the translation")
         }));
+    }
+
+    #[test]
+    fn deduplicates_and_sorts_explicit_audit_locales() {
+        let fixture = create_fixture_dir("catalog-audit-duplicate-locales");
+        let locale_dir = fixture.join("src/locales");
+        fs::create_dir_all(&locale_dir).expect("locale dir");
+        fs::write(
+            locale_dir.join("en.po"),
+            r#"msgid ""
+msgstr ""
+"Language: en\n"
+
+msgid "{count} of {count} sites covered"
+msgstr ""
+"#,
+        )
+        .expect("write en");
+        fs::write(
+            locale_dir.join("de.po"),
+            r#"msgid ""
+msgstr ""
+"Language: de\n"
+
+msgid "{count} of {count} sites covered"
+msgstr "{count} Standorte abgedeckt"
+"#,
+        )
+        .expect("write de");
+
+        let duplicate = audit_catalogs(CatalogAuditRequest {
+            config: config(&fixture),
+            locales: vec!["de".to_owned(), "de".to_owned()],
+            checks: CatalogAuditCheckOptions::default(),
+            metadata: Vec::new(),
+        })
+        .expect("audit duplicate locales");
+        assert_eq!(duplicate.summary.target_locales, 1);
+        assert_eq!(duplicate.summary.errors, 1);
+        assert_eq!(
+            duplicate
+                .diagnostics
+                .iter()
+                .filter(|diagnostic| diagnostic.code == "icu.argument_occurrence_mismatch")
+                .count(),
+            1
+        );
+
+        let first_order = audit_catalogs(CatalogAuditRequest {
+            config: config(&fixture),
+            locales: vec![
+                "fr".to_owned(),
+                "en".to_owned(),
+                "de".to_owned(),
+                "de".to_owned(),
+            ],
+            checks: CatalogAuditCheckOptions::default(),
+            metadata: Vec::new(),
+        })
+        .expect("audit first locale order");
+        let second_order = audit_catalogs(CatalogAuditRequest {
+            config: config(&fixture),
+            locales: vec![
+                "de".to_owned(),
+                "fr".to_owned(),
+                "en".to_owned(),
+                "de".to_owned(),
+            ],
+            checks: CatalogAuditCheckOptions::default(),
+            metadata: Vec::new(),
+        })
+        .expect("audit second locale order");
+
+        assert!(first_order.diagnostics.iter().any(|diagnostic| {
+            diagnostic.code == "catalog.missing_locale"
+                && diagnostic.locale.as_deref() == Some("fr")
+        }));
+        assert_eq!(
+            audit_signature(&first_order),
+            audit_signature(&second_order),
+            "explicit locale order must not change the audit result"
+        );
     }
 
     #[test]
@@ -783,6 +869,39 @@ msgstr "Hallo {{name}}"
                 path: "src/locales/{locale}".to_owned(),
                 format: PalamedesCatalogFormat::Po,
             }],
+        }
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct AuditSignature {
+        target_locales: usize,
+        diagnostics: usize,
+        errors: usize,
+        warnings: usize,
+        infos: usize,
+        source_messages: usize,
+        diagnostic_details: Vec<(String, Option<String>, Option<String>)>,
+    }
+
+    fn audit_signature(result: &super::CatalogAuditResult) -> AuditSignature {
+        AuditSignature {
+            target_locales: result.summary.target_locales,
+            diagnostics: result.summary.diagnostics,
+            errors: result.summary.errors,
+            warnings: result.summary.warnings,
+            infos: result.summary.infos,
+            source_messages: result.summary.source_messages,
+            diagnostic_details: result
+                .diagnostics
+                .iter()
+                .map(|diagnostic| {
+                    (
+                        diagnostic.code.clone(),
+                        diagnostic.locale.clone(),
+                        diagnostic.name.clone(),
+                    )
+                })
+                .collect(),
         }
     }
 


### PR DESCRIPTION
## Summary
- Align human audit status with the same resolved `--fail-on` predicate that determines the exit code.
- Normalize core audit target locales by sorting and de-duplicating them before every diagnostic pass.
- Add CLI and core regressions for warning/info thresholds, JSON output, duplicate locale input, stable ordering, and source/unknown locale handling.

## Root cause
Text rendering considered only error diagnostics while the exit verdict also considered warnings or info according to `--fail-on`; core audit passed duplicate explicit locales to each audit pass.

## Validation
- `cargo +1.95 fmt --all --check`
- `cargo +1.95 clippy --workspace --all-targets --locked -- -D warnings`
- `cargo +1.95 test --workspace --locked`
- `RUSTUP_TOOLCHAIN=1.95 pnpm build`
- `RUSTUP_TOOLCHAIN=1.95 pnpm check-types`
- `RUSTUP_TOOLCHAIN=1.95 pnpm test`
- `pnpm format:check`
- `pnpm lint`

Closes #579

🔧 Emily Carter · Implementation Agent