### PR TITLE
perf(next): cache selected sidecar catalog snapshots

### DIFF
--- a/crates/palamedes-node/src/catalog.rs
+++ b/crates/palamedes-node/src/catalog.rs
@@ -1,5 +1,6 @@
 use std::collections::{BTreeMap, HashMap};
 use std::path::PathBuf;
+use std::sync::OnceLock;
 
 use napi::bindgen_prelude::{Either, Result};
 use napi_derive::napi;
@@ -8,6 +9,18 @@ use crate::catalog_config::{
     CatalogArtifactConfig, CatalogArtifactRequest, CatalogArtifactSelectedRequest,
     CatalogConfigFormat,
 };
+const SELECTED_CATALOG_CACHE_CAPACITY: usize = 64;
+
+/*
+ * N-API entrypoints can be invoked from Node worker threads. The core cache
+ * coalesces construction per catalog-content key and has no mutable data after
+ * construction; this process-local holder only bounds its lifetime and size.
+ */
+fn selected_catalog_cache() -> &'static palamedes::CatalogCompilationCache {
+    static CACHE: OnceLock<palamedes::CatalogCompilationCache> = OnceLock::new();
+    CACHE.get_or_init(|| palamedes::CatalogCompilationCache::new(SELECTED_CATALOG_CACHE_CAPACITY))
+}
+
 use crate::shared::{checked_u32, to_napi_error};
 
 #[napi(object)]
@@ -1899,7 +1912,7 @@ pub fn compile_catalog_artifact_selected(
     request: CatalogArtifactSelectedRequest,
 ) -> Result<CatalogArtifactResult> {
     let request = request.into();
-    palamedes::compile_catalog_artifact_selected(&request)
+    palamedes::compile_catalog_artifact_selected_cached(selected_catalog_cache(), &request)
         .map(CatalogArtifactResult::from)
         .map_err(to_napi_error)
 }

--- a/crates/palamedes/src/catalog_artifact/cache.rs
+++ b/crates/palamedes/src/catalog_artifact/cache.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Condvar, Mutex, MutexGuard, PoisonError};
 
 use ferrocat::{CompiledCatalogIdIndex, CompiledKeyStrategy};
 
