### PR TITLE
fix(cli): restrict npm tarball runtime files

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -24,7 +24,9 @@
     "LICENSE",
     "README.md",
     "bin/pmds",
-    "scripts/"
+    "scripts/run.mjs",
+    "scripts/platform.mjs",
+    "scripts/native.mjs"
   ],
   "scripts": {
     "build": "node ./scripts/build.mjs",

--- a/packages/cli/scripts/smoke.mjs
+++ b/packages/cli/scripts/smoke.mjs
@@ -233,7 +233,7 @@ function assertPackedCliRuntimeFiles(archivePath) {
 
   const packedFiles = execFileSync("tar", ["-tzf", archivePath], { encoding: "utf8" })
     .trim()
-    .split("\n")
+    .split(/\r?\n/u)
     .filter(Boolean)
     .sort()
   const expectedRuntimeFiles = [

--- a/packages/cli/scripts/smoke.mjs
+++ b/packages/cli/scripts/smoke.mjs
@@ -17,6 +17,23 @@ import { resolvePlatformPackage } from "./platform.mjs"
 
 const packageDir = path.resolve(import.meta.dirname, "..")
 const repoRoot = path.resolve(packageDir, "../..")
+const expectedCliManifestFiles = [
+  "LICENSE",
+  "README.md",
+  "bin/pmds",
+  "scripts/run.mjs",
+  "scripts/platform.mjs",
+  "scripts/native.mjs",
+]
+const expectedPackedCliFiles = [
+  "package/LICENSE",
+  "package/README.md",
+  "package/bin/pmds",
+  "package/package.json",
+  "package/scripts/native.mjs",
+  "package/scripts/platform.mjs",
+  "package/scripts/run.mjs",
+]
 let platformPackage
 try {
   platformPackage = resolvePlatformPackage()
@@ -52,8 +69,8 @@ try {
   // node_modules tree. No lifecycle hook runs while constructing this fixture.
   const archiveDir = path.join(fixtureRoot, "archives")
   mkdirSync(archiveDir)
-  const cliArchive = packPackage(packageDir, archiveDir)
-  const nativeArchive = packPackage(platformPackageDir, archiveDir)
+  const cliArchive = packPackage(packageDir, archiveDir, "pnpm")
+  const nativeArchive = packPackage(platformPackageDir, archiveDir, "npm")
   assertPackedCliRuntimeFiles(cliArchive)
   const cliInstallDir = path.join(fixtureRoot, "node_modules", "@palamedes", "cli")
   const nativeInstallDir = path.join(fixtureRoot, "node_modules", ...platformPackage.split("/"))
@@ -188,9 +205,10 @@ if (output !== nativeOutput) {
   throw new Error("The npm wrapper changed built-in version output.")
 }
 
-function packPackage(packagePath, archiveDir) {
+function packPackage(packagePath, archiveDir, packageManagerName) {
   const before = new Set(readdirSync(archiveDir))
-  const packageManager = process.platform === "win32" ? "pnpm.cmd" : "pnpm"
+  const packageManager =
+    process.platform === "win32" ? `${packageManagerName}.cmd` : packageManagerName
   execFileSync(packageManager, ["pack", "--pack-destination", archiveDir], {
     cwd: packagePath,
     env: { ...process.env, npm_config_cache: path.join(archiveDir, "npm-cache") },
@@ -215,41 +233,61 @@ function extractPackage(archivePath, destination) {
 
 function assertPackedCliRuntimeFiles(archivePath) {
   const manifest = JSON.parse(readFileSync(path.join(packageDir, "package.json"), "utf8"))
-  const expectedManifestFiles = [
-    "LICENSE",
-    "README.md",
-    "bin/pmds",
-    "scripts/run.mjs",
-    "scripts/platform.mjs",
-    "scripts/native.mjs",
-  ]
-  if (JSON.stringify(manifest.files) !== JSON.stringify(expectedManifestFiles)) {
+  if (JSON.stringify(manifest.files) !== JSON.stringify(expectedCliManifestFiles)) {
     throw new Error(
-      `@palamedes/cli files must list only the launcher runtime surface: ${expectedManifestFiles.join(
+      `@palamedes/cli files must list only the launcher runtime surface: ${expectedCliManifestFiles.join(
         ", "
       )}`
     )
   }
 
-  const packedFiles = execFileSync("tar", ["-tzf", archivePath], { encoding: "utf8" })
-    .trim()
-    .split(/\r?\n/u)
-    .filter(Boolean)
-    .sort()
-  const expectedRuntimeFiles = [
-    "package/bin/pmds",
-    "package/scripts/native.mjs",
-    "package/scripts/platform.mjs",
-    "package/scripts/run.mjs",
-  ]
-  const packedRuntimeFiles = packedFiles.filter(
-    (file) => file.startsWith("package/scripts/") || file === "package/bin/pmds"
-  )
-  if (JSON.stringify(packedRuntimeFiles) !== JSON.stringify(expectedRuntimeFiles)) {
+  assertPackedCliFiles(readTarEntries(archivePath))
+  assertPackedCliFilesRejectMutations()
+}
+
+function readTarEntries(archivePath) {
+  const entries = execFileSync("tar", ["-tzf", archivePath], { encoding: "utf8" }).split(/\r?\n/u)
+  if (entries.pop() !== "") {
+    throw new Error("Packed @palamedes/cli tar listing must end with one newline.")
+  }
+  return entries.sort()
+}
+
+function assertPackedCliFiles(packedFiles) {
+  if (JSON.stringify(packedFiles) !== JSON.stringify(expectedPackedCliFiles)) {
     throw new Error(
-      `Packed @palamedes/cli runtime files drifted: expected ${expectedRuntimeFiles.join(
+      `Packed @palamedes/cli files drifted: expected ${expectedPackedCliFiles.join(
         ", "
-      )}; found ${packedRuntimeFiles.join(", ")}`
+      )}; found ${packedFiles.join(", ")}`
     )
   }
+}
+
+function assertPackedCliFilesRejectMutations() {
+  for (const requiredFile of expectedPackedCliFiles) {
+    assertPackedCliFilesRejects(`missing ${requiredFile}`, (files) =>
+      files.filter((file) => file !== requiredFile)
+    )
+  }
+  assertPackedCliFilesRejects("unexpected top-level file", (files) => [
+    ...files,
+    "package/unexpected.txt",
+  ])
+  assertPackedCliFilesRejects("leading whitespace corruption", (files) => [
+    ` ${files[0]}`,
+    ...files.slice(1),
+  ])
+  assertPackedCliFilesRejects("trailing whitespace corruption", (files) => [
+    ...files.slice(0, -1),
+    `${files.at(-1)} `,
+  ])
+}
+
+function assertPackedCliFilesRejects(description, mutate) {
+  try {
+    assertPackedCliFiles(mutate([...expectedPackedCliFiles]).sort())
+  } catch {
+    return
+  }
+  throw new Error(`Packed @palamedes/cli assertion accepted ${description}.`)
 }

--- a/packages/cli/scripts/smoke.mjs
+++ b/packages/cli/scripts/smoke.mjs
@@ -54,6 +54,7 @@ try {
   mkdirSync(archiveDir)
   const cliArchive = packPackage(packageDir, archiveDir)
   const nativeArchive = packPackage(platformPackageDir, archiveDir)
+  assertPackedCliRuntimeFiles(cliArchive)
   const cliInstallDir = path.join(fixtureRoot, "node_modules", "@palamedes", "cli")
   const nativeInstallDir = path.join(fixtureRoot, "node_modules", ...platformPackage.split("/"))
   extractPackage(cliArchive, cliInstallDir)
@@ -189,7 +190,7 @@ if (output !== nativeOutput) {
 
 function packPackage(packagePath, archiveDir) {
   const before = new Set(readdirSync(archiveDir))
-  const packageManager = process.platform === "win32" ? "npm.cmd" : "npm"
+  const packageManager = process.platform === "win32" ? "pnpm.cmd" : "pnpm"
   execFileSync(packageManager, ["pack", "--pack-destination", archiveDir], {
     cwd: packagePath,
     env: { ...process.env, npm_config_cache: path.join(archiveDir, "npm-cache") },
@@ -210,4 +211,45 @@ function extractPackage(archivePath, destination) {
   execFileSync("tar", ["-xzf", archivePath, "-C", destination, "--strip-components", "1"], {
     stdio: "pipe",
   })
+}
+
+function assertPackedCliRuntimeFiles(archivePath) {
+  const manifest = JSON.parse(readFileSync(path.join(packageDir, "package.json"), "utf8"))
+  const expectedManifestFiles = [
+    "LICENSE",
+    "README.md",
+    "bin/pmds",
+    "scripts/run.mjs",
+    "scripts/platform.mjs",
+    "scripts/native.mjs",
+  ]
+  if (JSON.stringify(manifest.files) !== JSON.stringify(expectedManifestFiles)) {
+    throw new Error(
+      `@palamedes/cli files must list only the launcher runtime surface: ${expectedManifestFiles.join(
+        ", "
+      )}`
+    )
+  }
+
+  const packedFiles = execFileSync("tar", ["-tzf", archivePath], { encoding: "utf8" })
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .sort()
+  const expectedRuntimeFiles = [
+    "package/bin/pmds",
+    "package/scripts/native.mjs",
+    "package/scripts/platform.mjs",
+    "package/scripts/run.mjs",
+  ]
+  const packedRuntimeFiles = packedFiles.filter(
+    (file) => file.startsWith("package/scripts/") || file === "package/bin/pmds"
+  )
+  if (JSON.stringify(packedRuntimeFiles) !== JSON.stringify(expectedRuntimeFiles)) {
+    throw new Error(
+      `Packed @palamedes/cli runtime files drifted: expected ${expectedRuntimeFiles.join(
+        ", "
+      )}; found ${packedRuntimeFiles.join(", ")}`
+    )
+  }
 }


### PR DESCRIPTION
Closes #584

## Summary

- Restrict `@palamedes/cli` to the `pmds` launcher and its three transitive runtime modules: `run.mjs`, `platform.mjs`, and `native.mjs`.
- Make the existing clean-tarball smoke test pack with `pnpm`, matching the publishing tool.
- Assert both the exact manifest allowlist and packed launcher runtime surface so package-list drift fails CI.

## Packed-file delta

`pnpm pack` now ships 7 files: `LICENSE`, `README.md`, `package.json`, `bin/pmds`, and the three required runtime modules. It removes the five non-runtime scripts: `build.mjs`, `build-native.mjs`, `platform.test.mjs`, `native.test.mjs`, and `smoke.mjs`.

## Validation

- `pnpm --filter @palamedes/cli build`
- `pnpm --filter @palamedes/cli test` (including clean extracted tarball, packed launcher version/flag/plugin paths, and native package)
- `pnpm pack --pack-destination …` plus `tar -tzf` inspection
- `pnpm --filter @palamedes/cli exec tsc --noEmit -p tsconfig.json`
- targeted `oxfmt` and ESLint
- `pnpm check:release-set`

🔧 Emily Carter · Implementation Agent
