### PR TITLE
fix(examples): preserve server locale during hydration

### DIFF
--- a/examples/solidstart-cookie/src/components/ClientReady.tsx
+++ b/examples/solidstart-cookie/src/components/ClientReady.tsx
@@ -1,4 +1,5 @@
 import { createSignal, onMount, Show } from "solid-js"
+import { Trans } from "@palamedes/solid/macro"
 
 export function ClientReady() {
   const [ready, setReady] = createSignal(false)
@@ -9,6 +10,9 @@ export function ClientReady() {
     <Show when={ready()}>
       <span data-testid="client-ready" hidden>
         ready
+      </span>
+      <span data-testid="client-locale-value" hidden>
+        <Trans>Add to cart</Trans>
       </span>
     </Show>
   )

--- a/examples/solidstart-cookie/src/entry-client.tsx
+++ b/examples/solidstart-cookie/src/entry-client.tsx
@@ -1,20 +1,16 @@
 import { mount, StartClient } from "@solidjs/start/client"
 
-import { DEFAULT_LOCALE, LOCALE_COOKIE, normalizeLocale, initializeClientI18n } from "./lib/i18n"
+import { initializeClientI18n, locales } from "./lib/i18n"
 
 function resolveInitialLocale() {
-  const cookieValue = document.cookie
-    .split(";")
-    .map((part) => part.trim())
-    .find((part) => part.startsWith(`${LOCALE_COOKIE}=`))
-    ?.slice(`${LOCALE_COOKIE}=`.length)
-
-  if (cookieValue) {
-    return normalizeLocale(cookieValue)
+  const locale = document.documentElement.lang
+  if (!locales.isLocale(locale)) {
+    throw new Error(
+      `Expected a supported server document locale, received ${JSON.stringify(locale)}`
+    )
   }
 
-  const preferredLanguage = navigator.language.split("-")[0] ?? DEFAULT_LOCALE
-  return normalizeLocale(preferredLanguage)
+  return locale
 }
 
 function ClientEntry() {

--- a/examples/solidstart-cookie/src/entry-server.tsx
+++ b/examples/solidstart-cookie/src/entry-server.tsx
@@ -1,19 +1,25 @@
 import { createHandler, StartServer } from "@solidjs/start/server"
+import { getRequestEvent } from "solid-js/web"
+import { resolveCookieLocale } from "./lib/server"
 
 export default createHandler(() => (
   <StartServer
-    document={({ assets, children, scripts }) => (
-      <html lang="en">
-        <head>
-          <meta charset="utf-8" />
-          <meta content="width=device-width, initial-scale=1" name="viewport" />
-          {assets}
-        </head>
-        <body>
-          <div id="app">{children}</div>
-          {scripts}
-        </body>
-      </html>
-    )}
+    document={({ assets, children, scripts }) => {
+      const { locale } = resolveCookieLocale(getRequestEvent()?.request)
+
+      return (
+        <html lang={locale}>
+          <head>
+            <meta charset="utf-8" />
+            <meta content="width=device-width, initial-scale=1" name="viewport" />
+            {assets}
+          </head>
+          <body>
+            <div id="app">{children}</div>
+            {scripts}
+          </body>
+        </html>
+      )
+    }}
   />
 ))

--- a/examples/solidstart-cookie/src/lib/i18n.ts
+++ b/examples/solidstart-cookie/src/lib/i18n.ts
@@ -54,20 +54,3 @@ export function initializeClientI18n(locale: Locale) {
   clientI18n.activate(locale)
   setClientI18n(clientI18n)
 }
-
-function bootstrapClientI18n() {
-  if (typeof window === "undefined") {
-    return
-  }
-
-  const cookieValue = document.cookie
-    .split(";")
-    .map((part) => part.trim())
-    .find((part) => part.startsWith(`${LOCALE_COOKIE}=`))
-    ?.slice(`${LOCALE_COOKIE}=`.length)
-
-  const preferredLanguage = navigator.language.split("-")[0] ?? DEFAULT_LOCALE
-  void initializeClientI18n(normalizeLocale(cookieValue ?? preferredLanguage))
-}
-
-bootstrapClientI18n()

--- a/examples/solidstart-cookie/src/lib/server.ts
+++ b/examples/solidstart-cookie/src/lib/server.ts
@@ -5,15 +5,19 @@ import { t } from "@palamedes/core/macro"
 import { activateServerI18n } from "./i18n.server"
 import { getLocaleLabel, LOCALE_COOKIE, type Locale, locales } from "./i18n"
 
+export function resolveCookieLocale(request: Request | undefined) {
+  return locales.resolve({
+    strategy: "cookie",
+    acceptLanguageHeader: request?.headers.get("accept-language"),
+    cookieHeader: request?.headers.get("cookie"),
+  })
+}
+
 export const loadHomePageData = query(async () => {
   "use server"
 
   const event = getRequestEvent()
-  const resolved = locales.resolve({
-    strategy: "cookie",
-    acceptLanguageHeader: event?.request.headers.get("accept-language"),
-    cookieHeader: event?.request.headers.get("cookie"),
-  })
+  const resolved = resolveCookieLocale(event?.request)
 
   await activateServerI18n(resolved.locale)
 
@@ -39,11 +43,7 @@ export const getLocalizedServerStatus = query(async () => {
   "use server"
 
   const event = getRequestEvent()
-  const resolved = locales.resolve({
-    strategy: "cookie",
-    acceptLanguageHeader: event?.request.headers.get("accept-language"),
-    cookieHeader: event?.request.headers.get("cookie"),
-  })
+  const resolved = resolveCookieLocale(event?.request)
 
   await activateServerI18n(resolved.locale)
 

--- a/examples/solidstart-route/src/entry-server.tsx
+++ b/examples/solidstart-route/src/entry-server.tsx
@@ -1,19 +1,25 @@
 import { createHandler, StartServer } from "@solidjs/start/server"
+import { getRequestEvent } from "solid-js/web"
+import { resolveRouteLocale } from "./lib/server"
 
 export default createHandler(() => (
   <StartServer
-    document={({ assets, children, scripts }) => (
-      <html lang="en">
-        <head>
-          <meta charset="utf-8" />
-          <meta content="width=device-width, initial-scale=1" name="viewport" />
-          {assets}
-        </head>
-        <body>
-          <div id="app">{children}</div>
-          {scripts}
-        </body>
-      </html>
-    )}
+    document={({ assets, children, scripts }) => {
+      const locale = resolveRouteLocale(getRequestEvent()?.request)
+
+      return (
+        <html lang={locale}>
+          <head>
+            <meta charset="utf-8" />
+            <meta content="width=device-width, initial-scale=1" name="viewport" />
+            {assets}
+          </head>
+          <body>
+            <div id="app">{children}</div>
+            {scripts}
+          </body>
+        </html>
+      )
+    }}
   />
 ))

--- a/examples/solidstart-route/src/lib/server.ts
+++ b/examples/solidstart-route/src/lib/server.ts
@@ -4,6 +4,12 @@ import { t } from "@palamedes/core/macro"
 import { activateServerI18n } from "./i18n.server"
 import { getLocaleLabel, locales, normalizeLocale } from "./i18n"
 
+export function resolveRouteLocale(request: Request | undefined) {
+  const pathname = request ? new URL(request.url).pathname : "/"
+  const routeLocale = pathname.split("/").filter(Boolean)[0]
+  return normalizeLocale(routeLocale)
+}
+
 export const loadRoutePageData = query(async (routeLocale: string) => {
   "use server"
 

--- a/examples/solidstart-subdomain/src/entry-server.tsx
+++ b/examples/solidstart-subdomain/src/entry-server.tsx
@@ -1,19 +1,25 @@
 import { createHandler, StartServer } from "@solidjs/start/server"
+import { getRequestEvent } from "solid-js/web"
+import { resolveHostLocale } from "./lib/server"
 
 export default createHandler(() => (
   <StartServer
-    document={({ assets, children, scripts }) => (
-      <html lang="en">
-        <head>
-          <meta charset="utf-8" />
-          <meta content="width=device-width, initial-scale=1" name="viewport" />
-          {assets}
-        </head>
-        <body>
-          <div id="app">{children}</div>
-          {scripts}
-        </body>
-      </html>
-    )}
+    document={({ assets, children, scripts }) => {
+      const { locale } = resolveHostLocale(getRequestEvent()?.request)
+
+      return (
+        <html lang={locale}>
+          <head>
+            <meta charset="utf-8" />
+            <meta content="width=device-width, initial-scale=1" name="viewport" />
+            {assets}
+          </head>
+          <body>
+            <div id="app">{children}</div>
+            {scripts}
+          </body>
+        </html>
+      )
+    }}
   />
 ))

--- a/examples/solidstart-subdomain/src/lib/server.ts
+++ b/examples/solidstart-subdomain/src/lib/server.ts
@@ -9,23 +9,23 @@ import { getLocaleLabel, locales } from "./i18n"
  * (`de.lvh.me` -> `de`). Server functions run on the same host the browser
  * requested, so the `Host` header is available here too.
  */
-function resolveHostLocale() {
-  const event = getRequestEvent()
-  const requestHost = event?.request.headers.get("host") ?? null
-  const acceptLanguageHeader = event?.request.headers.get("accept-language") ?? null
+export function resolveHostLocale(request: Request | undefined) {
+  const requestHost = request?.headers.get("host") ?? null
+  const acceptLanguageHeader = request?.headers.get("accept-language") ?? null
   const { locale } = locales.resolve({
     strategy: "subdomain",
     acceptLanguageHeader,
     requestHost,
   })
 
-  return { acceptLanguageHeader, event, locale, requestHost }
+  return { acceptLanguageHeader, locale, requestHost }
 }
 
 export const loadHomePageData = query(async () => {
   "use server"
 
-  const { acceptLanguageHeader, event, locale, requestHost } = resolveHostLocale()
+  const event = getRequestEvent()
+  const { acceptLanguageHeader, locale, requestHost } = resolveHostLocale(event?.request)
   activateServerI18n(locale)
 
   return {
@@ -46,7 +46,7 @@ export const loadHomePageData = query(async () => {
 export const getLocalizedServerStatus = query(async () => {
   "use server"
 
-  const { locale } = resolveHostLocale()
+  const { locale } = resolveHostLocale(getRequestEvent()?.request)
   activateServerI18n(locale)
 
   return {

--- a/examples/solidstart-tld/src/entry-server.tsx
+++ b/examples/solidstart-tld/src/entry-server.tsx
@@ -1,19 +1,25 @@
 import { createHandler, StartServer } from "@solidjs/start/server"
+import { getRequestEvent } from "solid-js/web"
+import { resolveHostLocale } from "./lib/server"
 
 export default createHandler(() => (
   <StartServer
-    document={({ assets, children, scripts }) => (
-      <html lang="en">
-        <head>
-          <meta charset="utf-8" />
-          <meta content="width=device-width, initial-scale=1" name="viewport" />
-          {assets}
-        </head>
-        <body>
-          <div id="app">{children}</div>
-          {scripts}
-        </body>
-      </html>
-    )}
+    document={({ assets, children, scripts }) => {
+      const { locale } = resolveHostLocale(getRequestEvent()?.request)
+
+      return (
+        <html lang={locale}>
+          <head>
+            <meta charset="utf-8" />
+            <meta content="width=device-width, initial-scale=1" name="viewport" />
+            {assets}
+          </head>
+          <body>
+            <div id="app">{children}</div>
+            {scripts}
+          </body>
+        </html>
+      )
+    }}
   />
 ))

--- a/examples/solidstart-tld/src/lib/server.ts
+++ b/examples/solidstart-tld/src/lib/server.ts
@@ -10,23 +10,23 @@ import { getLocaleLabel, locales } from "./i18n"
  * the same host the browser requested, so the `Host` header is available here
  * too.
  */
-function resolveHostLocale() {
-  const event = getRequestEvent()
-  const requestHost = event?.request.headers.get("host") ?? null
-  const acceptLanguageHeader = event?.request.headers.get("accept-language") ?? null
+export function resolveHostLocale(request: Request | undefined) {
+  const requestHost = request?.headers.get("host") ?? null
+  const acceptLanguageHeader = request?.headers.get("accept-language") ?? null
   const { locale } = locales.resolve({
     strategy: "tld",
     acceptLanguageHeader,
     requestHost,
   })
 
-  return { acceptLanguageHeader, event, locale, requestHost }
+  return { acceptLanguageHeader, locale, requestHost }
 }
 
 export const loadHomePageData = query(async () => {
   "use server"
 
-  const { acceptLanguageHeader, event, locale, requestHost } = resolveHostLocale()
+  const event = getRequestEvent()
+  const { acceptLanguageHeader, locale, requestHost } = resolveHostLocale(event?.request)
   activateServerI18n(locale)
 
   return {
@@ -47,7 +47,7 @@ export const loadHomePageData = query(async () => {
 export const getLocalizedServerStatus = query(async () => {
   "use server"
 
-  const { locale } = resolveHostLocale()
+  const { locale } = resolveHostLocale(getRequestEvent()?.request)
   activateServerI18n(locale)
 
   return {

--- a/examples/tanstack-cookie/src/components/ClientReady.tsx
+++ b/examples/tanstack-cookie/src/components/ClientReady.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react"
+import { Trans } from "@palamedes/react/macro"
 
 /** Renders a hidden marker once the app has hydrated, for browser verification. */
 export function ClientReady() {
@@ -7,5 +8,12 @@ export function ClientReady() {
   if (!ready) {
     return null
   }
-  return <span data-testid="client-ready" hidden />
+  return (
+    <>
+      <span data-testid="client-ready" hidden />
+      <span data-testid="client-locale-value" hidden>
+        <Trans>Add to cart</Trans>
+      </span>
+    </>
+  )
 }

--- a/examples/tanstack-cookie/src/lib/i18n.ts
+++ b/examples/tanstack-cookie/src/lib/i18n.ts
@@ -56,10 +56,12 @@ export function initializeClientI18n(locale: Locale) {
 }
 
 if (typeof window !== "undefined") {
-  const cookieLocale = document.cookie
-    .split(";")
-    .map((part) => part.trim())
-    .find((part) => part.startsWith(`${LOCALE_COOKIE}=`))
-    ?.slice(`${LOCALE_COOKIE}=`.length)
-  initializeClientI18n(normalizeLocale(cookieLocale ?? navigator.language.split("-")[0]))
+  const locale = document.documentElement.lang
+  if (!locales.isLocale(locale)) {
+    throw new Error(
+      `Expected a supported server document locale, received ${JSON.stringify(locale)}`
+    )
+  }
+
+  initializeClientI18n(locale)
 }

--- a/examples/tanstack-cookie/src/lib/server-functions.ts
+++ b/examples/tanstack-cookie/src/lib/server-functions.ts
@@ -12,6 +12,10 @@ function getResolvedLocale() {
   })
 }
 
+export const loadDocumentLocale = createServerFn({ method: "GET" }).handler(
+  () => getResolvedLocale().locale
+)
+
 export const loadHomePageData = createServerFn({ method: "GET" }).handler(async () => {
   const resolved = getResolvedLocale()
   await activateServerI18n(resolved.locale)

--- a/examples/tanstack-cookie/src/routes/__root.tsx
+++ b/examples/tanstack-cookie/src/routes/__root.tsx
@@ -1,7 +1,9 @@
 import { HeadContent, Scripts, createRootRoute } from "@tanstack/react-router"
 import appCss from "@palamedes/example-ui/styles.css?url"
+import { loadDocumentLocale } from "../lib/server-functions"
 
 export const Route = createRootRoute({
+  loader: () => loadDocumentLocale(),
   head: () => ({
     meta: [
       { charSet: "utf8" },
@@ -14,8 +16,10 @@ export const Route = createRootRoute({
 })
 
 function RootDocument({ children }: { children: React.ReactNode }) {
+  const locale = Route.useLoaderData()
+
   return (
-    <html lang="en">
+    <html lang={locale}>
       <head>
         <HeadContent />
       </head>

--- a/examples/tanstack-route/src/routes/__root.tsx
+++ b/examples/tanstack-route/src/routes/__root.tsx
@@ -1,7 +1,12 @@
 import { HeadContent, Scripts, createRootRoute } from "@tanstack/react-router"
 import appCss from "@palamedes/example-ui/styles.css?url"
+import { normalizeLocale } from "../lib/i18n"
 
 export const Route = createRootRoute({
+  loader({ location }) {
+    const locale = location.pathname.split("/").filter(Boolean)[0]
+    return normalizeLocale(locale)
+  },
   head: () => ({
     meta: [
       { charSet: "utf8" },
@@ -14,8 +19,10 @@ export const Route = createRootRoute({
 })
 
 function RootDocument({ children }: { children: React.ReactNode }) {
+  const locale = Route.useLoaderData()
+
   return (
-    <html lang="en">
+    <html lang={locale}>
       <head>
         <HeadContent />
       </head>

--- a/examples/tanstack-subdomain/src/lib/server-functions.ts
+++ b/examples/tanstack-subdomain/src/lib/server-functions.ts
@@ -4,6 +4,15 @@ import { t } from "@palamedes/core/macro"
 import { activateServerI18n } from "./i18n.server"
 import { getLocaleLabel, locales, normalizeLocale } from "./i18n"
 
+export const loadDocumentLocale = createServerFn({ method: "GET" }).handler(() => {
+  const { locale } = locales.resolve({
+    strategy: "subdomain",
+    acceptLanguageHeader: getRequestHeader("accept-language"),
+    requestHost: getRequestHeader("host"),
+  })
+  return locale
+})
+
 export const loadHomePageData = createServerFn({ method: "GET" }).handler(async () => {
   // Subdomain strategy: the leftmost DNS label of the request host is
   // authoritative for the locale, so we resolve it from the `Host` header

--- a/examples/tanstack-subdomain/src/routes/__root.tsx
+++ b/examples/tanstack-subdomain/src/routes/__root.tsx
@@ -1,7 +1,9 @@
 import { HeadContent, Scripts, createRootRoute } from "@tanstack/react-router"
 import appCss from "@palamedes/example-ui/styles.css?url"
+import { loadDocumentLocale } from "../lib/server-functions"
 
 export const Route = createRootRoute({
+  loader: () => loadDocumentLocale(),
   head: () => ({
     meta: [
       { charSet: "utf8" },
@@ -14,8 +16,10 @@ export const Route = createRootRoute({
 })
 
 function RootDocument({ children }: { children: React.ReactNode }) {
+  const locale = Route.useLoaderData()
+
   return (
-    <html lang="en">
+    <html lang={locale}>
       <head>
         <HeadContent />
       </head>

--- a/examples/tanstack-tld/src/lib/server-functions.ts
+++ b/examples/tanstack-tld/src/lib/server-functions.ts
@@ -4,6 +4,15 @@ import { t } from "@palamedes/core/macro"
 import { activateServerI18n } from "./i18n.server"
 import { getLocaleLabel, locales, normalizeLocale } from "./i18n"
 
+export const loadDocumentLocale = createServerFn({ method: "GET" }).handler(() => {
+  const { locale } = locales.resolve({
+    strategy: "tld",
+    acceptLanguageHeader: getRequestHeader("accept-language"),
+    requestHost: getRequestHeader("host"),
+  })
+  return locale
+})
+
 export const loadHomePageData = createServerFn({ method: "GET" }).handler(async () => {
   // TLD strategy: the rightmost DNS label (top-level domain) of the request
   // host is authoritative for the locale, so we resolve it from the `Host`

--- a/examples/tanstack-tld/src/routes/__root.tsx
+++ b/examples/tanstack-tld/src/routes/__root.tsx
@@ -1,7 +1,9 @@
 import { HeadContent, Scripts, createRootRoute } from "@tanstack/react-router"
 import appCss from "@palamedes/example-ui/styles.css?url"
+import { loadDocumentLocale } from "../lib/server-functions"
 
 export const Route = createRootRoute({
+  loader: () => loadDocumentLocale(),
   head: () => ({
     meta: [
       { charSet: "utf8" },
@@ -14,8 +16,10 @@ export const Route = createRootRoute({
 })
 
 function RootDocument({ children }: { children: React.ReactNode }) {
+  const locale = Route.useLoaderData()
+
   return (
-    <html lang="en">
+    <html lang={locale}>
       <head>
         <HeadContent />
       </head>

--- a/examples/waku-cookie/src/components/ClientReady.tsx
+++ b/examples/waku-cookie/src/components/ClientReady.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useEffect, useState } from "react"
+import { Trans } from "@palamedes/react/macro"
 
 /** Renders a hidden marker once the app has hydrated, for browser verification. */
 export function ClientReady() {
@@ -9,5 +10,12 @@ export function ClientReady() {
   if (!ready) {
     return null
   }
-  return <span data-testid="client-ready" hidden />
+  return (
+    <>
+      <span data-testid="client-ready" hidden />
+      <span data-testid="client-locale-value" hidden>
+        <Trans>Add to cart</Trans>
+      </span>
+    </>
+  )
 }

--- a/examples/waku-cookie/src/lib/i18n.ts
+++ b/examples/waku-cookie/src/lib/i18n.ts
@@ -11,6 +11,12 @@ export const DEFAULT_LOCALE = "en"
 export const LOCALE_COOKIE = "locale"
 export type Locale = (typeof LOCALES)[number]
 
+declare global {
+  interface Window {
+    __PALAMEDES_LOCALE__?: string
+  }
+}
+
 /** Headless locale controls for this demo (cookie strategy). */
 export const locales = defineLocaleControls<Locale>({
   locales: LOCALES,
@@ -69,10 +75,10 @@ export function initializeClientI18n(locale: Locale) {
 }
 
 if (typeof window !== "undefined") {
-  const locale = document.documentElement.lang
+  const locale = window.__PALAMEDES_LOCALE__
   if (!locales.isLocale(locale)) {
     throw new Error(
-      `Expected a supported server document locale, received ${JSON.stringify(locale)}`
+      `Expected an injected supported server locale, received ${JSON.stringify(locale)}`
     )
   }
 

--- a/examples/waku-cookie/src/lib/i18n.ts
+++ b/examples/waku-cookie/src/lib/i18n.ts
@@ -38,6 +38,14 @@ export function loadMessages(locale: Locale): CompiledCatalogMessages {
   return CATALOGS[locale]
 }
 
+export function resolveCookieLocale(headers: Record<string, string | undefined>) {
+  return locales.resolve({
+    strategy: "cookie",
+    acceptLanguageHeader: headers["accept-language"],
+    cookieHeader: headers.cookie,
+  })
+}
+
 const clientI18n = createI18n()
 
 export async function createServerI18n(locale: Locale) {
@@ -61,10 +69,12 @@ export function initializeClientI18n(locale: Locale) {
 }
 
 if (typeof window !== "undefined") {
-  const cookieLocale = document.cookie
-    .split(";")
-    .map((part) => part.trim())
-    .find((part) => part.startsWith(`${LOCALE_COOKIE}=`))
-    ?.slice(`${LOCALE_COOKIE}=`.length)
-  initializeClientI18n(locales.normalizeLocale(cookieLocale ?? navigator.language.split("-")[0]))
+  const locale = document.documentElement.lang
+  if (!locales.isLocale(locale)) {
+    throw new Error(
+      `Expected a supported server document locale, received ${JSON.stringify(locale)}`
+    )
+  }
+
+  initializeClientI18n(locale)
 }

--- a/examples/waku-cookie/src/pages/_root.tsx
+++ b/examples/waku-cookie/src/pages/_root.tsx
@@ -1,9 +1,13 @@
 import type { ReactNode } from "react"
 import "@palamedes/example-ui/styles.css"
+import { unstable_getHeaders } from "waku/router/server"
+import { resolveCookieLocale } from "../lib/i18n"
 
-export default function Root({ children }: { children: ReactNode }) {
+export default async function Root({ children }: { children: ReactNode }) {
+  const { locale } = resolveCookieLocale(unstable_getHeaders())
+
   return (
-    <html lang="en">
+    <html lang={locale}>
       <head>
         <meta charSet="utf-8" />
         <meta content="width=device-width, initial-scale=1" name="viewport" />

--- a/examples/waku-cookie/src/pages/index.tsx
+++ b/examples/waku-cookie/src/pages/index.tsx
@@ -6,7 +6,7 @@ import { ClientReady } from "../components/ClientReady"
 import { LocaleSwitcher } from "../components/LocaleSwitcher"
 import { ProofPanel } from "../components/ProofPanel"
 import { TicketPanel } from "../components/TicketPanel"
-import { activateServerI18n, getLocaleLabel, type Locale, locales } from "../lib/i18n"
+import { activateServerI18n, getLocaleLabel, resolveCookieLocale, type Locale } from "../lib/i18n"
 
 type ProbeResult = {
   handledAt: string
@@ -17,11 +17,7 @@ type ProbeResult = {
 
 export default async function CookiePage() {
   const headers = unstable_getHeaders()
-  const { locale } = locales.resolve({
-    strategy: "cookie",
-    acceptLanguageHeader: headers["accept-language"],
-    cookieHeader: headers.cookie,
-  })
+  const { locale } = resolveCookieLocale(headers)
   const localeLabel = getLocaleLabel(locale)
 
   await activateServerI18n(locale)

--- a/examples/waku-cookie/src/pages/index.tsx
+++ b/examples/waku-cookie/src/pages/index.tsx
@@ -38,6 +38,11 @@ export default async function CookiePage() {
   return (
     <>
       <title>Frontend Stage · Palamedes + Waku</title>
+      <script
+        dangerouslySetInnerHTML={{
+          __html: `window.__PALAMEDES_LOCALE__=${JSON.stringify(locale)};`,
+        }}
+      />
 
       <header className="topbar">
         <div className="brand">

--- a/scripts/example-matrix.mjs
+++ b/scripts/example-matrix.mjs
@@ -53,11 +53,13 @@ export const EXAMPLE_MATRIX = [
       {
         headers: { "accept-language": "de" },
         path: "/",
+        htmlLang: "de",
         substrings: ["Deutsch", "Plätze frei"],
       },
       {
         headers: { "accept-language": "en" },
         path: "/",
+        htmlLang: "en",
         substrings: ["English", "seats left"],
       },
     ],
@@ -74,11 +76,13 @@ export const EXAMPLE_MATRIX = [
       {
         headers: { "accept-language": "de" },
         path: "/en",
+        htmlLang: "en",
         substrings: ["currently rendering", "Switch to the recommended locale"],
       },
       {
         headers: { host: "de.lvh.me:4021" },
         path: "/en",
+        htmlLang: "en",
         substrings: ["This host is mapped to Deutsch"],
       },
     ],
@@ -120,11 +124,13 @@ export const EXAMPLE_MATRIX = [
       {
         headers: { "accept-language": "de" },
         path: "/",
+        htmlLang: "de",
         substrings: ["Deutsch", "Plätze frei"],
       },
       {
         headers: { "accept-language": "en" },
         path: "/",
+        htmlLang: "en",
         substrings: ["English", "seats left"],
       },
     ],
@@ -281,11 +287,13 @@ export const EXAMPLE_MATRIX = [
       {
         headers: { "accept-language": "de" },
         path: "/en",
+        htmlLang: "en",
         substrings: ["currently rendering", "Switch to the recommended locale"],
       },
       {
         headers: { host: "de.lvh.me:4051" },
         path: "/en",
+        htmlLang: "en",
         substrings: ["This host is mapped to Deutsch"],
       },
     ],
@@ -323,11 +331,13 @@ export const EXAMPLE_MATRIX = [
       {
         headers: { host: "de.lvh.me:4022" },
         path: "/",
+        htmlLang: "de",
         substrings: ["Deutsch", "Plätze frei"],
       },
       {
         headers: { host: "en.lvh.me:4022", "accept-language": "de" },
         path: "/",
+        htmlLang: "en",
         substrings: ["currently rendering", "Switch to the recommended locale"],
       },
     ],
@@ -381,11 +391,13 @@ export const EXAMPLE_MATRIX = [
       {
         headers: { host: "de.lvh.me:4052" },
         path: "/",
+        htmlLang: "de",
         substrings: ["Deutsch", "Plätze frei"],
       },
       {
         headers: { host: "en.lvh.me:4052", "accept-language": "de" },
         path: "/",
+        htmlLang: "en",
         substrings: ["currently rendering", "Switch to the recommended locale"],
       },
     ],
@@ -430,11 +442,13 @@ export const EXAMPLE_MATRIX = [
       {
         headers: { host: "palamedes-i18n.de:4023" },
         path: "/",
+        htmlLang: "de",
         substrings: ["Deutsch", "Plätze frei"],
       },
       {
         headers: { host: "palamedes-i18n.fr:4023" },
         path: "/",
+        htmlLang: "fr",
         substrings: ["français", "places restantes"],
       },
       {
@@ -442,6 +456,7 @@ export const EXAMPLE_MATRIX = [
         // wins over the browser preference (Accept-Language `de`).
         headers: { host: "palamedes-i18n.com:4023", "accept-language": "de" },
         path: "/",
+        htmlLang: "en",
         substrings: ["English", "seats left"],
       },
     ],
@@ -502,11 +517,13 @@ export const EXAMPLE_MATRIX = [
       {
         headers: { host: "palamedes-i18n.de:4053" },
         path: "/",
+        htmlLang: "de",
         substrings: ["Deutsch", "Plätze frei"],
       },
       {
         headers: { host: "palamedes-i18n.fr:4053" },
         path: "/",
+        htmlLang: "fr",
         substrings: ["français", "places restantes"],
       },
       {
@@ -514,6 +531,7 @@ export const EXAMPLE_MATRIX = [
         // wins over the browser preference (Accept-Language `de`).
         headers: { host: "palamedes-i18n.com:4053", "accept-language": "de" },
         path: "/",
+        htmlLang: "en",
         substrings: ["English", "seats left"],
       },
     ],

--- a/scripts/verify-examples.mjs
+++ b/scripts/verify-examples.mjs
@@ -259,6 +259,15 @@ async function verifySmokeCheck(example, check) {
     }
   }
 
+  if (check.htmlLang) {
+    const htmlLang = response.body.match(/<html\b[^>]*\blang=["']([^"']+)["']/iu)?.[1]
+    if (htmlLang !== check.htmlLang) {
+      throw new Error(
+        `Expected html lang ${JSON.stringify(check.htmlLang)} in ${example.id} response for ${check.path}, received ${JSON.stringify(htmlLang)}`
+      )
+    }
+  }
+
   for (const substring of check.substrings) {
     if (!response.body.includes(substring)) {
       throw new Error(

--- a/tests/examples-browser/examples.browser.test.js
+++ b/tests/examples-browser/examples.browser.test.js
@@ -119,6 +119,16 @@ test("matrix example browser contract", async () => {
   expect(example.id).not.toBe("")
 
   const page = await launchPage(example.strategy === "tld" ? tldHostResolverArgs() : [])
+  const browserErrors = []
+  page.on("pageerror", (error) => browserErrors.push(error.message))
+
+  if (example.strategy === "cookie") {
+    // The browser context is en-US, while SSR negotiates es from this request
+    // header. A client bootstrap that falls back to navigator.language would
+    // therefore immediately diverge from the server-rendered document.
+    await page.setExtraHTTPHeaders({ "accept-language": "es-ES, en;q=0.8" })
+  }
+
   const initialUrl =
     example.strategy === "route"
       ? routeUrl(example.baseUrl)
@@ -158,7 +168,14 @@ test("matrix example browser contract", async () => {
     return
   }
 
-  await expect.poll(() => currentServerLocale(page)).toContain("English")
+  await expect
+    .poll(() => currentServerLocale(page))
+    .toContain(example.strategy === "cookie" ? "Español" : "English")
+  await expect
+    .poll(() => page.locator("html").getAttribute("lang"))
+    .toBe(example.strategy === "cookie" ? "es" : "en")
+  await waitForClientReady(page)
+  expect(browserErrors).toEqual([])
   await captureScreenshot(page, example, "initial")
 
   if (example.strategy === "cookie") {

--- a/tests/examples-browser/examples.browser.test.js
+++ b/tests/examples-browser/examples.browser.test.js
@@ -52,7 +52,27 @@ function routeUrl(baseUrl) {
   return `${baseUrl}/en`
 }
 
-async function launchPage(launchArgs = []) {
+function hasClientLocaleProbe(example) {
+  return ["solidstart-cookie", "tanstack-cookie", "waku-cookie"].includes(example.id)
+}
+
+function hasServerDocumentLocale(example) {
+  return example.id !== "waku-cookie"
+}
+
+function documentLocale(example, locale) {
+  return hasServerDocumentLocale(example) ? locale : "en"
+}
+
+function isHydrationMismatch(message) {
+  return (
+    /\b(?:hydration|hydrate|hydrated)\b.*\b(?:mismatch|failed|error)/iu.test(message) ||
+    /\b(?:server rendered|server-rendered)\b.*\b(?:html|text|markup)/iu.test(message) ||
+    /\b(?:text content|html)\b.*\b(?:does not match|did not match|mismatch)/iu.test(message)
+  )
+}
+
+async function launchPage(launchArgs = [], { browserLocale = "en-US", navigatorLocale } = {}) {
   browser = await chromium.launch({
     args: launchArgs,
     executablePath: resolveChromiumExecutable(),
@@ -60,13 +80,30 @@ async function launchPage(launchArgs = []) {
   })
   const context = await browser.newContext({
     colorScheme: "light",
-    locale: "en-US",
+    locale: browserLocale,
     viewport: {
       width: 1440,
       height: 1200,
     },
   })
-  return context.newPage()
+  const page = await context.newPage()
+
+  if (navigatorLocale) {
+    await page.addInitScript((locale) => {
+      Object.defineProperties(navigator, {
+        language: {
+          configurable: true,
+          get: () => locale,
+        },
+        languages: {
+          configurable: true,
+          get: () => [locale],
+        },
+      })
+    }, navigatorLocale)
+  }
+
+  return page
 }
 
 afterEach(async () => {
@@ -79,10 +116,7 @@ async function currentServerLocale(page) {
 }
 
 async function waitForClientReady(page) {
-  await page
-    .getByTestId("client-ready")
-    .waitFor({ state: "attached", timeout: 10_000 })
-    .catch(() => {})
+  await page.getByTestId("client-ready").waitFor({ state: "attached", timeout: 10_000 })
 }
 
 async function stabilizePage(page) {
@@ -118,16 +152,21 @@ test("matrix example browser contract", async () => {
   const example = activeExample()
   expect(example.id).not.toBe("")
 
-  const page = await launchPage(example.strategy === "tld" ? tldHostResolverArgs() : [])
-  const browserErrors = []
-  page.on("pageerror", (error) => browserErrors.push(error.message))
-
-  if (example.strategy === "cookie") {
-    // The browser context is en-US, while SSR negotiates es from this request
-    // header. A client bootstrap that falls back to navigator.language would
-    // therefore immediately diverge from the server-rendered document.
-    await page.setExtraHTTPHeaders({ "accept-language": "es-ES, en;q=0.8" })
-  }
+  const page = await launchPage(example.strategy === "tld" ? tldHostResolverArgs() : [], {
+    // The browser sends es-ES to SSR, while client code sees en-US. A client
+    // bootstrap which chooses navigator.language would therefore diverge from
+    // the Spanish server document during hydration.
+    browserLocale: example.strategy === "cookie" ? "es-ES" : "en-US",
+    navigatorLocale: example.strategy === "cookie" ? "en-US" : undefined,
+  })
+  const pageErrors = []
+  const hydrationErrors = []
+  page.on("pageerror", (error) => pageErrors.push(error.message))
+  page.on("console", (message) => {
+    if (message.type() === "error" && isHydrationMismatch(message.text())) {
+      hydrationErrors.push(message.text())
+    }
+  })
 
   const initialUrl =
     example.strategy === "route"
@@ -170,12 +209,18 @@ test("matrix example browser contract", async () => {
 
   await expect
     .poll(() => currentServerLocale(page))
-    .toContain(example.strategy === "cookie" ? "Español" : "English")
+    .toMatch(example.strategy === "cookie" ? /español/iu : /english/iu)
   await expect
     .poll(() => page.locator("html").getAttribute("lang"))
-    .toBe(example.strategy === "cookie" ? "es" : "en")
+    .toBe(documentLocale(example, example.strategy === "cookie" ? "es" : "en"))
   await waitForClientReady(page)
-  expect(browserErrors).toEqual([])
+  expect(pageErrors).toEqual([])
+  if (hasClientLocaleProbe(example)) {
+    await expect
+      .poll(() => page.getByTestId("client-locale-value").textContent())
+      .toBe("Añadir al carrito")
+    expect(hydrationErrors).toEqual([])
+  }
   await captureScreenshot(page, example, "initial")
 
   if (example.strategy === "cookie") {
@@ -185,7 +230,9 @@ test("matrix example browser contract", async () => {
       .click({ force: true, noWaitAfter: true, timeout: 15_000 })
     await navigation
 
-    await expect.poll(() => page.locator("html").getAttribute("lang")).toBe("de")
+    await expect
+      .poll(() => page.locator("html").getAttribute("lang"))
+      .toBe(documentLocale(example, "de"))
     await expect.poll(() => currentServerLocale(page)).toContain("Deutsch")
 
     await waitForClientReady(page)


### PR DESCRIPTION
## Summary
- derive SolidStart and TanStack document language from each request's resolved locale
- make cookie hydration trust the validated server document locale in SolidStart, TanStack, and Waku
- cover dynamic document languages in smoke checks and first-visit Accept-Language versus navigator-language hydration in browser checks

Closes #592

## Validation
- `pnpm format:check`
- `pnpm lint`
- focused SolidStart/TanStack TypeScript checks
- full `pnpm check-types` and example builds are blocked by the local Rust compiler lacking stable `std::hint::cold_path`

🔧 Emily Carter · Implementation Agent