@@ -26,12 +26,20 @@ pub struct CatalogCompilationCache {
     state: Mutex<CacheState>,
     #[cfg(test)]
     statistics: Mutex<CacheStatistics>,
+    #[cfg(test)]
+    before_build: Mutex<Option<Arc<dyn Fn(&str) + Send + Sync>>>,
 }
 
 struct CacheState {
-    entries: HashMap<CompilationCacheKey, Arc<Mutex<Option<Arc<CachedCompilation>>>>>,
+    ready: HashMap<CompilationCacheKey, Arc<CachedCompilation>>,
+    in_flight: HashMap<CompilationCacheKey, Arc<InFlightBuild>>,
     clock: u64,
     last_used: HashMap<CompilationCacheKey, u64>,
+}
+
+struct InFlightBuild {
+    finished: Mutex<bool>,
+    wake: Condvar,
 }
 
 struct CachedCompilation {
@@ -73,12 +81,15 @@ impl CatalogCompilationCache {
         Self {
             capacity,
             state: Mutex::new(CacheState {
-                entries: HashMap::new(),
+                ready: HashMap::new(),
+                in_flight: HashMap::new(),
                 clock: 0,
                 last_used: HashMap::new(),
             }),
             #[cfg(test)]
             statistics: Mutex::new(CacheStatistics::default()),
+            #[cfg(test)]
+            before_build: Mutex::new(None),
         }
     }
 
@@ -86,77 +97,107 @@ impl CatalogCompilationCache {
         &self,
         request: &CatalogArtifactSelectedRequest,
     ) -> PalamedesResult<super::types::CatalogArtifactResult> {
-        let snapshot = prepare_compilation_snapshot(&request.config, &request.resource_path)?;
-        let key = CompilationCacheKey::new(&request.config, &snapshot);
+        let mut snapshot = Some(prepare_compilation_snapshot(
+            &request.config,
+            &request.resource_path,
+        )?);
+        let key = CompilationCacheKey::new(&request.config, snapshot.as_ref().expect("snapshot"));
 
         if self.capacity == 0 {
-            let cached = self.build(snapshot)?;
+            let cached = self.build(snapshot.take().expect("snapshot"))?;
             return compile_selected_prepared(&cached.prepared, &cached.compiled_id_index, request);
         }
 
-        let entry = self.entry(key);
-        let compiled = {
-            let mut entry = entry.lock().expect("catalog cache entry lock poisoned");
-            if entry.is_none() {
-                *entry = Some(Arc::new(self.build(snapshot)?));
+        loop {
+            if let Some(compiled) = self.ready(&key) {
+                return compile_selected_prepared(
+                    &compiled.prepared,
+                    &compiled.compiled_id_index,
+                    request,
+                );
             }
-            Arc::clone(entry.as_ref().expect("catalog cache entry initialized"))
-        };
-        // `CachedCompilation` is immutable after construction, so it remains
-        // safe to use after releasing the per-key construction lock.
-        compile_selected_prepared(&compiled.prepared, &compiled.compiled_id_index, request)
+
+            let (in_flight, builds) = self.in_flight(&key);
+            if builds {
+                let completion = InFlightCompletion::new(self, key.clone(), Arc::clone(&in_flight));
+                self.before_build(&key.locale);
+                let result = self.build(snapshot.take().expect("snapshot")).map(Arc::new);
+                if let Ok(compiled) = &result {
+                    self.insert_ready(key.clone(), Arc::clone(compiled));
+                }
+                drop(completion);
+                let compiled = result?;
+                return compile_selected_prepared(
+                    &compiled.prepared,
+                    &compiled.compiled_id_index,
+                    request,
+                );
+            }
+            in_flight.wait();
+        }
     }
 
-    fn entry(&self, key: CompilationCacheKey) -> Arc<Mutex<Option<Arc<CachedCompilation>>>> {
-        let mut state = self
-            .state
-            .lock()
-            .expect("catalog cache state lock poisoned");
+    fn ready(&self, key: &CompilationCacheKey) -> Option<Arc<CachedCompilation>> {
+        let mut state = lock_unpoison(&self.state);
+        let compiled = state.ready.get(key).map(Arc::clone)?;
         state.clock = state.clock.wrapping_add(1);
         let now = state.clock;
-        if let Some(entry) = state.entries.get(&key) {
-            let entry = Arc::clone(entry);
-            state.last_used.insert(key, now);
-            return entry;
-        }
+        state.last_used.insert(key.clone(), now);
+        Some(compiled)
+    }
 
-        if state.entries.len() >= self.capacity {
+    fn in_flight(&self, key: &CompilationCacheKey) -> (Arc<InFlightBuild>, bool) {
+        let mut state = lock_unpoison(&self.state);
+        if let Some(in_flight) = state.in_flight.get(key) {
+            return (Arc::clone(in_flight), false);
+        }
+        let in_flight = Arc::new(InFlightBuild::new());
+        state.in_flight.insert(key.clone(), Arc::clone(&in_flight));
+        (in_flight, true)
+    }
+
+    fn insert_ready(&self, key: CompilationCacheKey, compiled: Arc<CachedCompilation>) {
+        let mut state = lock_unpoison(&self.state);
+        if state.ready.len() >= self.capacity {
             if let Some(oldest) = state
                 .last_used
                 .iter()
                 .min_by_key(|(_, used)| *used)
                 .map(|(key, _)| key.clone())
             {
-                state.entries.remove(&oldest);
+                state.ready.remove(&oldest);
                 state.last_used.remove(&oldest);
             }
         }
-        let entry = Arc::new(Mutex::new(None));
-        state.entries.insert(key.clone(), Arc::clone(&entry));
+        state.clock = state.clock.wrapping_add(1);
+        let now = state.clock;
+        state.ready.insert(key.clone(), compiled);
         state.last_used.insert(key, now);
-        entry
+    }
+
+    fn finish_in_flight(&self, key: &CompilationCacheKey, in_flight: &Arc<InFlightBuild>) {
+        let mut state = lock_unpoison(&self.state);
+        if state
+            .in_flight
+            .get(key)
+            .is_some_and(|current| Arc::ptr_eq(current, in_flight))
+        {
+            state.in_flight.remove(key);
+        }
+        drop(state);
+        in_flight.finish();
     }
 
     fn build(&self, snapshot: CompilationSnapshot) -> PalamedesResult<CachedCompilation> {
-        #[cfg(test)]
-        let parses = snapshot.sources.len();
-        let prepared = snapshot.into_prepared()?;
+        let prepared = snapshot.into_prepared_with_observer(|| self.record_parse())?;
         let catalogs = prepared.loaded.values().collect::<Vec<_>>();
+        self.record_index_build();
         let compiled_id_index = CompiledCatalogIdIndex::new_with_policy(
             &catalogs,
             CompiledKeyStrategy::FerrocatV1,
             ferrocat::IcuSyntaxPolicy::RuntimeLiteralApostrophes,
         )
         .map_err(PalamedesError::BuildCompiledIdIndex)?;
-        #[cfg(test)]
-        {
-            let mut statistics = self
-                .statistics
-                .lock()
-                .expect("catalog cache statistics lock poisoned");
-            statistics.parses += parses;
-            statistics.index_builds += 1;
-        }
         Ok(CachedCompilation {
             prepared,
             compiled_id_index,
@@ -165,11 +206,102 @@ impl CatalogCompilationCache {
 
     #[cfg(test)]
     pub(super) fn statistics(&self) -> CacheStatistics {
-        *self
-            .statistics
-            .lock()
-            .expect("catalog cache statistics lock poisoned")
+        *lock_unpoison(&self.statistics)
     }
+
+    fn record_parse(&self) {
+        #[cfg(test)]
+        {
+            lock_unpoison(&self.statistics).parses += 1;
+        }
+    }
+
+    fn record_index_build(&self) {
+        #[cfg(test)]
+        {
+            lock_unpoison(&self.statistics).index_builds += 1;
+        }
+    }
+
+    #[cfg(test)]
+    pub(super) fn ready_len(&self) -> usize {
+        lock_unpoison(&self.state).ready.len()
+    }
+
+    #[cfg(test)]
+    pub(super) fn set_before_build_hook(&self, hook: Arc<dyn Fn(&str) + Send + Sync>) {
+        *lock_unpoison(&self.before_build) = Some(hook);
+    }
+
+    #[cfg(test)]
+    pub(super) fn clear_before_build_hook(&self) {
+        *lock_unpoison(&self.before_build) = None;
+    }
+
+    fn before_build(&self, locale: &str) {
+        #[cfg(not(test))]
+        let _ = locale;
+        #[cfg(test)]
+        let hook = lock_unpoison(&self.before_build).as_ref().map(Arc::clone);
+        #[cfg(test)]
+        if let Some(hook) = hook {
+            hook(locale);
+        }
+    }
+}
+
+impl InFlightBuild {
+    fn new() -> Self {
+        Self {
+            finished: Mutex::new(false),
+            wake: Condvar::new(),
+        }
+    }
+
+    fn wait(&self) {
+        let mut finished = lock_unpoison(&self.finished);
+        while !*finished {
+            finished = self
+                .wake
+                .wait(finished)
+                .unwrap_or_else(PoisonError::into_inner);
+        }
+    }
+
+    fn finish(&self) {
+        *lock_unpoison(&self.finished) = true;
+        self.wake.notify_all();
+    }
+}
+
+struct InFlightCompletion<'a> {
+    cache: &'a CatalogCompilationCache,
+    key: CompilationCacheKey,
+    in_flight: Arc<InFlightBuild>,
+}
+
+impl<'a> InFlightCompletion<'a> {
+    fn new(
+        cache: &'a CatalogCompilationCache,
+        key: CompilationCacheKey,
+        in_flight: Arc<InFlightBuild>,
+    ) -> Self {
+        Self {
+            cache,
+            key,
+            in_flight,
+        }
+    }
+}
+
+impl Drop for InFlightCompletion<'_> {
+    fn drop(&mut self) {
+        self.cache.finish_in_flight(&self.key, &self.in_flight);
+    }
+}
+
+fn lock_unpoison<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+    mutex.lock().unwrap_or_else(PoisonError::into_inner)
 }
 
 impl CompilationCacheKey {

--- a/crates/palamedes/src/catalog_artifact/cache.rs
+++ b/crates/palamedes/src/catalog_artifact/cache.rs
@@ -9,6 +9,9 @@ use super::resolve::{prepare_compilation_snapshot, CompilationSnapshot};
 use super::types::{CatalogArtifactConfig, CatalogArtifactSelectedRequest};
 use super::{compile_selected_prepared, PreparedCompilation};
 
+#[cfg(test)]
+type BeforeBuildHook = Arc<dyn Fn(&str) + Send + Sync>;
+
 /// A bounded cache for selected catalog compilation inputs.
 ///
 /// Callers own the cache. In particular, the Node binding keeps one bounded
@@ -27,7 +30,7 @@ pub struct CatalogCompilationCache {
     #[cfg(test)]
     statistics: Mutex<CacheStatistics>,
     #[cfg(test)]
-    before_build: Mutex<Option<Arc<dyn Fn(&str) + Send + Sync>>>,
+    before_build: Mutex<Option<BeforeBuildHook>>,
 }
 
 struct CacheState {
@@ -229,7 +232,7 @@ impl CatalogCompilationCache {
     }
 
     #[cfg(test)]
-    pub(super) fn set_before_build_hook(&self, hook: Arc<dyn Fn(&str) + Send + Sync>) {
+    pub(super) fn set_before_build_hook(&self, hook: BeforeBuildHook) {
         *lock_unpoison(&self.before_build) = Some(hook);
     }
 

--- a/crates/palamedes/src/catalog_artifact/cache.rs
+++ b/crates/palamedes/src/catalog_artifact/cache.rs
@@ -1,0 +1,204 @@
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use ferrocat::{CompiledCatalogIdIndex, CompiledKeyStrategy};
+
+use crate::error::{PalamedesError, PalamedesResult};
+
+use super::resolve::{prepare_compilation_snapshot, CompilationSnapshot};
+use super::types::{CatalogArtifactConfig, CatalogArtifactSelectedRequest};
+use super::{compile_selected_prepared, PreparedCompilation};
+
+/// A bounded cache for selected catalog compilation inputs.
+///
+/// Callers own the cache. In particular, the Node binding keeps one bounded
+/// cache for its native-process lifetime; Rust and CLI callers do not acquire
+/// an implicit process-global cache. Each lookup reads every dependency and
+/// hashes its content before reusing a value, so coarse timestamps, atomic
+/// replacement, and missing-file transitions cannot return stale catalogs.
+///
+/// Entries are keyed by the resolved catalog set, source locale, catalog
+/// configuration, fallback chain, and content hash. Work for a cache key is
+/// coalesced behind that key's mutex, while unrelated catalog sets parse and
+/// index concurrently.
+pub struct CatalogCompilationCache {
+    capacity: usize,
+    state: Mutex<CacheState>,
+    #[cfg(test)]
+    statistics: Mutex<CacheStatistics>,
+}
+
+struct CacheState {
+    entries: HashMap<CompilationCacheKey, Arc<Mutex<Option<Arc<CachedCompilation>>>>>,
+    clock: u64,
+    last_used: HashMap<CompilationCacheKey, u64>,
+}
+
+struct CachedCompilation {
+    prepared: PreparedCompilation,
+    compiled_id_index: CompiledCatalogIdIndex,
+}
+
+#[derive(Clone, Eq, Hash, PartialEq)]
+struct CompilationCacheKey {
+    root_dir: String,
+    locales: Vec<String>,
+    source_locale: String,
+    catalog_patterns: Vec<(String, super::types::PalamedesCatalogFormat)>,
+    locale: String,
+    fallback_chain: Vec<String>,
+    files: Vec<CatalogContentKey>,
+}
+
+#[derive(Clone, Eq, Hash, PartialEq)]
+struct CatalogContentKey {
+    path: String,
+    digest: [u8; 32],
+}
+
+#[cfg(test)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(super) struct CacheStatistics {
+    pub(super) parses: usize,
+    pub(super) index_builds: usize,
+}
+
+impl CatalogCompilationCache {
+    /// Creates a cache retaining at most `capacity` resolved catalog sets.
+    ///
+    /// A capacity of zero disables retention while preserving normal compile
+    /// behavior. Existing users can continue calling the uncached API.
+    #[must_use]
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            capacity,
+            state: Mutex::new(CacheState {
+                entries: HashMap::new(),
+                clock: 0,
+                last_used: HashMap::new(),
+            }),
+            #[cfg(test)]
+            statistics: Mutex::new(CacheStatistics::default()),
+        }
+    }
+
+    pub(super) fn compile_selected(
+        &self,
+        request: &CatalogArtifactSelectedRequest,
+    ) -> PalamedesResult<super::types::CatalogArtifactResult> {
+        let snapshot = prepare_compilation_snapshot(&request.config, &request.resource_path)?;
+        let key = CompilationCacheKey::new(&request.config, &snapshot);
+
+        if self.capacity == 0 {
+            let cached = self.build(snapshot)?;
+            return compile_selected_prepared(&cached.prepared, &cached.compiled_id_index, request);
+        }
+
+        let entry = self.entry(key);
+        let compiled = {
+            let mut entry = entry.lock().expect("catalog cache entry lock poisoned");
+            if entry.is_none() {
+                *entry = Some(Arc::new(self.build(snapshot)?));
+            }
+            Arc::clone(entry.as_ref().expect("catalog cache entry initialized"))
+        };
+        // `CachedCompilation` is immutable after construction, so it remains
+        // safe to use after releasing the per-key construction lock.
+        compile_selected_prepared(&compiled.prepared, &compiled.compiled_id_index, request)
+    }
+
+    fn entry(&self, key: CompilationCacheKey) -> Arc<Mutex<Option<Arc<CachedCompilation>>>> {
+        let mut state = self
+            .state
+            .lock()
+            .expect("catalog cache state lock poisoned");
+        state.clock = state.clock.wrapping_add(1);
+        let now = state.clock;
+        if let Some(entry) = state.entries.get(&key) {
+            let entry = Arc::clone(entry);
+            state.last_used.insert(key, now);
+            return entry;
+        }
+
+        if state.entries.len() >= self.capacity {
+            if let Some(oldest) = state
+                .last_used
+                .iter()
+                .min_by_key(|(_, used)| *used)
+                .map(|(key, _)| key.clone())
+            {
+                state.entries.remove(&oldest);
+                state.last_used.remove(&oldest);
+            }
+        }
+        let entry = Arc::new(Mutex::new(None));
+        state.entries.insert(key.clone(), Arc::clone(&entry));
+        state.last_used.insert(key, now);
+        entry
+    }
+
+    fn build(&self, snapshot: CompilationSnapshot) -> PalamedesResult<CachedCompilation> {
+        #[cfg(test)]
+        let parses = snapshot.sources.len();
+        let prepared = snapshot.into_prepared()?;
+        let catalogs = prepared.loaded.values().collect::<Vec<_>>();
+        let compiled_id_index = CompiledCatalogIdIndex::new_with_policy(
+            &catalogs,
+            CompiledKeyStrategy::FerrocatV1,
+            ferrocat::IcuSyntaxPolicy::RuntimeLiteralApostrophes,
+        )
+        .map_err(PalamedesError::BuildCompiledIdIndex)?;
+        #[cfg(test)]
+        {
+            let mut statistics = self
+                .statistics
+                .lock()
+                .expect("catalog cache statistics lock poisoned");
+            statistics.parses += parses;
+            statistics.index_builds += 1;
+        }
+        Ok(CachedCompilation {
+            prepared,
+            compiled_id_index,
+        })
+    }
+
+    #[cfg(test)]
+    pub(super) fn statistics(&self) -> CacheStatistics {
+        *self
+            .statistics
+            .lock()
+            .expect("catalog cache statistics lock poisoned")
+    }
+}
+
+impl CompilationCacheKey {
+    fn new(config: &CatalogArtifactConfig, snapshot: &CompilationSnapshot) -> Self {
+        Self {
+            root_dir: config.root_dir.clone(),
+            locales: config.locales.clone(),
+            source_locale: config.source_locale.clone(),
+            catalog_patterns: config
+                .catalogs
+                .iter()
+                .map(|catalog| (catalog.path.clone(), catalog.format))
+                .collect(),
+            locale: snapshot.locale.clone(),
+            fallback_chain: snapshot.fallback_chain.clone(),
+            files: snapshot
+                .sources
+                .iter()
+                .map(|source| CatalogContentKey {
+                    path: source.path.to_string_lossy().into_owned(),
+                    digest: source.digest,
+                })
+                .collect(),
+        }
+    }
+}
+
+impl Default for CatalogCompilationCache {
+    fn default() -> Self {
+        Self::new(64)
+    }
+}

--- a/crates/palamedes/src/catalog_artifact/load.rs
+++ b/crates/palamedes/src/catalog_artifact/load.rs
@@ -74,11 +74,23 @@ pub(super) fn parse_catalog_sources(
     sources: &[CatalogSource],
     source_locale: &str,
 ) -> PalamedesResult<LocaleCatalogs> {
+    parse_catalog_sources_with_observer(sources, source_locale, || {})
+}
+
+pub(super) fn parse_catalog_sources_with_observer<F>(
+    sources: &[CatalogSource],
+    source_locale: &str,
+    mut on_parse: F,
+) -> PalamedesResult<LocaleCatalogs>
+where
+    F: FnMut(),
+{
     let mut loaded = LocaleCatalogs::new();
     for source in sources {
         let options = ParseCatalogOptions::new(&source.content, source_locale)
             .with_locale(source.locale.as_str())
             .with_mode(source.format.ferrocat_mode());
+        on_parse();
         let parsed =
             parse_catalog(options).map_err(|source_error| PalamedesError::ParseCatalog {
                 path: source.path.clone(),

--- a/crates/palamedes/src/catalog_artifact/load.rs
+++ b/crates/palamedes/src/catalog_artifact/load.rs
@@ -3,6 +3,7 @@ use std::fs;
 use std::path::Path;
 
 use ferrocat::{parse_catalog, NormalizedParsedCatalog, ParseCatalogOptions};
+use sha2::{Digest, Sha256};
 
 use super::resolve::normalize_path;
 use super::types::{CatalogArtifactConfig, CatalogConfig};
@@ -10,48 +11,89 @@ use crate::error::{PalamedesError, PalamedesResult};
 
 pub(super) type LocaleCatalogs = BTreeMap<String, NormalizedParsedCatalog>;
 
+pub(super) struct CatalogSource {
+    pub(super) path: std::path::PathBuf,
+    pub(super) locale: String,
+    pub(super) format: super::types::PalamedesCatalogFormat,
+    pub(super) content: String,
+    pub(super) digest: [u8; 32],
+}
+
+pub(super) type CatalogSources = Vec<CatalogSource>;
+
 pub(super) fn load_catalogs(
     files: &[std::path::PathBuf],
     config: &CatalogArtifactConfig,
 ) -> PalamedesResult<LocaleCatalogs> {
-    let mut loaded = LocaleCatalogs::new();
+    let sources = read_catalog_sources(files, config)?;
+    parse_catalog_sources(&sources, &config.source_locale)
+}
 
-    for file in files {
-        if !file.exists() {
-            if file == &files[0] {
-                return Err(PalamedesError::CatalogFileNotFound { path: file.clone() });
-            }
-            continue;
-        }
+/// Reads every configured dependency before cache lookup. A content digest is
+/// deliberately used instead of metadata: some editors retain timestamps when
+/// atomically replacing a catalog, and serving that older snapshot would make
+/// dev rebuilds observably stale.
+pub(super) fn read_catalog_sources(
+    files: &[std::path::PathBuf],
+    config: &CatalogArtifactConfig,
+) -> PalamedesResult<CatalogSources> {
+    let mut sources = Vec::new();
 
+    for (index, file) in files.iter().enumerate() {
         let locale = infer_locale_from_path(file, config)
             .ok_or_else(|| PalamedesError::CouldNotInferLocale { path: file.clone() })?;
-        let content = fs::read_to_string(file).map_err(|source| PalamedesError::ReadFile {
-            path: file.clone(),
-            source,
-        })?;
-        let catalog = catalog_for_path(file, config)
-            .ok_or_else(|| PalamedesError::CouldNotInferLocale { path: file.clone() })?;
-        let options = ParseCatalogOptions::new(&content, &config.source_locale)
-            .with_locale(locale.as_str())
-            .with_mode(catalog.format.ferrocat_mode());
-
-        let parsed = parse_catalog(options).map_err(|source| PalamedesError::ParseCatalog {
-            path: file.clone(),
-            source,
-        })?;
-
-        loaded.insert(
-            locale,
-            parsed
-                .into_normalized_view()
-                .map_err(|source| PalamedesError::NormalizeCatalog {
+        let content = match fs::read_to_string(file) {
+            Ok(content) => content,
+            Err(source) if source.kind() == std::io::ErrorKind::NotFound && index == 0 => {
+                return Err(PalamedesError::CatalogFileNotFound { path: file.clone() });
+            }
+            Err(source) if source.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(source) => {
+                return Err(PalamedesError::ReadFile {
                     path: file.clone(),
                     source,
-                })?,
-        );
+                });
+            }
+        };
+        let catalog = catalog_for_path(file, config)
+            .ok_or_else(|| PalamedesError::CouldNotInferLocale { path: file.clone() })?;
+        let digest = Sha256::digest(content.as_bytes()).into();
+        sources.push(CatalogSource {
+            path: file.clone(),
+            locale,
+            format: catalog.format,
+            content,
+            digest,
+        });
     }
 
+    Ok(sources)
+}
+
+pub(super) fn parse_catalog_sources(
+    sources: &[CatalogSource],
+    source_locale: &str,
+) -> PalamedesResult<LocaleCatalogs> {
+    let mut loaded = LocaleCatalogs::new();
+    for source in sources {
+        let options = ParseCatalogOptions::new(&source.content, source_locale)
+            .with_locale(source.locale.as_str())
+            .with_mode(source.format.ferrocat_mode());
+        let parsed =
+            parse_catalog(options).map_err(|source_error| PalamedesError::ParseCatalog {
+                path: source.path.clone(),
+                source: source_error,
+            })?;
+        loaded.insert(
+            source.locale.clone(),
+            parsed.into_normalized_view().map_err(|source_error| {
+                PalamedesError::NormalizeCatalog {
+                    path: source.path.clone(),
+                    source: source_error,
+                }
+            })?,
+        );
+    }
     Ok(loaded)
 }
 

--- a/crates/palamedes/src/catalog_artifact/mod.rs
+++ b/crates/palamedes/src/catalog_artifact/mod.rs
@@ -1,3 +1,4 @@
+mod cache;
 mod compile;
 mod load;
 mod resolve;
@@ -17,6 +18,7 @@ use ferrocat::{
 
 use crate::error::{PalamedesError, PalamedesResult};
 
+pub use self::cache::CatalogCompilationCache;
 use self::compile::{build_artifact_result, runtime_icu_options};
 use self::load::LocaleCatalogs;
 use self::resolve::{ferrocat_fallback_chain, prepare_compilation};
@@ -37,7 +39,7 @@ pub(crate) fn resolve_catalog_path(
         .with_extension(catalog.format.extension())
 }
 
-struct PreparedCompilation {
+pub(super) struct PreparedCompilation {
     locale: String,
     fallback_chain: Vec<String>,
     watch_files: Vec<PathBuf>,
@@ -104,6 +106,27 @@ pub fn compile_catalog_artifact_selected(
         ferrocat::IcuSyntaxPolicy::RuntimeLiteralApostrophes,
     )
     .map_err(PalamedesError::BuildCompiledIdIndex)?;
+    compile_selected_prepared(&prepared, &compiled_id_index, request)
+}
+
+/// Compiles selected runtime IDs while reusing an explicit catalog cache.
+///
+/// The cache is caller-owned and validates catalog content on every call.
+/// This is intended for hosts that compile many independently selected module
+/// sidecars from the same catalog set.
+pub fn compile_catalog_artifact_selected_cached(
+    cache: &CatalogCompilationCache,
+    request: &CatalogArtifactSelectedRequest,
+) -> PalamedesResult<CatalogArtifactResult> {
+    cache.compile_selected(request)
+}
+
+pub(super) fn compile_selected_prepared(
+    prepared: &PreparedCompilation,
+    compiled_id_index: &CompiledCatalogIdIndex,
+    request: &CatalogArtifactSelectedRequest,
+) -> PalamedesResult<CatalogArtifactResult> {
+    let catalogs = prepared.loaded.values().collect::<Vec<_>>();
     let ferrocat_fallback_chain = ferrocat_fallback_chain(
         &prepared.fallback_chain,
         &prepared.locale,
@@ -134,13 +157,13 @@ pub fn compile_catalog_artifact_selected(
     .with_options(artifact_options);
 
     let artifact =
-        ferrocat_compile_catalog_artifact_selected(&catalogs, &compiled_id_index, &options)
+        ferrocat_compile_catalog_artifact_selected(&catalogs, compiled_id_index, &options)
             .map_err(PalamedesError::CompileSelectedCatalogArtifact)?;
 
     build_artifact_result(
         artifact,
-        prepared.watch_files,
-        prepared.fallback_chain,
+        prepared.watch_files.clone(),
+        prepared.fallback_chain.clone(),
         request.config.pseudo_locale.as_deref(),
         &prepared.locale,
     )

--- a/crates/palamedes/src/catalog_artifact/resolve.rs
+++ b/crates/palamedes/src/catalog_artifact/resolve.rs
@@ -4,7 +4,7 @@ use regex::Regex;
 
 use crate::error::{PalamedesError, PalamedesResult};
 
-use super::load::load_catalogs;
+use super::load::{load_catalogs, parse_catalog_sources, read_catalog_sources, CatalogSources};
 use super::types::{CatalogArtifactConfig, FallbackLocales};
 use super::{resolve_catalog_path, PreparedCompilation};
 
@@ -32,6 +32,46 @@ pub(super) fn prepare_compilation(
         fallback_chain,
         watch_files,
         loaded,
+    })
+}
+
+pub(super) struct CompilationSnapshot {
+    pub(super) locale: String,
+    pub(super) fallback_chain: Vec<String>,
+    pub(super) watch_files: Vec<PathBuf>,
+    pub(super) sources: CatalogSources,
+    source_locale: String,
+}
+
+impl CompilationSnapshot {
+    pub(super) fn into_prepared(self) -> PalamedesResult<PreparedCompilation> {
+        let loaded = parse_catalog_sources(&self.sources, &self.source_locale)?;
+        Ok(PreparedCompilation {
+            locale: self.locale,
+            fallback_chain: self.fallback_chain,
+            watch_files: self.watch_files,
+            loaded,
+        })
+    }
+}
+
+pub(super) fn prepare_compilation_snapshot(
+    config: &CatalogArtifactConfig,
+    resource_path: &str,
+) -> PalamedesResult<CompilationSnapshot> {
+    let resource_path = PathBuf::from(resource_path);
+    let root_dir = PathBuf::from(&config.root_dir);
+    let resolved = resolve_catalog_request(config, &resource_path)?;
+    let fallback_chain = resolve_locale_chain(config, &resolved.locale);
+    let watch_files =
+        collect_watch_files(&root_dir, &resolved.primary_file, config, &fallback_chain);
+    let sources = read_catalog_sources(&watch_files, config)?;
+    Ok(CompilationSnapshot {
+        locale: resolved.locale,
+        fallback_chain,
+        watch_files,
+        sources,
+        source_locale: config.source_locale.clone(),
     })
 }
 

--- a/crates/palamedes/src/catalog_artifact/resolve.rs
+++ b/crates/palamedes/src/catalog_artifact/resolve.rs
@@ -4,7 +4,9 @@ use regex::Regex;
 
 use crate::error::{PalamedesError, PalamedesResult};
 
-use super::load::{load_catalogs, parse_catalog_sources, read_catalog_sources, CatalogSources};
+use super::load::{
+    load_catalogs, parse_catalog_sources_with_observer, read_catalog_sources, CatalogSources,
+};
 use super::types::{CatalogArtifactConfig, FallbackLocales};
 use super::{resolve_catalog_path, PreparedCompilation};
 
@@ -44,8 +46,15 @@ pub(super) struct CompilationSnapshot {
 }
 
 impl CompilationSnapshot {
-    pub(super) fn into_prepared(self) -> PalamedesResult<PreparedCompilation> {
-        let loaded = parse_catalog_sources(&self.sources, &self.source_locale)?;
+    pub(super) fn into_prepared_with_observer<F>(
+        self,
+        on_parse: F,
+    ) -> PalamedesResult<PreparedCompilation>
+    where
+        F: FnMut(),
+    {
+        let loaded =
+            parse_catalog_sources_with_observer(&self.sources, &self.source_locale, on_parse)?;
         Ok(PreparedCompilation {
             locale: self.locale,
             fallback_chain: self.fallback_chain,

--- a/crates/palamedes/src/catalog_artifact/tests.rs
+++ b/crates/palamedes/src/catalog_artifact/tests.rs
@@ -1,7 +1,8 @@
 use super::{
-    compile_catalog_artifact, compile_catalog_artifact_selected, CatalogArtifactConfig,
+    compile_catalog_artifact, compile_catalog_artifact_selected,
+    compile_catalog_artifact_selected_cached, CatalogArtifactConfig,
     CatalogArtifactDiagnosticSeverity, CatalogArtifactRequest, CatalogArtifactSelectedRequest,
-    CatalogConfig, PalamedesCatalogFormat,
+    CatalogCompilationCache, CatalogConfig, PalamedesCatalogFormat,
 };
 use crate::test_support::scope_macro_test_source;
 use ferrocat::compiled_key;
@@ -591,6 +592,98 @@ msgstr "Hallo"
 }
 
 #[test]
+fn selected_catalog_cache_reuses_parses_and_index_across_sidecars() {
+    let fixture = create_fixture_dir("selected-catalog-cache-reuse");
+    let locale_dir = fixture.join("src/locales");
+    fs::create_dir_all(&locale_dir).expect("locale dir");
+    write_test_catalog(&locale_dir, "en", &[("Hello", ""), ("Goodbye", "")]);
+    write_test_catalog(
+        &locale_dir,
+        "de",
+        &[("Hello", "Hallo"), ("Goodbye", "Auf Wiedersehen")],
+    );
+    let request = selected_request(&fixture, &locale_dir, "Hello");
+    let cache = CatalogCompilationCache::new(8);
+
+    // This models many module sidecars selecting different subsets from one
+    // locale. Parsing/index construction scales with catalog snapshots, not
+    // with the number of selected module compiles.
+    for _ in 0..64 {
+        let result = compile_catalog_artifact_selected_cached(&cache, &request)
+            .expect("selected catalog artifact");
+        assert_eq!(result.messages.len(), 1);
+        assert_eq!(
+            result
+                .messages
+                .get(&compiled_key("Hello", None))
+                .map(String::as_str),
+            Some("Hallo")
+        );
+    }
+
+    assert_eq!(
+        cache.statistics(),
+        super::cache::CacheStatistics {
+            parses: 2,
+            index_builds: 1,
+        }
+    );
+}
+
+#[test]
+fn selected_catalog_cache_invalidates_equal_mtime_content_replacement() {
+    let fixture = create_fixture_dir("selected-catalog-cache-content-replacement");
+    let locale_dir = fixture.join("src/locales");
+    fs::create_dir_all(&locale_dir).expect("locale dir");
+    write_test_catalog(&locale_dir, "en", &[("Hello", "")]);
+    write_test_catalog(&locale_dir, "de", &[("Hello", "Hallo")]);
+    let request = selected_request(&fixture, &locale_dir, "Hello");
+    let cache = CatalogCompilationCache::new(8);
+
+    let first = compile_catalog_artifact_selected_cached(&cache, &request)
+        .expect("first selected catalog artifact");
+    assert_eq!(
+        first
+            .messages
+            .get(&compiled_key("Hello", None))
+            .map(String::as_str),
+        Some("Hallo")
+    );
+
+    let de_catalog = locale_dir.join("de.po");
+    let original_mtime = fs::metadata(&de_catalog)
+        .expect("catalog metadata")
+        .modified()
+        .expect("catalog modified time");
+    fs::write(&de_catalog, "this is not a catalog").expect("write malformed catalog");
+    restore_mtime(&de_catalog, original_mtime);
+    assert!(
+        compile_catalog_artifact_selected_cached(&cache, &request).is_err(),
+        "a changed malformed catalog must not be hidden behind the prior cached snapshot"
+    );
+
+    write_test_catalog(&locale_dir, "de", &[("Hello", "Guten Tag")]);
+    restore_mtime(&de_catalog, original_mtime);
+
+    let second = compile_catalog_artifact_selected_cached(&cache, &request)
+        .expect("updated selected catalog artifact");
+    assert_eq!(
+        second
+            .messages
+            .get(&compiled_key("Hello", None))
+            .map(String::as_str),
+        Some("Guten Tag")
+    );
+    assert_eq!(
+        cache.statistics(),
+        super::cache::CacheStatistics {
+            parses: 4,
+            index_builds: 2,
+        }
+    );
+}
+
+#[test]
 fn compile_catalog_artifact_selected_reports_icu_compatibility_diagnostics() {
     let fixture = create_fixture_dir("catalog-artifact-selected-icu-compatibility");
     let locale_dir = fixture.join("src/locales");
@@ -1091,6 +1184,37 @@ fn write_test_catalog(locale_dir: &Path, locale: &str, entries: &[(&str, &str)])
     }
 
     fs::write(locale_dir.join(format!("{locale}.po")), catalog).expect("write catalog");
+}
+
+fn selected_request(
+    fixture: &Path,
+    locale_dir: &Path,
+    message: &str,
+) -> CatalogArtifactSelectedRequest {
+    CatalogArtifactSelectedRequest {
+        config: CatalogArtifactConfig {
+            root_dir: fixture.to_string_lossy().into_owned(),
+            locales: vec!["en".to_owned(), "de".to_owned()],
+            source_locale: "en".to_owned(),
+            fallback_locales: None,
+            pseudo_locale: None,
+            catalogs: vec![CatalogConfig {
+                path: "src/locales/{locale}".to_owned(),
+                format: PalamedesCatalogFormat::Po,
+            }],
+        },
+        resource_path: locale_dir.join("de.po").to_string_lossy().into_owned(),
+        compiled_ids: vec![compiled_key(message, None)],
+    }
+}
+
+fn restore_mtime(path: &Path, mtime: SystemTime) {
+    fs::OpenOptions::new()
+        .write(true)
+        .open(path)
+        .expect("catalog file")
+        .set_times(std::fs::FileTimes::new().set_modified(mtime))
+        .expect("restore catalog mtime");
 }
 
 fn po_string(value: &str) -> String {

--- a/crates/palamedes/src/catalog_artifact/tests.rs
+++ b/crates/palamedes/src/catalog_artifact/tests.rs
@@ -8,7 +8,11 @@ use crate::test_support::scope_macro_test_source;
 use ferrocat::compiled_key;
 use std::collections::BTreeSet;
 use std::fs;
+use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::path::{Path, PathBuf};
+use std::sync::{mpsc, Arc, Mutex};
+use std::thread;
+use std::time::Duration;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 #[test]
@@ -596,28 +600,26 @@ fn selected_catalog_cache_reuses_parses_and_index_across_sidecars() {
     let fixture = create_fixture_dir("selected-catalog-cache-reuse");
     let locale_dir = fixture.join("src/locales");
     fs::create_dir_all(&locale_dir).expect("locale dir");
-    write_test_catalog(&locale_dir, "en", &[("Hello", ""), ("Goodbye", "")]);
-    write_test_catalog(
-        &locale_dir,
-        "de",
-        &[("Hello", "Hallo"), ("Goodbye", "Auf Wiedersehen")],
-    );
-    let request = selected_request(&fixture, &locale_dir, "Hello");
+    write_numbered_catalog(&locale_dir, "en", "", 64);
+    write_numbered_catalog(&locale_dir, "de", "DE ", 64);
     let cache = CatalogCompilationCache::new(8);
 
-    // This models many module sidecars selecting different subsets from one
-    // locale. Parsing/index construction scales with catalog snapshots, not
-    // with the number of selected module compiles.
-    for _ in 0..64 {
+    // Each distinct requested ID represents a separate module sidecar. The
+    // counters are incremented at the actual parser and ID-index construction
+    // sites, so this fails if either heavy operation is keyed by selection.
+    for index in 0..64 {
+        let message = format!("Message {index}");
+        let request = selected_request(&fixture, &locale_dir, &message);
         let result = compile_catalog_artifact_selected_cached(&cache, &request)
             .expect("selected catalog artifact");
         assert_eq!(result.messages.len(), 1);
+        let expected = format!("DE {message}");
         assert_eq!(
             result
                 .messages
-                .get(&compiled_key("Hello", None))
+                .get(&compiled_key(&message, None))
                 .map(String::as_str),
-            Some("Hallo")
+            Some(expected.as_str())
         );
     }
 
@@ -677,10 +679,134 @@ fn selected_catalog_cache_invalidates_equal_mtime_content_replacement() {
     assert_eq!(
         cache.statistics(),
         super::cache::CacheStatistics {
+            parses: 5,
+            index_builds: 2,
+        }
+    );
+}
+
+#[test]
+fn selected_catalog_cache_failures_do_not_consume_ready_capacity() {
+    let fixture = create_fixture_dir("selected-catalog-cache-failure-capacity");
+    let locale_dir = fixture.join("src/locales");
+    fs::create_dir_all(&locale_dir).expect("locale dir");
+    write_test_catalog(&locale_dir, "en", &[("Hello", "")]);
+    write_test_catalog(&locale_dir, "de", &[("Hello", "Hallo")]);
+    write_test_catalog(&locale_dir, "fr", &[("Hello", "Bonjour")]);
+    let cache = CatalogCompilationCache::new(1);
+    let fr = selected_request_for_locale(&fixture, &locale_dir, "fr", "Hello");
+    compile_catalog_artifact_selected_cached(&cache, &fr).expect("warm ready entry");
+
+    fs::write(locale_dir.join("de.po"), "not a catalog").expect("write malformed catalog");
+    let de = selected_request_for_locale(&fixture, &locale_dir, "de", "Hello");
+    for _ in 0..3 {
+        assert!(compile_catalog_artifact_selected_cached(&cache, &de).is_err());
+    }
+    assert_eq!(
+        cache.ready_len(),
+        1,
+        "failed snapshots must not occupy the LRU"
+    );
+    compile_catalog_artifact_selected_cached(&cache, &fr).expect("hot ready entry survives");
+    assert_eq!(
+        cache.statistics(),
+        super::cache::CacheStatistics {
+            parses: 5,
+            index_builds: 1,
+        }
+    );
+}
+
+#[test]
+fn selected_catalog_cache_keeps_identical_builds_coalesced_under_capacity_pressure() {
+    let fixture = create_fixture_dir("selected-catalog-cache-in-flight-capacity");
+    let locale_dir = fixture.join("src/locales");
+    fs::create_dir_all(&locale_dir).expect("locale dir");
+    write_test_catalog(&locale_dir, "en", &[("Hello", "")]);
+    write_test_catalog(&locale_dir, "de", &[("Hello", "Hallo")]);
+    write_test_catalog(&locale_dir, "fr", &[("Hello", "Bonjour")]);
+    let cache = Arc::new(CatalogCompilationCache::new(1));
+    let (started_tx, started_rx) = mpsc::sync_channel(2);
+    let (release_tx, release_rx) = mpsc::sync_channel(1);
+    let release_rx = Arc::new(Mutex::new(release_rx));
+    cache.set_before_build_hook(Arc::new(move |locale| {
+        if locale == "de" {
+            started_tx.send(()).expect("report build start");
+            release_rx
+                .lock()
+                .expect("release lock")
+                .recv()
+                .expect("release build");
+        }
+    }));
+
+    let first_cache = Arc::clone(&cache);
+    let first_fixture = fixture.clone();
+    let first_dir = locale_dir.clone();
+    let first = thread::spawn(move || {
+        compile_catalog_artifact_selected_cached(
+            &first_cache,
+            &selected_request_for_locale(&first_fixture, &first_dir, "de", "Hello"),
+        )
+    });
+    started_rx.recv().expect("first build started");
+    compile_catalog_artifact_selected_cached(
+        &cache,
+        &selected_request_for_locale(&fixture, &locale_dir, "fr", "Hello"),
+    )
+    .expect("capacity pressure build");
+
+    let second_cache = Arc::clone(&cache);
+    let second_fixture = fixture.clone();
+    let second_dir = locale_dir.clone();
+    let second = thread::spawn(move || {
+        compile_catalog_artifact_selected_cached(
+            &second_cache,
+            &selected_request_for_locale(&second_fixture, &second_dir, "de", "Hello"),
+        )
+    });
+    assert!(
+        matches!(
+            started_rx.recv_timeout(Duration::from_millis(200)),
+            Err(mpsc::RecvTimeoutError::Timeout)
+        ),
+        "an identical request must wait for the original in-flight build"
+    );
+    release_tx.send(()).expect("release first build");
+    first.join().expect("first join").expect("first result");
+    second.join().expect("second join").expect("second result");
+    assert_eq!(
+        cache.statistics(),
+        super::cache::CacheStatistics {
             parses: 4,
             index_builds: 2,
         }
     );
+}
+
+#[test]
+fn selected_catalog_cache_cleans_up_an_unwinding_in_flight_build() {
+    let fixture = create_fixture_dir("selected-catalog-cache-panic-cleanup");
+    let locale_dir = fixture.join("src/locales");
+    fs::create_dir_all(&locale_dir).expect("locale dir");
+    write_test_catalog(&locale_dir, "en", &[("Hello", "")]);
+    write_test_catalog(&locale_dir, "de", &[("Hello", "Hallo")]);
+    let cache = CatalogCompilationCache::new(1);
+    cache.set_before_build_hook(Arc::new(|locale| {
+        if locale == "de" {
+            panic!("test-only build interruption");
+        }
+    }));
+    let request = selected_request(&fixture, &locale_dir, "Hello");
+    assert!(catch_unwind(AssertUnwindSafe(|| {
+        compile_catalog_artifact_selected_cached(&cache, &request)
+    }))
+    .is_err());
+
+    cache.clear_before_build_hook();
+    compile_catalog_artifact_selected_cached(&cache, &request)
+        .expect("retry after unwinding build");
+    assert_eq!(cache.ready_len(), 1);
 }
 
 #[test]
@@ -1206,6 +1332,35 @@ fn selected_request(
         resource_path: locale_dir.join("de.po").to_string_lossy().into_owned(),
         compiled_ids: vec![compiled_key(message, None)],
     }
+}
+
+fn selected_request_for_locale(
+    fixture: &Path,
+    locale_dir: &Path,
+    locale: &str,
+    message: &str,
+) -> CatalogArtifactSelectedRequest {
+    let mut request = selected_request(fixture, locale_dir, message);
+    request.config.locales.push("fr".to_owned());
+    request.resource_path = locale_dir
+        .join(format!("{locale}.po"))
+        .to_string_lossy()
+        .into_owned();
+    request
+}
+
+fn write_numbered_catalog(locale_dir: &Path, locale: &str, translation_prefix: &str, count: usize) {
+    let mut catalog = format!("msgid \"\"\nmsgstr \"\"\n\"Language: {locale}\\n\"\n");
+    for index in 0..count {
+        let message = format!("Message {index}");
+        let translation = format!("{translation_prefix}{message}");
+        catalog.push_str(&format!(
+            "\nmsgid {}\nmsgstr {}\n",
+            po_string(&message),
+            po_string(&translation)
+        ));
+    }
+    fs::write(locale_dir.join(format!("{locale}.po")), catalog).expect("write numbered catalog");
 }
 
 fn restore_mtime(path: &Path, mtime: SystemTime) {

--- a/crates/palamedes/src/catalog_artifact/types.rs
+++ b/crates/palamedes/src/catalog_artifact/types.rs
@@ -66,7 +66,7 @@ pub struct CatalogConfig {
 }
 
 /// Palamedes catalog storage format.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum PalamedesCatalogFormat {
     /// gettext PO catalogs.

--- a/crates/palamedes/src/lib.rs
+++ b/crates/palamedes/src/lib.rs
@@ -50,10 +50,11 @@ use ferrocat::{parse_po as ferrocat_parse_po, MsgStr, PoFile, PoItem};
 use serde::Serialize;
 
 pub use catalog_artifact::{
-    compile_catalog_artifact, compile_catalog_artifact_selected, CatalogArtifactConfig,
-    CatalogArtifactDiagnostic, CatalogArtifactDiagnosticSeverity, CatalogArtifactMissingMessage,
-    CatalogArtifactRequest, CatalogArtifactResult, CatalogArtifactSelectedRequest,
-    CatalogArtifactSourceKey, CatalogConfig, FallbackLocales, PalamedesCatalogFormat,
+    compile_catalog_artifact, compile_catalog_artifact_selected,
+    compile_catalog_artifact_selected_cached, CatalogArtifactConfig, CatalogArtifactDiagnostic,
+    CatalogArtifactDiagnosticSeverity, CatalogArtifactMissingMessage, CatalogArtifactRequest,
+    CatalogArtifactResult, CatalogArtifactSelectedRequest, CatalogArtifactSourceKey,
+    CatalogCompilationCache, CatalogConfig, FallbackLocales, PalamedesCatalogFormat,
 };
 pub use catalog_audit::{
     audit_catalogs, CatalogAuditCheckOptions, CatalogAuditDiagnostic, CatalogAuditRequest,


### PR DESCRIPTION
Closes #589

## Summary

- Add a bounded, content-addressed cache for selected catalog compilation snapshots in the native Node process.
- Reuse normalized primary/fallback catalogs and the compiled ID index across sidecar selections while leaving generated modules, diagnostics, fallback behavior, and public Node APIs unchanged.
- Read and SHA-256 every dependency before each cache lookup. Content replacement with unchanged mtimes, newly present/missing fallbacks, parse/read failures, source-locale changes, and fallback/config changes cannot return a stale snapshot.
- Coalesce identical concurrent snapshot construction per cache key while allowing unrelated catalog sets to proceed independently. The N-API cache holds at most 64 immutable snapshots.

## Evidence

- New deterministic scaling regression: 64 selected compiles reuse two catalog parses and one ID-index build.
- New equal-mtime replacement regression confirms changed content is recompiled and malformed content still surfaces an error.
- `cargo +1.95 test -p palamedes --lib` (288 passed)
- `cargo +1.95 clippy -p palamedes -p palamedes-node -- -D warnings`
- Next loader Vitest could not run in this fresh worktree because its incomplete dependency store attempted registry downloads and sandbox DNS cannot resolve the registry.

🔧 Emily Carter · Implementation Agent