### PR TITLE
fix(next): degrade failed client catalog fragments

### DIFF
--- a/docs/api/next-plugin.md
+++ b/docs/api/next-plugin.md
@@ -145,9 +145,11 @@ message-bearing Client Component or transitive browser helper, the loader emits
 one selected PO import per configured locale. Module evaluation awaits only the
 import selected by `document.documentElement.lang`, initializes one shared
 parser-free client instance, and loads that source module's fragment before its
-exports can render. Initial hydration and later client navigation therefore
-follow `active locale × evaluated client module graph`; other locales and
-unvisited route messages remain in separate chunks.
+exports can render. In production, a rejected fragment is logged and skipped
+so the module can still evaluate; that module's translations are unavailable
+unless a fallback is retained. Initial hydration and later client navigation
+therefore follow `active locale × evaluated client module graph`; other locales
+and unvisited route messages remain in separate chunks.
 
 The bootstrap is generated for browser modules only. Server Components keep
 using the request-local scope above, and no executable message function crosses
@@ -192,6 +194,12 @@ code renders. It also omits translator comments and context metadata from
 runtime descriptors. Set `keepSourceFallbacks: true` when production must
 retain readable source-message fallbacks. The option is forwarded identically
 to the Turbopack and webpack transform loaders.
+
+Production does not immediately retry a rejected fragment import. This is a
+deliberate trade-off: likely deterministic CDN, ad-blocker, or stale-deploy
+failures need backoff or a later navigation rather than another request in the
+same bootstrap turn. Development remains fail-fast to surface catalog wiring
+errors while editing.
 
 The plugin configures both Turbopack and webpack paths, and requires Next.js
 16 (`peerDependencies: next ^16` — the emitted top-level `turbopack.rules`

--- a/packages/next-plugin/README.md
+++ b/packages/next-plugin/README.md
@@ -145,6 +145,16 @@ invalidate their affected subsets under Turbopack and webpack; Next may apply
 Fast Refresh or fall back to a full document reload at an async-module
 boundary. A document reload is the supported fallback.
 
+Each production fragment import is attempted once. If one rejects, Palamedes
+logs the failure with the module path and locale, skips only that fragment, and
+continues hydrating the client graph (including any other fragments that did
+load). It deliberately does not immediately retry: browsers commonly retain a
+failed dynamic-import result, so a retry adds noise without making the graph
+more reliable. Development remains fail-fast so catalog wiring failures stay
+visible while editing. In a production build, set `keepSourceFallbacks: true`
+if readable source text is required when a skipped fragment has no loaded
+translation; the compact default does not retain source messages.
+
 `messageSplitting` currently supports PO catalogs and defaults to `false` for
 compatibility. Keep using `createClientCatalogBoundary()` from
 `@palamedes/react/client` when an app needs a complete active-locale catalog or

--- a/packages/next-plugin/README.md
+++ b/packages/next-plugin/README.md
@@ -148,10 +148,11 @@ boundary. A document reload is the supported fallback.
 Each production fragment import is attempted once. If one rejects, Palamedes
 logs the failure with the module path and locale, skips only that fragment, and
 continues hydrating the client graph (including any other fragments that did
-load). It deliberately does not immediately retry: browsers commonly retain a
-failed dynamic-import result, so a retry adds noise without making the graph
-more reliable. Development remains fail-fast so catalog wiring failures stay
-visible while editing. In a production build, set `keepSourceFallbacks: true`
+load). It deliberately avoids an immediate, unbacked-off retry: deterministic
+CDN, ad-blocker, and stale-deploy failures are unlikely to improve in the same
+turn, while a retry can add a request without restoring the graph. Development
+remains fail-fast so catalog wiring failures stay visible while editing. In a
+production build, set `keepSourceFallbacks: true`
 if readable source text is required when a skipped fragment has no loaded
 translation; the compact default does not retain source messages.
 

--- a/packages/next-plugin/palamedes-loader.cjs
+++ b/packages/next-plugin/palamedes-loader.cjs
@@ -106,7 +106,7 @@ function selectedMessageImports(config, sourcePath, compiledIds) {
   )
 }
 
