### PR TITLE
fix(next): harden split-catalog dev invalidation

### DIFF
--- a/examples/nextjs-cookie/scripts/message-splitting-development.test.mjs
+++ b/examples/nextjs-cookie/scripts/message-splitting-development.test.mjs
@@ -12,16 +12,32 @@ const baseUrl = `http://127.0.0.1:${port}`
 const require = createRequire(import.meta.url)
 const nextCli = require.resolve("next/dist/bin/next")
 const catalogUrl = new URL("../src/locales/de.po", import.meta.url)
+const sourceCatalogUrl = new URL("../src/locales/en.po", import.meta.url)
+const configUrl = new URL("../palamedes.yaml", import.meta.url)
 const nextEnvUrl = new URL("../next-env.d.ts", import.meta.url)
-const [originalCatalog, originalNextEnv] = await Promise.all([
-  readFile(catalogUrl, "utf8"),
-  readFile(nextEnvUrl, "utf8"),
-])
+const [originalCatalog, originalSourceCatalog, originalConfig, originalNextEnv] = await Promise.all(
+  [
+    readFile(catalogUrl, "utf8"),
+    readFile(sourceCatalogUrl, "utf8"),
+    readFile(configUrl, "utf8"),
+    readFile(nextEnvUrl, "utf8"),
+  ]
+)
 const changedCatalog = originalCatalog.replace(
   'msgstr "In den Warenkorb"',
   'msgstr "In den Warenkorb (Dev-Update)"'
 )
 assert.notEqual(changedCatalog, originalCatalog)
