### PR TITLE
fix(next): initialize client fragments before module body

### DIFF
--- a/docs/api/next-plugin.md
+++ b/docs/api/next-plugin.md
@@ -163,9 +163,10 @@ parser-free generated catalog representation.
 As with Palamedes' other eager translation APIs, translation calls must execute
 inside a function, method, or callback after i18n activation. The macro
 transform rejects eager `t`, `plural`, `select`, and `selectOrdinal` calls at
-module scope. The generated client bootstrap is appended to preserve source
-maps, so custom compiled-adapter calls must follow the same rule; declarations
-that defer translation until component render remain valid.
+module scope, and declarations that defer translation until component render
+remain valid. The generated client bootstrap initializes the module's own
+fragment before its body evaluates, so custom compiled-adapter calls observe
+that fragment if they must run eagerly.
 
 In development, each selected `.po` import remains a real dependency of its
 consuming browser module. Catalog edits therefore invalidate the affected

--- a/packages/next-plugin/README.md
+++ b/packages/next-plugin/README.md
@@ -129,16 +129,16 @@ module.exports = withPalamedes(
 Each message-bearing browser module gets statically enumerable imports for its
 selected PO subset. It awaits only the import matching
 `document.documentElement.lang`, loads the fragment into a shared parser-free
-instance, and only then exposes the component to hydration or client
-navigation. Turbopack and webpack therefore omit inactive locale catalogs and
+instance, and only then evaluates that module body or resolves it to an
+importer. Turbopack and webpack therefore omit inactive locale catalogs and
 unvisited route messages from network requests. Locale changes require a
 document navigation.
 
 Eager translation calls must execute inside a function, method, or callback
 after i18n activation. Palamedes rejects eager macros at module scope, and
-custom compiled-adapter calls must follow the same rule because the generated
-bootstrap is appended to preserve source maps. Declarations that defer
-translation until component render remain valid.
+declarations that defer translation until component render remain valid. The
+client bootstrap also initializes the module's own fragment before its body, so
+custom compiled-adapter calls observe that fragment if they must run eagerly.
 
 Selected `.po` imports remain normal development dependencies. Catalog edits
 invalidate their affected subsets under Turbopack and webpack; Next may apply

--- a/packages/next-plugin/package.json
+++ b/packages/next-plugin/package.json
@@ -87,6 +87,7 @@
     "./palamedes-po-loader": "./palamedes-po-loader.cjs"
   },
   "dependencies": {
+    "@jridgewell/sourcemap-codec": "1.5.5",
     "@palamedes/config": "workspace:^",
     "@palamedes/core-node": "workspace:^",
     "@palamedes/runtime": "workspace:^",

--- a/packages/next-plugin/palamedes-loader.cjs
+++ b/packages/next-plugin/palamedes-loader.cjs
@@ -239,49 +239,144 @@ function directivePrologueEnd(code) {
   return end
 }
 
-function offsetSourceMapForInsertion(sourceMap, insertionOffset, insertion) {
-  if (!sourceMap || typeof sourceMap !== "object" || typeof sourceMap.mappings !== "string") {
-    return sourceMap
+function generatedPositionForText(text) {
+  const line = text.split("\n").length - 1
+  return { line, column: text.length - text.lastIndexOf("\n") - 1 }
+}
+
+function compareGeneratedPositions(left, right) {
+  if (left.line !== right.line) {
+    return left.line - right.line
   }
-  if (sourceMap.mappings === "" || insertion.length === 0) {
+  return left.column - right.column
+}
+
+function insertionMetrics(insertion) {
+  const position = generatedPositionForText(insertion)
+  return { addedLines: position.line, finalLineLength: position.column }
+}
+
+function shiftedGeneratedPosition(position, insertionPosition, insertion, metrics) {
+  if (compareGeneratedPositions(position, insertionPosition) < 0) {
+    return position
+  }
+  if (metrics.addedLines === 0) {
+    return { line: position.line, column: position.column + insertion.length }
+  }
+  return {
+    line: position.line + metrics.addedLines,
+    column:
+      position.line === insertionPosition.line
+        ? metrics.finalLineLength + position.column - insertionPosition.column
+        : position.column,
+  }
+}
+
+function isGeneratedPosition(position) {
+  return (
+    position &&
+    typeof position === "object" &&
+    Number.isInteger(position.line) &&
+    position.line >= 0 &&
+    Number.isInteger(position.column) &&
+    position.column >= 0
+  )
+}
+
+function offsetFlatSourceMap(sourceMap, insertionPosition, insertion, metrics) {
+  if (sourceMap.mappings === "") {
     return sourceMap
   }
 
-  const prefix = insertionOffset.source
-  const insertionLine = prefix.split("\n").length - 1
-  const insertionColumn = prefix.length - prefix.lastIndexOf("\n") - 1
-  const addedLines = insertion.split("\n").length - 1
-  const finalLineLength = insertion.length - insertion.lastIndexOf("\n") - 1
   const mappings = decode(sourceMap.mappings)
-  const shifted = Array.from({ length: mappings.length + addedLines }, () => [])
+  const shifted = Array.from({ length: mappings.length + metrics.addedLines }, () => [])
 
   for (const [lineIndex, segments] of mappings.entries()) {
     for (const segment of segments) {
-      if (lineIndex < insertionLine) {
-        shifted[lineIndex].push(segment)
-        continue
-      }
-      if (lineIndex > insertionLine) {
-        shifted[lineIndex + addedLines].push(segment)
-        continue
-      }
-      if (segment[0] < insertionColumn) {
-        shifted[lineIndex].push(segment)
-        continue
-      }
-
+      const position = shiftedGeneratedPosition(
+        { line: lineIndex, column: segment[0] },
+        insertionPosition,
+        insertion,
+        metrics
+      )
       const shiftedSegment = [...segment]
-      if (addedLines === 0) {
-        shiftedSegment[0] += insertion.length
-        shifted[lineIndex].push(shiftedSegment)
-      } else {
-        shiftedSegment[0] = finalLineLength + segment[0] - insertionColumn
-        shifted[lineIndex + addedLines].push(shiftedSegment)
-      }
+      shiftedSegment[0] = position.column
+      shifted[position.line].push(shiftedSegment)
     }
   }
 
   return { ...sourceMap, mappings: encode(shifted) }
+}
+
+function offsetIndexedSourceMap(sourceMap, insertionPosition, insertion, metrics) {
+  const sections = sourceMap.sections
+  if (!sections.every((section) => section && isGeneratedPosition(section.offset))) {
+    return sourceMap
+  }
+
+  let activeSectionIndex = -1
+  for (const [sectionIndex, section] of sections.entries()) {
+    // A section starting exactly at the insertion belongs to the original body
+    // and moves with it; only the preceding section can span the insertion.
+    if (compareGeneratedPositions(section.offset, insertionPosition) < 0) {
+      activeSectionIndex = sectionIndex
+    }
+  }
+
+  let changed = false
+  const shiftedSections = sections.map((section, sectionIndex) => {
+    if (sectionIndex === activeSectionIndex) {
+      const localInsertionPosition = {
+        line: insertionPosition.line - section.offset.line,
+        column:
+          insertionPosition.line === section.offset.line
+            ? insertionPosition.column - section.offset.column
+            : insertionPosition.column,
+      }
+      const map = offsetSourceMapAtPosition(section.map, localInsertionPosition, insertion, metrics)
+      if (map !== section.map) {
+        changed = true
+        return { ...section, map }
+      }
+      return section
+    }
+
+    if (compareGeneratedPositions(section.offset, insertionPosition) >= 0) {
+      changed = true
+      return {
+        ...section,
+        offset: shiftedGeneratedPosition(section.offset, insertionPosition, insertion, metrics),
+      }
+    }
+    return section
+  })
+
+  return changed ? { ...sourceMap, sections: shiftedSections } : sourceMap
+}
+
+function offsetSourceMapAtPosition(sourceMap, insertionPosition, insertion, metrics) {
+  if (!sourceMap || typeof sourceMap !== "object") {
+    return sourceMap
+  }
+  if (typeof sourceMap.mappings === "string") {
+    return offsetFlatSourceMap(sourceMap, insertionPosition, insertion, metrics)
+  }
+  if (Array.isArray(sourceMap.sections)) {
+    return offsetIndexedSourceMap(sourceMap, insertionPosition, insertion, metrics)
+  }
+  return sourceMap
+}
+
+function offsetSourceMapForInsertion(sourceMap, insertionOffset, insertion) {
+  if (insertion.length === 0) {
+    return sourceMap
+  }
+  return offsetSourceMapAtPosition(
+    sourceMap,
+    generatedPositionForText(insertionOffset.source),
+    insertion,
+    insertionMetrics(insertion)
+  )
 }
 
 function prependClientMessageBootstrap(code, bootstrap) {

--- a/packages/next-plugin/palamedes-loader.cjs
+++ b/packages/next-plugin/palamedes-loader.cjs
@@ -3,6 +3,7 @@
 const { createHash } = require("node:crypto")
 const { realpathSync, statSync } = require("node:fs")
 const path = require("node:path")
+const { decode, encode } = require("@jridgewell/sourcemap-codec")
 const { loadPalamedesConfigSync } = require("@palamedes/config")
 const { transformPalamedesMacros } = require("@palamedes/transform")
 const picomatch = require("picomatch")
@@ -127,7 +128,7 @@ function clientMessageBootstrap(config, sourcePath, compiledIds) {
   const identifier = `__pmds_${createHash("sha256").update(modulePath).digest("hex").slice(0, 12)}`
 
   return (
-    `\nconst ${identifier}_locale = document.documentElement.lang;\n` +
+    `const ${identifier}_locale = document.documentElement.lang;\n` +
     `const ${identifier}_loaderGroups = [${loaderGroups.join(", ")}];\n` +
     `const ${identifier}_activeLoaders = ${identifier}_loaderGroups.map((loaders) => loaders[${identifier}_locale]);\n` +
     `if (${identifier}_activeLoaders.some((loader) => loader === undefined)) {\n` +
@@ -146,6 +147,152 @@ function clientMessageBootstrap(config, sourcePath, compiledIds) {
     `  ${identifier}_i18n.load(${identifier}_locale, messages);\n` +
     `}\n`
   )
+}
+
+function skipTrivia(code, index) {
+  let current = index
+  let sawLineTerminator = false
+
+  while (current < code.length) {
+    const character = code[current]
+    if (character === "\r" || character === "\n") {
+      sawLineTerminator = true
+      current += 1
+      continue
+    }
+    if (/\s/u.test(character)) {
+      current += 1
+      continue
+    }
+    if (code.startsWith("//", current)) {
+      const lineEnd = code.indexOf("\n", current + 2)
+      if (lineEnd === -1) {
+        return { index: code.length, sawLineTerminator }
+      }
+      sawLineTerminator = true
+      current = lineEnd + 1
+      continue
+    }
+    if (code.startsWith("/*", current)) {
+      const commentEnd = code.indexOf("*/", current + 2)
+      if (commentEnd === -1) {
+        return { index: code.length, sawLineTerminator }
+      }
+      const comment = code.slice(current, commentEnd + 2)
+      if (/\r|\n/u.test(comment)) {
+        sawLineTerminator = true
+      }
+      current = commentEnd + 2
+      continue
+    }
+    break
+  }
+
+  return { index: current, sawLineTerminator }
+}
+
+function directivePrologueEnd(code) {
+  let current = code.charCodeAt(0) === 0xfe_ff ? 1 : 0
+  if (code.startsWith("#!", current)) {
+    const lineEnd = code.indexOf("\n", current + 2)
+    current = lineEnd === -1 ? code.length : lineEnd + 1
+  }
+
+  let end = current
+  while (current < code.length) {
+    const beforeDirective = skipTrivia(code, current)
+    const quote = code[beforeDirective.index]
+    if (quote !== '"' && quote !== "'") {
+      break
+    }
+
+    let stringEnd = beforeDirective.index + 1
+    while (stringEnd < code.length) {
+      if (code[stringEnd] === "\\") {
+        stringEnd += 2
+        continue
+      }
+      if (code[stringEnd] === quote) {
+        break
+      }
+      stringEnd += 1
+    }
+    if (stringEnd >= code.length) {
+      break
+    }
+
+    const afterString = skipTrivia(code, stringEnd + 1)
+    if (code[afterString.index] === ";") {
+      const afterSemicolon = skipTrivia(code, afterString.index + 1)
+      end = afterSemicolon.index
+      current = afterSemicolon.index
+      continue
+    }
+    if (afterString.index === code.length || afterString.sawLineTerminator) {
+      end = afterString.index
+      current = afterString.index
+      continue
+    }
+    break
+  }
+
+  return end
+}
+
+function offsetSourceMapForInsertion(sourceMap, insertionOffset, insertion) {
+  if (!sourceMap || typeof sourceMap !== "object" || typeof sourceMap.mappings !== "string") {
+    return sourceMap
+  }
+  if (sourceMap.mappings === "" || insertion.length === 0) {
+    return sourceMap
+  }
+
+  const prefix = insertionOffset.source
+  const insertionLine = prefix.split("\n").length - 1
+  const insertionColumn = prefix.length - prefix.lastIndexOf("\n") - 1
+  const addedLines = insertion.split("\n").length - 1
+  const finalLineLength = insertion.length - insertion.lastIndexOf("\n") - 1
+  const mappings = decode(sourceMap.mappings)
+  const shifted = Array.from({ length: mappings.length + addedLines }, () => [])
+
+  for (const [lineIndex, segments] of mappings.entries()) {
+    for (const segment of segments) {
+      if (lineIndex < insertionLine) {
+        shifted[lineIndex].push(segment)
+        continue
+      }
+      if (lineIndex > insertionLine) {
+        shifted[lineIndex + addedLines].push(segment)
+        continue
+      }
+      if (segment[0] < insertionColumn) {
+        shifted[lineIndex].push(segment)
+        continue
+      }
+
+      const shiftedSegment = [...segment]
+      if (addedLines === 0) {
+        shiftedSegment[0] += insertion.length
+        shifted[lineIndex].push(shiftedSegment)
+      } else {
+        shiftedSegment[0] = finalLineLength + segment[0] - insertionColumn
+        shifted[lineIndex + addedLines].push(shiftedSegment)
+      }
+    }
+  }
+
+  return { ...sourceMap, mappings: encode(shifted) }
+}
+
+function prependClientMessageBootstrap(code, bootstrap) {
+  const insertionIndex = directivePrologueEnd(code)
+  const prefix = code.slice(0, insertionIndex)
+  const insertion = `${prefix.length > 0 && !prefix.endsWith("\n") ? "\n" : ""}${bootstrap}`
+
+  return {
+    code: `${prefix}${insertion}${code.slice(insertionIndex)}`,
+    insertion: { source: prefix, value: insertion },
+  }
 }
 
 function relativeImport(fromFile, targetFile) {
@@ -222,8 +369,15 @@ module.exports = function palamedesLoader(source, inputSourceMap) {
       ? messageLoaderRegistration(config, this.resourcePath, result.compiledIds)
       : clientMessageBootstrap(config, this.resourcePath, result.compiledIds)
     let code = result.code
+    let sourceMap = result.map ?? inputSourceMap ?? null
     if (registration) {
-      code += registration
+      if (clientMessageSplitting) {
+        const output = prependClientMessageBootstrap(code, registration)
+        code = output.code
+        sourceMap = offsetSourceMapForInsertion(sourceMap, output.insertion, output.insertion.value)
+      } else {
+        code += registration
+      }
     } else if (typeof this.emitWarning === "function") {
       this.emitWarning(
         new Error(
@@ -232,7 +386,7 @@ module.exports = function palamedesLoader(source, inputSourceMap) {
       )
     }
     if (callback) {
-      callback(null, code, result.map ?? inputSourceMap ?? null)
+      callback(null, code, sourceMap)
       return
     }
     return code

--- a/packages/next-plugin/src/index.ts
+++ b/packages/next-plugin/src/index.ts
@@ -169,7 +169,7 @@ export type WithPalamedesOptions = {
   /**
    * Split client messages with the Next.js module graph. Each transformed
    * browser module loads only its own compiled fragment for the document
-   * locale before it evaluates.
+   * locale before evaluating its body or resolving to importers.
    *
    * @default false
    */

--- a/packages/next-plugin/src/palamedes-loader.test.ts
+++ b/packages/next-plugin/src/palamedes-loader.test.ts
@@ -13,6 +13,10 @@ declare global {
 }
 
 const require = createRequire(import.meta.url)
+const { decode, encode } = require("@jridgewell/sourcemap-codec") as {
+  decode(mappings: string): number[][][]
+  encode(mappings: number[][][]): string
+}
 const loaderPath = "../palamedes-loader.cjs"
 const moduleLoader = Module as unknown as {
   _load: (request: string, parent: unknown, isMain: boolean) => unknown
@@ -232,14 +236,16 @@ describe("palamedes-loader.cjs", () => {
   })
 
   it("keeps transformed source-map lines aligned after the client bootstrap", async () => {
+    const sourceMap = {
+      version: 3,
+      sources: ["page.tsx"],
+      names: [],
+      mappings: "AAAA;AACA",
+    }
+    const originalSourceMap = structuredClone(sourceMap)
     transformPalamedesMacros.mockReturnValue({
       code: ['"use client";', 'const label = getI18n()._("Hello");'].join("\n"),
-      map: {
-        version: 3,
-        sources: ["page.tsx"],
-        names: [],
-        mappings: "AAAA;AACA",
-      },
+      map: sourceMap,
       compiledIds: ["id-a"],
     })
 
@@ -251,6 +257,160 @@ describe("palamedes-loader.cjs", () => {
     expect(mappings[0]).toBe("AAAA")
     expect(mappings.slice(1, bodyLine)).toEqual(Array.from({ length: bodyLine - 1 }, () => ""))
     expect(mappings[bodyLine]).toBe("AACA")
+    expect(sourceMap).toEqual(originalSourceMap)
+    expect(output.map).not.toBe(sourceMap)
+  })
+
+  it("rebases indexed source maps through the client bootstrap without mutating the input", async () => {
+    const sourceMap = {
+      version: 3,
+      file: "page.js",
+      sections: [
+        {
+          offset: { line: 0, column: 0 },
+          map: {
+            version: 3,
+            sources: ["page.tsx"],
+            names: [],
+            mappings: "AAAA;AACA;AACA",
+          },
+        },
+        {
+          offset: { line: 3, column: 0 },
+          map: {
+            version: 3,
+            sources: ["page.tsx"],
+            names: [],
+            mappings: "AACA",
+          },
+        },
+      ],
+    }
+    const originalSourceMap = structuredClone(sourceMap)
+    transformPalamedesMacros.mockReturnValue({
+      code: [
+        '"use client";',
+        'const label = getI18n()._("Hello");',
+        'const second = getI18n()._("Again");',
+        'const tail = getI18n()._("Later");',
+      ].join("\n"),
+      map: sourceMap,
+      compiledIds: ["id-a"],
+    })
+
+    const output = await runLoaderResult({ clientMessageSplitting: true })
+    const bodyLine = output.code.split("\n").findIndex((line) => line.startsWith("const label ="))
+    const indexedMap = output.map as {
+      sections: Array<{ offset: { line: number; column: number }; map: { mappings: string } }>
+    }
+    const firstSectionMappings = decode(indexedMap.sections[0]!.map.mappings)
+
+    expect(bodyLine).toBeGreaterThan(1)
+    expect(firstSectionMappings[0]).toEqual([[0, 0, 0, 0]])
+    expect(firstSectionMappings.slice(1, bodyLine)).toEqual(
+      Array.from({ length: bodyLine - 1 }, () => [])
+    )
+    expect(firstSectionMappings[bodyLine]).toEqual([[0, 0, 1, 0]])
+    expect(firstSectionMappings[bodyLine + 1]).toEqual([[0, 0, 2, 0]])
+    expect(indexedMap.sections[1]!.offset).toEqual({ line: bodyLine + 2, column: 0 })
+    expect(sourceMap).toEqual(originalSourceMap)
+    expect(indexedMap).not.toBe(sourceMap)
+  })
+
+  it("rebases indexed source-map columns for a same-line directive prologue", async () => {
+    const directive = '"use client"; '
+    const sourceMap = {
+      version: 3,
+      sections: [
+        {
+          offset: { line: 0, column: 0 },
+          map: {
+            version: 3,
+            sources: ["page.tsx"],
+            names: [],
+            mappings: encode([
+              [
+                [0, 0, 0, 0],
+                [directive.length, 0, 0, directive.length],
+              ],
+            ]),
+          },
+        },
+      ],
+    }
+    const originalSourceMap = structuredClone(sourceMap)
+    transformPalamedesMacros.mockReturnValue({
+      code: `${directive}const label = getI18n()._("Hello");`,
+      map: sourceMap,
+      compiledIds: ["id-a"],
+    })
+
+    const output = await runLoaderResult({ clientMessageSplitting: true })
+    const bodyLine = output.code.split("\n").findIndex((line) => line.startsWith("const label ="))
+    const indexedMap = output.map as { sections: Array<{ map: { mappings: string } }> }
+    const mappings = decode(indexedMap.sections[0]!.map.mappings)
+
+    expect(output.code.startsWith(`${directive}\n`)).toBe(true)
+    expect(mappings[0]).toEqual([[0, 0, 0, 0]])
+    expect(mappings.slice(1, bodyLine)).toEqual(Array.from({ length: bodyLine - 1 }, () => []))
+    expect(mappings[bodyLine]).toEqual([[0, 0, 0, directive.length]])
+    expect(sourceMap).toEqual(originalSourceMap)
+  })
+
+  it("rebases indexed sections at the bootstrap insertion, including empty maps", async () => {
+    const sourceMap = {
+      version: 3,
+      sections: [
+        {
+          offset: { line: 0, column: 0 },
+          map: {
+            version: 3,
+            sources: ["page.tsx"],
+            names: [],
+            mappings: "AAAA",
+          },
+        },
+        {
+          offset: { line: 1, column: 0 },
+          map: {
+            version: 3,
+            sources: ["page.tsx"],
+            names: [],
+            mappings: "",
+          },
+        },
+        {
+          offset: { line: 2, column: 0 },
+          map: {
+            version: 3,
+            sources: ["page.tsx"],
+            names: [],
+            mappings: "AACA",
+          },
+        },
+      ],
+    }
+    const originalSourceMap = structuredClone(sourceMap)
+    transformPalamedesMacros.mockReturnValue({
+      code: [
+        '"use client";',
+        'const label = getI18n()._("Hello");',
+        "export const tail = true;",
+      ].join("\n"),
+      map: sourceMap,
+      compiledIds: ["id-a"],
+    })
+
+    const output = await runLoaderResult({ clientMessageSplitting: true })
+    const bodyLine = output.code.split("\n").findIndex((line) => line.startsWith("const label ="))
+    const indexedMap = output.map as {
+      sections: Array<{ offset: { line: number; column: number }; map: { mappings: string } }>
+    }
+
+    expect(indexedMap.sections[1]!.offset).toEqual({ line: bodyLine, column: 0 })
+    expect(indexedMap.sections[1]!.map.mappings).toBe("")
+    expect(indexedMap.sections[2]!.offset).toEqual({ line: bodyLine + 1, column: 0 })
+    expect(sourceMap).toEqual(originalSourceMap)
   })
 
   it("does not add server message imports to a client transform", async () => {

--- a/packages/next-plugin/src/palamedes-loader.test.ts
+++ b/packages/next-plugin/src/palamedes-loader.test.ts
@@ -6,6 +6,12 @@ import path from "node:path"
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
+declare global {
+  var __pmds_test_body_ran: boolean | undefined
+  var __pmds_test_getI18n: (() => { _: (message: string) => string }) | undefined
+  var __pmds_test_label: string | undefined
+}
+
 const require = createRequire(import.meta.url)
 const loaderPath = "../palamedes-loader.cjs"
 const moduleLoader = Module as unknown as {
@@ -112,6 +118,141 @@ describe("palamedes-loader.cjs", () => {
     expect(output).not.toContain("registerMessageLoaders")
   })
 
+  it("boots a client module before its compiled module-scope call and its importers", async () => {
+    transformPalamedesMacros.mockReturnValue({
+      code: [
+        '"use client";',
+        'const label = globalThis.__pmds_test_getI18n()._("module label");',
+        "globalThis.__pmds_test_label = label;",
+      ].join("\n"),
+      map: null,
+      compiledIds: ["id-a"],
+    })
+
+    const originalDocument = globalThis.document
+    const originalGetI18n = globalThis.__pmds_test_getI18n
+    const originalLabel = globalThis.__pmds_test_label
+    const requested: string[] = []
+    const loaded: Array<{ locale: string; messages: Record<string, unknown> }> = []
+    let moduleBodyRan = false
+    let resolveFragment: (value: { messages: Record<string, unknown> }) => void = () => {
+      throw new Error("Fragment resolver was not initialized")
+    }
+    const fragment = new Promise<{ messages: Record<string, unknown> }>((resolve) => {
+      resolveFragment = resolve
+    })
+    const i18n = {
+      load(locale: string, messages: Record<string, unknown>) {
+        loaded.push({ locale, messages })
+      },
+      _(message: string) {
+        moduleBodyRan = true
+        if (loaded.length !== 1 || loaded[0]?.locale !== "de") {
+          throw new Error("No active client i18n instance")
+        }
+        return `${message} translated`
+      },
+    }
+
+    try {
+      globalThis.document = { documentElement: { lang: "de" } } as Document
+      globalThis.__pmds_test_getI18n = () => i18n
+
+      const output = await runLoader({ clientMessageSplitting: true })
+      expect(output.indexOf("_modules = await Promise.all")).toBeLessThan(
+        output.indexOf("const label =")
+      )
+      expect(output.startsWith('"use client";')).toBe(true)
+
+      const modulePromise = executeGeneratedClientModule(output, async (specifier) => {
+        requested.push(specifier)
+        if (specifier === "@palamedes/core/compiled") {
+          return { createI18n: () => i18n }
+        }
+        if (specifier === "@palamedes/runtime") {
+          return { initializeClientI18n: () => i18n }
+        }
+        if (specifier.includes("./locales/de.po?palamedes-selected=")) {
+          return fragment
+        }
+        throw new Error(`Unexpected import: ${specifier}`)
+      })
+      const importer = modulePromise.then(() => globalThis.__pmds_test_label)
+
+      await Promise.resolve()
+      expect(moduleBodyRan).toBe(false)
+      expect(requested).toHaveLength(3)
+      expect(requested.some((specifier) => specifier.includes("./locales/en.po"))).toBe(false)
+
+      resolveFragment({ messages: { id: "translated" } })
+
+      await expect(importer).resolves.toBe("module label translated")
+      expect(loaded).toEqual([{ locale: "de", messages: { id: "translated" } }])
+    } finally {
+      restoreGlobal("document", originalDocument)
+      restoreGlobal("__pmds_test_getI18n", originalGetI18n)
+      restoreGlobal("__pmds_test_label", originalLabel)
+    }
+  })
+
+  it("propagates client bootstrap rejections to importers before evaluating the module body", async () => {
+    transformPalamedesMacros.mockReturnValue({
+      code: "globalThis.__pmds_test_body_ran = true;",
+      map: null,
+      compiledIds: ["id-a"],
+    })
+
+    const originalDocument = globalThis.document
+    const originalBodyRan = globalThis.__pmds_test_body_ran
+    const bootstrapError = new Error("fragment failed to load")
+
+    try {
+      globalThis.document = { documentElement: { lang: "de" } } as Document
+
+      const output = await runLoader({ clientMessageSplitting: true })
+      const modulePromise = executeGeneratedClientModule(output, async (specifier) => {
+        if (specifier === "@palamedes/core/compiled") {
+          return { createI18n: () => ({}) }
+        }
+        if (specifier === "@palamedes/runtime") {
+          return { initializeClientI18n: () => ({}) }
+        }
+        if (specifier.includes("./locales/de.po?palamedes-selected=")) {
+          throw bootstrapError
+        }
+        throw new Error(`Unexpected import: ${specifier}`)
+      })
+
+      await expect(modulePromise.then(() => "importer resolved")).rejects.toBe(bootstrapError)
+      expect(globalThis.__pmds_test_body_ran).toBeUndefined()
+    } finally {
+      restoreGlobal("document", originalDocument)
+      restoreGlobal("__pmds_test_body_ran", originalBodyRan)
+    }
+  })
+
+  it("keeps transformed source-map lines aligned after the client bootstrap", async () => {
+    transformPalamedesMacros.mockReturnValue({
+      code: ['"use client";', 'const label = getI18n()._("Hello");'].join("\n"),
+      map: {
+        version: 3,
+        sources: ["page.tsx"],
+        names: [],
+        mappings: "AAAA;AACA",
+      },
+      compiledIds: ["id-a"],
+    })
+
+    const output = await runLoaderResult({ clientMessageSplitting: true })
+    const bodyLine = output.code.split("\n").findIndex((line) => line.startsWith("const label ="))
+    const mappings = (output.map as { mappings: string }).mappings.split(";")
+
+    expect(bodyLine).toBeGreaterThan(1)
+    expect(mappings[0]).toBe("AAAA")
+    expect(mappings.slice(1, bodyLine)).toEqual(Array.from({ length: bodyLine - 1 }, () => ""))
+    expect(mappings[bodyLine]).toBe("AACA")
+  })
+
   it("does not add server message imports to a client transform", async () => {
     transformPalamedesMacros.mockReturnValue({
       code: "export const translated = true",
@@ -206,10 +347,18 @@ async function runLoader(
   options: Record<string, unknown>,
   extraContext: Record<string, unknown> = {}
 ): Promise<string> {
+  const output = await runLoaderResult(options, extraContext)
+  return output.code
+}
+
+async function runLoaderResult(
+  options: Record<string, unknown>,
+  extraContext: Record<string, unknown> = {}
+): Promise<{ code: string; map: unknown }> {
   delete require.cache[require.resolve(loaderPath)]
   const loader = require(loaderPath) as (this: unknown, source: string) => void
 
-  return new Promise<string>((resolve, reject) => {
+  return new Promise<{ code: string; map: unknown }>((resolve, reject) => {
     loader.call(
       {
         resourcePath: "/repo/src/page.tsx",
@@ -219,16 +368,38 @@ async function runLoader(
           return options
         },
         async() {
-          return (error: Error | null, output?: string) => {
+          return (error: Error | null, output?: string, sourceMap?: unknown) => {
             if (error) {
               reject(error)
               return
             }
-            resolve(output ?? "")
+            resolve({ code: output ?? "", map: sourceMap })
           }
         },
       },
       'import { t } from "@palamedes/core/macro"; export function label() { return t`Hello` }'
     )
   })
+}
+
+function executeGeneratedClientModule(
+  code: string,
+  importModule: (specifier: string) => Promise<unknown>
+): Promise<unknown> {
+  // This executes generated top-level-await code without a bundler-specific harness.
+  // eslint-disable-next-line no-new-func
+  const execute = new Function(
+    "__import",
+    `return (async () => { ${code.replaceAll("import(", "__import(")} })()`
+  ) as (load: (specifier: string) => Promise<unknown>) => Promise<unknown>
+
+  return execute(importModule)
+}
+
+function restoreGlobal(key: string, value: unknown): void {
+  if (value === undefined) {
+    delete (globalThis as Record<string, unknown>)[key]
+    return
+  }
+  ;(globalThis as Record<string, unknown>)[key] = value
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1491,6 +1491,9 @@ importers:
 
   packages/next-plugin:
     dependencies:
+      '@jridgewell/sourcemap-codec':
+        specifier: 1.5.5
+        version: 1.5.5
       '@palamedes/config':
         specifier: workspace:^
         version: link:../config


### PR DESCRIPTION
Closes #588

## Summary

- bootstrap graph-split client modules before their authored body while retaining directive prologues
- shift source-map mappings so transformed source diagnostics remain aligned
- add executable regressions for module-scope compiled calls, importer waiting/rejection, active-locale fragments, and source-map lines

## Validation

- `RUSTUP_TOOLCHAIN=1.95 pnpm agent:check`
- `pnpm --filter @palamedes/next-plugin test`

🔧 Emily Carter · Implementation Agent