-function clientMessageBootstrap(config, sourcePath, compiledIds) {
+function clientMessageBootstrap(config, sourcePath, compiledIds, fragmentFailureMode) {
   const importsByCatalog = selectedMessageImports(config, sourcePath, compiledIds)
   if (!importsByCatalog) {
     return null
@@ -127,26 +127,42 @@ function clientMessageBootstrap(config, sourcePath, compiledIds) {
   )
   const identifier = `__pmds_${createHash("sha256").update(modulePath).digest("hex").slice(0, 12)}`
 
-  return (
-    `const ${identifier}_locale = document.documentElement.lang;\n` +
-    `const ${identifier}_loaderGroups = [${loaderGroups.join(", ")}];\n` +
-    `const ${identifier}_activeLoaders = ${identifier}_loaderGroups.map((loaders) => loaders[${identifier}_locale]);\n` +
-    `if (${identifier}_activeLoaders.some((loader) => loader === undefined)) {\n` +
-    `  throw new Error(\`Palamedes client graph bootstrap does not support document locale "\${${identifier}_locale}". Configured locales: ${supportedLocales}.\`);\n` +
-    `}\n` +
+  const imports =
     `const ${identifier}_modules = await Promise.all([\n` +
     `  import("@palamedes/core/compiled"),\n` +
     `  import("@palamedes/runtime"),\n` +
-    `  ...${identifier}_activeLoaders.map((load) => load()),\n` +
     `]);\n` +
     `const ${identifier}_i18n = ${identifier}_modules[1].initializeClientI18n(\n` +
     `  ${identifier}_locale,\n` +
     `  ${identifier}_modules[0].createI18n,\n` +
-    `);\n` +
-    `for (const { messages } of ${identifier}_modules.slice(2)) {\n` +
-    `  ${identifier}_i18n.load(${identifier}_locale, messages);\n` +
-    `}\n`
-  )
+    `);\n`
+  const fragmentImports =
+    fragmentFailureMode === "degrade"
+      ? `const ${identifier}_fragments = await Promise.all(${identifier}_activeLoaders.map(async (load) => {\n` +
+        `  try {\n` +
+        `    return await load();\n` +
+        `  } catch (error) {\n` +
+        `    console.error(\n` +
+        `      \`Palamedes client graph message splitting failed to load a catalog fragment for ${modulePath} (\${${identifier}_locale}). Continuing without that fragment.\`,\n` +
+        `      error,\n` +
+        `    );\n` +
+        `    return null;\n` +
+        `  }\n` +
+        `}));\n`
+      : `const ${identifier}_fragments = await Promise.all(${identifier}_activeLoaders.map((load) => load()));\n`
+
+  return `const ${identifier}_locale = document.documentElement.lang;
+const ${identifier}_loaderGroups = [${loaderGroups.join(", ")}];
+const ${identifier}_activeLoaders = ${identifier}_loaderGroups.map((loaders) => loaders[${identifier}_locale]);
+if (${identifier}_activeLoaders.some((loader) => loader === undefined)) {
+  throw new Error(\`Palamedes client graph bootstrap does not support document locale "\${${identifier}_locale}". Configured locales: ${supportedLocales}.\`);
+}
+${imports}${fragmentImports}for (const fragment of ${identifier}_fragments) {
+  if (fragment === null) continue;
+  const { messages } = fragment;
+  ${identifier}_i18n.load(${identifier}_locale, messages);
+}
+`
 }
 
 function skipTrivia(code, index) {
@@ -462,7 +478,12 @@ module.exports = function palamedesLoader(source, inputSourceMap) {
     }
     const registration = serverMessageSplitting
       ? messageLoaderRegistration(config, this.resourcePath, result.compiledIds)
-      : clientMessageBootstrap(config, this.resourcePath, result.compiledIds)
+      : clientMessageBootstrap(
+          config,
+          this.resourcePath,
+          result.compiledIds,
+          options.clientFragmentFailureMode === "degrade" ? "degrade" : "throw"
+        )
     let code = result.code
     let sourceMap = result.map ?? inputSourceMap ?? null
     if (registration) {

--- a/packages/next-plugin/palamedes-loader.cjs
+++ b/packages/next-plugin/palamedes-loader.cjs
@@ -126,6 +126,10 @@ function clientMessageBootstrap(config, sourcePath, compiledIds, fragmentFailure
     path.relative(canonicalPath(config.rootDir), canonicalPath(sourcePath))
   )
   const identifier = `__pmds_${createHash("sha256").update(modulePath).digest("hex").slice(0, 12)}`
+  const fragmentFailurePrefix = JSON.stringify(
+    `Palamedes client graph message splitting failed to load a catalog fragment for ${modulePath} (`
+  )
+  const fragmentFailureSuffix = JSON.stringify("). Continuing without that fragment.")
 
   const imports =
     `const ${identifier}_modules = await Promise.all([\n` +
@@ -142,10 +146,16 @@ function clientMessageBootstrap(config, sourcePath, compiledIds, fragmentFailure
         `  try {\n` +
         `    return await load();\n` +
         `  } catch (error) {\n` +
-        `    console.error(\n` +
-        `      \`Palamedes client graph message splitting failed to load a catalog fragment for ${modulePath} (\${${identifier}_locale}). Continuing without that fragment.\`,\n` +
-        `      error,\n` +
-        `    );\n` +
+        `    try {\n` +
+        `      console.error(\n` +
+        `        ${fragmentFailurePrefix},\n` +
+        `        ${identifier}_locale,\n` +
+        `        ${fragmentFailureSuffix},\n` +
+        `        error,\n` +
+        `      );\n` +
+        `    } catch {\n` +
+        `      // Logging must not prevent the client graph from hydrating.\n` +
+        `    }\n` +
         `    return null;\n` +
         `  }\n` +
         `}));\n`

--- a/packages/next-plugin/src/index.test.ts
+++ b/packages/next-plugin/src/index.test.ts
@@ -145,27 +145,37 @@ describe("withPalamedes turbopack config", () => {
     expect(browserRule?.loaders?.[0]?.options).not.toHaveProperty("serverMessageSplitting")
   })
 
-  it("enables graph-split client bootstrapping only in the Turbopack browser graph", () => {
-    const configuredRules = getRules(withPalamedes({}, { messageSplitting: true }))[
-      "*"
-    ] as RuleItem[]
-    const browserRule = configuredRules.find((candidate) =>
-      conditionList(candidate).includes("browser")
-    )
-    const serverRule = configuredRules.find((candidate) =>
-      conditionList(candidate).some(
-        (condition) =>
-          typeof condition === "object" &&
-          condition !== null &&
-          "not" in condition &&
-          condition.not === "browser"
+  it.each([
+    ["development", "throw"],
+    ["production", "degrade"],
+  ] as const)(
+    "enables graph-split client bootstrapping with %s fragment failures set to %s in the Turbopack browser graph",
+    (mode, clientFragmentFailureMode) => {
+      vi.stubEnv("NODE_ENV", mode)
+      const configuredRules = getRules(withPalamedes({}, { messageSplitting: true }))[
+        "*"
+      ] as RuleItem[]
+      const browserRule = configuredRules.find((candidate) =>
+        conditionList(candidate).includes("browser")
       )
-    )
+      const serverRule = configuredRules.find((candidate) =>
+        conditionList(candidate).some(
+          (condition) =>
+            typeof condition === "object" &&
+            condition !== null &&
+            "not" in condition &&
+            condition.not === "browser"
+        )
+      )
 
-    expect(browserRule?.loaders?.[0]?.options).toMatchObject({ clientMessageSplitting: true })
-    expect(serverRule?.loaders?.[0]?.options).not.toHaveProperty("clientMessageSplitting")
-    expect(serverRule?.loaders?.[0]?.options).not.toHaveProperty("serverMessageSplitting")
-  })
+      expect(browserRule?.loaders?.[0]?.options).toMatchObject({
+        clientMessageSplitting: true,
+        clientFragmentFailureMode,
+      })
+      expect(serverRule?.loaders?.[0]?.options).not.toHaveProperty("clientMessageSplitting")
+      expect(serverRule?.loaders?.[0]?.options).not.toHaveProperty("serverMessageSplitting")
+    }
+  )
 
   it("requires the conventional Server Function entry module when enabled", () => {
     vi.spyOn(process, "cwd").mockReturnValue(path.join(nextExampleRoot, "missing"))
@@ -295,18 +305,28 @@ describe("withPalamedes webpack config", () => {
     expect(transformRule?.use?.[0]?.options).not.toHaveProperty("serverMessageSplitting")
   })
 
-  it("enables graph-split client bootstrapping only in the webpack client compiler", () => {
-    const configured = withPalamedes({}, { messageSplitting: true })
-    const clientRule = collectWebpackRules(configured, { isServer: false }).find((rule) =>
-      rule.use?.[0]?.loader.includes("palamedes-loader")
-    )
-    const serverRule = collectWebpackRules(configured, { isServer: true }).find((rule) =>
-      rule.use?.[0]?.loader.includes("palamedes-loader")
-    )
+  it.each([
+    ["development", "throw"],
+    ["production", "degrade"],
+  ] as const)(
+    "enables graph-split client bootstrapping with %s fragment failures set to %s in the webpack client compiler",
+    (mode, clientFragmentFailureMode) => {
+      vi.stubEnv("NODE_ENV", mode)
+      const configured = withPalamedes({}, { messageSplitting: true })
+      const clientRule = collectWebpackRules(configured, { isServer: false }).find((rule) =>
+        rule.use?.[0]?.loader.includes("palamedes-loader")
+      )
+      const serverRule = collectWebpackRules(configured, { isServer: true }).find((rule) =>
+        rule.use?.[0]?.loader.includes("palamedes-loader")
+      )
 
-    expect(clientRule?.use?.[0]?.options).toMatchObject({ clientMessageSplitting: true })
-    expect(serverRule?.use?.[0]?.options).not.toHaveProperty("clientMessageSplitting")
-  })
+      expect(clientRule?.use?.[0]?.options).toMatchObject({
+        clientMessageSplitting: true,
+        clientFragmentFailureMode,
+      })
+      expect(serverRule?.use?.[0]?.options).not.toHaveProperty("clientMessageSplitting")
+    }
+  )
 
   it("enables webpack async modules only for graph-split client builds", () => {
     const configured = withPalamedes({}, { messageSplitting: true })

--- a/packages/next-plugin/src/index.ts
+++ b/packages/next-plugin/src/index.ts
@@ -322,6 +322,10 @@ export function withPalamedes(
     ...(configPath ? { configPath } : {}),
     ...(serverFunctions ? { serverFunctions } : {}),
   }
+  // A missing production chunk must not make the entire client entry module
+  // unevaluable. Development stays fail-fast so broken catalog wiring is
+  // surfaced immediately instead of being hidden behind source fallbacks.
+  const clientFragmentFailureMode = process.env.NODE_ENV === "production" ? "degrade" : "throw"
 
   const rules: TurbopackRules = { ...baseConfig.turbopack?.rules }
 
@@ -350,7 +354,9 @@ export function withPalamedes(
           loader: oxcLoaderPath,
           options: {
             ...transformLoaderOptions,
-            ...(messageSplitting ? { clientMessageSplitting: true } : {}),
+            ...(messageSplitting
+              ? { clientMessageSplitting: true, clientFragmentFailureMode }
+              : {}),
           },
         },
       ],
@@ -445,7 +451,9 @@ export function withPalamedes(
             options: {
               ...transformLoaderOptions,
               ...(serverFunctions && context.isServer ? { serverMessageSplitting: true } : {}),
-              ...(messageSplitting && !context.isServer ? { clientMessageSplitting: true } : {}),
+              ...(messageSplitting && !context.isServer
+                ? { clientMessageSplitting: true, clientFragmentFailureMode }
+                : {}),
             },
           },
         ],

--- a/packages/next-plugin/src/palamedes-loader.test.ts
+++ b/packages/next-plugin/src/palamedes-loader.test.ts
@@ -218,6 +218,7 @@ describe("palamedes-loader.cjs", () => {
 
     const originalDocument = globalThis.document
     const originalBodyRan = globalThis.__pmds_test_body_ran
+    const originalInjected = (globalThis as Record<string, unknown>).__pmds_test_injected
     const originalConsoleError = console.error
     const bootstrapError = new Error("fragment failed to load")
     const errors: unknown[][] = []
@@ -235,11 +236,15 @@ describe("palamedes-loader.cjs", () => {
     try {
       globalThis.document = { documentElement: { lang: "de" } } as Document
       console.error = (...args: unknown[]) => errors.push(args)
+      const adversarialPath = "/repo/src/fragment` ${globalThis.__pmds_test_injected = true}.tsx"
 
-      const output = await runLoader({
-        clientMessageSplitting: true,
-        clientFragmentFailureMode: "degrade",
-      })
+      const output = await runLoader(
+        {
+          clientMessageSplitting: true,
+          clientFragmentFailureMode: "degrade",
+        },
+        { resourcePath: adversarialPath }
+      )
       expect(output).toContain("Continuing without that fragment")
       const modulePromise = executeGeneratedClientModule(output, async (specifier) => {
         if (specifier === "@palamedes/core/compiled") {
@@ -264,12 +269,61 @@ describe("palamedes-loader.cjs", () => {
       expect(loaded).toEqual([{ locale: "de", messages: { id: "translated" } }])
       expect(fragmentRequests).toBe(1)
       expect(successfulFragmentRequests).toBe(1)
+      expect((globalThis as Record<string, unknown>).__pmds_test_injected).toBeUndefined()
       expect(errors).toEqual([
         [
-          "Palamedes client graph message splitting failed to load a catalog fragment for src/page.tsx (de). Continuing without that fragment.",
+          "Palamedes client graph message splitting failed to load a catalog fragment for src/fragment` ${globalThis.__pmds_test_injected = true}.tsx (",
+          "de",
+          "). Continuing without that fragment.",
           bootstrapError,
         ],
       ])
+    } finally {
+      restoreGlobal("document", originalDocument)
+      restoreGlobal("__pmds_test_body_ran", originalBodyRan)
+      restoreGlobal("__pmds_test_injected", originalInjected)
+      console.error = originalConsoleError
+    }
+  })
+
+  it("continues production hydration when diagnostic logging throws", async () => {
+    transformPalamedesMacros.mockReturnValue({
+      code: "globalThis.__pmds_test_body_ran = true;",
+      map: null,
+      compiledIds: ["id-a"],
+    })
+
+    const originalDocument = globalThis.document
+    const originalBodyRan = globalThis.__pmds_test_body_ran
+    const originalConsoleError = console.error
+    const bootstrapError = new Error("fragment failed to load")
+    const loggerError = new Error("logger failed")
+
+    try {
+      globalThis.document = { documentElement: { lang: "de" } } as Document
+      console.error = () => {
+        throw loggerError
+      }
+
+      const output = await runLoader({
+        clientMessageSplitting: true,
+        clientFragmentFailureMode: "degrade",
+      })
+      const modulePromise = executeGeneratedClientModule(output, async (specifier) => {
+        if (specifier === "@palamedes/core/compiled") {
+          return { createI18n: () => ({}) }
+        }
+        if (specifier === "@palamedes/runtime") {
+          return { initializeClientI18n: () => ({}) }
+        }
+        if (specifier.includes("./locales/de.po?palamedes-selected=")) {
+          throw bootstrapError
+        }
+        throw new Error(`Unexpected import: ${specifier}`)
+      })
+
+      await expect(modulePromise).resolves.toBeUndefined()
+      expect(globalThis.__pmds_test_body_ran).toBe(true)
     } finally {
       restoreGlobal("document", originalDocument)
       restoreGlobal("__pmds_test_body_ran", originalBodyRan)

--- a/packages/next-plugin/src/palamedes-loader.test.ts
+++ b/packages/next-plugin/src/palamedes-loader.test.ts
@@ -115,6 +115,7 @@ describe("palamedes-loader.cjs", () => {
 
     expect(output).toContain("_locale = document.documentElement.lang")
     expect(output).toContain("_modules = await Promise.all")
+    expect(output).toContain("_fragments = await Promise.all")
     expect(output).toContain('"en": () => import("./locales/en.po?palamedes-selected=')
     expect(output).toContain('"de": () => import("./locales/de.po?palamedes-selected=')
     expect(output).toContain(".initializeClientI18n(")
@@ -183,9 +184,8 @@ describe("palamedes-loader.cjs", () => {
       })
       const importer = modulePromise.then(() => globalThis.__pmds_test_label)
 
-      await Promise.resolve()
+      await vi.waitFor(() => expect(requested).toHaveLength(3))
       expect(moduleBodyRan).toBe(false)
-      expect(requested).toHaveLength(3)
       expect(requested.some((specifier) => specifier.includes("./locales/en.po"))).toBe(false)
 
       resolveFragment({ messages: { id: "translated" } })
@@ -199,7 +199,85 @@ describe("palamedes-loader.cjs", () => {
     }
   })
 
-  it("propagates client bootstrap rejections to importers before evaluating the module body", async () => {
+  it("degrades a rejected production catalog fragment, logs it, and hydrates the module", async () => {
+    transformPalamedesMacros.mockReturnValue({
+      code: "globalThis.__pmds_test_body_ran = true;",
+      map: null,
+      compiledIds: ["id-a"],
+    })
+    loadPalamedesConfigSync.mockReturnValue({
+      configPath: "/repo/palamedes.yaml",
+      rootDir: "/repo",
+      locales: ["en", "de"],
+      sourceLocale: "en",
+      catalogs: [
+        { path: "src/locales/{locale}", include: ["src/**/*.tsx"] },
+        { path: "src/secondary-locales/{locale}", include: ["src/**/*.tsx"] },
+      ],
+    })
+
+    const originalDocument = globalThis.document
+    const originalBodyRan = globalThis.__pmds_test_body_ran
+    const originalConsoleError = console.error
+    const bootstrapError = new Error("fragment failed to load")
+    const errors: unknown[][] = []
+    const loaded: Array<{ locale: string; messages: Record<string, unknown> }> = []
+    let fragmentRequests = 0
+    let successfulFragmentRequests = 0
+    const i18n = {
+      locale: "de",
+      activate: vi.fn(),
+      load(locale: string, messages: Record<string, unknown>) {
+        loaded.push({ locale, messages })
+      },
+    }
+
+    try {
+      globalThis.document = { documentElement: { lang: "de" } } as Document
+      console.error = (...args: unknown[]) => errors.push(args)
+
+      const output = await runLoader({
+        clientMessageSplitting: true,
+        clientFragmentFailureMode: "degrade",
+      })
+      expect(output).toContain("Continuing without that fragment")
+      const modulePromise = executeGeneratedClientModule(output, async (specifier) => {
+        if (specifier === "@palamedes/core/compiled") {
+          return { createI18n: () => i18n }
+        }
+        if (specifier === "@palamedes/runtime") {
+          return { initializeClientI18n: () => i18n }
+        }
+        if (specifier.includes("./locales/de.po?palamedes-selected=")) {
+          fragmentRequests += 1
+          throw bootstrapError
+        }
+        if (specifier.includes("./secondary-locales/de.po?palamedes-selected=")) {
+          successfulFragmentRequests += 1
+          return { messages: { id: "translated" } }
+        }
+        throw new Error(`Unexpected import: ${specifier}`)
+      })
+
+      await expect(modulePromise).resolves.toBeUndefined()
+      expect(globalThis.__pmds_test_body_ran).toBe(true)
+      expect(loaded).toEqual([{ locale: "de", messages: { id: "translated" } }])
+      expect(fragmentRequests).toBe(1)
+      expect(successfulFragmentRequests).toBe(1)
+      expect(errors).toEqual([
+        [
+          "Palamedes client graph message splitting failed to load a catalog fragment for src/page.tsx (de). Continuing without that fragment.",
+          bootstrapError,
+        ],
+      ])
+    } finally {
+      restoreGlobal("document", originalDocument)
+      restoreGlobal("__pmds_test_body_ran", originalBodyRan)
+      console.error = originalConsoleError
+    }
+  })
+
+  it("fails fast in development mode when a catalog fragment rejects", async () => {
     transformPalamedesMacros.mockReturnValue({
       code: "globalThis.__pmds_test_body_ran = true;",
       map: null,
@@ -213,7 +291,10 @@ describe("palamedes-loader.cjs", () => {
     try {
       globalThis.document = { documentElement: { lang: "de" } } as Document
 
-      const output = await runLoader({ clientMessageSplitting: true })
+      const output = await runLoader({
+        clientMessageSplitting: true,
+        clientFragmentFailureMode: "throw",
+      })
       const modulePromise = executeGeneratedClientModule(output, async (specifier) => {
         if (specifier === "@palamedes/core/compiled") {
           return { createI18n: () => ({}) }
@@ -227,7 +308,43 @@ describe("palamedes-loader.cjs", () => {
         throw new Error(`Unexpected import: ${specifier}`)
       })
 
-      await expect(modulePromise.then(() => "importer resolved")).rejects.toBe(bootstrapError)
+      await expect(modulePromise).rejects.toBe(bootstrapError)
+      expect(globalThis.__pmds_test_body_ran).toBeUndefined()
+    } finally {
+      restoreGlobal("document", originalDocument)
+      restoreGlobal("__pmds_test_body_ran", originalBodyRan)
+    }
+  })
+
+  it("does not swallow production runtime bootstrap failures", async () => {
+    transformPalamedesMacros.mockReturnValue({
+      code: "globalThis.__pmds_test_body_ran = true;",
+      map: null,
+      compiledIds: ["id-a"],
+    })
+
+    const originalDocument = globalThis.document
+    const originalBodyRan = globalThis.__pmds_test_body_ran
+    const bootstrapError = new Error("runtime failed to load")
+
+    try {
+      globalThis.document = { documentElement: { lang: "de" } } as Document
+
+      const output = await runLoader({
+        clientMessageSplitting: true,
+        clientFragmentFailureMode: "degrade",
+      })
+      const modulePromise = executeGeneratedClientModule(output, async (specifier) => {
+        if (specifier === "@palamedes/core/compiled") {
+          return { createI18n: () => ({}) }
+        }
+        if (specifier === "@palamedes/runtime") {
+          throw bootstrapError
+        }
+        throw new Error(`Unexpected import: ${specifier}`)
+      })
+
+      await expect(modulePromise).rejects.toBe(bootstrapError)
       expect(globalThis.__pmds_test_body_ran).toBeUndefined()
     } finally {
       restoreGlobal("document", originalDocument)


### PR DESCRIPTION
## Summary

- make production graph-split client bootstraps handle catalog fragment imports independently
- safely log and skip only a rejected fragment while loading successful sibling fragments and completing hydration
- retain fail-fast behavior in development; core/runtime bootstrap failures remain fatal

## Behavior

Production uses a deliberate no-immediate-retry degradation policy. A rejected catalog fragment is logged with safely serialized module-path context and the locale, then skipped without allowing a faulty logger to reject the module. Palamedes avoids an immediate, unbacked-off retry because likely deterministic CDN, ad-blocker, or stale-deploy failures generally need backoff or a later navigation rather than another request in the same bootstrap turn. Set `keepSourceFallbacks: true` when readable source text is required after a production fragment is skipped.

## Validation

- `vitest run packages/next-plugin/src/palamedes-loader.test.ts packages/next-plugin/src/index.test.ts` — 39 passed
- repository-wide `oxfmt --check` and `oxlint --deny-warnings`
- `node --check packages/next-plugin/palamedes-loader.cjs`
- `git diff --check`

A direct package typecheck cannot run authoritatively from this fresh worktree: dependencies are reused read-only from the saved checkout, whose workspace symlinks resolve against a different source tree and produce unrelated existing errors for `@palamedes/next-plugin/server-function-entry`, `loadRegisteredMessages`, and `createI18n`. Exact-head CI performs the authoritative typecheck.

Closes #591

🔧 Emily Carter · Implementation Agent