+const changedSourceCatalog = originalSourceCatalog.replace(
+  'msgstr "Source fallback development probe"',
+  'msgstr "Source fallback development probe (Dev-Update)"'
+)
+assert.notEqual(changedSourceCatalog, originalSourceCatalog)
+const changedConfig = originalConfig.replace(
+  "source-locale: en\n",
+  "source-locale: en\nfallback-locales:\n  de: [es]\n"
+)
+assert.notEqual(changedConfig, originalConfig)
 
 const executablePath = [
   process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE,
@@ -65,6 +81,19 @@ async function stopServer() {
   await Promise.race([once(server, "exit"), new Promise((resolve) => setTimeout(resolve, 5000))])
 }
 
+async function reloadUntil(page, locator, expectedText) {
+  const deadline = Date.now() + 15_000
+  let actualText = ""
+  while (Date.now() < deadline) {
+    await page.reload()
+    await locator.waitFor()
+    actualText = (await locator.textContent()) ?? ""
+    if (actualText === expectedText) return
+    await new Promise((resolve) => setTimeout(resolve, 200))
+  }
+  assert.equal(actualText, expectedText)
+}
+
 let browser
 try {
   await waitForServer()
@@ -75,24 +104,25 @@ try {
   })
   const page = await context.newPage()
   const callToAction = page.locator(".ticket .cta")
+  const fallbackProbe = page.locator(".ticket .fallback-probe")
   await page.goto(baseUrl)
   await callToAction.waitFor()
   assert.equal(await callToAction.textContent(), "In den Warenkorb")
+  assert.equal(await fallbackProbe.textContent(), "Source fallback development probe")
 
   await writeFile(catalogUrl, changedCatalog)
+  await reloadUntil(page, callToAction, "In den Warenkorb (Dev-Update)")
 
-  const deadline = Date.now() + 15_000
-  let updatedText = ""
-  while (Date.now() < deadline) {
-    await page.reload()
-    await callToAction.waitFor()
-    updatedText = (await callToAction.textContent()) ?? ""
-    if (updatedText === "In den Warenkorb (Dev-Update)") break
-    await new Promise((resolve) => setTimeout(resolve, 200))
-  }
+  await writeFile(sourceCatalogUrl, changedSourceCatalog)
+  await reloadUntil(page, fallbackProbe, "Source fallback development probe (Dev-Update)")
 
-  assert.equal(updatedText, "In den Warenkorb (Dev-Update)")
-  console.log("Next development catalog invalidation passed through document reload")
+  await writeFile(configUrl, changedConfig)
+  await reloadUntil(page, fallbackProbe, "Sondeo de reserva de desarrollo")
+
+  // This is a Turbopack dev test and verifies the supported document-reload
+  // fallback. Webpack's top-level-await client modules are build-covered, but
+  // do not have an equivalent HMR contract asserted here.
+  console.log("Next development catalog and config invalidation passed through document reload")
   await context.close()
 } catch (error) {
   console.error(serverOutput)
@@ -102,6 +132,8 @@ try {
   await stopServer()
   await Promise.all([
     writeFile(catalogUrl, originalCatalog),
+    writeFile(sourceCatalogUrl, originalSourceCatalog),
+    writeFile(configUrl, originalConfig),
     writeFile(nextEnvUrl, originalNextEnv),
   ])
 }

--- a/examples/nextjs-cookie/src/components/TicketPanel.tsx
+++ b/examples/nextjs-cookie/src/components/TicketPanel.tsx
@@ -109,6 +109,9 @@ export function TicketPanel({ locale: _locale }: TicketPanelProps) {
         <button className="cta" type="button">
           <Trans>Add to cart</Trans>
         </button>
+        <p className="fallback-probe">
+          <Trans>Source fallback development probe</Trans>
+        </p>
       </div>
     </article>
   )

--- a/examples/nextjs-cookie/src/locales/en.po
+++ b/examples/nextjs-cookie/src/locales/en.po
@@ -66,6 +66,9 @@ msgstr "Server"
 msgid "Server action confirmed locale {locale}."
 msgstr "Server action confirmed locale {locale}."
 
+msgid "Source fallback development probe"
+msgstr "Source fallback development probe"
+
 msgid "Three days of talks on the craft of building for the web. Choose your tickets below."
 msgstr "Three days of talks on the craft of building for the web. Choose your tickets below."
 

--- a/examples/nextjs-cookie/src/locales/es.po
+++ b/examples/nextjs-cookie/src/locales/es.po
@@ -66,6 +66,9 @@ msgstr "Servidor"
 msgid "Server action confirmed locale {locale}."
 msgstr "La acción de servidor confirmó el idioma {locale}."
 
+msgid "Source fallback development probe"
+msgstr "Sondeo de reserva de desarrollo"
+
 msgid "Three days of talks on the craft of building for the web. Choose your tickets below."
 msgstr "Tres días de charlas sobre el oficio de construir para la web. Elige tus entradas abajo."
 

--- a/packages/next-plugin/README.md
+++ b/packages/next-plugin/README.md
@@ -140,10 +140,16 @@ declarations that defer translation until component render remain valid. The
 client bootstrap also initializes the module's own fragment before its body, so
 custom compiled-adapter calls observe that fragment if they must run eagerly.
 
-Selected `.po` imports remain normal development dependencies. Catalog edits
-invalidate their affected subsets under Turbopack and webpack; Next may apply
-Fast Refresh or fall back to a full document reload at an async-module
-boundary. A document reload is the supported fallback.
+Selected `.po` imports remain normal development dependencies. Their
+source-locale fallbacks and the Palamedes config are also registered as loader
+dependencies, so catalog and fallback-policy edits invalidate the affected
+subset under supported hosts. If a custom loader host does not implement
+`addDependency()`, Palamedes emits one development warning; restart after
+changing a fallback catalog or config in that host. Next may apply Fast Refresh
+or fall back to a full document reload at an async-module boundary. A document
+reload is the supported fallback. The development invalidation regression runs
+under Turbopack. Webpack's top-level-await client build is covered in
+production, but does not claim an equivalent HMR contract.
 
 Each production fragment import is attempted once. If one rejects, Palamedes
 logs the failure with the module path and locale, skips only that fragment, and
@@ -262,7 +268,12 @@ long-lived server runtime can therefore retain registrations from more than one
 action graph, so a later action may load a superset of its own dependency
 closure. This affects the upper performance bound, not lookup correctness:
 Palamedes still imports only the active locale and only the selected ids from
-each registered source module.
+each registered source module. During webpack development, each generated
+server module releases its exact registration on HMR disposal, and a
+re-evaluated module atomically replaces all of its sidecars. Turbopack does not
+currently expose an equivalent server-module disposal hook to loader output;
+edits and catalog/config changes replace active registrations, but a module
+removed from the graph can remain registered until the dev server restarts.
 
 Parameter defaults execute before the function body. Palamedes therefore
 rejects eager macros in Server Function parameter initializers, including

--- a/packages/next-plugin/package.json
+++ b/packages/next-plugin/package.json
@@ -40,6 +40,7 @@
     "README.md",
     "dist/",
     "palamedes-loader.cjs",
+    "palamedes-dev-warning.cjs",
     "palamedes-po-loader.cjs"
   ],
   "exports": {

--- a/packages/next-plugin/palamedes-dev-warning.cjs
+++ b/packages/next-plugin/palamedes-dev-warning.cjs
@@ -1,0 +1,36 @@
+"use strict"
+
+const MISSING_ADD_DEPENDENCY_WARNING =
+  "Palamedes message splitting cannot watch fallback catalogs or configuration changes because this loader host does not implement addDependency(). Restart the development server after editing those files."
+const WARNING_STATE_KEY = Symbol.for("palamedes.nextPlugin.missingAddDependencyWarnings")
+
+function warningTargets() {
+  const state = globalThis[WARNING_STATE_KEY]
+  if (state) return state
+
+  const targets = new WeakSet()
+  globalThis[WARNING_STATE_KEY] = targets
+  return targets
+}
+
+function warnMissingAddDependency(loaderContext) {
+  if (process.env.NODE_ENV === "production" || typeof loaderContext.addDependency === "function") {
+    return
+  }
+
+  const target =
+    loaderContext._compilation && typeof loaderContext._compilation === "object"
+      ? loaderContext._compilation
+      : globalThis
+  const targets = warningTargets()
+  if (targets.has(target)) return
+  targets.add(target)
+
+  if (typeof loaderContext.emitWarning === "function") {
+    loaderContext.emitWarning(new Error(MISSING_ADD_DEPENDENCY_WARNING))
+  } else {
+    console.warn(MISSING_ADD_DEPENDENCY_WARNING)
+  }
+}
+
+module.exports = { MISSING_ADD_DEPENDENCY_WARNING, warnMissingAddDependency }

--- a/packages/next-plugin/palamedes-loader.cjs
+++ b/packages/next-plugin/palamedes-loader.cjs
@@ -535,6 +535,7 @@ module.exports = function palamedesLoader(source, inputSourceMap) {
     }
     if (
       serverMessageSplitting &&
+      result.compiledIds.length > 0 &&
       !registration?.matchesCatalog &&
       typeof this.emitWarning === "function"
     ) {

--- a/packages/next-plugin/palamedes-loader.cjs
+++ b/packages/next-plugin/palamedes-loader.cjs
@@ -7,6 +7,7 @@ const { decode, encode } = require("@jridgewell/sourcemap-codec")
 const { loadPalamedesConfigSync } = require("@palamedes/config")
 const { transformPalamedesMacros } = require("@palamedes/transform")
 const picomatch = require("picomatch")
+const { warnMissingAddDependency } = require("./palamedes-dev-warning.cjs")
 
 const SELECTED_MESSAGES_QUERY = "palamedes-selected"
 const configCache = new Map()
@@ -424,30 +425,44 @@ function relativeImport(fromFile, targetFile) {
   return relative
 }
 
-function messageLoaderRegistration(config, sourcePath, compiledIds) {
+function messageLoaderRegistration(config, sourcePath, compiledIds, clearUnmatchedRegistration) {
   const importsByCatalog = selectedMessageImports(config, sourcePath, compiledIds)
-  if (!importsByCatalog) {
-    return null
-  }
-
   const modulePath = normalizePath(
     path.relative(canonicalPath(config.rootDir), canonicalPath(sourcePath))
   )
   const moduleKey = createHash("sha256").update(modulePath).digest("hex").slice(0, 12)
-  const registrations = importsByCatalog.map((imports, catalogIndex) => {
-    const loaders = imports
-      .map(
-        ({ locale, specifier }) =>
-          `${JSON.stringify(locale)}: () => import(${JSON.stringify(specifier)}).then(({ messages }) => messages)`
-      )
-      .join(", ")
-    return `registerMessageLoaders(${JSON.stringify(`${moduleKey}:${catalogIndex}`)}, { ${loaders} });`
-  })
+  if (!importsByCatalog) {
+    if (!clearUnmatchedRegistration) {
+      return null
+    }
+    return {
+      code:
+        `\nimport { registerMessageLoaderGroup } from "@palamedes/runtime";\n` +
+        `registerMessageLoaderGroup(${JSON.stringify(moduleKey)}, []);\n`,
+      matchesCatalog: false,
+    }
+  }
 
-  return (
-    `\nimport { registerMessageLoaders } from "@palamedes/runtime";\n` +
-    `${registrations.join("\n")}\n`
-  )
+  const registrations =
+    compiledIds.length === 0
+      ? []
+      : importsByCatalog.map((imports) => {
+          const loaders = imports
+            .map(
+              ({ locale, specifier }) =>
+                `${JSON.stringify(locale)}: () => import(${JSON.stringify(specifier)}).then(({ messages }) => messages)`
+            )
+            .join(", ")
+          return `{ ${loaders} }`
+        })
+
+  return {
+    code:
+      `\nimport { registerMessageLoaderGroup } from "@palamedes/runtime";\n` +
+      `const __pmds_releaseMessageLoaders = registerMessageLoaderGroup(${JSON.stringify(moduleKey)}, [${registrations.join(", ")}]);\n` +
+      `if (import.meta.webpackHot) import.meta.webpackHot.dispose(__pmds_releaseMessageLoaders);\n`,
+    matchesCatalog: true,
+  }
 }
 
 module.exports = function palamedesLoader(source, inputSourceMap) {
@@ -473,7 +488,12 @@ module.exports = function palamedesLoader(source, inputSourceMap) {
 
   const serverMessageSplitting = options.serverMessageSplitting === true
   const clientMessageSplitting = options.clientMessageSplitting === true
-  if ((!serverMessageSplitting && !clientMessageSplitting) || !result.compiledIds?.length) {
+  const clearsServerRegistration = serverMessageSplitting && process.env.NODE_ENV !== "production"
+  if (
+    (!serverMessageSplitting && !clientMessageSplitting) ||
+    !Array.isArray(result.compiledIds) ||
+    (!result.compiledIds?.length && !clearsServerRegistration)
+  ) {
     if (callback) {
       callback(null, result.code, result.map ?? inputSourceMap ?? null)
       return
@@ -485,9 +505,16 @@ module.exports = function palamedesLoader(source, inputSourceMap) {
     const config = loadConfigCached(options.configPath)
     if (typeof this.addDependency === "function" && config.configPath) {
       this.addDependency(config.configPath)
+    } else {
+      warnMissingAddDependency(this)
     }
     const registration = serverMessageSplitting
-      ? messageLoaderRegistration(config, this.resourcePath, result.compiledIds)
+      ? messageLoaderRegistration(
+          config,
+          this.resourcePath,
+          result.compiledIds,
+          clearsServerRegistration
+        )
       : clientMessageBootstrap(
           config,
           this.resourcePath,
@@ -497,17 +524,29 @@ module.exports = function palamedesLoader(source, inputSourceMap) {
     let code = result.code
     let sourceMap = result.map ?? inputSourceMap ?? null
     if (registration) {
+      const registrationCode = serverMessageSplitting ? registration.code : registration
       if (clientMessageSplitting) {
-        const output = prependClientMessageBootstrap(code, registration)
+        const output = prependClientMessageBootstrap(code, registrationCode)
         code = output.code
         sourceMap = offsetSourceMapForInsertion(sourceMap, output.insertion, output.insertion.value)
       } else {
-        code += registration
+        code += registrationCode
       }
-    } else if (typeof this.emitWarning === "function") {
+    }
+    if (
+      serverMessageSplitting &&
+      !registration?.matchesCatalog &&
+      typeof this.emitWarning === "function"
+    ) {
       this.emitWarning(
         new Error(
-          `Palamedes ${serverMessageSplitting ? "Server Function" : "client graph"} message splitting: ${this.resourcePath} uses messages but is not included in any configured catalog.`
+          `Palamedes Server Function message splitting: ${this.resourcePath} uses messages but is not included in any configured catalog.`
+        )
+      )
+    } else if (!registration && typeof this.emitWarning === "function") {
+      this.emitWarning(
+        new Error(
+          `Palamedes client graph message splitting: ${this.resourcePath} uses messages but is not included in any configured catalog.`
         )
       )
     }

--- a/packages/next-plugin/palamedes-po-loader.cjs
+++ b/packages/next-plugin/palamedes-po-loader.cjs
@@ -5,6 +5,7 @@ const path = require("node:path")
 const { loadPalamedesConfig } = require("@palamedes/config")
 const { compileCatalogArtifactSelected, compileCatalogModule } = require("@palamedes/core-node")
 const { createCatalogLoaderResult, createMissingErrorMessage } = require("@palamedes/transform")
+const { warnMissingAddDependency } = require("./palamedes-dev-warning.cjs")
 
 const SELECTED_MESSAGES_QUERY = "palamedes-selected"
 
@@ -96,6 +97,10 @@ module.exports = function palamedesPoLoader() {
       result.watchFiles.forEach((file) => {
         this.addDependency(file)
       })
+    } else if (selection) {
+      // Selected artifacts fold fallback catalogs into a split sidecar. Without
+      // addDependency a host cannot invalidate those indirect inputs.
+      warnMissingAddDependency(this)
     }
 
     result.warnings.forEach((warning) => {

--- a/packages/next-plugin/src/palamedes-loader.test.ts
+++ b/packages/next-plugin/src/palamedes-loader.test.ts
@@ -138,6 +138,30 @@ describe("palamedes-loader.cjs", () => {
     expect(output).toContain('registerMessageLoaderGroup("514d17c76993", []);')
   })
 
+  it("cleans up a message-free server module outside catalogs without warning", async () => {
+    transformPalamedesMacros.mockReturnValue({
+      code: '"use server"; export async function save() {}',
+      map: null,
+      compiledIds: [],
+    })
+    loadPalamedesConfigSync.mockReturnValue({
+      configPath: "/repo/palamedes.yaml",
+      rootDir: "/repo",
+      locales: ["en"],
+      sourceLocale: "en",
+      catalogs: [{ path: "src/locales/{locale}", include: ["other/**/*.tsx"] }],
+    })
+    const emitWarning = vi.fn()
+
+    const output = await runLoader(
+      { serverMessageSplitting: true },
+      { addDependency() {}, emitWarning }
+    )
+
+    expect(output).toContain('registerMessageLoaderGroup("514d17c76993", []);')
+    expect(emitWarning).not.toHaveBeenCalled()
+  })
+
   it("does not add no-op server cleanup registrations to production modules", async () => {
     vi.stubEnv("NODE_ENV", "production")
     transformPalamedesMacros.mockReturnValue({
@@ -175,6 +199,7 @@ describe("palamedes-loader.cjs", () => {
         message: expect.stringContaining("not included in any configured catalog"),
       })
     )
+    expect(emitWarning).toHaveBeenCalledOnce()
   })
 
   it("blocks a client module on only the document locale's compiled fragments", async () => {

--- a/packages/next-plugin/src/palamedes-loader.test.ts
+++ b/packages/next-plugin/src/palamedes-loader.test.ts
@@ -52,6 +52,7 @@ beforeEach(() => {
 
 afterEach(() => {
   moduleLoader._load = originalLoad
+  vi.unstubAllEnvs()
   vi.restoreAllMocks()
   delete require.cache[require.resolve(loaderPath)]
 })
@@ -97,11 +98,83 @@ describe("palamedes-loader.cjs", () => {
       { addDependency: (file: string) => dependencies.push(file) }
     )
 
-    expect(output).toContain('import { registerMessageLoaders } from "@palamedes/runtime";')
+    expect(output).toContain('import { registerMessageLoaderGroup } from "@palamedes/runtime";')
     expect(output).toContain('"en": () => import("./locales/en.po?palamedes-selected=')
     expect(output).toContain('"de": () => import("./locales/de.po?palamedes-selected=')
     expect(output).toContain(".then(({ messages }) => messages)")
     expect(dependencies).toEqual(["/repo/palamedes.yaml"])
+  })
+
+  it("warns once per development compilation when splitting cannot add config dependencies", async () => {
+    transformPalamedesMacros.mockReturnValue({
+      code: "export const translated = true",
+      map: null,
+      compiledIds: ["id-a"],
+    })
+    const emitWarning = vi.fn()
+    const compilation = {}
+    const context = { _compilation: compilation, emitWarning }
+
+    await runLoader({ serverMessageSplitting: true }, context)
+    await runLoader({ serverMessageSplitting: true }, context)
+
+    expect(emitWarning).toHaveBeenCalledOnce()
+    expect(emitWarning).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining("does not implement addDependency"),
+      })
+    )
+  })
+
+  it("clears a server module's previous registrations when it no longer uses messages", async () => {
+    transformPalamedesMacros.mockReturnValue({
+      code: '"use server"; export async function save() {}',
+      map: null,
+      compiledIds: [],
+    })
+
+    const output = await runLoader({ serverMessageSplitting: true }, { addDependency() {} })
+
+    expect(output).toContain('registerMessageLoaderGroup("514d17c76993", []);')
+  })
+
+  it("does not add no-op server cleanup registrations to production modules", async () => {
+    vi.stubEnv("NODE_ENV", "production")
+    transformPalamedesMacros.mockReturnValue({
+      code: '"use server"; export async function save() {}',
+      map: null,
+      compiledIds: [],
+    })
+
+    await expect(runLoader({ serverMessageSplitting: true })).resolves.toBe(
+      '"use server"; export async function save() {}'
+    )
+  })
+
+  it("preserves the production warning path for source modules outside a catalog", async () => {
+    vi.stubEnv("NODE_ENV", "production")
+    transformPalamedesMacros.mockReturnValue({
+      code: "export const translated = true",
+      map: null,
+      compiledIds: ["id-a"],
+    })
+    loadPalamedesConfigSync.mockReturnValue({
+      configPath: "/repo/palamedes.yaml",
+      rootDir: "/repo",
+      locales: ["en"],
+      sourceLocale: "en",
+      catalogs: [{ path: "src/locales/{locale}", include: ["other/**/*.tsx"] }],
+    })
+    const emitWarning = vi.fn()
+
+    const output = await runLoader({ serverMessageSplitting: true }, { emitWarning })
+
+    expect(output).not.toContain("registerMessageLoaderGroup")
+    expect(emitWarning).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining("not included in any configured catalog"),
+      })
+    )
   })
 
   it("blocks a client module on only the document locale's compiled fragments", async () => {
@@ -120,7 +193,7 @@ describe("palamedes-loader.cjs", () => {
     expect(output).toContain('"de": () => import("./locales/de.po?palamedes-selected=')
     expect(output).toContain(".initializeClientI18n(")
     expect(output).toContain("_i18n.load(")
-    expect(output).not.toContain("registerMessageLoaders")
+    expect(output).not.toContain("registerMessageLoaderGroup")
   })
 
   it("boots a client module before its compiled module-scope call and its importers", async () => {
@@ -593,7 +666,7 @@ describe("palamedes-loader.cjs", () => {
 
     const output = await runLoader({ serverMessageSplitting: false })
 
-    expect(output).not.toContain("registerMessageLoaders")
+    expect(output).not.toContain("registerMessageLoaderGroup")
     expect(loadPalamedesConfigSync).not.toHaveBeenCalled()
   })
 
@@ -641,7 +714,7 @@ describe("palamedes-loader.cjs", () => {
         }
       )
 
-      expect(output).toContain('import { registerMessageLoaders } from "@palamedes/runtime";')
+      expect(output).toContain('import { registerMessageLoaderGroup } from "@palamedes/runtime";')
       expect(warnings).toEqual([])
     } finally {
       await rm(fixtureDirectory, { force: true, recursive: true })

--- a/packages/next-plugin/src/palamedes-po-loader.test.ts
+++ b/packages/next-plugin/src/palamedes-po-loader.test.ts
@@ -143,6 +143,28 @@ describe("palamedes-po-loader.cjs", () => {
     expect(result.code).toContain('"greeting":"Hallo"')
   })
 
+  it("warns once per development compilation when a selected sidecar host cannot add dependencies", async () => {
+    const selection = Buffer.from(JSON.stringify(["id-a"])).toString("base64url")
+    const emitWarning = vi.fn()
+    const compilation = {}
+    const context = {
+      _compilation: compilation,
+      addDependency: undefined,
+      emitWarning,
+      resourceQuery: `?palamedes-selected=${selection}`,
+    }
+
+    await runLoader({}, context)
+    await runLoader({}, context)
+
+    expect(emitWarning).toHaveBeenCalledOnce()
+    expect(emitWarning).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining("does not implement addDependency"),
+      })
+    )
+  })
+
   it("warns about selected messages missing from a non-pseudo locale", async () => {
     compileCatalogArtifactSelected.mockReturnValue({
       messages: {},
@@ -172,7 +194,6 @@ async function runLoader(
 
   const code = await new Promise<string>((resolve, reject) => {
     const context = {
-      ...extraContext,
       resourcePath: "/repo/src/locales/de.po",
       async() {
         return (error: Error | null, output?: string) => {
@@ -189,6 +210,7 @@ async function runLoader(
       addDependency(file: string) {
         dependencies.push(file)
       },
+      ...extraContext,
     }
 
     loader.call(context)

--- a/packages/runtime/src/index.test.ts
+++ b/packages/runtime/src/index.test.ts
@@ -7,6 +7,7 @@ import {
   getI18n,
   initializeClientI18n,
   loadRegisteredMessages,
+  registerMessageLoaderGroup,
   registerMessageLoaders,
   registerMessages,
   resetI18nRuntime,
@@ -257,6 +258,54 @@ describe("registerMessages", () => {
     expect(first).toHaveBeenCalledOnce()
     expect(second).toHaveBeenCalledOnce()
     expect(i18n.loaded["reg-server-hmr"]).toEqual([{ keyK: "old" }, { keyK: "new" }])
+  })
+
+  it("replaces a source module's entire registration group", async () => {
+    const oldLoader = vi.fn(async () => ({ keyM: "old" }))
+    const newLoader = vi.fn(async () => ({ keyM: "new" }))
+    registerMessageLoaderGroup("reg-server-group", [{ "reg-server-group": oldLoader }])
+    const first = createLoadableI18n("reg-server-group")
+    await loadRegisteredMessages(first, "reg-server-group")
+
+    registerMessageLoaderGroup("reg-server-group", [{ "reg-server-group": newLoader }])
+    const second = createLoadableI18n("reg-server-group")
+    await loadRegisteredMessages(second, "reg-server-group")
+
+    expect(oldLoader).toHaveBeenCalledOnce()
+    expect(newLoader).toHaveBeenCalledOnce()
+    expect(second.loaded["reg-server-group"]).toEqual([{ keyM: "new" }])
+  })
+
+  it("removes a source module's registrations when it no longer has messages", async () => {
+    const loader = vi.fn(async () => ({ keyN: "stale" }))
+    registerMessageLoaderGroup("reg-server-removed", [{ "reg-server-removed": loader }])
+    registerMessageLoaderGroup("reg-server-removed", [])
+
+    await loadRegisteredMessages(createLoadableI18n("reg-server-removed"), "reg-server-removed")
+
+    expect(loader).not.toHaveBeenCalled()
+  })
+
+  it("does not let an old module disposal remove its HMR replacement", async () => {
+    const oldLoader = vi.fn(async () => ({ keyO: "old" }))
+    const newLoader = vi.fn(async () => ({ keyO: "new" }))
+    const releaseOld = registerMessageLoaderGroup("reg-server-dispose", [
+      { "reg-server-dispose": oldLoader },
+    ])
+    const releaseNew = registerMessageLoaderGroup("reg-server-dispose", [
+      { "reg-server-dispose": newLoader },
+    ])
+    releaseOld()
+
+    const i18n = createLoadableI18n("reg-server-dispose")
+    await loadRegisteredMessages(i18n, "reg-server-dispose")
+
+    expect(oldLoader).not.toHaveBeenCalled()
+    expect(newLoader).toHaveBeenCalledOnce()
+    releaseNew()
+    await expect(
+      loadRegisteredMessages(createLoadableI18n("reg-server-dispose"), "reg-server-dispose")
+    ).resolves.toBeDefined()
   })
 
   it("rejects a non-loadable instance only when graph messages exist", async () => {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -10,6 +10,9 @@ const SERVER_I18N_GETTER_KEY = Symbol.for("palamedes.runtime.serverI18nGetter")
 const SERVER_SCOPE_STATE_KEY = Symbol.for("palamedes.runtime.serverI18nScopeState")
 const REGISTERED_MESSAGES_KEY = Symbol.for("palamedes.runtime.registeredMessages")
 const REGISTERED_MESSAGE_LOADERS_KEY = Symbol.for("palamedes.runtime.registeredMessageLoaders")
+const REGISTERED_MESSAGE_LOADER_GROUPS_KEY = Symbol.for(
+  "palamedes.runtime.registeredMessageLoaderGroups"
+)
 
 export type RegisteredMessages = Record<string, Record<string, unknown>>
 
@@ -27,6 +30,10 @@ export type RegisteredMessageLoader = () => Promise<Record<string, unknown>>
 type RegisteredMessageLoaderState = {
   loaders: Record<string, RegisteredMessageLoader>
   resources: Map<string, Promise<Record<string, unknown>>>
+}
+
+type RegisteredMessageLoaderGroup = {
+  registrations: Map<string, RegisteredMessageLoaderState>
 }
 
 export type ServerI18nScope<T extends I18nInstance = I18nInstance> = {
@@ -59,6 +66,7 @@ type GlobalRuntimeState = typeof globalThis & {
   }
   [REGISTERED_MESSAGES_KEY]?: Map<string, Record<string, unknown>[]>
   [REGISTERED_MESSAGE_LOADERS_KEY]?: Map<string, RegisteredMessageLoaderState>
+  [REGISTERED_MESSAGE_LOADER_GROUPS_KEY]?: Map<string, RegisteredMessageLoaderGroup>
 }
 
 function globalRuntimeState(): GlobalRuntimeState {
@@ -93,6 +101,25 @@ function getRegisteredMessageLoaders(
   const registered = new Map<string, RegisteredMessageLoaderState>()
   state[REGISTERED_MESSAGE_LOADERS_KEY] = registered
   return registered
+}
+
+function getRegisteredMessageLoaderGroups(
+  state = globalRuntimeState()
+): Map<string, RegisteredMessageLoaderGroup> {
+  const existing = state[REGISTERED_MESSAGE_LOADER_GROUPS_KEY]
+  if (existing) {
+    return existing
+  }
+
+  const registered = new Map<string, RegisteredMessageLoaderGroup>()
+  state[REGISTERED_MESSAGE_LOADER_GROUPS_KEY] = registered
+  return registered
+}
+
+function createRegisteredMessageLoaderState(
+  loaders: Record<string, RegisteredMessageLoader>
+): RegisteredMessageLoaderState {
+  return { loaders, resources: new Map() }
 }
 
 /**
@@ -144,11 +171,62 @@ export function registerMessages(catalogs: RegisteredMessages): void {
 export function registerMessageLoaders(
   key: string,
   loaders: Record<string, RegisteredMessageLoader>
-): void {
-  getRegisteredMessageLoaders().set(key, {
-    loaders,
-    resources: new Map(),
-  })
+): () => void {
+  const registered = getRegisteredMessageLoaders()
+  const registration = createRegisteredMessageLoaderState(loaders)
+  registered.set(key, registration)
+  return () => {
+    if (registered.get(key) === registration) {
+      registered.delete(key)
+    }
+  }
+}
+
+/**
+ * Replace every lazy sidecar registration owned by a generated source module.
+ * The returned release function only removes this exact registration, so an
+ * old HMR module cannot unregister the replacement that evaluated after it.
+ */
+export function registerMessageLoaderGroup(
+  key: string,
+  loaderGroups: ReadonlyArray<Record<string, RegisteredMessageLoader>>
+): () => void {
+  const registered = getRegisteredMessageLoaders()
+  const groups = getRegisteredMessageLoaderGroups()
+  const previous = groups.get(key)
+  if (previous) {
+    for (const [registrationKey, registration] of previous.registrations) {
+      if (registered.get(registrationKey) === registration) {
+        registered.delete(registrationKey)
+      }
+    }
+  }
+
+  if (loaderGroups.length === 0) {
+    groups.delete(key)
+    return () => {}
+  }
+
+  const group: RegisteredMessageLoaderGroup = { registrations: new Map() }
+  groups.set(key, group)
+  for (const [index, loaders] of loaderGroups.entries()) {
+    const registrationKey = `${key}:${index}`
+    const registration = createRegisteredMessageLoaderState(loaders)
+    group.registrations.set(registrationKey, registration)
+    registered.set(registrationKey, registration)
+  }
+
+  return () => {
+    if (groups.get(key) !== group) {
+      return
+    }
+    groups.delete(key)
+    for (const [registrationKey, registration] of group.registrations) {
+      if (registered.get(registrationKey) === registration) {
+        registered.delete(registrationKey)
+      }
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

- Emit one development-only warning per loader compilation when message splitting cannot register dependencies with `addDependency()`.
- Watch source-locale fallback catalogs and configuration changes in the real Turbopack development regression.
- Replace server-side lazy loader registrations by source-module group and release webpack registrations on HMR disposal.

## Behavior and limitations

Supported hosts continue to use dependency registration and production remains warning-free. A host without `addDependency()` receives one actionable development warning and requires a restart after fallback/config edits.

The development regression validates Turbopack's supported document-reload fallback. Webpack top-level-await client output remains production-build-covered; this PR does not claim an equivalent HMR contract. Webpack server modules now release exact registrations on disposal; Turbopack does not expose a compatible server-module disposal hook, so a module removed from its graph can remain registered until the development server restarts.

## Validation

- `RUSTUP_TOOLCHAIN=1.97.1 pnpm build`
- `RUSTUP_TOOLCHAIN=1.97.1 pnpm check-types`
- `pnpm --filter @palamedes/next-plugin test`
- `pnpm --filter @palamedes/runtime test`
- `pnpm --filter @palamedes/example-nextjs-cookie test:message-splitting:development`
- `pnpm lint`
- `pnpm format:check`

Closes #590

🔧 Emily Carter · Implementation Agent
