### PR TITLE
ci: repair remix next canary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,10 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Check remix@next canary workflow contract
+        if: matrix.os == 'ubuntu-24.04' && matrix.node == 24
+        run: pnpm check:remix-next-canary
+
       - name: Check release package set
         if: ${{ matrix.full }}
         run: pnpm check:release-set
@@ -154,43 +158,3 @@ jobs:
       - name: Check shipped binary size
         if: matrix.toolchain == '1.95'
         run: node ./scripts/check-binary-size.mjs
-
-  remix-next-canary:
-    name: remix next canary
-    runs-on: ubuntu-24.04
-
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v7
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v7
-        with:
-          node-version: 24
-
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Override Remix examples to remix@next
-        run: pnpm --filter "@palamedes/example-remix-*" add remix@next --save-exact
-
-      - name: Smoke-test Remix examples against remix@next
-        id: remix-next-smoke
-        continue-on-error: true
-        run: pnpm verify:examples:smoke -- --framework remix
-
-      - name: Summarize remix@next canary failure
-        if: steps.remix-next-smoke.outcome == 'failure'
-        run: |
-          {
-            echo "### remix@next canary"
-            echo ""
-            echo "The pinned Remix beta remains the release gate. The remix@next canary failed and should be treated as an early warning for upstream beta churn."
-          } >> "$GITHUB_STEP_SUMMARY"
-          echo "::warning::remix@next canary failed; see the step summary for details."

