### PR TITLE
chore: remove reactive locale leftovers

### DIFF
--- a/packages/react/src/client.tsx
+++ b/packages/react/src/client.tsx
@@ -155,7 +155,7 @@ export function createClientCatalogBoundary<TLocale extends string>({
     const isClient = typeof window !== "undefined"
     if (isClient && locale !== clientLocale) {
       throw new Error(
-        `Palamedes reload catalog boundary received locale "${locale}", but this document was initialized for "${clientLocale}". Perform a document navigation to change locale.`
+        `Palamedes client catalog boundary received locale "${locale}", but this document was initialized for "${clientLocale}". Perform a document navigation to change locale.`
       )
     }
 

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -107,9 +107,9 @@ function getRegisteredMessageLoaders(
  * runtime rejects unbranded copies. Merging across registrations is the
  * instance's `load()` responsibility.
  *
- * Registrations are module-evaluation facts, not instance state: like the
- * framework bindings' listener stores, they survive `resetI18nRuntime()`,
- * because the registering modules will not evaluate a second time.
+ * Registrations are module-evaluation facts, not instance state. They survive
+ * `resetI18nRuntime()` because the registering modules will not evaluate a
+ * second time.
  */
 export function registerMessages(catalogs: RegisteredMessages): void {
   const state = globalRuntimeState()


### PR DESCRIPTION
## Summary

- Rename the stale client boundary error to match `ClientCatalogBoundary`.
- Remove the deleted listener-store comparison from the runtime registration comment.
- Leave the separately tracked SolidStart bootstrap work out of scope.

## Validation

- `pnpm format:check`
- `pnpm --filter @palamedes/core build`
- `pnpm --filter @palamedes/runtime build`
- `pnpm --filter @palamedes/react build`
- `pnpm --filter @palamedes/react test`
- `pnpm --filter @palamedes/runtime test`
- `pnpm --filter @palamedes/react exec tsc --noEmit -p tsconfig.json`
- `pnpm --filter @palamedes/runtime exec tsc --noEmit -p tsconfig.json`

Closes #593

🔧 Emily Carter · Implementation Agent