### PR TITLE
fix(core): reject invalid plural ICU patches

### DIFF
--- a/crates/palamedes-node/Cargo.toml
+++ b/crates/palamedes-node/Cargo.toml
@@ -12,6 +12,9 @@ publish = false
 path = "src/lib.rs"
 crate-type = ["cdylib"]
 
+[features]
+test-support = ["palamedes/test-support"]
+
 [dependencies]
 napi = { version = "3.9.4", default-features = false, features = ["napi9"] }
 napi-derive = "3.5.7"

--- a/crates/palamedes-node/src/catalog.rs
+++ b/crates/palamedes-node/src/catalog.rs
@@ -1,7 +1,8 @@
 use std::collections::{BTreeMap, HashMap};
 use std::path::PathBuf;
 
-use napi::bindgen_prelude::{Either, Result};
+use napi::bindgen_prelude::{Either, JsObjectValue, Result};
+use napi::{Env, Error, Status};
 use napi_derive::napi;
 
 use crate::catalog_config::{
@@ -239,6 +240,11 @@ pub struct TranslationPatchResult {
     pub outcomes: Vec<TranslationPatchOutcome>,
     pub diagnostics: Vec<TranslationWorkflowDiagnostic>,
 }
+
+const TRANSLATION_PATCH_WRITE_ERROR_CODE: &str = "ERR_PALAMEDES_TRANSLATION_PATCH_WRITE";
+const TRANSLATION_PATCH_WRITE_CAUSE_CODE: &str = "ERR_PALAMEDES_CATALOG_WRITE";
+const TRANSLATION_PATCH_WRITE_ERROR_MESSAGE: &str =
+    "Failed to replace a translation catalog; completed per-file outcomes are available in error.report.";
 
 #[napi(object)]
 pub struct CatalogCombineInput {
@@ -1712,14 +1718,69 @@ pub fn list_translation_candidates(
 ///
 /// # Errors
 ///
-/// Returns an error when a configured catalog cannot be read, rendered, or replaced.
+/// Returns an error when a configured catalog cannot be read, rendered, or replaced. A replacement
+/// failure throws an error with code `ERR_PALAMEDES_TRANSLATION_PATCH_WRITE`; its `report`
+/// property contains completed per-file outcomes, while `cause` contains the catalog write error.
 pub fn apply_translation_patches(
+    env: Env,
     request: TranslationPatchRequest,
 ) -> Result<TranslationPatchResult> {
     let request = request.try_into()?;
-    palamedes::apply_translation_patches(request)
-        .map_err(to_napi_error)
-        .and_then(TranslationPatchResult::try_from)
+    translation_patch_result_or_throw(env, palamedes::apply_translation_patches(request))
+}
+
+#[cfg(feature = "test-support")]
+#[doc(hidden)]
+#[napi(catch_unwind)]
+#[allow(clippy::needless_pass_by_value)]
+pub fn apply_translation_patches_with_injected_write_failure(
+    env: Env,
+    request: TranslationPatchRequest,
+    failing_path: String,
+) -> Result<TranslationPatchResult> {
+    let request = request.try_into()?;
+    translation_patch_result_or_throw(
+        env,
+        palamedes::apply_translation_patches_with_injected_write_failure(
+            request,
+            std::path::Path::new(&failing_path),
+        ),
+    )
+}
+
+fn translation_patch_result_or_throw(
+    env: Env,
+    result: palamedes::PalamedesResult<palamedes::TranslationPatchResult>,
+) -> Result<TranslationPatchResult> {
+    match result {
+        Ok(result) => TranslationPatchResult::try_from(result),
+        Err(palamedes::PalamedesError::TranslationPatchWrite { result, source }) => {
+            throw_translation_patch_write_error(env, result, source)
+        }
+        Err(error) => Err(to_napi_error(error)),
+    }
+}
+
+fn throw_translation_patch_write_error(
+    env: Env,
+    result: palamedes::TranslationPatchResult,
+    source: Box<palamedes::PalamedesError>,
+) -> Result<TranslationPatchResult> {
+    let report = TranslationPatchResult::try_from(result)?;
+    let mut cause = env.create_error(Error::new(Status::GenericFailure, source.to_string()))?;
+    cause.set_named_property("code", TRANSLATION_PATCH_WRITE_CAUSE_CODE)?;
+    let mut error = env.create_error(Error::new(
+        Status::GenericFailure,
+        TRANSLATION_PATCH_WRITE_ERROR_MESSAGE,
+    ))?;
+    error.set_named_property("code", TRANSLATION_PATCH_WRITE_ERROR_CODE)?;
+    error.set_named_property("cause", cause)?;
+    error.set_named_property("report", report)?;
+    env.throw(error)?;
+    Err(Error::new(
+        Status::PendingException,
+        "translation patch catalog replacement failed",
+    ))
 }
 
 #[napi(catch_unwind)]

--- a/crates/palamedes-node/src/catalog.rs
+++ b/crates/palamedes-node/src/catalog.rs
@@ -1705,7 +1705,10 @@ pub fn list_translation_candidates(
 
 #[napi(catch_unwind)]
 #[allow(clippy::needless_pass_by_value)]
-/// Validates and atomically applies provider-neutral translation patches.
+/// Validates provider-neutral translation patches and atomically replaces each changed catalog.
+///
+/// Validation failures leave every catalog unchanged. A batch spanning multiple catalogs has
+/// per-file atomicity rather than filesystem-transaction semantics.
 ///
 /// # Errors
 ///

--- a/crates/palamedes/Cargo.toml
+++ b/crates/palamedes/Cargo.toml
@@ -7,6 +7,9 @@ repository.workspace = true
 rust-version.workspace = true
 description = "Rust core for Palamedes."
 
+[features]
+test-support = []
+
 [dependencies]
 ferrocat = "=3.4.2"
 ferrocat-icu = "=3.4.2"

--- a/crates/palamedes/src/error.rs
+++ b/crates/palamedes/src/error.rs
@@ -2,6 +2,8 @@ use std::path::PathBuf;
 
 use thiserror::Error;
 
+use crate::TranslationPatchResult;
+
 /// Shared result type for the Rust core.
 pub type PalamedesResult<T> = Result<T, PalamedesError>;
 
@@ -34,6 +36,17 @@ pub enum PalamedesError {
         #[source]
         /// Underlying filesystem error.
         source: std::io::Error,
+    },
+    /// Replacing a translation catalog failed after one or more catalog outcomes completed.
+    #[error(
+        "Failed to replace a translation catalog; inspect translation_patch_result() for completed outcomes: {source}"
+    )]
+    TranslationPatchWrite {
+        /// Completed per-file outcomes before the failing catalog replacement.
+        result: TranslationPatchResult,
+        #[source]
+        /// Underlying catalog replacement failure.
+        source: Box<PalamedesError>,
     },
     /// The worker pool for parallel extraction could not be created.
     #[error("Could not create the extraction worker pool: {message}")]
@@ -224,4 +237,15 @@ pub enum PalamedesError {
         /// Source location of the nested macro.
         location: String,
     },
+}
+
+impl PalamedesError {
+    /// Returns completed translation-patch outcomes retained with a write failure.
+    #[must_use]
+    pub fn translation_patch_result(&self) -> Option<&TranslationPatchResult> {
+        match self {
+            Self::TranslationPatchWrite { result, .. } => Some(result),
+            _ => None,
+        }
+    }
 }

--- a/crates/palamedes/src/lib.rs
+++ b/crates/palamedes/src/lib.rs
@@ -117,6 +117,9 @@ pub use transform::{
     transform_macros, NativeTransformEdit, NativeTransformOptions, NativeTransformResult,
     NativeTransformSourceMap, ServerFunctionTransformOptions,
 };
+#[cfg(feature = "test-support")]
+#[doc(hidden)]
+pub use translation_candidates::apply_translation_patches_with_injected_write_failure;
 pub use translation_candidates::{
     apply_translation_patches, list_translation_candidates, TranslationCandidate,
     TranslationCandidateId, TranslationCandidateRequest, TranslationCandidateResult,

--- a/crates/palamedes/src/translation_candidates.rs
+++ b/crates/palamedes/src/translation_candidates.rs
@@ -373,6 +373,16 @@ pub fn list_translation_candidates(
 pub fn apply_translation_patches(
     request: TranslationPatchRequest,
 ) -> PalamedesResult<TranslationPatchResult> {
+    apply_translation_patches_with_replacement(request, atomic_replace_catalog)
+}
+
+fn apply_translation_patches_with_replacement<F>(
+    request: TranslationPatchRequest,
+    mut replace_catalog: F,
+) -> PalamedesResult<TranslationPatchResult>
+where
+    F: FnMut(&PreparedCatalog, &str, Option<&PoOutputOptions>) -> PalamedesResult<()>,
+{
     let requested_count = request.patches.len();
     if request.patches.is_empty() {
         return Ok(TranslationPatchResult {
@@ -579,7 +589,7 @@ pub fn apply_translation_patches(
     for catalog in &prepared {
         if catalog.changed {
             if let Err(source) =
-                atomic_replace_catalog(catalog, &request.config.source_locale, request.po.as_ref())
+                replace_catalog(catalog, &request.config.source_locale, request.po.as_ref())
             {
                 return Err(PalamedesError::TranslationPatchWrite {
                     result: completed_translation_patch_result(
@@ -602,6 +612,23 @@ pub fn apply_translation_patches(
         &completed_patches,
         catalogs_updated,
     ))
+}
+
+#[cfg(feature = "test-support")]
+#[doc(hidden)]
+pub fn apply_translation_patches_with_injected_write_failure(
+    request: TranslationPatchRequest,
+    failing_path: &std::path::Path,
+) -> PalamedesResult<TranslationPatchResult> {
+    apply_translation_patches_with_replacement(request, |catalog, source_locale, po| {
+        if catalog.path == failing_path {
+            return Err(PalamedesError::WriteFile {
+                path: catalog.path.clone(),
+                source: std::io::Error::other("injected catalog replacement failure"),
+            });
+        }
+        atomic_replace_catalog(catalog, source_locale, po)
+    })
 }
 
 fn default_max_origins() -> usize {
@@ -1193,12 +1220,13 @@ mod tests {
     };
 
     use super::{
-        apply_translation_patches, list_translation_candidates, TranslationCandidate,
+        apply_translation_patches, apply_translation_patches_with_replacement,
+        atomic_replace_catalog, list_translation_candidates, TranslationCandidate,
         TranslationCandidateId, TranslationCandidateRequest, TranslationMachineProvenance,
         TranslationPatch, TranslationPatchOutcomeStatus, TranslationPatchRequest,
         TranslationPluralKind, TranslationValue,
     };
-    use crate::{CatalogArtifactConfig, CatalogConfig, PalamedesCatalogFormat};
+    use crate::{CatalogArtifactConfig, CatalogConfig, PalamedesCatalogFormat, PalamedesError};
 
     const FIXTURE: &str = include_str!("../fixtures/translation-workflow.de.po");
 
@@ -1702,11 +1730,8 @@ mod tests {
         assert_eq!(fs::read_to_string(&path).unwrap(), before);
     }
 
-    #[cfg(unix)]
     #[test]
     fn retains_completed_per_file_outcomes_when_a_later_replacement_fails() {
-        use std::os::unix::fs::PermissionsExt;
-
         let fixture = tempfile::tempdir().expect("fixture directory");
         let first_path = fixture.path().join("first/de.po");
         let second_path = fixture.path().join("second/de.po");
@@ -1732,24 +1757,35 @@ mod tests {
             .iter()
             .find(|candidate| candidate.id.catalog == "second/{locale}")
             .expect("second catalog candidate");
-        let second_directory = second_path.parent().expect("second catalog directory");
-        let original_permissions = fs::metadata(second_directory)
-            .expect("read second directory permissions")
-            .permissions();
-        fs::set_permissions(second_directory, std::fs::Permissions::from_mode(0o555))
-            .expect("make second catalog directory read-only");
-        let result = apply_translation_patches(TranslationPatchRequest {
-            config: two_catalog_config(fixture.path()),
-            po: None,
-            patches: vec![
-                singular_patch(first, "Hallo"),
-                singular_patch(second, "Servus"),
-            ],
-        });
-        fs::set_permissions(second_directory, original_permissions)
-            .expect("restore second catalog directory permissions");
+        let result = apply_translation_patches_with_replacement(
+            TranslationPatchRequest {
+                config: two_catalog_config(fixture.path()),
+                po: None,
+                patches: vec![
+                    singular_patch(first, "Hallo"),
+                    singular_patch(second, "Servus"),
+                ],
+            },
+            |catalog, source_locale, po| {
+                if catalog.path == second_path {
+                    return Err(PalamedesError::WriteFile {
+                        path: catalog.path.clone(),
+                        source: std::io::Error::other("injected catalog replacement failure"),
+                    });
+                }
+                atomic_replace_catalog(catalog, source_locale, po)
+            },
+        );
 
         let error = result.expect_err("second replacement should fail");
+        let PalamedesError::TranslationPatchWrite { source, .. } = &error else {
+            panic!("expected a translation patch write error");
+        };
+        let PalamedesError::WriteFile { source, .. } = source.as_ref() else {
+            panic!("expected the injected write-file source error");
+        };
+        assert_eq!(source.kind(), std::io::ErrorKind::Other);
+        assert_eq!(source.to_string(), "injected catalog replacement failure");
         let report = error
             .translation_patch_result()
             .expect("write error retains completed patch report");

--- a/crates/palamedes/src/translation_candidates.rs
+++ b/crates/palamedes/src/translation_candidates.rs
@@ -198,7 +198,7 @@ pub struct TranslationPatchResult {
     pub stats: TranslationPatchStats,
     /// One outcome per requested patch in request order.
     pub outcomes: Vec<TranslationPatchOutcome>,
-    /// Structured validation diagnostics. Any error leaves all catalogs unchanged.
+    /// Structured validation diagnostics. Validation failures leave all catalogs unchanged.
     pub diagnostics: Vec<TranslationWorkflowDiagnostic>,
 }
 
@@ -226,7 +226,7 @@ pub enum TranslationPatchOutcomeStatus {
     Unchanged,
     /// Patch was rejected by validation.
     Rejected,
-    /// Patch was valid but not written because another patch invalidated the atomic batch.
+    /// Patch was valid but its catalog was not replaced before the batch stopped.
     NotApplied,
 }
 
@@ -270,6 +270,7 @@ struct PreparedCatalog {
     path: PathBuf,
     format: PalamedesCatalogFormat,
     locale: String,
+    patch_indexes: Vec<usize>,
     content: String,
     changed: bool,
 }
@@ -366,7 +367,9 @@ pub fn list_translation_candidates(
 ///
 /// # Errors
 ///
-/// Returns an error when catalogs cannot be read, parsed, rendered, or replaced.
+/// Returns an error when catalogs cannot be read, parsed, rendered, or replaced. When replacing
+/// a later catalog fails, the error retains the completed per-file report through
+/// [`PalamedesError::translation_patch_result`].
 pub fn apply_translation_patches(
     request: TranslationPatchRequest,
 ) -> PalamedesResult<TranslationPatchResult> {
@@ -387,6 +390,15 @@ pub fn apply_translation_patches(
     let mut groups = BTreeMap::<CatalogBatchKey, Vec<usize>>::new();
 
     for (index, patch) in request.patches.iter().enumerate() {
+        for message in validate_plural_translation_branches(&patch.translation) {
+            rejected.insert(index);
+            diagnostics.push(workflow_diagnostic(
+                "translation.invalid_icu",
+                message,
+                Some(patch.id.clone()),
+            ));
+        }
+
         if let Some(previous) = identities.insert(patch.id.clone(), index) {
             rejected.insert(previous);
             rejected.insert(index);
@@ -528,6 +540,7 @@ pub fn apply_translation_patches(
                 path: loaded.path,
                 format: loaded.format,
                 locale: batch.locale,
+                patch_indexes,
                 changed: content != loaded.original,
                 content,
             });
@@ -561,35 +574,34 @@ pub fn apply_translation_patches(
         });
     }
 
-    let catalogs_updated = prepared.iter().filter(|catalog| catalog.changed).count();
-    for catalog in prepared.iter().filter(|catalog| catalog.changed) {
-        atomic_replace_catalog(catalog, &request.config.source_locale, request.po.as_ref())?;
+    let mut completed_patches = BTreeSet::new();
+    let mut catalogs_updated = 0;
+    for catalog in &prepared {
+        if catalog.changed {
+            if let Err(source) =
+                atomic_replace_catalog(catalog, &request.config.source_locale, request.po.as_ref())
+            {
+                return Err(PalamedesError::TranslationPatchWrite {
+                    result: completed_translation_patch_result(
+                        &request.patches,
+                        &changed_patches,
+                        &completed_patches,
+                        catalogs_updated,
+                    ),
+                    source: Box::new(source),
+                });
+            }
+            catalogs_updated += 1;
+        }
+        completed_patches.extend(&catalog.patch_indexes);
     }
-    let outcomes = request
-        .patches
-        .into_iter()
-        .enumerate()
-        .map(|(index, patch)| TranslationPatchOutcome {
-            id: patch.id,
-            status: if changed_patches.contains(&index) {
-                TranslationPatchOutcomeStatus::Applied
-            } else {
-                TranslationPatchOutcomeStatus::Unchanged
-            },
-        })
-        .collect();
 
-    Ok(TranslationPatchResult {
-        updated: catalogs_updated > 0,
-        stats: TranslationPatchStats {
-            requested: requested_count,
-            applied: changed_patches.len(),
-            unchanged: requested_count - changed_patches.len(),
-            catalogs_updated,
-        },
-        outcomes,
-        diagnostics,
-    })
+    Ok(completed_translation_patch_result(
+        &request.patches,
+        &changed_patches,
+        &completed_patches,
+        catalogs_updated,
+    ))
 }
 
 fn default_max_origins() -> usize {
@@ -904,6 +916,31 @@ fn validate_patch_translation(
     }
 }
 
+fn validate_plural_translation_branches(value: &TranslationValue) -> Vec<String> {
+    let TranslationValue::Plural {
+        variable,
+        plural_kind,
+        values,
+        ..
+    } = value
+    else {
+        return Vec::new();
+    };
+
+    values
+        .iter()
+        .filter_map(|(selector, branch)| {
+            parse_plural_branch(variable, *plural_kind, branch)
+                .err()
+                .map(|source| {
+                    format!(
+                        "Plural translation branch `translation.values.{selector}` is not valid ICU: {source}"
+                    )
+                })
+        })
+        .collect()
+}
+
 fn validate_machine_provenance(machine: &TranslationMachineProvenance) -> Result<(), &'static str> {
     if let Some(ai) = &machine.ai {
         if ai.model.trim().is_empty() {
@@ -1086,6 +1123,45 @@ fn find_po_item<'a>(po: &'a PoFile, key: &CatalogMessageKey) -> Option<&'a PoIte
     po.items
         .iter()
         .find(|item| item.msgid == key.msgid && item.msgctxt == key.msgctxt)
+}
+
+fn completed_translation_patch_result(
+    patches: &[TranslationPatch],
+    changed_patches: &BTreeSet<usize>,
+    completed_patches: &BTreeSet<usize>,
+    catalogs_updated: usize,
+) -> TranslationPatchResult {
+    let applied = changed_patches
+        .iter()
+        .filter(|index| completed_patches.contains(index))
+        .count();
+    let unchanged = completed_patches.len() - applied;
+    let outcomes = patches
+        .iter()
+        .enumerate()
+        .map(|(index, patch)| TranslationPatchOutcome {
+            id: patch.id.clone(),
+            status: if !completed_patches.contains(&index) {
+                TranslationPatchOutcomeStatus::NotApplied
+            } else if changed_patches.contains(&index) {
+                TranslationPatchOutcomeStatus::Applied
+            } else {
+                TranslationPatchOutcomeStatus::Unchanged
+            },
+        })
+        .collect();
+
+    TranslationPatchResult {
+        updated: catalogs_updated > 0,
+        stats: TranslationPatchStats {
+            requested: patches.len(),
+            applied,
+            unchanged,
+            catalogs_updated,
+        },
+        outcomes,
+        diagnostics: Vec::new(),
+    }
 }
 
 fn workflow_diagnostic(
@@ -1489,6 +1565,217 @@ mod tests {
     }
 
     #[test]
+    fn rejects_invalid_plural_icu_as_a_per_patch_diagnostic_without_writing() {
+        let fixture = tempfile::tempdir().expect("fixture directory");
+        let path = fixture.path().join("messages/de.po");
+        write_po_fixture(&path, "de");
+        let listed = list_translation_candidates(&TranslationCandidateRequest {
+            config: po_config(fixture.path()),
+            locales: vec!["de".to_owned()],
+            targets: vec![
+                id("messages/{locale}", "de", "Hello", None),
+                id(
+                    "messages/{locale}",
+                    "de",
+                    "{count, plural, one {# file} other {# files}}",
+                    None,
+                ),
+            ],
+            max_origins: 8,
+        })
+        .expect("list plural patch candidates");
+        let hello = candidate(&listed.candidates, "Hello");
+        let plural = candidate(
+            &listed.candidates,
+            "{count, plural, one {# file} other {# files}}",
+        );
+        let mut translation = plural.source.clone();
+        let TranslationValue::Plural { values, .. } = &mut translation else {
+            panic!("expected a plural candidate");
+        };
+        values.insert("one".to_owned(), "# Datei }".to_owned());
+        values.insert("other".to_owned(), "# Dateien }".to_owned());
+        let before = fs::read_to_string(&path).expect("read catalog before invalid patch");
+
+        let result = apply_translation_patches(TranslationPatchRequest {
+            config: po_config(fixture.path()),
+            po: None,
+            patches: vec![
+                singular_patch(hello, "Hallo"),
+                TranslationPatch {
+                    id: plural.id.clone(),
+                    fingerprint: plural.fingerprint.clone(),
+                    translation,
+                    machine: None,
+                },
+            ],
+        })
+        .expect("reject invalid ICU as a diagnostic");
+
+        assert!(!result.updated);
+        assert_eq!(result.stats.requested, 2);
+        assert_eq!(
+            result
+                .outcomes
+                .iter()
+                .map(|outcome| outcome.status)
+                .collect::<Vec<_>>(),
+            vec![
+                TranslationPatchOutcomeStatus::NotApplied,
+                TranslationPatchOutcomeStatus::Rejected,
+            ]
+        );
+        let diagnostics = result
+            .diagnostics
+            .iter()
+            .filter(|diagnostic| diagnostic.code == "translation.invalid_icu")
+            .collect::<Vec<_>>();
+        assert_eq!(diagnostics.len(), 2);
+        assert!(diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.id.as_ref() == Some(&plural.id)));
+        assert!(diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.message.contains("translation.values.one")));
+        assert!(diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.message.contains("translation.values.other")));
+        assert_eq!(fs::read_to_string(&path).unwrap(), before);
+    }
+
+    #[test]
+    fn rejects_invalid_selectordinal_branch_as_a_structured_diagnostic() {
+        let fixture = tempfile::tempdir().expect("fixture directory");
+        let path = fixture.path().join("messages/de.po");
+        write_po_fixture(&path, "de");
+        let content = fs::read_to_string(&path).expect("read fixture");
+        fs::write(
+            &path,
+            format!(
+                "{content}\nmsgid \"{{position, selectordinal, one {{#st}} two {{#nd}} few {{#rd}} other {{#th}}}}\"\nmsgstr \"\"\n"
+            ),
+        )
+        .expect("add ordinal candidate");
+        let source = "{position, selectordinal, one {#st} two {#nd} few {#rd} other {#th}}";
+        let listed = list_translation_candidates(&TranslationCandidateRequest {
+            config: po_config(fixture.path()),
+            locales: vec!["de".to_owned()],
+            targets: vec![id("messages/{locale}", "de", source, None)],
+            max_origins: 8,
+        })
+        .expect("list ordinal candidate");
+        let ordinal = candidate(&listed.candidates, source);
+        let mut translation = ordinal.source.clone();
+        let TranslationValue::Plural {
+            plural_kind,
+            values,
+            ..
+        } = &mut translation
+        else {
+            panic!("expected an ordinal plural candidate");
+        };
+        assert_eq!(*plural_kind, TranslationPluralKind::Ordinal);
+        values.insert("other".to_owned(), "#te }".to_owned());
+        let before = fs::read_to_string(&path).expect("read catalog before invalid ordinal patch");
+
+        let result = apply_translation_patches(TranslationPatchRequest {
+            config: po_config(fixture.path()),
+            po: None,
+            patches: vec![TranslationPatch {
+                id: ordinal.id.clone(),
+                fingerprint: ordinal.fingerprint.clone(),
+                translation,
+                machine: None,
+            }],
+        })
+        .expect("reject invalid ordinal ICU as a diagnostic");
+
+        assert_eq!(
+            result.outcomes[0].status,
+            TranslationPatchOutcomeStatus::Rejected
+        );
+        assert!(result.diagnostics.iter().any(|diagnostic| {
+            diagnostic.code == "translation.invalid_icu"
+                && diagnostic.id.as_ref() == Some(&ordinal.id)
+                && diagnostic.message.contains("translation.values.other")
+        }));
+        assert_eq!(fs::read_to_string(&path).unwrap(), before);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn retains_completed_per_file_outcomes_when_a_later_replacement_fails() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let fixture = tempfile::tempdir().expect("fixture directory");
+        let first_path = fixture.path().join("first/de.po");
+        let second_path = fixture.path().join("second/de.po");
+        write_po_fixture(&first_path, "de");
+        write_po_fixture(&second_path, "de");
+        let listed = list_translation_candidates(&TranslationCandidateRequest {
+            config: two_catalog_config(fixture.path()),
+            locales: vec!["de".to_owned()],
+            targets: vec![
+                id("first/{locale}", "de", "Hello", None),
+                id("second/{locale}", "de", "Hello", None),
+            ],
+            max_origins: 8,
+        })
+        .expect("list candidates for both files");
+        let first = listed
+            .candidates
+            .iter()
+            .find(|candidate| candidate.id.catalog == "first/{locale}")
+            .expect("first catalog candidate");
+        let second = listed
+            .candidates
+            .iter()
+            .find(|candidate| candidate.id.catalog == "second/{locale}")
+            .expect("second catalog candidate");
+        let second_directory = second_path.parent().expect("second catalog directory");
+        let original_permissions = fs::metadata(second_directory)
+            .expect("read second directory permissions")
+            .permissions();
+        fs::set_permissions(second_directory, std::fs::Permissions::from_mode(0o555))
+            .expect("make second catalog directory read-only");
+        let result = apply_translation_patches(TranslationPatchRequest {
+            config: two_catalog_config(fixture.path()),
+            po: None,
+            patches: vec![
+                singular_patch(first, "Hallo"),
+                singular_patch(second, "Servus"),
+            ],
+        });
+        fs::set_permissions(second_directory, original_permissions)
+            .expect("restore second catalog directory permissions");
+
+        let error = result.expect_err("second replacement should fail");
+        let report = error
+            .translation_patch_result()
+            .expect("write error retains completed patch report");
+        assert!(report.updated);
+        assert_eq!(report.stats.catalogs_updated, 1);
+        assert_eq!(report.stats.applied, 1);
+        assert_eq!(
+            report
+                .outcomes
+                .iter()
+                .map(|outcome| outcome.status)
+                .collect::<Vec<_>>(),
+            vec![
+                TranslationPatchOutcomeStatus::Applied,
+                TranslationPatchOutcomeStatus::NotApplied,
+            ]
+        );
+        assert!(fs::read_to_string(&first_path)
+            .expect("read first catalog")
+            .contains("msgstr \"Hallo\""));
+        assert!(fs::read_to_string(&second_path)
+            .expect("read second catalog")
+            .contains("msgstr \"\""));
+    }
+
+    #[test]
     fn rejects_duplicate_unknown_and_stale_patches_without_writing() {
         let fixture = tempfile::tempdir().expect("fixture directory");
         let path = fixture.path().join("messages/de.po");
@@ -1643,6 +1930,26 @@ mod tests {
         config.locales = vec!["en".to_owned(), "de".to_owned()];
         config.catalogs.remove(0);
         config
+    }
+
+    fn two_catalog_config(root: &Path) -> CatalogArtifactConfig {
+        CatalogArtifactConfig {
+            root_dir: root.to_string_lossy().into_owned(),
+            locales: vec!["en".to_owned(), "de".to_owned()],
+            source_locale: "en".to_owned(),
+            fallback_locales: None,
+            pseudo_locale: None,
+            catalogs: vec![
+                CatalogConfig {
+                    path: "first/{locale}".to_owned(),
+                    format: PalamedesCatalogFormat::Po,
+                },
+                CatalogConfig {
+                    path: "second/{locale}".to_owned(),
+                    format: PalamedesCatalogFormat::Po,
+                },
+            ],
+        }
     }
 
     fn write_catalog_matrix(root: &Path) {

--- a/docs/translation-candidate-patches.md
+++ b/docs/translation-candidate-patches.md
@@ -51,7 +51,10 @@ files has per-file atomicity; it is not a filesystem transaction across files.
 If a later replacement fails, the call still returns a hard error. Rust callers
 can recover the completed per-file outcomes from
 `PalamedesError::translation_patch_result()`; remaining patches are reported as
-`notApplied`.
+`notApplied`. Node callers receive an `Error` with code
+`ERR_PALAMEDES_TRANSLATION_PATCH_WRITE`; its `report` property is the completed
+`TranslationPatchResult`, and its `cause` describes the failed catalog write.
+This remains an error rather than a successful partial result.
 
 Applying a patch does not clear `fuzzy` or other review flags automatically.
 That is workflow policy and remains the caller's responsibility.
@@ -61,6 +64,7 @@ That is workflow policy and remains the caller's responsibility.
 ```ts
 import {
   applyTranslationPatches,
+  isTranslationPatchWriteError,
   listTranslationCandidates,
   type CatalogArtifactConfig,
   type TranslationPatch,
@@ -110,7 +114,15 @@ const patches: TranslationPatch[] = candidates.map((candidate) => ({
         },
 }))
 
-const result = applyTranslationPatches({ config, patches })
+let result
+try {
+  result = applyTranslationPatches({ config, patches })
+} catch (error) {
+  if (isTranslationPatchWriteError(error)) {
+    console.error(error.code, error.message, error.cause, error.report)
+  }
+  throw error
+}
 
 if (result.diagnostics.length > 0) {
   // Re-enumerate stale candidates before retrying them.

--- a/docs/translation-candidate-patches.md
+++ b/docs/translation-candidate-patches.md
@@ -40,14 +40,18 @@ version, discard in-flight candidates and list them again before patching.
 
 `applyTranslationPatches()` validates the complete request before writing any
 catalog. Unknown or ambiguous catalogs, unknown messages, duplicate identities,
-stale fingerprints, shape mismatches, and invalid provenance are returned as
-structured diagnostics. A rejected validation batch leaves every original
-catalog unchanged.
+stale fingerprints, shape mismatches, invalid ICU plural branches, and invalid
+provenance are returned as structured diagnostics with the rejected patch
+identity. A rejected validation batch leaves every original catalog unchanged.
 
 On success, Palamedes preserves unrelated translations, comments, origins,
 flags, obsolete entries, and PO headers. Each changed PO or FCL file is replaced
 atomically through Ferrocat's format-aware writer. A batch spanning several
 files has per-file atomicity; it is not a filesystem transaction across files.
+If a later replacement fails, the call still returns a hard error. Rust callers
+can recover the completed per-file outcomes from
+`PalamedesError::translation_patch_result()`; remaining patches are reported as
+`notApplied`.
 
 Applying a patch does not clear `fuzzy` or other review flags automatically.
 That is workflow policy and remains the caller's responsibility.

--- a/packages/core-node/src/index.test.ts
+++ b/packages/core-node/src/index.test.ts
@@ -1,6 +1,9 @@
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { execFileSync } from "node:child_process"
+import { createRequire } from "node:module"
+import { copyFile, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
+import { fileURLToPath } from "node:url"
 
 import { afterEach, describe, expect, it } from "vitest"
 
@@ -20,6 +23,11 @@ import {
   transformMacrosNative,
   updateCatalogFile,
 } from "./index"
+import type {
+  NativeBindings as GeneratedNativeBindings,
+  TranslationPatchRequest as GeneratedTranslationPatchRequest,
+  TranslationPatchResult as GeneratedTranslationPatchResult,
+} from "./generated/palamedes-node-types"
 
 type SourceMapLike = {
   mappings?: string
@@ -290,6 +298,87 @@ msgstr ""
     const output = await readFile(targetPath, "utf8")
     expect(output).toContain('msgstr "Hallo"')
     expect(output).toContain("{count, plural, one {# Datei} other {# Dateien}}")
+  })
+
+  it("exposes a partial report on a later native catalog write failure", async () => {
+    const rootDir = await createTempDir()
+    const firstPath = path.join(rootDir, "first", "de.po")
+    const secondPath = path.join(rootDir, "second", "de.po")
+    const config = {
+      rootDir,
+      locales: ["en", "de"],
+      sourceLocale: "en",
+      catalogs: [
+        { path: "first/{locale}", include: ["src"] },
+        { path: "second/{locale}", include: ["src"] },
+      ],
+    }
+    const catalog = `msgid ""
+msgstr ""
+"Language: de\\n"
+
+msgid "Hello"
+msgstr ""
+`
+    await mkdir(path.dirname(firstPath), { recursive: true })
+    await mkdir(path.dirname(secondPath), { recursive: true })
+    await Promise.all([writeFile(firstPath, catalog), writeFile(secondPath, catalog)])
+
+    const addon = await loadTestSupportAddon(rootDir)
+    const listed = addon.listTranslationCandidates({ config, locales: ["de"], maxOrigins: 8 })
+    const first = listed.candidates.find((candidate) => candidate.id.catalog === "first/{locale}")
+    const second = listed.candidates.find((candidate) => candidate.id.catalog === "second/{locale}")
+    if (!first || !second) {
+      throw new Error("Expected candidates from both catalogs")
+    }
+    const request: GeneratedTranslationPatchRequest = {
+      config,
+      patches: [
+        {
+          id: first.id,
+          fingerprint: first.fingerprint,
+          translation: { kind: "Singular", value: "Hallo" },
+        },
+        {
+          id: second.id,
+          fingerprint: second.fingerprint,
+          translation: { kind: "Singular", value: "Servus" },
+        },
+      ],
+    }
+
+    let thrown: unknown
+    try {
+      addon.applyTranslationPatchesWithInjectedWriteFailure(request, secondPath)
+      throw new Error("Expected the injected replacement failure")
+    } catch (error) {
+      thrown = error
+    }
+    const error = thrown as Error & {
+      code?: unknown
+      cause?: Error & { code?: unknown }
+      report?: GeneratedTranslationPatchResult
+    }
+
+    expect(error).toBeInstanceOf(Error)
+    expect(error.message).toBe(
+      "Failed to replace a translation catalog; completed per-file outcomes are available in error.report."
+    )
+    expect(error.code).toBe("ERR_PALAMEDES_TRANSLATION_PATCH_WRITE")
+    expect(error.cause).toBeInstanceOf(Error)
+    expect(error.cause?.code).toBe("ERR_PALAMEDES_CATALOG_WRITE")
+    expect(error.cause?.message).toContain("injected catalog replacement failure")
+    expect(error.report).toMatchObject({
+      updated: true,
+      stats: { requested: 2, applied: 1, catalogsUpdated: 1 },
+      outcomes: [
+        { id: first.id, status: "Applied" },
+        { id: second.id, status: "NotApplied" },
+      ],
+      diagnostics: [],
+    })
+    await expect(readFile(firstPath, "utf8")).resolves.toContain('msgstr "Hallo"')
+    await expect(readFile(secondPath, "utf8")).resolves.toBe(catalog)
   })
 
   it("patches candidates listed with truncated origins using a stable fingerprint", async () => {
@@ -639,4 +728,30 @@ async function createTempDir(): Promise<string> {
   const dir = await mkdtemp(path.join(os.tmpdir(), "palamedes-core-node-"))
   tempDirs.push(dir)
   return dir
+}
+
+type TestSupportBindings = Pick<GeneratedNativeBindings, "listTranslationCandidates"> & {
+  applyTranslationPatchesWithInjectedWriteFailure(
+    request: GeneratedTranslationPatchRequest,
+    failingPath: string
+  ): GeneratedTranslationPatchResult
+}
+
+async function loadTestSupportAddon(tempDir: string): Promise<TestSupportBindings> {
+  const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..")
+  execFileSync("cargo", ["build", "--package", "palamedes-node", "--features", "test-support"], {
+    cwd: repoRoot,
+    stdio: "inherit",
+  })
+  const extension =
+    process.platform === "win32" ? "dll" : process.platform === "darwin" ? "dylib" : "so"
+  const libraryName = `${process.platform === "win32" ? "" : "lib"}palamedes_node.${extension}`
+  const addonPath = path.join(tempDir, "palamedes-node.node")
+  await copyFile(path.join(repoRoot, "target", "debug", libraryName), addonPath)
+  if (process.platform === "darwin") {
+    execFileSync("codesign", ["--force", "--sign", "-", "--timestamp=none", addonPath], {
+      stdio: "inherit",
+    })
+  }
+  return createRequire(import.meta.url)(addonPath) as TestSupportBindings
 }

--- a/packages/core-node/src/index.test.ts
+++ b/packages/core-node/src/index.test.ts
@@ -379,7 +379,7 @@ msgstr ""
     })
     await expect(readFile(firstPath, "utf8")).resolves.toContain('msgstr "Hallo"')
     await expect(readFile(secondPath, "utf8")).resolves.toBe(catalog)
-  })
+  }, 30_000)
 
   it("patches candidates listed with truncated origins using a stable fingerprint", async () => {
     const rootDir = await createTempDir()

--- a/packages/core-node/src/index.ts
+++ b/packages/core-node/src/index.ts
@@ -174,6 +174,14 @@ export type TranslationPatchResult = Omit<
   outcomes: TranslationPatchOutcome[]
   diagnostics: TranslationWorkflowDiagnostic[]
 }
+export const TRANSLATION_PATCH_WRITE_ERROR_CODE = "ERR_PALAMEDES_TRANSLATION_PATCH_WRITE"
+export const TRANSLATION_PATCH_WRITE_ERROR_MESSAGE =
+  "Failed to replace a translation catalog; completed per-file outcomes are available in error.report."
+export type TranslationPatchWriteError = Error & {
+  code: typeof TRANSLATION_PATCH_WRITE_ERROR_CODE
+  cause: Error
+  report: TranslationPatchResult
+}
 export type CatalogAuditDiagnostic = Omit<GeneratedCatalogAuditDiagnostic, "severity"> & {
   severity: CatalogDiagnosticSeverity
 }
@@ -520,7 +528,46 @@ export function applyTranslationPatches(request: TranslationPatchRequest): Trans
     patches: request.patches.map(toNativeTranslationPatch),
     po: toNativePoOptions(request.po),
   }
-  const result: GeneratedTranslationPatchResult = native.applyTranslationPatches(nativeRequest)
+  try {
+    const result: GeneratedTranslationPatchResult = native.applyTranslationPatches(nativeRequest)
+    return fromNativeTranslationPatchResult(result)
+  } catch (error) {
+    if (isNativeTranslationPatchWriteError(error)) {
+      const writeError = error as unknown as TranslationPatchWriteError
+      writeError.report = fromNativeTranslationPatchResult(error.report)
+    }
+    throw error
+  }
+}
+
+export function isTranslationPatchWriteError(error: unknown): error is TranslationPatchWriteError {
+  const candidate = error as { code?: unknown }
+  return (
+    error instanceof Error &&
+    candidate.code === TRANSLATION_PATCH_WRITE_ERROR_CODE &&
+    "report" in error
+  )
+}
+
+type NativeTranslationPatchWriteError = Error & {
+  code: typeof TRANSLATION_PATCH_WRITE_ERROR_CODE
+  report: GeneratedTranslationPatchResult
+}
+
+function isNativeTranslationPatchWriteError(
+  error: unknown
+): error is NativeTranslationPatchWriteError {
+  const candidate = error as { code?: unknown }
+  return (
+    error instanceof Error &&
+    candidate.code === TRANSLATION_PATCH_WRITE_ERROR_CODE &&
+    "report" in error
+  )
+}
+
+function fromNativeTranslationPatchResult(
+  result: GeneratedTranslationPatchResult
+): TranslationPatchResult {
   return {
     ...result,
     outcomes: result.outcomes.map((outcome) => ({


### PR DESCRIPTION
## Summary

- Validate every plural patch branch before catalog mutation and return patch-scoped `translation.invalid_icu` diagnostics.
- Preserve completed per-file outcomes in a hard write error when a later replacement fails.
- Document per-file atomicity and cover plural, selectordinal, batch isolation, and write-failure behavior.

## Validation

- `cargo +1.97.1 test --workspace --locked`
- `cargo +1.97.1 clippy --workspace --all-targets --locked -- -D warnings`
- `cargo +1.97.1 fmt --all --check`
- `pnpm format:check`
- `RUSTUP_TOOLCHAIN=1.97.1 pnpm check:native-types`

Closes #569

🔧 Emily Carter · Implementation Agent