--- a/.github/workflows/remix-next-canary.yml
+++ b/.github/workflows/remix-next-canary.yml
@@ -1,0 +1,111 @@
+name: Remix next canary
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    # Main catches Palamedes regressions; this catches upstream Remix churn.
+    - cron: "23 5 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: remix-next-canary-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  remix-next-canary:
+    name: remix next canary
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          # This caches pnpm's download store only. remix@next is still resolved
+          # afresh below, so the cache cannot pin or mask the canary version.
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Create isolated canary workspace
+        id: canary-worktree
+        run: |
+          canary_dir="$RUNNER_TEMP/remix-next-canary"
+          git worktree add --detach "$canary_dir" "$GITHUB_SHA"
+          echo "path=$canary_dir" >> "$GITHUB_OUTPUT"
+
+      - name: Install locked dependencies
+        id: install-dependencies
+        working-directory: ${{ steps.canary-worktree.outputs.path }}
+        run: pnpm install --frozen-lockfile
+
+      # Recursive pnpm runs dependency packages before their dependents: the
+      # native platform package precedes its JS wrapper, then the complete
+      # @palamedes/remix workspace closure. The selector keeps unrelated
+      # packages (notably the CLI) out of this compatibility canary.
+      - name: Build workspace packages required by Remix
+        id: build-workspace
+        working-directory: ${{ steps.canary-worktree.outputs.path }}
+        run: pnpm --filter "@palamedes/remix..." -r build
+
+      - name: Override Remix only inside canary workspace
+        id: install-remix-next
+        working-directory: ${{ steps.canary-worktree.outputs.path }}
+        run: pnpm --filter "@palamedes/example-remix-*" add remix@next --save-exact
+
+      - name: Record resolved remix@next version
+        id: remix-next-version
+        working-directory: ${{ steps.canary-worktree.outputs.path }}/examples/remix-cookie
+        run: echo "version=$(node -p \"require('remix/package.json').version\")" >> "$GITHUB_OUTPUT"
+
+      - name: Smoke-test every Remix strategy against remix@next
+        id: remix-next-smoke
+        working-directory: ${{ steps.canary-worktree.outputs.path }}
+        run: pnpm verify:examples:smoke -- --framework remix
+
+      - name: Summarize remix@next canary
+        if: ${{ always() }}
+        env:
+          BUILD_OUTCOME: ${{ steps.build-workspace.outcome }}
+          INSTALL_OUTCOME: ${{ steps.install-remix-next.outcome }}
+          VERSION_OUTCOME: ${{ steps.remix-next-version.outcome }}
+          REMIX_VERSION: ${{ steps.remix-next-version.outputs.version }}
+          SMOKE_OUTCOME: ${{ steps.remix-next-smoke.outcome }}
+        run: |
+          {
+            echo "## remix@next canary"
+            echo ""
+            echo "- Trigger: \`${{ github.event_name }}\`"
+            echo "- Revision: \`${{ github.sha }}\`"
+            if [[ "$BUILD_OUTCOME" != "success" || "$INSTALL_OUTCOME" != "success" || "$VERSION_OUTCOME" != "success" ]]; then
+              echo ""
+              echo "### Infrastructure/setup failure"
+              echo "The workspace dependency build or remix@next installation failed before compatibility assertions could run. This is not an upstream Remix compatibility result."
+            elif [[ "$SMOKE_OUTCOME" == "success" ]]; then
+              echo ""
+              echo "### Compatibility passed"
+              echo "All four Remix strategies built, started, and passed their runtime assertions against \`remix@$REMIX_VERSION\`."
+            else
+              echo ""
+              echo "### Upstream compatibility failure"
+              echo "Workspace setup completed with \`remix@$REMIX_VERSION\`; the Remix build/type/runtime smoke assertions then failed. Investigate this as a potential upstream-canary incompatibility."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Remove isolated canary workspace
+        if: ${{ always() }}
+        run: git worktree remove --force "$RUNNER_TEMP/remix-next-canary" || true

--- a/.github/workflows/remix-next-canary.yml
+++ b/.github/workflows/remix-next-canary.yml
@@ -30,13 +30,18 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: 24
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Set up pnpm cache
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
           # This caches pnpm's download store only. remix@next is still resolved
           # afresh below, so the cache cannot pin or mask the canary version.
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
-
-      - name: Enable Corepack
-        run: corepack enable
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "check:native-types": "pnpm --filter @palamedes/core-node check-native-types",
     "check:published-types": "node ./scripts/check-published-types.mjs",
     "check:release-set": "node ./scripts/check-release-set.mjs",
+    "check:remix-next-canary": "node ./scripts/check-remix-next-canary.mjs",
     "check-types": "pnpm check:native-types && pnpm -r --filter \"./packages/**\" exec tsc --noEmit -p tsconfig.json",
     "lint": "pnpm lint:oxlint && pnpm lint:eslint",
     "lint:fix": "pnpm lint:oxlint:fix && pnpm lint:eslint:fix",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "check:native-types": "pnpm --filter @palamedes/core-node check-native-types",
     "check:published-types": "node ./scripts/check-published-types.mjs",
     "check:release-set": "node ./scripts/check-release-set.mjs",
-    "check:remix-next-canary": "node ./scripts/check-remix-next-canary.mjs",
+    "check:remix-next-canary": "node --test ./scripts/check-remix-next-canary.test.mjs",
     "check-types": "pnpm check:native-types && pnpm -r --filter \"./packages/**\" exec tsc --noEmit -p tsconfig.json",
     "lint": "pnpm lint:oxlint && pnpm lint:eslint",
     "lint:fix": "pnpm lint:oxlint:fix && pnpm lint:eslint:fix",

--- a/scripts/check-remix-next-canary.mjs
+++ b/scripts/check-remix-next-canary.mjs
@@ -1,48 +1,161 @@
 import assert from "node:assert/strict"
 import { readFile } from "node:fs/promises"
+import { createRequire } from "node:module"
+import { fileURLToPath } from "node:url"
 import { EXAMPLE_MATRIX } from "./example-matrix.mjs"
 
-const workflow = await readFile(
-  new URL("../.github/workflows/remix-next-canary.yml", import.meta.url),
-  "utf8"
-)
+const require = createRequire(new URL("../packages/config/package.json", import.meta.url))
+const { parseDocument } = require("yaml")
 
-const requiredSteps = [
-  'git worktree add --detach "$canary_dir" "$GITHUB_SHA"',
-  "pnpm install --frozen-lockfile",
-  'pnpm --filter "@palamedes/remix..." -r build',
-  'pnpm --filter "@palamedes/example-remix-*" add remix@next --save-exact',
-  "working-directory: ${{ steps.canary-worktree.outputs.path }}/examples/remix-cookie",
-  "require('remix/package.json').version",
-  "pnpm verify:examples:smoke -- --framework remix",
+export const CANARY_WORKTREE = "${{ steps.canary-worktree.outputs.path }}"
+export const ORDERED_STEP_IDS = [
+  "canary-worktree",
+  "install-dependencies",
+  "build-workspace",
+  "install-remix-next",
+  "remix-next-version",
+  "remix-next-smoke",
 ]
 
-for (const step of requiredSteps) {
-  assert.ok(workflow.includes(step), `remix@next canary must contain: ${step}`)
+export function parseWorkflow(source) {
+  const document = parseDocument(source)
+  assert.equal(
+    document.errors.length,
+    0,
+    `invalid Remix canary YAML: ${document.errors.join("; ")}`
+  )
+  return document.toJS()
 }
 
-const buildIndex = workflow.indexOf('pnpm --filter "@palamedes/remix..." -r build')
-const overrideIndex = workflow.indexOf(
-  'pnpm --filter "@palamedes/example-remix-*" add remix@next --save-exact'
-)
-const smokeIndex = workflow.indexOf("pnpm verify:examples:smoke -- --framework remix")
+function canarySteps(workflow) {
+  const steps = workflow?.jobs?.["remix-next-canary"]?.steps
+  assert.ok(Array.isArray(steps), "remix@next canary job must define steps")
+  return steps
+}
 
-assert.ok(
-  buildIndex < overrideIndex,
-  "workspace packages must build before remix@next is installed"
-)
-assert.ok(overrideIndex < smokeIndex, "remix@next must be installed before the smoke verifier runs")
-assert.match(workflow, /schedule:\n[\s\S]*cron:/u, "canary must continue to detect upstream churn")
-assert.match(workflow, /push:\n\s+branches:\n\s+- main/u, "canary must run after main changes")
-assert.match(workflow, /workflow_dispatch:/u, "canary must be manually runnable")
-assert.doesNotMatch(workflow, /continue-on-error:/u, "canary failures must remain visible")
+function findStep(steps, id) {
+  const step = steps.find((candidate) => candidate.id === id)
+  assert.ok(step, `remix@next canary must define step ${id}`)
+  return step
+}
 
-assert.deepEqual(
-  EXAMPLE_MATRIX.filter((example) => example.framework === "remix").map(
-    (example) => example.strategy
-  ),
-  ["cookie", "route", "subdomain", "tld"],
-  "the remix@next smoke verifier must cover every intended Remix strategy"
-)
+function stepIndex(steps, id) {
+  const index = steps.findIndex((step) => step.id === id)
+  assert.notEqual(index, -1, `remix@next canary must define step ${id}`)
+  return index
+}
 
-console.log("remix@next canary workflow contract is intact")
+function assertSetupBootstrap(steps) {
+  const node = steps.find((step) => step.name === "Set up Node.js")
+  const corepack = steps.find((step) => step.name === "Enable Corepack")
+  const cache = steps.find((step) => step.name === "Set up pnpm cache")
+
+  assert.equal(node?.uses, "actions/setup-node@v7", "Node setup must use setup-node@v7")
+  assert.equal(node?.with?.["node-version"], 24, "Node setup must select Node 24")
+  assert.equal(
+    node?.with?.cache,
+    undefined,
+    "Node setup must not cache pnpm before Corepack is enabled"
+  )
+  assert.equal(corepack?.run, "corepack enable", "Corepack must be enabled before pnpm caching")
+  assert.equal(cache?.uses, "actions/setup-node@v7", "pnpm cache must use setup-node@v7")
+  assert.equal(cache?.with?.["node-version"], 24, "pnpm cache setup must select Node 24")
+  assert.equal(cache?.with?.cache, "pnpm", "pnpm cache setup must cache pnpm's store")
+  assert.ok(
+    steps.indexOf(node) < steps.indexOf(corepack) && steps.indexOf(corepack) < steps.indexOf(cache),
+    "Node setup, Corepack, and pnpm cache setup must run in that order"
+  )
+}
+
+function assertWorkspaceBinding(steps, id, workingDirectory) {
+  assert.equal(
+    findStep(steps, id)["working-directory"],
+    workingDirectory,
+    `${id} must run inside the isolated canary worktree`
+  )
+}
+
+function assertPhaseCommands(steps) {
+  const expectedCommands = new Map([
+    ["canary-worktree", /git worktree add --detach/u],
+    ["install-dependencies", /^pnpm install --frozen-lockfile$/u],
+    ["build-workspace", /^pnpm --filter "@palamedes\/remix\.\.\." -r build$/u],
+    [
+      "install-remix-next",
+      /^pnpm --filter "@palamedes\/example-remix-\*" add remix@next --save-exact$/u,
+    ],
+    ["remix-next-version", /require\('remix\/package\.json'\)\.version/u],
+    ["remix-next-smoke", /^pnpm verify:examples:smoke -- --framework remix$/u],
+  ])
+
+  for (const [id, command] of expectedCommands) {
+    assert.match(findStep(steps, id).run ?? "", command, `${id} must run its canary command`)
+  }
+}
+
+export function assertRemixNextCanaryWorkflow(workflow) {
+  const triggers = workflow.on
+  assert.ok(triggers, "remix@next canary must define triggers")
+  assert.equal(triggers.pull_request, undefined, "remix@next canary must not run on pull requests")
+  assert.deepEqual(
+    triggers.push?.branches,
+    ["main"],
+    "remix@next canary must run after main changes"
+  )
+  assert.ok(
+    Array.isArray(triggers.schedule) && triggers.schedule.length > 0,
+    "canary must detect upstream churn"
+  )
+  assert.ok("workflow_dispatch" in triggers, "canary must be manually runnable")
+
+  const steps = canarySteps(workflow)
+  assertSetupBootstrap(steps)
+  assertPhaseCommands(steps)
+
+  for (let index = 1; index < ORDERED_STEP_IDS.length; index += 1) {
+    const id = ORDERED_STEP_IDS[index]
+    const suffix = id === "remix-next-version" ? "/examples/remix-cookie" : ""
+    assertWorkspaceBinding(steps, id, `${CANARY_WORKTREE}${suffix}`)
+  }
+
+  for (let index = 1; index < ORDERED_STEP_IDS.length; index += 1) {
+    assert.ok(
+      stepIndex(steps, ORDERED_STEP_IDS[index - 1]) < stepIndex(steps, ORDERED_STEP_IDS[index]),
+      `canary steps must run ${ORDERED_STEP_IDS[index - 1]} before ${ORDERED_STEP_IDS[index]}`
+    )
+  }
+
+  const cleanup = steps.find((step) => step.name === "Remove isolated canary workspace")
+  assert.equal(cleanup?.if, "${{ always() }}", "canary cleanup must always run")
+  assert.match(
+    cleanup?.run ?? "",
+    /git worktree remove --force "\$RUNNER_TEMP\/remix-next-canary"/u,
+    "canary cleanup must remove the isolated worktree"
+  )
+  assert.doesNotMatch(
+    JSON.stringify(workflow),
+    /continue-on-error/u,
+    "canary failures must remain visible"
+  )
+
+  assert.deepEqual(
+    EXAMPLE_MATRIX.filter((example) => example.framework === "remix").map(
+      (example) => example.strategy
+    ),
+    ["cookie", "route", "subdomain", "tld"],
+    "the remix@next smoke verifier must cover every intended Remix strategy"
+  )
+}
+
+export async function assertCheckedWorkflow() {
+  const source = await readFile(
+    new URL("../.github/workflows/remix-next-canary.yml", import.meta.url),
+    "utf8"
+  )
+  assertRemixNextCanaryWorkflow(parseWorkflow(source))
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  await assertCheckedWorkflow()
+  console.log("remix@next canary workflow contract is intact")
+}

--- a/scripts/check-remix-next-canary.mjs
+++ b/scripts/check-remix-next-canary.mjs
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+import { EXAMPLE_MATRIX } from "./example-matrix.mjs"
+
+const workflow = await readFile(
+  new URL("../.github/workflows/remix-next-canary.yml", import.meta.url),
+  "utf8"
+)
+
+const requiredSteps = [
+  'git worktree add --detach "$canary_dir" "$GITHUB_SHA"',
+  "pnpm install --frozen-lockfile",
+  'pnpm --filter "@palamedes/remix..." -r build',
+  'pnpm --filter "@palamedes/example-remix-*" add remix@next --save-exact',
+  "working-directory: ${{ steps.canary-worktree.outputs.path }}/examples/remix-cookie",
+  "require('remix/package.json').version",
+  "pnpm verify:examples:smoke -- --framework remix",
+]
+
+for (const step of requiredSteps) {
+  assert.ok(workflow.includes(step), `remix@next canary must contain: ${step}`)
+}
+
+const buildIndex = workflow.indexOf('pnpm --filter "@palamedes/remix..." -r build')
+const overrideIndex = workflow.indexOf(
+  'pnpm --filter "@palamedes/example-remix-*" add remix@next --save-exact'
+)
+const smokeIndex = workflow.indexOf("pnpm verify:examples:smoke -- --framework remix")
+
+assert.ok(
+  buildIndex < overrideIndex,
+  "workspace packages must build before remix@next is installed"
+)
+assert.ok(overrideIndex < smokeIndex, "remix@next must be installed before the smoke verifier runs")
+assert.match(workflow, /schedule:\n[\s\S]*cron:/u, "canary must continue to detect upstream churn")
+assert.match(workflow, /push:\n\s+branches:\n\s+- main/u, "canary must run after main changes")
+assert.match(workflow, /workflow_dispatch:/u, "canary must be manually runnable")
+assert.doesNotMatch(workflow, /continue-on-error:/u, "canary failures must remain visible")
+
+assert.deepEqual(
+  EXAMPLE_MATRIX.filter((example) => example.framework === "remix").map(
+    (example) => example.strategy
+  ),
+  ["cookie", "route", "subdomain", "tld"],
+  "the remix@next smoke verifier must cover every intended Remix strategy"
+)
+
+console.log("remix@next canary workflow contract is intact")

--- a/scripts/check-remix-next-canary.test.mjs
+++ b/scripts/check-remix-next-canary.test.mjs
@@ -1,0 +1,125 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import { readFile } from "node:fs/promises"
+import { createRequire } from "node:module"
+import {
+  CANARY_WORKTREE,
+  ORDERED_STEP_IDS,
+  assertRemixNextCanaryWorkflow,
+  parseWorkflow,
+} from "./check-remix-next-canary.mjs"
+
+const require = createRequire(new URL("../packages/config/package.json", import.meta.url))
+const { stringify } = require("yaml")
+const source = await readFile(
+  new URL("../.github/workflows/remix-next-canary.yml", import.meta.url),
+  "utf8"
+)
+
+function workflowWith(mutate) {
+  const workflow = parseWorkflow(source)
+  mutate(workflow)
+  return workflow
+}
+
+function stepsFor(workflow) {
+  return workflow.jobs["remix-next-canary"].steps
+}
+
+function assertRejected(mutate, message) {
+  assert.throws(() => assertRemixNextCanaryWorkflow(workflowWith(mutate)), undefined, message)
+}
+
+test("accepts the committed Remix canary workflow", () => {
+  assertRemixNextCanaryWorkflow(parseWorkflow(source))
+})
+
+test("rejects a pull request trigger", () => {
+  assertRejected((workflow) => {
+    workflow.on.pull_request = {}
+  })
+})
+
+test("rejects a pnpm cache before Corepack", () => {
+  assertRejected((workflow) => {
+    const nodeSetup = stepsFor(workflow).find((step) => step.name === "Set up Node.js")
+    nodeSetup.with.cache = "pnpm"
+  })
+})
+
+test("rejects a missing cache setup after Corepack", () => {
+  assertRejected((workflow) => {
+    const steps = stepsFor(workflow)
+    steps.splice(
+      steps.findIndex((step) => step.name === "Set up pnpm cache"),
+      1
+    )
+  })
+})
+
+test("rejects cache setup before Corepack", () => {
+  assertRejected((workflow) => {
+    const steps = stepsFor(workflow)
+    const corepackIndex = steps.findIndex((step) => step.name === "Enable Corepack")
+    ;[steps[corepackIndex], steps[corepackIndex + 1]] = [
+      steps[corepackIndex + 1],
+      steps[corepackIndex],
+    ]
+  })
+})
+
+test("rejects every missing or incorrectly bound canary phase", () => {
+  for (const id of ORDERED_STEP_IDS) {
+    assertRejected((workflow) => {
+      const steps = stepsFor(workflow)
+      steps.splice(
+        steps.findIndex((step) => step.id === id),
+        1
+      )
+    }, `must reject a missing ${id} phase`)
+  }
+
+  for (const id of ORDERED_STEP_IDS.slice(1)) {
+    assertRejected((workflow) => {
+      stepsFor(workflow).find((step) => step.id === id)["working-directory"] = "."
+    }, `must reject ${id} outside ${CANARY_WORKTREE}`)
+  }
+})
+
+test("rejects every adjacent phase reordering", () => {
+  for (let index = 1; index < ORDERED_STEP_IDS.length; index += 1) {
+    assertRejected(
+      (workflow) => {
+        const steps = stepsFor(workflow)
+        const currentIndex = steps.findIndex((step) => step.id === ORDERED_STEP_IDS[index])
+        ;[steps[currentIndex - 1], steps[currentIndex]] = [
+          steps[currentIndex],
+          steps[currentIndex - 1],
+        ]
+      },
+      `must reject ${ORDERED_STEP_IDS[index]} before ${ORDERED_STEP_IDS[index - 1]}`
+    )
+  }
+})
+
+test("rejects missing or conditional cleanup", () => {
+  assertRejected((workflow) => {
+    const steps = stepsFor(workflow)
+    steps.splice(
+      steps.findIndex((step) => step.name === "Remove isolated canary workspace"),
+      1
+    )
+  })
+
+  assertRejected((workflow) => {
+    stepsFor(workflow).find((step) => step.name === "Remove isolated canary workspace").if =
+      "${{ success() }}"
+  })
+})
+
+test("rejects a serialized, valid YAML mutation", () => {
+  const mutation = workflowWith((workflow) => {
+    workflow.on.pull_request = {}
+  })
+  assert.throws(() => assertRemixNextCanaryWorkflow(parseWorkflow(stringify(mutation))))
+})


### PR DESCRIPTION
## Summary

Repairs the Remix-next canary so it builds the exact `@palamedes/remix` workspace dependency closure before testing every Remix strategy. The canary now runs in an isolated worktree, so `pnpm add remix@next` can update only that disposable checkout.

The new dedicated workflow runs after `main` changes, weekly for upstream churn, and manually; it no longer consumes a runner on every pull request. Setup failures and post-setup upstream compatibility failures are hard failures with distinct step summaries. A CI-enforced static contract prevents removal or reordering of the required build, override, and smoke steps.

## Root cause

The former CI job invoked the smoke verifier without building gitignored workspace `dist/` outputs. Remix example typechecking therefore failed before any meaningful canary compatibility assertion ran.

## Validation

- `pnpm check:remix-next-canary`
- `pnpm format:check`
- `pnpm lint`
- Prettier YAML/package validation and `git diff --check`
- Isolated local canary equivalent: locked install, topological Remix dependency-closure build, `remix@next` override, and all four Remix smoke strategies (typecheck/build/start/runtime assertions)

Closes #586

🔧 Emily Carter · Implementation Agent
