### PR TITLE
ci: verify example matrix

### DIFF
--- a/.github/workflows/example-verification.yml
+++ b/.github/workflows/example-verification.yml
@@ -1,0 +1,116 @@
+name: Example Verification
+
+on:
+  pull_request:
+    paths:
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "crates/**"
+      - "examples/**"
+      - "packages/**"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - "package.json"
+      - "scripts/example-matrix.mjs"
+      - "scripts/verify-examples*.mjs"
+      - "scripts/check-example-matrix.mjs"
+      - "tests/examples-browser/**"
+      - "tsconfig*.json"
+      - "vitest.examples.config.mjs"
+      - ".github/workflows/example-verification.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "crates/**"
+      - "examples/**"
+      - "packages/**"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - "package.json"
+      - "scripts/example-matrix.mjs"
+      - "scripts/verify-examples*.mjs"
+      - "scripts/check-example-matrix.mjs"
+      - "tests/examples-browser/**"
+      - "tsconfig*.json"
+      - "vitest.examples.config.mjs"
+      - ".github/workflows/example-verification.yml"
+  schedule:
+    - cron: "17 5 * * 1"
+  workflow_dispatch:
+    inputs:
+      run_browser:
+        description: Run the scheduled Playwright browser layer as well as smoke verification
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: example-verification-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  verify:
+    name: example matrix
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Restore pnpm cache
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Check example matrix selection
+        run: pnpm check:example-matrix
+
+      - name: Build workspace packages
+        run: pnpm build
+
+      - name: Smoke-test all 25 examples
+        run: pnpm verify:examples:smoke
+
+      - name: Install Playwright Chromium
+        if: github.event_name == 'schedule' || inputs.run_browser
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Browser-test 21 UI examples
+        if: github.event_name == 'schedule' || inputs.run_browser
+        env:
+          PALAMEDES_SCREENSHOT_DIR: artifacts/example-screenshots
+        run: pnpm verify:examples:browser -- --capture-screenshots
+
+      - name: Upload browser diagnostics
+        if: ${{ always() && (github.event_name == 'schedule' || inputs.run_browser) }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: example-browser-diagnostics-${{ github.run_id }}
+          path: artifacts/example-screenshots
+          if-no-files-found: warn
+          retention-days: 7

--- a/.github/workflows/example-verification.yml
+++ b/.github/workflows/example-verification.yml
@@ -11,7 +11,8 @@ on:
       - "pnpm-lock.yaml"
       - "pnpm-workspace.yaml"
       - "package.json"
-      - "scripts/example-matrix.mjs"
+      - "scripts/example-matrix*.mjs"
+      - "scripts/container/**"
       - "scripts/verify-examples*.mjs"
       - "scripts/check-example-matrix.mjs"
       - "tests/examples-browser/**"
@@ -30,7 +31,8 @@ on:
       - "pnpm-lock.yaml"
       - "pnpm-workspace.yaml"
       - "package.json"
-      - "scripts/example-matrix.mjs"
+      - "scripts/example-matrix*.mjs"
+      - "scripts/container/**"
       - "scripts/verify-examples*.mjs"
       - "scripts/check-example-matrix.mjs"
       - "tests/examples-browser/**"
@@ -88,7 +90,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Check example matrix selection
-        run: pnpm check:example-matrix
+        run: pnpm check:example-matrix && pnpm check:example-contracts
 
       - name: Build workspace packages
         run: pnpm build
@@ -100,7 +102,7 @@ jobs:
         if: github.event_name == 'schedule' || inputs.run_browser
         run: pnpm exec playwright install --with-deps chromium
 
-      - name: Browser-test 21 UI examples
+      - name: Browser-test 21 browser-capable examples
         if: github.event_name == 'schedule' || inputs.run_browser
         env:
           PALAMEDES_SCREENSHOT_DIR: artifacts/example-screenshots

--- a/.github/workflows/example-verification.yml
+++ b/.github/workflows/example-verification.yml
@@ -51,7 +51,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: example-verification-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: example-verification-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:

--- a/Containerfile
+++ b/Containerfile
@@ -9,6 +9,7 @@
 #     -p 4040:4040 -p 4041:4041 -p 4042:4042 -p 4043:4043 \
 #     -p 4050:4050 -p 4051:4051 -p 4052:4052 -p 4053:4053 \
 #     -p 4060:4060 -p 4061:4061 -p 4062:4062 -p 4063:4063 \
+#     -p 4070:4070 \
 #     palamedes-examples
 #
 # (or let the matrix generate the flags: `podman run --init \
@@ -67,13 +68,13 @@ COPY --from=build --chown=node:node /app /app
 # Global pnpm at the version pinned in package.json (packageManager) so the
 # unprivileged `node` user can run the example start scripts.
 RUN npm install -g "pnpm@$(node -p 'require("./package.json").packageManager.split("@")[1].split("+")[0]')"
-# Run the 24 public servers as a non-root user (least privilege).
+# Run all 25 example servers as a non-root user (least privilege).
 USER node
 
 # Fixed ports — informational only; the authoritative list is
 # scripts/example-matrix.mjs. Publish them without drift via:
 #   podman run $(node ./scripts/container/print-podman-ports.mjs) palamedes-examples
-EXPOSE 4010 4011 4012 4013 4020 4021 4022 4023 4030 4031 4032 4033 4040 4041 4042 4043 4050 4051 4052 4053 4060 4061 4062 4063
+EXPOSE 4010 4011 4012 4013 4020 4021 4022 4023 4030 4031 4032 4033 4040 4041 4042 4043 4050 4051 4052 4053 4060 4061 4062 4063 4070
 
 # tini is the init/reaper (no external `--init` needed). `-s` registers it as a
 # subreaper so reaping still works if it ends up not as PID 1 (e.g. when the

--- a/Containerfile
+++ b/Containerfile
@@ -41,7 +41,7 @@ COPY . .
 
 RUN pnpm install --frozen-lockfile
 # `pnpm build` builds the workspace packages and compiles the native addon via
-# cargo; `pnpm build:examples` builds all 24 example apps.
+# cargo; `pnpm build:examples` builds all 25 example apps.
 RUN pnpm build
 RUN pnpm build:examples
 # Drop build-only artifacts before they reach the runtime image: the compiled

--- a/README.md
+++ b/README.md
@@ -26,14 +26,15 @@ We are not asking you to trust a slogan. The repo shows the work.
 The current proof:
 
 - Six framework families, each with cookie, route, subdomain, and tld locale
-  strategies: all 25 are smoke-verified on relevant PRs and `main`; five
-  browser-capable families use the same scheduled Playwright flow, while
-  server-first Remix v3 remains smoke-verified.
+  strategies, plus Vite MDX: all 25 are smoke-verified on relevant PRs and
+  `main`; five UI-adapter families and Vite make 21 browser-capable examples
+  for the scheduled Playwright flow, while server-first Remix v3 remains
+  smoke-verified.
 - The image above is one demo in three locales: switch language and the copy,
-  plural seat counts, currency, and dates all change together. Each verified
-  framework and strategy renders the same design, so per-framework captures live in
+  plural seat counts, currency, and dates all change together. The 20
+  UI-adapter examples have versioned captures in
   [docs/example-screenshots](docs/example-screenshots) instead of repeating the
-  same picture here. All of it is versioned browser output, not a mockup.
+  same picture here. Those captures are browser output, not mockups.
 - A numbered [ADR series](https://palamedes.dev/decisions) explains the
   runtime model, message identity, native boundary, adapter architecture, and
   the work deliberately kept out of scope.
@@ -96,9 +97,10 @@ easier to review, and easier to carry from one framework to the next.
 ## Current Status
 
 - Recommended for new projects and teams that want cleaner i18n foundations
-- Verified today across Next.js, TanStack Start, SolidStart, Waku, and React
-  Router on Node.js `>=22.22`; server-first Remix v3 is smoke-verified and
-  requires Node.js `>=24.3`
+- All 25 examples are smoke-verified on relevant PRs and `main`; 21
+  browser-capable examples across Next.js, TanStack Start, SolidStart, Waku,
+  React Router, and Vite run Playwright weekly or manually. Server-first Remix
+  v3 is smoke-only and requires Node.js `>=24.3`
 - Source-string-first catalogs are stable and powered by `ferrocat`, including structured audits and ICU authoring diagnostics
 - Placeholder top-level packages exist, but there is no `palamedes` or `create-palamedes` first-run entry yet
 - 1.0 stability tiers and public API expectations are documented in [Stability and versioning](https://github.com/sebastian-software/palamedes/blob/main/docs/stability.md)
@@ -107,7 +109,8 @@ easier to review, and easier to carry from one framework to the next.
 
 - An example matrix across six framework families — five browser-verified,
   Remix v3 smoke-verified
-- Versioned screenshots generated from the same Playwright-based verifier used in CI
+- Versioned screenshots for the 20 UI-adapter examples, generated from the same
+  Playwright-based verifier used in CI
 - Reproducible benchmark commands for transform, extract, catalog update, compile steps, and end-to-end extract/update workflows
 - Structured catalog audit and metadata validation APIs backed by `ferrocat`
 - Decision records and architecture docs that explain the choices behind the product

--- a/README.md
+++ b/README.md
@@ -26,8 +26,9 @@ We are not asking you to trust a slogan. The repo shows the work.
 The current proof:
 
 - Six framework families, each with cookie, route, subdomain, and tld locale
-  strategies: five are browser-verified through the same Playwright-based flow
-  used in CI, and server-first Remix v3 is smoke-verified.
+  strategies: all 25 are smoke-verified on relevant PRs and `main`; five
+  browser-capable families use the same scheduled Playwright flow, while
+  server-first Remix v3 remains smoke-verified.
 - The image above is one demo in three locales: switch language and the copy,
   plural seat counts, currency, and dates all change together. Each verified
   framework and strategy renders the same design, so per-framework captures live in

--- a/docs/example-screenshots/README.md
+++ b/docs/example-screenshots/README.md
@@ -1,9 +1,11 @@
 # Example Screenshots
 
-These screenshots are generated from the same Playwright-based browser verifier
-that checks 21 browser-capable examples weekly and on manual dispatch. All 25
-examples receive smoke verification on relevant pull requests and `main`
-pushes. They are versioned verification artifacts, not manually curated mockups.
+These screenshots are generated from the Playwright-based browser verifier that
+checks 21 browser-capable examples weekly and on manual dispatch. The 20
+UI-adapter examples represented here have versioned captures; Vite MDX has no
+capture artifact. All 25 examples receive smoke verification on relevant pull
+requests and `main` pushes. They are versioned verification artifacts, not
+manually curated mockups.
 
 Refresh them with:
 
@@ -11,7 +13,7 @@ Refresh them with:
 pnpm capture:example-screenshots
 ```
 
-Each example has two screenshots. They are intentionally captured in two
+Each UI-adapter example has two screenshots. They are intentionally captured in two
 different locales — that language change is the expected outcome of the
 verification flow, **not** a hydration glitch or a discarded server render:
 

--- a/docs/example-screenshots/README.md
+++ b/docs/example-screenshots/README.md
@@ -1,8 +1,9 @@
 # Example Screenshots
 
 These screenshots are generated from the same Playwright-based browser verifier
-used by the example matrix. They are versioned verification artifacts, not
-manually curated mockups.
+that checks 21 browser-capable examples weekly and on manual dispatch. All 25
+examples receive smoke verification on relevant pull requests and `main`
+pushes. They are versioned verification artifacts, not manually curated mockups.
 
 Refresh them with:
 

--- a/docs/operations/run-examples-container.md
+++ b/docs/operations/run-examples-container.md
@@ -1,6 +1,6 @@
 # Running all examples together in one container
 
-This document describes how to run all 24 Palamedes example apps together in
+This document describes how to run all 25 Palamedes example apps together in
 **one** Podman container – each on its own fixed port. It builds on the
 `Containerfile` in the repo root and the supervisor
 `scripts/container/start-all.mjs`.
@@ -42,7 +42,7 @@ The build is multi-stage:
 
 1. **Build stage** (glibc/Debian): `pnpm install`, `pnpm build` (builds the
    packages including the native addon via `cargo` in release profile) and
-   `pnpm build:examples` (builds all 24 apps). The `cargo` compilation makes the
+   `pnpm build:examples` (builds all 25 apps). The `cargo` compilation makes the
    first build noticeably longer.
 2. **Runtime stage** (slimmer Debian slim): takes over the finished workspace and
    starts the supervisor. Dev dependencies stay installed because TanStack's
@@ -70,7 +70,7 @@ Spelled out, this is `-p 4010:4010 -p 4011:4011 … -p 4063:4063`.
 The supervisor starts all apps from `scripts/example-matrix.mjs`, prefixes their
 output with the example id (`[nextjs-cookie] …`), and intentionally exits the
 container with an error code as soon as a server dies unexpectedly (fail-fast).
-`podman stop` terminates all 24 servers via forwarded `SIGTERM`.
+`podman stop` terminates all 25 servers via forwarded `SIGTERM`.
 
 ## Port overview
 

--- a/docs/operations/run-examples-container.md
+++ b/docs/operations/run-examples-container.md
@@ -57,7 +57,7 @@ from the ports the servers actually bind:
 podman run $(node ./scripts/container/print-podman-ports.mjs) palamedes-examples
 ```
 
-Spelled out, this is `-p 4010:4010 -p 4011:4011 … -p 4063:4063`.
+Spelled out, this is `-p 4010:4010 -p 4011:4011 … -p 4063:4063 -p 4070:4070`.
 
 - **Init/reaping:** the image ships `tini` as its entrypoint, so reparented child
   processes are reaped cleanly with no extra flag (also works later via
@@ -92,6 +92,7 @@ container with an error code as soon as a server dies unexpectedly (fail-fast).
 | 4061 | `remix-route`          | route     |
 | 4062 | `remix-subdomain`      | subdomain |
 | 4063 | `remix-tld`            | tld       |
+| 4070 | `vite-mdx`             | client    |
 
 `scripts/example-matrix.mjs` is the single source of truth for the ports. The
 supervisor binds according to it automatically, and the `print-podman-ports.mjs`
@@ -111,6 +112,8 @@ touching the example `package.json` files:
   cannot be reliably overridden by an appended flag (Vite's CLI parser collects
   repeated flags into an array), so the supervisor runs `vite preview` directly
   with a single `--host 0.0.0.0`
+- **Vite MDX** (`vite preview`): uses the same container-only direct start plan
+  with a single `--host 0.0.0.0` and fixed port `4070`
 
 Next.js and React Router already bind `0.0.0.0` / honor `HOST`. Waku is driven via
 `HOST=0.0.0.0`; on the first container run, confirm external reachability of

--- a/docs/proof-and-benchmarks.md
+++ b/docs/proof-and-benchmarks.md
@@ -11,7 +11,7 @@ uses all of them. The goal is confidence, not hype.
 
 This repo can credibly prove five things:
 
-- Palamedes is browser-verified across Next.js, TanStack Start, SolidStart, Waku, and React Router, with server-first Remix v3 smoke-verified
+- all 25 examples receive smoke verification on relevant pull requests and `main` pushes; 21 browser-capable examples (Next.js, TanStack Start, SolidStart, Waku, React Router, and Vite) receive Playwright verification weekly and on manual dispatch, while Remix v3 remains smoke-only
 - the runtime model stays centered on `getI18n()`
 - the message identity model stays centered on `message + context`
 - transform, extract, source analysis, catalog update, and catalog compile steps are measured locally and reproducibly
@@ -22,16 +22,16 @@ evidence easy to inspect.
 
 ## Current Maturity
 
-| Topic                 | Current state                                                                                                      |
-| --------------------- | ------------------------------------------------------------------------------------------------------------------ |
-| Recommended use cases | New projects, i18n cleanup, teams already comfortable with Lingui-style authoring                                  |
-| Supported frameworks  | Browser-verified examples for Next.js, TanStack Start, SolidStart, Waku, and React Router; Remix v3 smoke-verified |
-| Runtime model         | `@palamedes/runtime` with `getI18n()`                                                                              |
-| Catalog model         | Source-string-first, `message + context` identity; PO default, FCL opt-in                                          |
-| Native core           | Rust + `napi-rs`                                                                                                   |
-| Catalog semantics     | Delegated to `ferrocat`, including audit and ICU diagnostics                                                       |
-| Node requirement      | `>=22.22`                                                                                                          |
-| Not yet productized   | Top-level `palamedes` install, `create-palamedes` scaffold                                                         |
+| Topic                 | Current state                                                                     |
+| --------------------- | --------------------------------------------------------------------------------- |
+| Recommended use cases | New projects, i18n cleanup, teams already comfortable with Lingui-style authoring |
+| Supported frameworks  | See verification cadence above; Remix v3 smoke-only                               |
+| Runtime model         | `@palamedes/runtime` with `getI18n()`                                             |
+| Catalog model         | Source-string-first, `message + context` identity; PO default, FCL opt-in         |
+| Native core           | Rust + `napi-rs`                                                                  |
+| Catalog semantics     | Delegated to `ferrocat`, including audit and ICU diagnostics                      |
+| Node requirement      | `>=22.22`                                                                         |
+| Not yet productized   | Top-level `palamedes` install, `create-palamedes` scaffold                        |
 
 ## What Counts As Proof In This Repo
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -13,8 +13,12 @@ uses all six frameworks. Each example is independently useful as a reference
 for its own host and locale strategy.
 
 The matrix is intended to be run locally and validated in CI — that remains the
-canonical verification path. Public demo URLs are documented as the live
-reference surface, but reachability depends on the hosting and DNS rows in
+canonical verification path. The `Example Verification` workflow smoke-tests
+all 25 examples on relevant pull requests and `main` pushes. Its weekly run
+(and an opt-in manual dispatch) also exercises the 21 browser-capable examples
+with Playwright; the four server-first Remix v3 examples remain smoke-only.
+Public demo URLs are documented as the live reference surface, but reachability
+depends on the hosting and DNS rows in
 [docs/demo-deployments.md](../docs/demo-deployments.md).
 
 The server-framework matrix intentionally uses the package-root compatibility
@@ -304,6 +308,15 @@ Together they cover:
 - canonical redirect/switch targets
 - locale switching
 - localized server action or server function output after interaction
+
+`Example Verification` runs the smoke layer across the complete 25-example
+matrix on relevant pull requests and `main` pushes, including the deterministic
+request-scope concurrency checks for React Router, SolidStart, TanStack Start,
+and Waku. It runs the Playwright layer for its 21 browser-capable examples on a
+weekly schedule or when a maintainer selects `run_browser` in manual dispatch.
+The four Remix v3 examples are intentionally excluded from that browser layer:
+their server-first beta adapter has no shared client-interaction contract yet,
+but all four locale strategies are covered by smoke verification.
 
 For the decision model behind cookie, route, subdomain, tld, and domain handling, see:
 

--- a/examples/react-router-cookie/README.md
+++ b/examples/react-router-cookie/README.md
@@ -22,5 +22,5 @@ also binds `PORT=4040`.
 - `app/po.d.ts` declares `.po` imports for TypeScript.
 - `app/lib/i18n.ts` wires the runtime and locale controls.
 
-The canonical overview for all 24 examples is
+The canonical overview for all 25 examples is
 [`examples/README.md`](../README.md).

--- a/examples/react-router-route/README.md
+++ b/examples/react-router-route/README.md
@@ -22,5 +22,5 @@ also binds `PORT=4041`.
 - `app/po.d.ts` declares `.po` imports for TypeScript.
 - `app/lib/i18n.ts` wires the runtime and route locale controls.
 
-The canonical overview for all 24 examples is
+The canonical overview for all 25 examples is
 [`examples/README.md`](../README.md).

--- a/examples/react-router-subdomain/README.md
+++ b/examples/react-router-subdomain/README.md
@@ -23,5 +23,5 @@ leftmost subdomain label can select the locale without editing DNS.
 - `app/po.d.ts` declares `.po` imports for TypeScript.
 - `app/lib/i18n.ts` wires the runtime and subdomain locale controls.
 
-The canonical overview for all 24 examples is
+The canonical overview for all 25 examples is
 [`examples/README.md`](../README.md).

--- a/examples/react-router-tld/README.md
+++ b/examples/react-router-tld/README.md
@@ -24,5 +24,5 @@ locale without public DNS.
 - `app/po.d.ts` declares `.po` imports for TypeScript.
 - `app/lib/i18n.ts` wires the runtime and tld locale controls.
 
-The canonical overview for all 24 examples is
+The canonical overview for all 25 examples is
 [`examples/README.md`](../README.md).

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "container:ports": "node ./scripts/container/print-podman-ports.mjs",
     "capture:example-screenshots": "node ./scripts/capture-example-screenshots.mjs",
     "verify:examples": "pnpm build && node ./scripts/verify-examples-all.mjs",
+    "check:example-matrix": "node ./scripts/check-example-matrix.mjs",
     "verify:examples:smoke": "node ./scripts/verify-examples.mjs",
     "verify:examples:browser": "node ./scripts/verify-examples-browser.mjs",
     "benchmark:proof": "pnpm build && node ./scripts/benchmark-proof.mjs",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "capture:example-screenshots": "node ./scripts/capture-example-screenshots.mjs",
     "verify:examples": "pnpm build && node ./scripts/verify-examples-all.mjs",
     "check:example-matrix": "node ./scripts/check-example-matrix.mjs",
+    "check:example-contracts": "vitest run scripts/example-matrix-guard.test.mjs scripts/container/start-plan.test.mjs",
     "verify:examples:smoke": "node ./scripts/verify-examples.mjs",
     "verify:examples:browser": "node ./scripts/verify-examples-browser.mjs",
     "benchmark:proof": "pnpm build && node ./scripts/benchmark-proof.mjs",

--- a/scripts/check-example-matrix.mjs
+++ b/scripts/check-example-matrix.mjs
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict"
+
+import { EXAMPLE_MATRIX, selectBrowserExamples, selectExamples } from "./example-matrix.mjs"
+
+const SERVER_FRAMEWORKS = ["nextjs", "tanstack", "waku", "react-router", "solidstart", "remix"]
+const STRATEGIES = ["cookie", "route", "subdomain", "tld"]
+
+assert.equal(EXAMPLE_MATRIX.length, 25, "the verification matrix must contain 25 examples")
+assert.equal(
+  new Set(EXAMPLE_MATRIX.map((example) => example.id)).size,
+  25,
+  "example ids must be unique"
+)
+assert.equal(
+  new Set(EXAMPLE_MATRIX.map((example) => example.port)).size,
+  25,
+  "example ports must be unique"
+)
+
+for (const framework of SERVER_FRAMEWORKS) {
+  const examples = selectExamples({ framework })
+  assert.equal(examples.length, STRATEGIES.length, `${framework} must cover every locale strategy`)
+
+  for (const strategy of STRATEGIES) {
+    assert.equal(
+      selectExamples({ framework, strategy }).length,
+      1,
+      `${framework}/${strategy} must select exactly one example`
+    )
+  }
+}
+
+assert.equal(selectExamples({ framework: "vite", strategy: "client" }).length, 1)
+assert.equal(
+  selectBrowserExamples({}).length,
+  21,
+  "the browser layer must cover five full families plus Vite"
+)
+assert.equal(selectBrowserExamples({ framework: "remix" }).length, 0, "Remix is smoke-only")
+
+console.log(
+  "Example matrix verified: 25 smoke examples; 21 browser examples; 6 server families × 4 strategies + Vite MDX."
+)

--- a/scripts/check-example-matrix.mjs
+++ b/scripts/check-example-matrix.mjs
@@ -1,9 +1,14 @@
 import assert from "node:assert/strict"
 
-import { EXAMPLE_MATRIX, selectBrowserExamples, selectExamples } from "./example-matrix.mjs"
-
-const SERVER_FRAMEWORKS = ["nextjs", "tanstack", "waku", "react-router", "solidstart", "remix"]
-const STRATEGIES = ["cookie", "route", "subdomain", "tld"]
+import {
+  EXAMPLE_MATRIX,
+  LOCALE_STRATEGIES,
+  SERVER_EXAMPLES,
+  SERVER_FRAMEWORKS,
+  selectBrowserExamples,
+  selectExamples,
+  selectScreenshotExamples,
+} from "./example-matrix.mjs"
 
 assert.equal(EXAMPLE_MATRIX.length, 25, "the verification matrix must contain 25 examples")
 assert.equal(
@@ -19,9 +24,13 @@ assert.equal(
 
 for (const framework of SERVER_FRAMEWORKS) {
   const examples = selectExamples({ framework })
-  assert.equal(examples.length, STRATEGIES.length, `${framework} must cover every locale strategy`)
+  assert.equal(
+    examples.length,
+    LOCALE_STRATEGIES.length,
+    `${framework} must cover every locale strategy`
+  )
 
-  for (const strategy of STRATEGIES) {
+  for (const strategy of LOCALE_STRATEGIES) {
     assert.equal(
       selectExamples({ framework, strategy }).length,
       1,
@@ -30,6 +39,9 @@ for (const framework of SERVER_FRAMEWORKS) {
   }
 }
 
+assert.equal(SERVER_EXAMPLES.length, 24, "the server matrix must contain 24 examples")
+assert.equal(SERVER_FRAMEWORKS.length, 6, "the server matrix must contain six framework families")
+assert.equal(LOCALE_STRATEGIES.length, 4, "the server matrix must contain four locale strategies")
 assert.equal(selectExamples({ framework: "vite", strategy: "client" }).length, 1)
 assert.equal(
   selectBrowserExamples({}).length,
@@ -37,6 +49,17 @@ assert.equal(
   "the browser layer must cover five full families plus Vite"
 )
 assert.equal(selectBrowserExamples({ framework: "remix" }).length, 0, "Remix is smoke-only")
+assert.equal(
+  selectScreenshotExamples({}).length,
+  20,
+  "versioned screenshots must cover only the five UI-adapter families"
+)
+assert.equal(
+  selectScreenshotExamples({ framework: "vite" }).length,
+  0,
+  "Vite has no screenshot artifact"
+)
+assert.equal(selectScreenshotExamples({ framework: "remix" }).length, 0, "Remix is smoke-only")
 
 console.log(
   "Example matrix verified: 25 smoke examples; 21 browser examples; 6 server families × 4 strategies + Vite MDX."

--- a/scripts/check-example-matrix.mjs
+++ b/scripts/check-example-matrix.mjs
@@ -1,5 +1,3 @@
-import assert from "node:assert/strict"
-
 import {
   EXAMPLE_MATRIX,
   LOCALE_STRATEGIES,
@@ -9,57 +7,33 @@ import {
   selectExamples,
   selectScreenshotExamples,
 } from "./example-matrix.mjs"
+import { assertExampleMatrix } from "./example-matrix-guard.mjs"
 
-assert.equal(EXAMPLE_MATRIX.length, 25, "the verification matrix must contain 25 examples")
-assert.equal(
-  new Set(EXAMPLE_MATRIX.map((example) => example.id)).size,
-  25,
-  "example ids must be unique"
-)
-assert.equal(
-  new Set(EXAMPLE_MATRIX.map((example) => example.port)).size,
-  25,
-  "example ports must be unique"
-)
+assertExampleMatrix(EXAMPLE_MATRIX)
 
-for (const framework of SERVER_FRAMEWORKS) {
-  const examples = selectExamples({ framework })
-  assert.equal(
-    examples.length,
-    LOCALE_STRATEGIES.length,
-    `${framework} must cover every locale strategy`
-  )
-
-  for (const strategy of LOCALE_STRATEGIES) {
-    assert.equal(
-      selectExamples({ framework, strategy }).length,
-      1,
-      `${framework}/${strategy} must select exactly one example`
-    )
-  }
+if (
+  SERVER_EXAMPLES.length !== 24 ||
+  SERVER_FRAMEWORKS.length !== 6 ||
+  LOCALE_STRATEGIES.length !== 4
+) {
+  throw new Error("canonical server matrix exports must remain six families by four strategies")
 }
-
-assert.equal(SERVER_EXAMPLES.length, 24, "the server matrix must contain 24 examples")
-assert.equal(SERVER_FRAMEWORKS.length, 6, "the server matrix must contain six framework families")
-assert.equal(LOCALE_STRATEGIES.length, 4, "the server matrix must contain four locale strategies")
-assert.equal(selectExamples({ framework: "vite", strategy: "client" }).length, 1)
-assert.equal(
-  selectBrowserExamples({}).length,
-  21,
-  "the browser layer must cover five full families plus Vite"
-)
-assert.equal(selectBrowserExamples({ framework: "remix" }).length, 0, "Remix is smoke-only")
-assert.equal(
-  selectScreenshotExamples({}).length,
-  20,
-  "versioned screenshots must cover only the five UI-adapter families"
-)
-assert.equal(
-  selectScreenshotExamples({ framework: "vite" }).length,
-  0,
-  "Vite has no screenshot artifact"
-)
-assert.equal(selectScreenshotExamples({ framework: "remix" }).length, 0, "Remix is smoke-only")
+if (selectExamples({ framework: "vite", strategy: "client" }).length !== 1) {
+  throw new Error("the Vite selector must return the single client-only proof")
+}
+if (
+  selectBrowserExamples({}).length !== 21 ||
+  selectBrowserExamples({ framework: "remix" }).length !== 0
+) {
+  throw new Error("the browser selector must include Vite and exclude Remix")
+}
+if (
+  selectScreenshotExamples({}).length !== 20 ||
+  selectScreenshotExamples({ framework: "vite" }).length !== 0 ||
+  selectScreenshotExamples({ framework: "remix" }).length !== 0
+) {
+  throw new Error("the screenshot selector must include only the UI-adapter matrix")
+}
 
 console.log(
   "Example matrix verified: 25 smoke examples; 21 browser examples; 6 server families × 4 strategies + Vite MDX."

--- a/scripts/container/port-plan.mjs
+++ b/scripts/container/port-plan.mjs
@@ -1,0 +1,6 @@
+// Pure publish-plan helper shared by the container documentation command and
+// contract tests. Keeping it matrix-driven prevents published ports from
+// drifting away from the supervisor's start plan.
+export function buildPublishArgs(examples) {
+  return examples.flatMap((example) => ["-p", `${example.port}:${example.port}`])
+}

--- a/scripts/container/print-podman-ports.mjs
+++ b/scripts/container/print-podman-ports.mjs
@@ -7,6 +7,7 @@
 
 import process from "node:process"
 import { EXAMPLE_MATRIX } from "../example-matrix.mjs"
+import { buildPublishArgs } from "./port-plan.mjs"
 
-const flags = EXAMPLE_MATRIX.flatMap((example) => ["-p", `${example.port}:${example.port}`])
+const flags = buildPublishArgs(EXAMPLE_MATRIX)
 process.stdout.write(`${flags.join(" ")}\n`)

--- a/scripts/container/start-plan.mjs
+++ b/scripts/container/start-plan.mjs
@@ -10,23 +10,23 @@ export const CONTAINER_HOST = "0.0.0.0"
 //   0.0.0.0 already / honor the HOST env — no CLI override, just the HOST env.
 // - SolidStart v2's generated Nitro server honors HOST and PORT; the matrix
 //   defaults HOST to 127.0.0.1 and buildStartEnv overrides it to 0.0.0.0.
-// - TanStack binds 127.0.0.1 via a hardcoded `vite preview --host 127.0.0.1` in
-//   its package script; handled specially in buildStartArgs.
+// - TanStack and Vite MDX bind 127.0.0.1 via hardcoded `vite preview` scripts;
+//   handled specially in buildStartArgs.
 // We never edit the example package.json files; the container-only overrides
 // live here on top of the shared EXAMPLE_MATRIX.
 
 // Build the `pnpm` arguments for an example's start script.
 //
-// TanStack is special-cased: its `preview` script hardcodes `--host 127.0.0.1`,
-// and appending a second `--host` would NOT reliably override it — Vite's CLI
-// parser (cac) collects repeated flags into an array, which breaks
-// `server.listen`. We run `vite preview` directly with a single host/port
-// instead, leaving the example package.json untouched. Every other framework
-// runs its matrix start script unchanged and binds 0.0.0.0 via the HOST env
-// (see buildStartEnv); appending a CLI host flag is unsafe (e.g. `next start`
-// treats a trailing `-H` as a positional project directory).
+// TanStack and Vite MDX are special-cased: their `preview` scripts hardcode
+// `--host 127.0.0.1`, and appending a second `--host` would NOT reliably
+// override it — Vite's CLI parser (cac) collects repeated flags into an array,
+// which breaks `server.listen`. We run `vite preview` directly with a single
+// host/port instead, leaving the example package.json files untouched. Every
+// other framework runs its matrix start script unchanged and binds 0.0.0.0 via
+// the HOST env (see buildStartEnv); appending a CLI host flag is unsafe (e.g.
+// `next start` treats a trailing `-H` as a positional project directory).
 export function buildStartArgs(example) {
-  if (example.framework === "tanstack") {
+  if (example.framework === "tanstack" || example.framework === "vite") {
     return ["exec", "vite", "preview", "--host", CONTAINER_HOST, "--port", String(example.port)]
   }
   return [...example.start]

--- a/scripts/container/start-plan.test.mjs
+++ b/scripts/container/start-plan.test.mjs
@@ -1,4 +1,9 @@
+import { readFile } from "node:fs/promises"
+import { resolve } from "node:path"
+
 import { describe, expect, it } from "vitest"
+import { EXAMPLE_MATRIX } from "../example-matrix.mjs"
+import { buildPublishArgs } from "./port-plan.mjs"
 import { CONTAINER_HOST, buildStartArgs, buildStartEnv } from "./start-plan.mjs"
 
 describe("buildStartArgs", () => {
@@ -11,6 +16,18 @@ describe("buildStartArgs", () => {
       CONTAINER_HOST,
       "--port",
       "4020",
+    ])
+  })
+
+  it("runs Vite MDX directly with a container-reachable host and fixed port", () => {
+    expect(buildStartArgs({ framework: "vite", start: ["preview"], port: 4070 })).toEqual([
+      "exec",
+      "vite",
+      "preview",
+      "--host",
+      CONTAINER_HOST,
+      "--port",
+      "4070",
     ])
   })
 
@@ -43,5 +60,28 @@ describe("buildStartEnv", () => {
       startEnv: { HOST: "127.0.0.1" },
     })
     expect(env.HOST).toBe(CONTAINER_HOST)
+  })
+})
+
+describe("container publish contract", () => {
+  it("publishes Vite MDX on its container-reachable start-plan port", async () => {
+    const vite = EXAMPLE_MATRIX.find((example) => example.id === "vite-mdx")
+    expect(vite).toBeDefined()
+    expect(buildStartArgs(vite)).toEqual([
+      "exec",
+      "vite",
+      "preview",
+      "--host",
+      CONTAINER_HOST,
+      "--port",
+      "4070",
+    ])
+    expect(buildPublishArgs(EXAMPLE_MATRIX)).toContain("4070:4070")
+
+    const containerfile = await readFile(
+      resolve(import.meta.dirname, "../../Containerfile"),
+      "utf8"
+    )
+    expect(containerfile).toMatch(/^EXPOSE .*\b4070\b/m)
   })
 })

--- a/scripts/example-matrix-guard.mjs
+++ b/scripts/example-matrix-guard.mjs
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict"
+
+import { LOCALE_STRATEGIES, SERVER_FRAMEWORKS, VITE_EXAMPLE } from "./example-matrix.mjs"
+
+function sortedUnique(values) {
+  return [...new Set(values)].sort()
+}
+
+const CANONICAL_SERVER_FRAMEWORKS = [...SERVER_FRAMEWORKS].sort()
+const CANONICAL_LOCALE_STRATEGIES = [...LOCALE_STRATEGIES].sort()
+
+export function assertExampleMatrix(matrix) {
+  assert.equal(matrix.length, 25, "the verification matrix must contain 25 examples")
+  assert.equal(new Set(matrix.map((example) => example.id)).size, 25, "example ids must be unique")
+  assert.equal(
+    new Set(matrix.map((example) => example.port)).size,
+    25,
+    "example ports must be unique"
+  )
+
+  const serverExamples = matrix.filter((example) => SERVER_FRAMEWORKS.includes(example.framework))
+  assert.deepEqual(
+    sortedUnique(serverExamples.map((example) => example.framework)),
+    CANONICAL_SERVER_FRAMEWORKS,
+    "server framework identities must match the canonical list"
+  )
+  assert.deepEqual(
+    sortedUnique(serverExamples.map((example) => example.strategy)),
+    CANONICAL_LOCALE_STRATEGIES,
+    "server locale strategy identities must match the canonical list"
+  )
+  assert.equal(serverExamples.length, 24, "the server matrix must contain 24 examples")
+
+  for (const framework of SERVER_FRAMEWORKS) {
+    for (const strategy of LOCALE_STRATEGIES) {
+      assert.equal(
+        matrix.filter((example) => example.framework === framework && example.strategy === strategy)
+          .length,
+        1,
+        `${framework}/${strategy} must appear exactly once in the server matrix`
+      )
+    }
+  }
+
+  const viteExamples = matrix.filter(
+    (example) =>
+      example.framework === VITE_EXAMPLE.framework && example.strategy === VITE_EXAMPLE.strategy
+  )
+  assert.equal(viteExamples.length, 1, "Vite must be the one client-only proof entry")
+  assert.equal(viteExamples[0].id, VITE_EXAMPLE.id, "Vite must retain its canonical example id")
+
+  const browserExamples = matrix.filter((example) => example.framework !== "remix")
+  assert.equal(
+    browserExamples.length,
+    21,
+    "the browser layer must cover five full families plus Vite"
+  )
+  assert.equal(
+    browserExamples.filter((example) => example.framework === VITE_EXAMPLE.framework).length,
+    1,
+    "Vite must be included in the browser layer"
+  )
+
+  const screenshotExamples = matrix.filter(
+    (example) => example.framework !== "remix" && example.framework !== VITE_EXAMPLE.framework
+  )
+  assert.equal(
+    screenshotExamples.length,
+    20,
+    "versioned screenshots must cover only the five UI-adapter families"
+  )
+  assert.equal(
+    screenshotExamples.filter((example) => example.framework === VITE_EXAMPLE.framework).length,
+    0,
+    "Vite has no screenshot artifact"
+  )
+}

--- a/scripts/example-matrix-guard.test.mjs
+++ b/scripts/example-matrix-guard.test.mjs
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  EXAMPLE_MATRIX,
+  selectBrowserExamples,
+  selectExamples,
+  selectScreenshotExamples,
+} from "./example-matrix.mjs"
+import { assertExampleMatrix } from "./example-matrix-guard.mjs"
+
+function cloneMatrix() {
+  return EXAMPLE_MATRIX.map((example) => ({ ...example }))
+}
+
+describe("example matrix guard", () => {
+  it("accepts the canonical matrix", () => {
+    expect(() => assertExampleMatrix(EXAMPLE_MATRIX)).not.toThrow()
+  })
+
+  it("rejects a whole-family typo with unchanged cardinality", () => {
+    const matrix = cloneMatrix().map((example) =>
+      example.framework === "nextjs" ? { ...example, framework: "next-js" } : example
+    )
+
+    expect(() => assertExampleMatrix(matrix)).toThrow(/server framework identities/)
+  })
+
+  it("rejects a whole-strategy typo with unchanged cardinality", () => {
+    const matrix = cloneMatrix().map((example) =>
+      example.strategy === "subdomain" ? { ...example, strategy: "sub-domain" } : example
+    )
+
+    expect(() => assertExampleMatrix(matrix)).toThrow(/server locale strategy identities/)
+  })
+
+  it("rejects a missing/replaced Cartesian pair with unchanged cardinality", () => {
+    const matrix = cloneMatrix()
+    const cookieIndex = matrix.findIndex(
+      (example) => example.framework === "nextjs" && example.strategy === "cookie"
+    )
+    matrix[cookieIndex] = { ...matrix[cookieIndex], strategy: "route" }
+
+    expect(() => assertExampleMatrix(matrix)).toThrow(/nextjs\/cookie/)
+  })
+
+  it("rejects duplicate ids and ports", () => {
+    const duplicatedId = cloneMatrix()
+    duplicatedId[1] = { ...duplicatedId[1], id: duplicatedId[0].id }
+    expect(() => assertExampleMatrix(duplicatedId)).toThrow(/ids must be unique/)
+
+    const duplicatedPort = cloneMatrix()
+    duplicatedPort[1] = { ...duplicatedPort[1], port: duplicatedPort[0].port }
+    expect(() => assertExampleMatrix(duplicatedPort)).toThrow(/ports must be unique/)
+  })
+
+  it("keeps Vite as the single client-only browser proof", () => {
+    const misplacedVite = cloneMatrix()
+    const viteIndex = misplacedVite.findIndex((example) => example.id === "vite-mdx")
+    misplacedVite[viteIndex] = { ...misplacedVite[viteIndex], strategy: "cookie" }
+
+    expect(() => assertExampleMatrix(misplacedVite)).toThrow(
+      /Vite must be the one client-only proof entry/
+    )
+  })
+
+  it("keeps Vite in browser selection and out of screenshot selection", () => {
+    expect(
+      selectExamples({ framework: "vite", strategy: "client" }).map((example) => example.id)
+    ).toEqual(["vite-mdx"])
+    expect(selectBrowserExamples({ framework: "vite" }).map((example) => example.id)).toEqual([
+      "vite-mdx",
+    ])
+    expect(selectScreenshotExamples({ framework: "vite" })).toEqual([])
+  })
+})

--- a/scripts/example-matrix.mjs
+++ b/scripts/example-matrix.mjs
@@ -556,3 +556,10 @@ export function selectExamples(filters) {
     return true
   })
 }
+
+// Remix v3 is deliberately server-first while its component/UI adapter settles.
+// Its four entries have smoke contracts, but not the shared browser-interaction
+// contract that the other framework families and Vite exercise.
+export function selectBrowserExamples(filters) {
+  return selectExamples(filters).filter((example) => example.framework !== "remix")
+}

--- a/scripts/example-matrix.mjs
+++ b/scripts/example-matrix.mjs
@@ -3,6 +3,20 @@ import { fileURLToPath } from "node:url"
 
 export const ROOT = path.resolve(import.meta.dirname, "..")
 
+// These public identities are deliberately independent of EXAMPLE_MATRIX.
+// The guard compares matrix-derived values to them so a whole-family or
+// whole-strategy rename cannot preserve cardinality while breaking selectors.
+export const SERVER_FRAMEWORKS = [
+  "nextjs",
+  "tanstack",
+  "waku",
+  "react-router",
+  "solidstart",
+  "remix",
+]
+export const LOCALE_STRATEGIES = ["cookie", "route", "subdomain", "tld"]
+export const VITE_EXAMPLE = { framework: "vite", strategy: "client", id: "vite-mdx" }
+
 export const EXAMPLE_MATRIX = [
   {
     id: "nextjs-cookie",
@@ -560,9 +574,9 @@ export function selectExamples(filters) {
 // The server matrix is six framework families by four locale strategies. Vite
 // is an additional client-only MDX proof, rather than a seventh server family
 // or a fifth locale strategy.
-export const SERVER_EXAMPLES = EXAMPLE_MATRIX.filter((example) => example.framework !== "vite")
-export const SERVER_FRAMEWORKS = [...new Set(SERVER_EXAMPLES.map((example) => example.framework))]
-export const LOCALE_STRATEGIES = [...new Set(SERVER_EXAMPLES.map((example) => example.strategy))]
+export const SERVER_EXAMPLES = EXAMPLE_MATRIX.filter((example) =>
+  SERVER_FRAMEWORKS.includes(example.framework)
+)
 
 // Remix v3 is deliberately server-first while its component/UI adapter settles.
 // Its four entries have smoke contracts, but not the shared browser-interaction

--- a/scripts/example-matrix.mjs
+++ b/scripts/example-matrix.mjs
@@ -557,9 +557,24 @@ export function selectExamples(filters) {
   })
 }
 
+// The server matrix is six framework families by four locale strategies. Vite
+// is an additional client-only MDX proof, rather than a seventh server family
+// or a fifth locale strategy.
+export const SERVER_EXAMPLES = EXAMPLE_MATRIX.filter((example) => example.framework !== "vite")
+export const SERVER_FRAMEWORKS = [...new Set(SERVER_EXAMPLES.map((example) => example.framework))]
+export const LOCALE_STRATEGIES = [...new Set(SERVER_EXAMPLES.map((example) => example.strategy))]
+
 // Remix v3 is deliberately server-first while its component/UI adapter settles.
 // Its four entries have smoke contracts, but not the shared browser-interaction
 // contract that the other framework families and Vite exercise.
 export function selectBrowserExamples(filters) {
   return selectExamples(filters).filter((example) => example.framework !== "remix")
+}
+
+// The checked-in screenshot set records the established UI-adapter matrix.
+// Vite has the browser contract but no capture artifact, and Remix is smoke-only.
+export function selectScreenshotExamples(filters) {
+  return selectExamples(filters).filter(
+    (example) => example.framework !== "remix" && example.framework !== "vite"
+  )
 }

--- a/scripts/verify-examples-browser.mjs
+++ b/scripts/verify-examples-browser.mjs
@@ -1,12 +1,15 @@
 import { execFileSync, spawn } from "node:child_process"
 import http from "node:http"
 import path from "node:path"
-import { parseExampleArgs, ROOT, selectExamples } from "./example-matrix.mjs"
+import { parseExampleArgs, ROOT, selectBrowserExamples } from "./example-matrix.mjs"
 
 function parseBrowserArgs(argv) {
   return {
     captureScreenshots: argv.includes("--capture-screenshots"),
-    screenshotDir: path.join(ROOT, "docs/example-screenshots"),
+    screenshotDir: path.resolve(
+      ROOT,
+      process.env.PALAMEDES_SCREENSHOT_DIR ?? "docs/example-screenshots"
+    ),
   }
 }
 
@@ -218,10 +221,10 @@ async function verifyExample(example, options) {
 
 async function main() {
   const browserOptions = parseBrowserArgs(process.argv)
-  const selected = selectExamples(parseExampleArgs(process.argv))
+  const selected = selectBrowserExamples(parseExampleArgs(process.argv))
 
   if (selected.length === 0) {
-    throw new Error("No examples matched the provided filters")
+    throw new Error("No browser-verifiable examples matched the provided filters")
   }
 
   for (const example of selected) {

--- a/site/app/components/home/ProofStrip.tsx
+++ b/site/app/components/home/ProofStrip.tsx
@@ -19,7 +19,11 @@ interface Stat {
  * benchmark report), so none of these numbers can silently drift.
  */
 const STATS: Stat[] = [
-  { value: `${contentStats.exampleCount}`, label: "verified example apps", href: "/frameworks" },
+  {
+    value: `${contentStats.smokeExampleCount}`,
+    label: "smoke-verified example apps",
+    href: "/frameworks",
+  },
   {
     value: `${contentStats.frameworkCount} × ${contentStats.strategyCount}`,
     label: "frameworks × locale strategies",

--- a/site/app/components/home/ProofStrip.tsx
+++ b/site/app/components/home/ProofStrip.tsx
@@ -25,8 +25,8 @@ const STATS: Stat[] = [
     href: "/frameworks",
   },
   {
-    value: `${contentStats.frameworkCount} × ${contentStats.strategyCount}`,
-    label: "frameworks × locale strategies",
+    value: `${contentStats.serverFrameworkCount} × ${contentStats.localeStrategyCount}`,
+    label: "server frameworks × locale strategies",
     href: "/frameworks",
   },
   {

--- a/site/app/data/posts.ts
+++ b/site/app/data/posts.ts
@@ -30,9 +30,9 @@ export const POSTS: Post[] = [
     readMinutes: 7,
   },
   {
-    title: "Browser-verifying i18n across six frameworks",
+    title: "Browser-verifying i18n across five frameworks",
     excerpt:
-      "How 24 example apps get driven by the same verification flow in CI — and why versioned screenshots beat compatibility tables.",
+      "How 20 UI-adapter apps share a browser verification flow and versioned screenshots, within a 25-app smoke matrix.",
     href: blogHref("browser-verifying-i18n-across-five-frameworks"),
     readMinutes: 6,
   },

--- a/site/app/data/rivals.ts
+++ b/site/app/data/rivals.ts
@@ -179,7 +179,7 @@ export const RIVALS: Rival[] = [
       {
         criterion: "Verified host coverage",
         rival: "Broad UI-framework packages",
-        palamedes: `${contentStats.exampleCount} browser-verified host applications`,
+        palamedes: `${contentStats.smokeExampleCount} smoke-verified examples; ${contentStats.browserExampleCount} browser-checked weekly`,
       },
     ],
     code: {
@@ -373,7 +373,7 @@ plural(seats, {
       },
       {
         title: "The model outlives the framework choice",
-        body: `Palamedes runs the same runtime and identity model across Next.js, TanStack Start, SolidStart, Waku, React Router and Remix v3, with ${contentStats.exampleCount} browser-verified example apps in CI covering ${contentStats.strategyCount} locale strategies each. That is not a compatibility table — it is a test suite. Changing meta-framework changes your routing layer and nothing about your messages.`,
+        body: `Palamedes runs the same runtime and identity model across Next.js, TanStack Start, SolidStart, Waku, React Router and Remix v3, with ${contentStats.smokeExampleCount} examples smoke-checked on relevant PRs and main pushes across four locale strategies. ${contentStats.browserExampleCount} browser-capable examples run the Playwright contract weekly or on manual dispatch. That is not a compatibility table — it is a test suite. Changing meta-framework changes your routing layer and nothing about your messages.`,
       },
       {
         title: "Source strings as the stable path, not the experiment",
@@ -859,7 +859,7 @@ function buyLabel(seats) {
       {
         criterion: "Framework coverage",
         rival: "The widest here — ~19 first-party adapters",
-        palamedes: `React and Solid across ${contentStats.frameworkCount} meta-frameworks, ${contentStats.exampleCount} apps verified in CI`,
+        palamedes: `React and Solid across ${contentStats.frameworkCount} meta-frameworks, ${contentStats.smokeExampleCount} apps smoke-checked in CI`,
       },
       {
         criterion: "Extract + update speed",

--- a/site/app/data/rivals.ts
+++ b/site/app/data/rivals.ts
@@ -174,7 +174,7 @@ export const RIVALS: Rival[] = [
       {
         criterion: "Framework coverage",
         rival: "React, React Native, Vue, Solid, vanilla",
-        palamedes: `React and Solid across ${contentStats.frameworkCount} meta-frameworks; no Vue, no React Native`,
+        palamedes: `React and Solid across ${contentStats.serverFrameworkCount} server frameworks; no Vue, no React Native`,
       },
       {
         criterion: "Verified host coverage",
@@ -343,7 +343,7 @@ plural(seats, {
     metaDescription:
       "next-intl is the most Next.js-idiomatic i18n library there is, routing included. Palamedes trades that depth for one runtime and message model across supported hosts — and ships source-string extraction as the stable path, not an experiment.",
     eyebrow: "Compare · next-intl",
-    headline: `One framework deep, or ${contentStats.frameworkCount} frameworks wide.`,
+    headline: `One framework deep, or ${contentStats.serverFrameworkCount} server frameworks wide.`,
     lede: "next-intl is built into Next.js as far as a library can be — localized pathnames, domain routing and RSC integration are the product, not add-ons. That depth is genuinely valuable and it is also the shape of the lock-in. Palamedes draws the boundary differently: your framework keeps routing, while Palamedes carries the same authoring, catalog, validation, and runtime model across supported hosts.",
     card: "Next-native depth including routing, against one shared model across supported hosts.",
     facts: [
@@ -631,7 +631,7 @@ function buyLabel(seats) {
       {
         criterion: "Framework coverage",
         rival: "Broad, via one Vite plugin",
-        palamedes: `React and Solid across ${contentStats.frameworkCount} verified meta-frameworks`,
+        palamedes: `React and Solid across ${contentStats.serverFrameworkCount} verified server frameworks`,
       },
       {
         criterion: "Extract + update speed",
@@ -741,7 +741,7 @@ function buyLabel(seats) {
       {
         criterion: "Framework bindings",
         rival: "React, Vue, Angular and Svelte",
-        palamedes: `React and Solid across ${contentStats.frameworkCount} verified meta-frameworks`,
+        palamedes: `React and Solid across ${contentStats.serverFrameworkCount} verified server frameworks`,
       },
       {
         criterion: "Extract + update speed",
@@ -859,7 +859,7 @@ function buyLabel(seats) {
       {
         criterion: "Framework coverage",
         rival: "The widest here — ~19 first-party adapters",
-        palamedes: `React and Solid across ${contentStats.frameworkCount} meta-frameworks, ${contentStats.smokeExampleCount} apps smoke-checked in CI`,
+        palamedes: `React and Solid across ${contentStats.serverFrameworkCount} server frameworks, ${contentStats.smokeExampleCount} apps smoke-checked in CI`,
       },
       {
         criterion: "Extract + update speed",

--- a/site/app/data/topics.ts
+++ b/site/app/data/topics.ts
@@ -98,13 +98,13 @@ export const TOPICS: Topic[] = [
       ],
     },
     evidence: {
-      title: "Verified in a browser, on every change",
+      title: "Smoke-checked on relevant changes; browser-checked weekly",
       lede: "Server-component rendering is exactly the kind of claim that is easy to assert and tedious to prove, so it is proven mechanically instead.",
       items: [
         {
           label: "Example apps",
-          value: `${contentStats.exampleCount}`,
-          note: "Every one is built against the workspace packages and driven by Playwright in CI — no mocked integrations.",
+          value: `${contentStats.smokeExampleCount}`,
+          note: `${contentStats.browserExampleCount} browser-capable examples run Playwright weekly or on manual dispatch; all are built and smoke-checked on relevant PRs and main pushes — no mocked integrations.`,
         },
         {
           label: "Meta-frameworks",
@@ -381,13 +381,13 @@ select(gender, {
         },
         {
           title: "Every strategy is exercised, not just documented",
-          body: `Each of the ${contentStats.frameworkCount} supported meta-frameworks has an example app for all ${contentStats.strategyCount} strategies, driven in a real browser in CI. The tradeoffs below are written from apps that run, not from a table someone maintained by hand.`,
+          body: `Each of the six server frameworks has an example app for all four strategies. All ${contentStats.smokeExampleCount} examples are smoke-checked on relevant PRs and main pushes; ${contentStats.browserExampleCount} browser-capable examples run the real-browser contract weekly or on manual dispatch. The tradeoffs below are written from apps that run, not from a table someone maintained by hand.`,
         },
       ],
     },
     evidence: {
       title: "The four strategies, and what each one costs",
-      lede: "All four are implemented and browser-verified for every supported framework. The differences are real and worth reading before you commit.",
+      lede: `All four are implemented for every server framework and smoke-checked across ${contentStats.smokeExampleCount} examples. The ${contentStats.browserExampleCount} browser-capable examples run Playwright weekly or on manual dispatch. The differences are real and worth reading before you commit.`,
       items: [
         {
           label: "Cookie",
@@ -432,7 +432,7 @@ select(gender, {
       },
       {
         q: "How do I know these actually work?",
-        a: `Every strategy has a running example app per framework — ${contentStats.exampleCount} in total — built against the workspace packages and driven by Playwright in CI, with versioned screenshots checked into the repository.`,
+        a: `Every strategy has a running example app per framework — ${contentStats.smokeExampleCount} in total — built and smoke-checked against the workspace packages on relevant PRs and main pushes. ${contentStats.browserExampleCount} browser-capable examples run Playwright weekly or on manual dispatch, with versioned screenshots checked into the repository.`,
       },
     ],
     related: [

--- a/site/app/data/topics.ts
+++ b/site/app/data/topics.ts
@@ -93,7 +93,7 @@ export const TOPICS: Topic[] = [
         },
         {
           title: "Not a Next.js feature",
-          body: `The same model runs across ${contentStats.frameworkCount} meta-frameworks, including the RSC-capable ones beyond Next.js — Waku and TanStack Start among them. Server-component support here is a property of the architecture, not an integration written for one framework.`,
+          body: `The same model runs across ${contentStats.serverFrameworkCount} server frameworks, including the RSC-capable ones beyond Next.js — Waku and TanStack Start among them. Server-component support here is a property of the architecture, not an integration written for one framework.`,
         },
       ],
     },
@@ -108,12 +108,12 @@ export const TOPICS: Topic[] = [
         },
         {
           label: "Meta-frameworks",
-          value: `${contentStats.frameworkCount}`,
+          value: `${contentStats.serverFrameworkCount}`,
           note: "Next.js, TanStack Start, SolidStart, Waku, React Router and Remix v3, each with the same runtime model.",
         },
         {
           label: "Locale strategies each",
-          value: `${contentStats.strategyCount}`,
+          value: `${contentStats.localeStrategyCount}`,
           note: "Cookie, route, subdomain and top-level domain, so the server path is exercised under every resolution mode.",
         },
         {
@@ -151,7 +151,7 @@ export default async function CheckoutHeading({ seats }) {
       },
       {
         q: "Does this work outside Next.js?",
-        a: `Yes. The same model is verified across ${contentStats.frameworkCount} meta-frameworks in CI, including the RSC-capable ones beyond Next.js. Palamedes ships React and Solid packages; there is no Vue or React Native support.`,
+        a: `Yes. The same model is verified across ${contentStats.serverFrameworkCount} server frameworks in CI, including the RSC-capable ones beyond Next.js. Palamedes ships React and Solid packages; there is no Vue or React Native support.`,
       },
       {
         q: "Why can't React Intl support server components?",
@@ -432,7 +432,7 @@ select(gender, {
       },
       {
         q: "How do I know these actually work?",
-        a: `Every strategy has a running example app per framework — ${contentStats.smokeExampleCount} in total — built and smoke-checked against the workspace packages on relevant PRs and main pushes. ${contentStats.browserExampleCount} browser-capable examples run Playwright weekly or on manual dispatch, with versioned screenshots checked into the repository.`,
+        a: `Every strategy has a running example app per framework — ${contentStats.smokeExampleCount} in total — built and smoke-checked against the workspace packages on relevant PRs and main pushes. ${contentStats.browserExampleCount} browser-capable examples run Playwright weekly or on manual dispatch; ${contentStats.screenshotExampleCount} UI-adapter examples have versioned screenshots.`,
       },
     ],
     related: [

--- a/site/app/routes/frameworks.tsx
+++ b/site/app/routes/frameworks.tsx
@@ -46,19 +46,20 @@ export default function Frameworks() {
 
       <Section
         num="01 — Matrix"
-        title={`The ${contentStats.frameworkCount} × ${contentStats.strategyCount} verified matrix.`}
+        title={`The ${contentStats.serverFrameworkCount} × ${contentStats.localeStrategyCount} server matrix, plus Vite.`}
       >
         <FrameworkMatrix scan />
         <p className="mt-4 max-w-[52em] text-[12.5px] text-gray-spec">
           All {contentStats.smokeExampleCount} apps are smoke-checked on relevant pull requests and
-          main pushes. The {contentStats.browserExampleCount} browser-capable examples — the 20
-          established UI-adapter matrix apps plus the Vite MDX proof — cover SSR output, locale
-          switching, and localized server actions or functions in weekly or manual Playwright runs;
-          the four Remix v3 apps cover server responses and locale handling through smoke checks.
-          Screenshots cover the browser-capable set and are versioned in the repo. Cookie, route,
-          and subdomain demos are publicly hosted for the five browser-verified frameworks; the TLD
-          domains are still being provisioned, and Remix v3 has no public hosting yet. Hosting
-          status is documented in the repo&apos;s demo-deployments guide.
+          main pushes. The {contentStats.browserExampleCount} browser-capable examples — the
+          {contentStats.screenshotExampleCount} established UI-adapter matrix apps plus the Vite MDX
+          proof — cover SSR output, locale switching, and localized server actions or functions in
+          weekly or manual Playwright runs; the four Remix v3 apps cover server responses and locale
+          handling through smoke checks. Versioned screenshots cover the{" "}
+          {contentStats.screenshotExampleCount} UI-adapter examples; Vite has no capture artifact.
+          Cookie, route, and subdomain demos are publicly hosted for the five browser-verified
+          frameworks; the TLD domains are still being provisioned, and Remix v3 has no public
+          hosting yet. Hosting status is documented in the repo&apos;s demo-deployments guide.
         </p>
       </Section>
 

--- a/site/app/routes/frameworks.tsx
+++ b/site/app/routes/frameworks.tsx
@@ -50,14 +50,15 @@ export default function Frameworks() {
       >
         <FrameworkMatrix scan />
         <p className="mt-4 max-w-[52em] text-[12.5px] text-gray-spec">
-          All {contentStats.exampleCount} apps are verified in CI. The{" "}
-          {contentStats.exampleCount - contentStats.strategyCount} established UI-adapter apps cover
-          SSR output, locale switching, and localized server actions or functions in the browser;
-          the {contentStats.strategyCount} Remix v3 apps cover server responses and locale handling
-          through smoke checks. Screenshots cover the UI-adapter matrix and are versioned in the
-          repo. Cookie, route, and subdomain demos are publicly hosted for the five browser-verified
-          frameworks; the TLD domains are still being provisioned, and Remix v3 has no public
-          hosting yet. Hosting status is documented in the repo&apos;s demo-deployments guide.
+          All {contentStats.smokeExampleCount} apps are smoke-checked on relevant pull requests and
+          main pushes. The {contentStats.browserExampleCount} browser-capable examples — the 20
+          established UI-adapter matrix apps plus the Vite MDX proof — cover SSR output, locale
+          switching, and localized server actions or functions in weekly or manual Playwright runs;
+          the four Remix v3 apps cover server responses and locale handling through smoke checks.
+          Screenshots cover the browser-capable set and are versioned in the repo. Cookie, route,
+          and subdomain demos are publicly hosted for the five browser-verified frameworks; the TLD
+          domains are still being provisioned, and Remix v3 has no public hosting yet. Hosting
+          status is documented in the repo&apos;s demo-deployments guide.
         </p>
       </Section>
 

--- a/site/app/routes/home.tsx
+++ b/site/app/routes/home.tsx
@@ -92,7 +92,7 @@ export default function Home() {
       <Section
         num="03 — Proof"
         title="We don't ask you to trust a slogan. The repo shows the work."
-        lede="Every combination in the verified framework matrix is a real app, re-checked in CI through the same Playwright flow — with public demos where the hosting is ready. Every benchmark number links to a checked-in, re-runnable report. Palamedes carries two bars: the cold run every tool performs, and the cached re-run you actually trigger all day."
+        lede={`Every combination in the verified framework matrix is a real app: all ${contentStats.smokeExampleCount} are smoke-checked on relevant PRs and main pushes, while ${contentStats.browserExampleCount} browser-capable examples run the Playwright flow weekly or on manual dispatch. Public demos are available where hosting is ready. Every benchmark number links to a checked-in, re-runnable report. Palamedes carries two bars: the cold run every tool performs, and the cached re-run you actually trigger all day.`}
       >
         <div className="space-y-10">
           <FrameworkMatrix />

--- a/site/app/routes/proof.tsx
+++ b/site/app/routes/proof.tsx
@@ -16,7 +16,7 @@ export const handle = { layout: "bare" }
 export function meta() {
   return pageMeta({
     title: "Palamedes — benchmarks, verification, and the decision trail",
-    description: `Claims you can re-run: checked-in extraction benchmarks, an executable ICU semantics proof, ${contentStats.exampleCount} browser-verified example apps, and ${contentStats.adrCount} decision records.`,
+    description: `Claims you can re-run: checked-in extraction benchmarks, an executable ICU semantics proof, ${contentStats.smokeExampleCount} smoke-verified examples and ${contentStats.browserExampleCount} scheduled browser checks, and ${contentStats.adrCount} decision records.`,
     path: "/proof",
   })
 }
@@ -24,11 +24,11 @@ export function meta() {
 const VERIFICATION_STEPS = [
   {
     title: "Build",
-    body: `All ${contentStats.exampleCount} example apps build against the workspace packages — no mocked integrations.`,
+    body: `All ${contentStats.smokeExampleCount} example apps build and smoke-test against the workspace packages on relevant PRs and main pushes — no mocked integrations.`,
   },
   {
     title: "Drive",
-    body: "A Playwright flow loads each app, checks SSR output, switches locales, and exercises localized server actions.",
+    body: `${contentStats.browserExampleCount} browser-capable examples run the Playwright flow weekly or on manual dispatch: load, SSR output, locale switch, and localized server actions.`,
   },
   {
     title: "Capture",
@@ -88,7 +88,7 @@ export default function Proof() {
 
       <Section
         num="02 — Verification"
-        title={`${contentStats.exampleCount} apps, verified in a real browser, on every change.`}
+        title={`${contentStats.smokeExampleCount} apps smoke-checked on relevant changes; ${contentStats.browserExampleCount} browser-checked weekly.`}
       >
         <div className="hairline-grid mb-10 grid-cols-3 max-tight:grid-cols-1">
           {VERIFICATION_STEPS.map((step, index) => (

--- a/site/content/blog/a-calmer-path-for-javascript-i18n.md
+++ b/site/content/blog/a-calmer-path-for-javascript-i18n.md
@@ -46,8 +46,9 @@ The proof is visible in the repo:
 - the [example matrix](../../../examples/README.md) covers Next.js, TanStack
   Start, SolidStart, Waku, and React Router
 - each framework family has cookie, route, subdomain, and tld locale strategies
-- [browser screenshots](../../../docs/example-screenshots/README.md) are generated
-  from the same Playwright verification flow used in CI
+- [browser screenshots](../../../docs/example-screenshots/README.md) cover the
+  20 UI-adapter examples and are generated from their Playwright verification
+  flow in CI
 - [ADRs](../../../adr/001-project-scope-and-positioning.md) explain the runtime
   model, message identity, adapter architecture, and native boundary
 - [benchmark commands](../../../docs/proof-and-benchmarks.md) are checked in so local

--- a/site/content/blog/browser-verifying-i18n-across-five-frameworks.md
+++ b/site/content/blog/browser-verifying-i18n-across-five-frameworks.md
@@ -2,7 +2,7 @@
 date: "2026-07-05"
 ---
 
-# How We Browser-Verify i18n Across Six Frameworks
+# How We Browser-Verify i18n Across Five Frameworks
 
 Status: draft
 
@@ -14,21 +14,27 @@ interaction, and server actions all have to agree.
 
 Palamedes treats that as a verification problem.
 
-The repo contains an example matrix across six framework families:
+The repo contains 25 examples: six server framework families with four locale
+strategies each, plus a focused Vite MDX app. All 25 are smoke-checked on
+relevant pull requests and `main` pushes.
+
+This article is about the 20 established UI-adapter examples that share the
+browser interaction contract and versioned screenshots:
 
 - Next.js
 - TanStack Start
 - SolidStart
 - Waku
 - React Router
-- Remix v3
 
 Each family has four locale strategies:
 
 - cookie-based locale persistence
 - route-segment locale persistence
+- subdomain-based locale persistence
+- top-level-domain locale persistence
 
-That gives 24 example apps. Each one has visible checks for the parts that
+That gives 20 UI-adapter example apps. Each one has visible checks for the parts that
 usually hide i18n bugs:
 
 - server-rendered localized text before hydration
@@ -36,14 +42,16 @@ usually hide i18n bugs:
 - server-side localized action or query output
 - the same runtime model behind the framework-specific wiring
 
-The screenshots are versioned in the repo:
+Those 20 UI-adapter examples have two versioned screenshots each:
 
 - [example screenshots](../../../docs/example-screenshots/README.md)
 - [matrix visual](../../../docs/assets/palamedes-localized-matrix.png)
 
 The useful detail is that the screenshots are not hand-picked marketing
 images. They come from the same Playwright-based verification flow that checks
-the examples.
+those UI-adapter examples weekly and on manual dispatch. The browser lane also
+checks the Vite MDX app; the four server-first Remix v3 examples remain
+smoke-only and have no browser capture.
 
 That changes the value of the asset. The matrix is evidence that the product
 thesis is being exercised.
@@ -56,7 +64,8 @@ For Palamedes, the thesis is:
 The matrix is where that thesis has to survive contact with frameworks.
 
 Next.js and React Router do not fail in the same places. TanStack Start,
-SolidStart, Waku, and Remix v3 each have their own server/client boundaries.
+SolidStart, and Waku each have their own server/client boundaries. Remix v3 is
+covered separately by the smoke lane while its UI adapter settles.
 Route-based locale state and cookie-based locale state put pressure on different
 parts of the adapter layer.
 
@@ -67,7 +76,8 @@ If each adapter grows its own message semantics, the matrix becomes ten
 different products. Palamedes keeps catalog semantics in `ferrocat`, runtime
 access behind `getI18n()`, and message identity at `message + context`.
 
-The verifier then checks that every host can express the same model.
+The browser verifier checks that each UI-adapter host can express the same
+model, while the smoke lane covers the full 25-example matrix.
 
 This is not the final proof that Palamedes covers every edge case. It is a
 repeatable baseline. A team evaluating the project can inspect the examples,

--- a/site/content/blog/micro-content-round-1.md
+++ b/site/content/blog/micro-content-round-1.md
@@ -13,9 +13,11 @@ piece of evidence.
 
 Cross-framework i18n should not be a README claim.
 
-Palamedes keeps 24 examples in the repo: six framework families, each with
-cookie, route, subdomain, and tld locale strategies. The screenshots are
-versioned and come from the same verification flow used in CI.
+Palamedes keeps 25 examples in the repo: six server framework families, each
+with cookie, route, subdomain, and tld locale strategies, plus a Vite MDX app.
+All 25 are smoke-checked on relevant PRs and `main`; 21 browser-capable apps
+run Playwright weekly or manually, and 20 UI-adapter apps have versioned
+screenshots.
 
 Evidence: `docs/example-screenshots`
 

--- a/site/scripts/prebuild-content.mjs
+++ b/site/scripts/prebuild-content.mjs
@@ -5,6 +5,7 @@ import { dirname, extname, join, posix, relative, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 
 import { generateApiDocs } from "ardo/typedoc"
+import { EXAMPLE_MATRIX, selectBrowserExamples } from "../../scripts/example-matrix.mjs"
 
 const siteRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..")
 const repoRoot = resolve(siteRoot, "..")
@@ -95,11 +96,19 @@ async function writeContentStats(adrEntries) {
   const exampleDirs = (await readdir(join(repoRoot, "examples"), { withFileTypes: true }))
     .filter((entry) => entry.isDirectory())
     .map((entry) => entry.name)
+  const matrixIds = new Set(EXAMPLE_MATRIX.map((example) => example.id))
+
+  if (matrixIds.size !== exampleDirs.length || exampleDirs.some((id) => !matrixIds.has(id))) {
+    throw new Error("The example matrix and examples directory must contain the same entries")
+  }
+
   const frameworks = new Set(exampleDirs.map((name) => name.slice(0, name.lastIndexOf("-"))))
   const strategies = new Set(exampleDirs.map((name) => name.slice(name.lastIndexOf("-") + 1)))
   const stats = {
     adrCount: adrEntries.length,
     exampleCount: exampleDirs.length,
+    smokeExampleCount: EXAMPLE_MATRIX.length,
+    browserExampleCount: selectBrowserExamples({}).length,
     frameworkCount: frameworks.size,
     strategyCount: strategies.size,
   }

--- a/site/scripts/prebuild-content.mjs
+++ b/site/scripts/prebuild-content.mjs
@@ -5,7 +5,13 @@ import { dirname, extname, join, posix, relative, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 
 import { generateApiDocs } from "ardo/typedoc"
-import { EXAMPLE_MATRIX, selectBrowserExamples } from "../../scripts/example-matrix.mjs"
+import {
+  EXAMPLE_MATRIX,
+  LOCALE_STRATEGIES,
+  SERVER_FRAMEWORKS,
+  selectBrowserExamples,
+  selectScreenshotExamples,
+} from "../../scripts/example-matrix.mjs"
 
 const siteRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..")
 const repoRoot = resolve(siteRoot, "..")
@@ -102,15 +108,14 @@ async function writeContentStats(adrEntries) {
     throw new Error("The example matrix and examples directory must contain the same entries")
   }
 
-  const frameworks = new Set(exampleDirs.map((name) => name.slice(0, name.lastIndexOf("-"))))
-  const strategies = new Set(exampleDirs.map((name) => name.slice(name.lastIndexOf("-") + 1)))
   const stats = {
     adrCount: adrEntries.length,
     exampleCount: exampleDirs.length,
     smokeExampleCount: EXAMPLE_MATRIX.length,
     browserExampleCount: selectBrowserExamples({}).length,
-    frameworkCount: frameworks.size,
-    strategyCount: strategies.size,
+    screenshotExampleCount: selectScreenshotExamples({}).length,
+    serverFrameworkCount: SERVER_FRAMEWORKS.length,
+    localeStrategyCount: LOCALE_STRATEGIES.length,
   }
   const generatedDir = join(siteRoot, "app/data/generated")
   await mkdir(generatedDir, { recursive: true })


### PR DESCRIPTION
## Summary

Adds a path-filtered Example Verification workflow that builds workspace packages and smoke-tests all 25 examples on relevant pull requests and main pushes. The weekly and opt-in manual lane also runs the existing Playwright contract for 21 browser-capable examples, retaining screenshot diagnostics for seven days.

The browser selector now intentionally excludes the four server-first Remix v3 examples, whose shared client-interaction contract is not implemented; they remain covered across all four strategies by smoke verification. A matrix guard asserts the complete six-family × four-strategy coverage plus Vite MDX.

## Issue

Closes #574

## Validation

- pnpm check:example-matrix
- pnpm format:check
- targeted ESLint for changed verifier scripts
- RUSTUP_TOOLCHAIN=1.95-aarch64-apple-darwin pnpm build
- RUSTUP_TOOLCHAIN=1.95-aarch64-apple-darwin pnpm verify:examples:smoke -- --framework remix
- RUSTUP_TOOLCHAIN=1.95-aarch64-apple-darwin pnpm verify:examples:smoke -- --framework react-router
- RUSTUP_TOOLCHAIN=1.95-aarch64-apple-darwin PALAMEDES_SCREENSHOT_DIR=/tmp/palamedes-browser-diagnostics pnpm verify:examples:browser -- --framework react-router --capture-screenshots

## Follow-up

The existing remix@next canary defect is tracked separately in #586 and is intentionally not changed here.

🔧 Emily Carter · Implementation Agent