### PR TITLE
docs: keep llms context files current

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,10 @@ jobs:
         if: ${{ matrix.full }}
         run: pnpm proof:icu:check
 
+      - name: Check llms context surface
+        if: ${{ matrix.full }}
+        run: pnpm check:llms
+
       - name: Build site
         if: ${{ matrix.full }}
         run: pnpm build:site

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,7 @@ cargo clippy --workspace --all-targets -- -D warnings
 pnpm verify:examples:smoke
 pnpm check:release-set
 pnpm check:binary-size
+pnpm check:llms
 ```
 
 `pnpm check:binary-size` builds the release CLI and holds it under a fixed
@@ -82,6 +83,13 @@ When adding a feature, include:
 - the failure mode or diagnostics users will see
 - the migration note if behavior changes
 - a short validation command
+
+`llms.txt` and `llms-full.txt` are curated context files for coding assistants,
+not generated API dumps. When a public CLI command, flag, package, or Node API
+changes, refresh the relevant level of detail in both files and run `pnpm
+check:llms`. The check ties the maintained context contract to the CLI docs,
+published package manifests, and exported Node API names; the site build copies
+the checked files to `palamedes.dev`.
 
 ## Pull Requests
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -48,7 +48,7 @@ Recommended app-facing packages:
 - `@palamedes/vite-plugin`: Vite integration and `.po` loading
 - `@palamedes/next-plugin`: Next.js integration
 - `@palamedes/remix`: server-first Remix v3 integration (requires Node.js `>=24.3`)
-- `@palamedes/cli`: native CLI (`pmds extract`, `pmds lint`, `pmds audit`, `pmds report`, `pmds catalog merge`, `pmds catalog merge-driver`, `pmds catalog convert`); also hosts explicitly configured CLI plugins via `@palamedes/cli/plugin`
+- `@palamedes/cli`: native CLI (`pmds extract`, `pmds lint`, `pmds audit`, `pmds report`, `pmds catalog merge`, `pmds catalog merge-driver`, `pmds catalog convert`, `pmds version`); also dispatches explicitly configured binary CLI plugins
 - `@palamedes/config`: config loading for the JS plugin loaders; also reads legacy `palamedes.config.ts`/`.js` as a compatibility path (the native CLI reads only YAML/JSON/TOML)
 
 Advanced/custom-tooling packages:
@@ -272,10 +272,14 @@ import {
 candidates plus diagnostics. A candidate has a stable identity and a
 `fingerprint`; carry that fingerprint into `applyTranslationPatches(...)` so a
 patch is rejected when the current catalog no longer matches the candidate.
-The patch result reports `applied`, `unchanged`, `rejected`, or `notApplied`
-outcomes and diagnostics. A failed catalog replacement throws an error with a
-partial report; do not treat a thrown write error as proof that no earlier
-catalog patch completed.
+The candidate/patch type surface is `TranslationCandidateId`,
+`TranslationCandidate`, `TranslationCandidateRequest`,
+`TranslationCandidateResult`, `TranslationPatch`, `TranslationPatchRequest`,
+`TranslationPatchOutcomeStatus`, `TranslationPatchOutcome`,
+`TranslationPatchResult`, and `TranslationPatchWriteError`. The patch result
+reports `applied`, `unchanged`, `rejected`, or `notApplied` outcomes and
+diagnostics. A failed catalog replacement throws an error with a partial report;
+do not treat a thrown write error as proof that no earlier catalog patch completed.
 
 ## CLI model
 
@@ -302,6 +306,13 @@ pnpm exec pmds audit --fail-on warning
 pnpm exec pmds report --json
 pnpm exec pmds report --fail-if-below 90
 ```
+
+`extract`, `lint`, `audit`, `report`, `catalog merge`, `catalog merge-driver`,
+and `catalog convert` accept `--config <path>` where configuration is relevant.
+Use `pmds extract --force-clean` to remove every obsolete entry. `audit` and
+`report` accept `--locale <locale...>`. `catalog merge`, `catalog merge-driver`,
+and `catalog convert` accept `--source-locale <locale>` and `--locale <locale>`
+for catalog semantics.
 
 `pmds lint` is non-mutating source-authoring validation for the configured
 source files (including MDX). It has human or deterministic JSON output;
@@ -348,10 +359,9 @@ pnpm exec pmds <plugin> <command> [...args]
 ```
 
 Third-party CLI plugins must be explicitly listed under `plugins` in the
-Palamedes configuration — installed packages are never auto-discovered. Node
-plugins implement `definePlugin` from `@palamedes/cli/plugin` (API version 1);
-standalone executables can implement the versioned binary plugin protocol
-instead. See `/docs/api/cli-plugin.md`, `/docs/api/cli-binary-plugin.md`,
+Palamedes configuration — installed packages are never auto-discovered.
+Plugins are binary-only native executables that implement the versioned binary
+plugin protocol. See `/docs/cli.md`, `/docs/api/cli-binary-plugin.md`,
 `/adr/017-cli-plugin-execution-boundary.md`, and
 `/adr/018-binary-plugin-protocol.md`.
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -48,14 +48,15 @@ Recommended app-facing packages:
 - `@palamedes/vite-plugin`: Vite integration and `.po` loading
 - `@palamedes/next-plugin`: Next.js integration
 - `@palamedes/remix`: server-first Remix v3 integration (requires Node.js `>=24.3`)
-- `@palamedes/cli`: native CLI (`pmds extract`, `pmds audit`, `pmds report`, `pmds catalog merge`, `pmds catalog convert`); also hosts explicitly configured CLI plugins via `@palamedes/cli/plugin`
+- `@palamedes/cli`: native CLI (`pmds extract`, `pmds lint`, `pmds audit`, `pmds report`, `pmds catalog merge`, `pmds catalog merge-driver`, `pmds catalog convert`); also hosts explicitly configured CLI plugins via `@palamedes/cli/plugin`
 - `@palamedes/config`: config loading for the JS plugin loaders; also reads legacy `palamedes.config.ts`/`.js` as a compatibility path (the native CLI reads only YAML/JSON/TOML)
 
 Advanced/custom-tooling packages:
 
 - `@palamedes/transform`
 - `@palamedes/extractor`
-- `@palamedes/core-node`: native Node wrapper for transform, extract, catalog audit, metadata validation, and catalog combine workflows
+- `@palamedes/core-node`: native Node wrapper for transform, extract, catalog audit, metadata validation, catalog combine workflows, and typed translation candidate/patch APIs
+- `@palamedes/eslint-plugin`: Preview ESLint/Oxlint facade over native source diagnostics. Oxlint's JavaScript plugin API is still alpha; `pmds lint` remains the stable CI and MDX path.
 
 Reserved placeholder packages, not the normal starting point today:
 
@@ -255,12 +256,34 @@ Important consequences:
 - catalog health checks should use `pmds audit` or the `auditCatalogs(...)` API
 - completeness gates should use `pmds report --fail-if-below <percent>`
 
+### Translation candidate and patch APIs
+
+Custom translation tooling can use the synchronous typed APIs from
+`@palamedes/core-node`:
+
+```ts
+import {
+  applyTranslationPatches,
+  listTranslationCandidates,
+} from "@palamedes/core-node"
+```
+
+`listTranslationCandidates(...)` reads configured PO/FCL catalogs and returns
+candidates plus diagnostics. A candidate has a stable identity and a
+`fingerprint`; carry that fingerprint into `applyTranslationPatches(...)` so a
+patch is rejected when the current catalog no longer matches the candidate.
+The patch result reports `applied`, `unchanged`, `rejected`, or `notApplied`
+outcomes and diagnostics. A failed catalog replacement throws an error with a
+partial report; do not treat a thrown write error as proof that no earlier
+catalog patch completed.
+
 ## CLI model
 
 Core commands:
 
 ```bash
 pnpm exec pmds extract
+pnpm exec pmds lint
 pnpm exec pmds audit
 pnpm exec pmds report
 ```
@@ -269,27 +292,50 @@ Useful options include:
 
 ```bash
 pnpm exec pmds extract --clean
+pnpm exec pmds extract --check --json
 pnpm exec pmds extract --watch
 pnpm exec pmds extract --verbose
+pnpm exec pmds lint --json
+pnpm exec pmds lint --fail-on warning
 pnpm exec pmds audit --json
 pnpm exec pmds audit --fail-on warning
 pnpm exec pmds report --json
 pnpm exec pmds report --fail-if-below 90
 ```
 
+`pmds lint` is non-mutating source-authoring validation for the configured
+source files (including MDX). It has human or deterministic JSON output;
+`--fail-on warning` also makes warnings fail. Its cache is shared with
+extraction; use `--no-cache` when the run must not write the cache.
+
+`pmds extract --check --json` projects the configured PO/FCL catalogs through
+the normal extraction and serialization path, compares the result with disk,
+and reports deterministic clean, drift, or error data. It exits nonzero for
+drift without writing catalog files or creating missing catalog directories.
+The extraction cache may still be updated unless `--no-cache` is passed.
+
 Catalog utilities:
 
 ```bash
 pnpm exec pmds catalog merge --format=po --conflict-strategy=use-first --output out.po a.po b.po
+pnpm exec pmds catalog merge-driver %O %A %B %A --path %P --format po --conflict-strategy use-first
 pnpm exec pmds catalog convert --to fcl input.po
 ```
 
-`catalog merge` takes exactly two input files and also works as a Git merge driver:
+`catalog merge` takes exactly two input files. Add `--base base.po` for a
+deletion-aware three-way merge. For Git, use `catalog merge-driver` rather than
+reconstructing Git role mapping in a wrapper:
 
 ```bash
 git config merge.palamedes-catalog.driver \
-  'pmds catalog merge --format=po --conflict-strategy=use-first --output %A %A %B'
+  'pmds catalog merge-driver %O %A %B %A --path %P --format po --conflict-strategy use-first'
 ```
+
+The merge driver receives ancestor, current, other, and output positional paths
+from Git and needs `--path %P` to apply configured catalog formatting. It
+detects rebases and swaps Git's temporary roles so `use-first` consistently
+means the branch being merged or rebased. Use `--operation merge` or
+`--operation rebase` only for unusual Git orchestration.
 
 Extraction performance is already handled by the CLI and needs no user tuning by default. `pmds extract` runs a bounded parallel read/parse pass (`--threads <COUNT>`, or `extract-threads` in the config) and reuses an on-disk extraction cache (`--no-cache` disables it for one run; `extract-cache: false` disables it permanently).
 

--- a/llms.txt
+++ b/llms.txt
@@ -106,8 +106,19 @@ pnpm exec pmds report
 ## Catalog workflow commands
 
 - `pmds report --fail-if-below 90`: per-locale completeness gate for CI
-- `pmds catalog merge --format=po --conflict-strategy=use-first --output out.po a.po b.po`: semantic merge of exactly two catalogs (also usable as a Git merge driver)
+- `pmds lint --json --fail-on warning`: non-mutating source-authoring diagnostics for configured JS, TS, JSX, TSX, and MDX files. Use `pmds lint` rather than a browser adapter for stable CI and MDX.
+- `pmds extract --check --json`: CI drift check; it compares projected catalog output without changing catalog files or creating catalog directories. It can still update the extraction cache unless `--no-cache` is passed.
+- `pmds catalog merge --format=po --conflict-strategy=use-first --output out.po a.po b.po`: semantic merge of exactly two catalogs; add `--base base.po` for a deletion-aware three-way merge.
+- `pmds catalog merge-driver %O %A %B %A --path %P --format po --conflict-strategy use-first`: deletion-aware three-way merge driver for Git. It maps merge and rebase roles so `use-first` stays the branch being merged or rebased.
 - `pmds catalog convert --to fcl input.po`: convert PO catalogs to the opt-in FCL format
+
+## Lint adapters and translation automation APIs
+
+`@palamedes/eslint-plugin` is a Preview ESLint/Oxlint facade over native source
+diagnostics; `pmds lint` remains the stable CI and MDX interface. For custom
+translation tooling, `@palamedes/core-node` exposes
+`listTranslationCandidates(...)` and `applyTranslationPatches(...)`; create a
+patch from the candidate `fingerprint` so stale catalog state is rejected.
 
 ## CLI plugins
 

--- a/llms.txt
+++ b/llms.txt
@@ -106,7 +106,7 @@ pnpm exec pmds report
 ## Catalog workflow commands
 
 - `pmds report --fail-if-below 90`: per-locale completeness gate for CI
-- `pmds lint --json --fail-on warning`: non-mutating source-authoring diagnostics for configured JS, TS, JSX, TSX, and MDX files. Use `pmds lint` rather than a browser adapter for stable CI and MDX.
+- `pmds lint --json --fail-on warning`: non-mutating source-authoring diagnostics for configured JS, TS, JSX, TSX, and MDX files. Use `pmds lint` rather than the Preview ESLint/Oxlint adapter for stable CI and MDX.
 - `pmds extract --check --json`: CI drift check; it compares projected catalog output without changing catalog files or creating catalog directories. It can still update the extraction cache unless `--no-cache` is passed.
 - `pmds catalog merge --format=po --conflict-strategy=use-first --output out.po a.po b.po`: semantic merge of exactly two catalogs; add `--base base.po` for a deletion-aware three-way merge.
 - `pmds catalog merge-driver %O %A %B %A --path %P --format po --conflict-strategy use-first`: deletion-aware three-way merge driver for Git. It maps merge and rebase roles so `use-first` stays the branch being merged or rebased.
@@ -124,9 +124,8 @@ patch from the candidate `fingerprint` so stale catalog state is rejected.
 
 Third-party commands run as `pmds <plugin> <command>` and must be explicitly
 listed under `plugins` in the Palamedes configuration — installed packages are
-never auto-discovered. Node plugins use `@palamedes/cli/plugin`
-(`definePlugin`, API version 1); standalone executables can use the versioned
-binary plugin protocol instead. See `/docs/api/cli-plugin.md` and
+never auto-discovered. Plugins are binary-only native executables using the
+versioned binary plugin protocol. See `/docs/cli.md` and
 `/docs/api/cli-binary-plugin.md`.
 
 ## Recommended docs

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "node": ">=22.22.0"
   },
   "scripts": {
+    "check:llms": "node ./scripts/check-llms-surface.mjs",
     "build": "pnpm -r --filter \"./packages/**\" build",
     "build:examples": "pnpm -r --filter \"./examples/**\" build",
     "build:site": "pnpm --filter @palamedes/site build",
@@ -50,7 +51,7 @@
     "build:native": "cargo build --workspace",
     "check:rust": "cargo check --workspace",
     "test:rust": "cargo test --workspace",
-    "agent:check": "pnpm build && concurrently --kill-others-on-fail --group --names release,published-types,format,lint,test,types,rustfmt,rust \"pnpm check:release-set\" \"pnpm check:published-types\" \"pnpm format:check\" \"pnpm lint\" \"pnpm test\" \"pnpm check-types\" \"cargo fmt --all --check\" \"cargo clippy --workspace --all-targets --locked -- -D warnings && cargo test --workspace --locked\""
+    "agent:check": "pnpm build && concurrently --kill-others-on-fail --group --names release,published-types,llms,format,lint,test,types,rustfmt,rust \"pnpm check:release-set\" \"pnpm check:published-types\" \"pnpm check:llms\" \"pnpm format:check\" \"pnpm lint\" \"pnpm test\" \"pnpm check-types\" \"cargo fmt --all --check\" \"cargo clippy --workspace --all-targets --locked -- -D warnings && cargo test --workspace --locked\""
   },
   "devDependencies": {
     "@playwright/test": "^1.62.1",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "node": ">=22.22.0"
   },
   "scripts": {
-    "check:llms": "node ./scripts/check-llms-surface.mjs",
+    "test:llms": "node --test ./scripts/check-llms-surface.test.mjs",
+    "check:llms": "node ./scripts/check-llms-surface.mjs && pnpm test:llms",
     "build": "pnpm -r --filter \"./packages/**\" build",
     "build:examples": "pnpm -r --filter \"./examples/**\" build",
     "build:site": "pnpm --filter @palamedes/site build",
@@ -34,7 +35,7 @@
     "benchmark:runtime-browser": "pnpm build && pnpm --filter @palamedes/example-vite-mdx build && node ./scripts/check-runtime-browser-bundle.mjs",
     "proof:icu": "pnpm build && node ./scripts/proof-icu-semantics.mjs",
     "proof:icu:check": "node ./scripts/proof-icu-semantics.mjs",
-    "test": "pnpm -r --filter \"./packages/**\" --if-present test",
+    "test": "pnpm test:llms && pnpm -r --filter \"./packages/**\" --if-present test",
     "check:binary-size": "node ./scripts/check-binary-size.mjs",
     "check:native-types": "pnpm --filter @palamedes/core-node check-native-types",
     "check:published-types": "node ./scripts/check-published-types.mjs",

--- a/scripts/check-llms-surface.mjs
+++ b/scripts/check-llms-surface.mjs
@@ -1,19 +1,69 @@
-import { readFileSync } from "node:fs"
+import { readdirSync, readFileSync } from "node:fs"
 import path from "node:path"
 import process from "node:process"
 import { pathToFileURL } from "node:url"
 
-import { llmsFiles, llmsSurfaceContract } from "./llms-surface-contract.mjs"
+import {
+  compactCommandInventory,
+  compactPackageInventory,
+  compactTranslationApiInventory,
+  featureNarrative,
+  platformPackageParents,
+  platformPackageInventory,
+  publishedPackageInventory,
+  translationApiInventory,
+  translationPatchOutcomeInventory,
+} from "./llms-surface-contract.mjs"
+
+const commandSources = {
+  Extract: {
+    command: "pmds extract",
+    file: "crates/palamedes-cli/src/commands/extract/mod.rs",
+    type: "ExtractOptions",
+  },
+  Lint: {
+    command: "pmds lint",
+    file: "crates/palamedes-cli/src/commands/lint.rs",
+    type: "LintOptions",
+  },
+  Audit: {
+    command: "pmds audit",
+    file: "crates/palamedes-cli/src/commands/audit.rs",
+    type: "AuditOptions",
+  },
+  Report: {
+    command: "pmds report",
+    file: "crates/palamedes-cli/src/commands/report.rs",
+    type: "ReportOptions",
+  },
+  Catalog: {
+    command: "pmds catalog",
+    file: "crates/palamedes-cli/src/commands/catalog/mod.rs",
+    type: "CatalogCommand",
+  },
+  Version: { command: "pmds version" },
+}
+
+const catalogCommandSources = {
+  Merge: {
+    command: "pmds catalog merge",
+    file: "crates/palamedes-cli/src/commands/catalog/merge.rs",
+    type: "MergeOptions",
+  },
+  MergeDriver: {
+    command: "pmds catalog merge-driver",
+    file: "crates/palamedes-cli/src/commands/catalog/merge.rs",
+    type: "MergeDriverOptions",
+  },
+  Convert: {
+    command: "pmds catalog convert",
+    file: "crates/palamedes-cli/src/commands/catalog/convert.rs",
+    type: "ConvertOptions",
+  },
+}
 
 export function normalize(text) {
   return text.replaceAll(/\s+/gu, " ").trim()
-}
-
-function sectionFor(text, heading) {
-  const start = text.indexOf(heading)
-  if (start === -1) return ""
-  const nextHeading = text.indexOf("\n## ", start + heading.length)
-  return text.slice(start, nextHeading === -1 ? undefined : nextHeading)
 }
 
 function assertContains(text, expected, label) {
@@ -22,82 +72,195 @@ function assertContains(text, expected, label) {
   }
 }
 
-function readManifest(read, manifestPath) {
-  try {
-    return JSON.parse(read(manifestPath))
-  } catch (error) {
-    throw new Error(`Could not read published package manifest ${manifestPath}: ${error.message}`, {
-      cause: error,
+function assertSameInventory(actual, expected, label) {
+  const actualSorted = [...actual].sort()
+  const expectedSorted = [...expected].sort()
+  if (actualSorted.join("\n") !== expectedSorted.join("\n")) {
+    throw new Error(
+      `${label} changed; update the intentional LLMS inventory. Expected ${expectedSorted.join(", ")}; found ${actualSorted.join(", ")}`
+    )
+  }
+}
+
+function blockFor(text, startPattern) {
+  const start = text.search(startPattern)
+  if (start === -1) return ""
+  const open = text.indexOf("{", start)
+  if (open === -1) return ""
+  let depth = 0
+  for (let index = open; index < text.length; index += 1) {
+    if (text[index] === "{") depth += 1
+    if (text[index] === "}") {
+      depth -= 1
+      if (depth === 0) return text.slice(open + 1, index)
+    }
+  }
+  return ""
+}
+
+function kebabCase(name) {
+  return name
+    .replaceAll(/([a-z0-9])([A-Z])/gu, "$1-$2")
+    .replaceAll("_", "-")
+    .toLowerCase()
+}
+
+export function discoverClapOptions(source, type) {
+  const body = blockFor(source, new RegExp(`pub struct ${type}\\b`, "u"))
+  if (!body) throw new Error(`Could not discover Clap options for ${type}`)
+  return [...body.matchAll(/#\[arg\(([^\]]*)\)\]\s*([A-Za-z_][A-Za-z0-9_]*)\s*:/gu)]
+    .filter(([, attributes]) => attributes.includes("long"))
+    .map((match) => `--${kebabCase(match[2])}`)
+}
+
+function discoverEnumVariants(source, enumName) {
+  const body = blockFor(source, new RegExp(`(?:pub )?enum ${enumName}\\b`, "u"))
+  if (!body) throw new Error(`Could not discover ${enumName}`)
+  return [
+    ...body.matchAll(
+      /^\s*(?:\/\/\/[^\n]*\n\s*)*(?:#\[[^\]]+\]\s*)*([A-Z][A-Za-z0-9_]*)\s*(?:\([^)]*\))?,/gmu
+    ),
+  ].map(([, variant]) => variant)
+}
+
+export function discoverCliInventory(read) {
+  const rootCommands = discoverEnumVariants(
+    read("crates/palamedes-cli/src/cli.rs"),
+    "Command"
+  ).filter((variant) => variant !== "Plugin")
+  assertSameInventory(rootCommands, Object.keys(commandSources), "Built-in pmds command inventory")
+
+  const commands = rootCommands.map((variant) => {
+    const source = commandSources[variant]
+    return {
+      command: source.command,
+      flags: source.file ? discoverClapOptions(read(source.file), source.type) : [],
+    }
+  })
+  const catalogVariants = discoverEnumVariants(
+    read("crates/palamedes-cli/src/commands/catalog/mod.rs"),
+    "CatalogSubcommand"
+  )
+  assertSameInventory(
+    catalogVariants,
+    Object.keys(catalogCommandSources),
+    "pmds catalog subcommand inventory"
+  )
+  for (const variant of catalogVariants) {
+    const source = catalogCommandSources[variant]
+    commands.push({
+      command: source.command,
+      flags: discoverClapOptions(read(source.file), source.type),
     })
   }
+  return commands
 }
 
-function verifyAuthority(read, surface) {
-  const { authority } = surface
-
-  if (authority.package) {
-    const manifest = readManifest(read, authority.package.manifest)
-    if (manifest.private || manifest.name !== authority.package.name) {
-      throw new Error(
-        `${surface.id}: ${authority.package.manifest} does not publish ${authority.package.name}`
-      )
+export function discoverPublishedPackages(read, listDirectories = () => readdirSync("packages")) {
+  const packages = []
+  for (const directory of listDirectories()) {
+    const manifestPath = `packages/${directory}/package.json`
+    try {
+      const manifest = JSON.parse(read(manifestPath))
+      if (!manifest.private && manifest.name) packages.push({ manifestPath, name: manifest.name })
+    } catch (error) {
+      if (error.code !== "ENOENT") throw error
     }
   }
+  return packages
+}
 
-  if (authority.documentation) {
-    const documentation = read(authority.documentation.file)
-    for (const marker of authority.documentation.markers) {
-      assertContains(documentation, marker, `${surface.id}: ${authority.documentation.file}`)
+function platformParent(packageName) {
+  if (!platformPackageInventory.includes(packageName)) return undefined
+  return platformPackageParents.find((parent) => packageName.startsWith(`${parent}-`))
+}
+
+export function discoverTranslationApi(source) {
+  const names = [
+    ...source.matchAll(
+      /^export (?:type )?(Translation(?:Candidate|Patch)[A-Za-z0-9_]*)\b|^export function (listTranslationCandidates|applyTranslationPatches)\b/gmu
+    ),
+  ].map(([, typeName, functionName]) => typeName ?? functionName)
+  const outcome = source.match(/export type TranslationPatchOutcomeStatus\s*=\s*([^\n;]+)/u)
+  if (!outcome) throw new Error("Could not discover TranslationPatchOutcomeStatus")
+  const outcomes = [...outcome[1].matchAll(/"([^"]+)"/gu)].map(([, value]) => value)
+  return { names, outcomes }
+}
+
+function verifyPackages(read, listDirectories) {
+  const packages = discoverPublishedPackages(read, listDirectories)
+  const directPackages = packages
+    .filter(({ name }) => !platformParent(name))
+    .map(({ name }) => name)
+  const platformPackages = packages
+    .filter(({ name }) => platformParent(name))
+    .map(({ name }) => name)
+  assertSameInventory(directPackages, publishedPackageInventory, "Published package inventory")
+  assertSameInventory(platformPackages, platformPackageInventory, "Platform package inventory")
+
+  for (const { name } of packages) {
+    const parent = platformParent(name)
+    assertContains(read("llms-full.txt"), parent ?? name, "published packages: llms-full.txt")
+  }
+  for (const name of compactPackageInventory)
+    assertContains(read("llms.txt"), name, "compact package inventory: llms.txt")
+}
+
+function verifyCli(read) {
+  const commands = discoverCliInventory(read)
+  const full = read("llms-full.txt")
+  const cliDocs = read("docs/cli.md")
+  for (const { command, flags } of commands) {
+    assertContains(cliDocs, command, "CLI reference")
+    assertContains(full, command, "complete CLI inventory: llms-full.txt")
+    for (const flag of flags) {
+      assertContains(cliDocs, flag, `CLI reference for ${command}`)
+      assertContains(full, flag, `complete CLI option inventory: llms-full.txt`)
     }
   }
+  for (const command of compactCommandInventory)
+    assertContains(read("llms.txt"), command, "compact CLI inventory: llms.txt")
+}
 
-  if (authority.api) {
-    const api = read(authority.api.file)
-    for (const exportedName of authority.api.exports) {
-      assertContains(api, `export function ${exportedName}`, `${surface.id}: ${authority.api.file}`)
-    }
+function verifyTranslationApi(read) {
+  const { names, outcomes } = discoverTranslationApi(read("packages/core-node/src/index.ts"))
+  assertSameInventory(names, translationApiInventory, "Translation candidate/patch API inventory")
+  assertSameInventory(
+    outcomes,
+    translationPatchOutcomeInventory,
+    "Translation patch outcome inventory"
+  )
+  const full = read("llms-full.txt")
+  for (const name of names) assertContains(full, name, "translation API inventory: llms-full.txt")
+  for (const outcome of outcomes)
+    assertContains(full, outcome, "translation patch outcomes: llms-full.txt")
+  for (const name of compactTranslationApiInventory) {
+    assertContains(read("llms.txt"), name, "compact translation API inventory: llms.txt")
   }
+}
 
-  if (authority.cli) {
-    const cli = authority.cli
-    const documentation = read(cli.documentation)
-    const section = sectionFor(documentation, cli.heading)
-    if (!section) {
-      throw new Error(`${surface.id}: ${cli.documentation} is missing ${cli.heading}`)
-    }
-    assertContains(section, cli.command, `${surface.id}: ${cli.documentation}`)
-    for (const flag of cli.flags) {
-      assertContains(section, flag, `${surface.id}: ${cli.documentation}`)
-    }
-
-    const implementation = read(cli.implementation)
-    for (const marker of cli.implementationMarkers) {
-      assertContains(implementation, marker, `${surface.id}: ${cli.implementation}`)
+function verifyFeatureNarrative(read) {
+  const concise = read("llms.txt")
+  const full = read("llms-full.txt")
+  for (const [feature, terms] of Object.entries(featureNarrative)) {
+    for (const document of [concise, full]) {
+      for (const term of terms) assertContains(document, term, `${feature} context`)
     }
   }
 }
 
-function verifyDocuments(read, surface) {
-  for (const file of llmsFiles) {
-    const document = read(file)
-    for (const requiredSurface of surface.documents[file]) {
-      assertContains(document, requiredSurface, `${surface.id}: ${file}`)
-    }
-  }
-}
-
-export function checkLlmsSurface({ read } = {}) {
+export function checkLlmsSurface({ read, listDirectories } = {}) {
   const readFile = read ?? ((file) => readFileSync(path.join(process.cwd(), file), "utf8"))
-  for (const surface of llmsSurfaceContract) {
-    verifyAuthority(readFile, surface)
-    verifyDocuments(readFile, surface)
-  }
+  verifyPackages(readFile, listDirectories)
+  verifyCli(readFile)
+  verifyTranslationApi(readFile)
+  verifyFeatureNarrative(readFile)
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
   try {
     checkLlmsSurface()
-    console.log(`LLMS surface is current across ${llmsSurfaceContract.length} contracts.`)
+    console.log("LLMS public-surface inventories are current.")
   } catch (error) {
     console.error(`check-llms-surface: ${error.message}`)
     process.exitCode = 1

--- a/scripts/check-llms-surface.mjs
+++ b/scripts/check-llms-surface.mjs
@@ -171,7 +171,7 @@ export function discoverPublishedPackages(read, listDirectories = () => readdirS
 }
 
 function platformParent(packageName) {
-  if (!platformPackageInventory.includes(packageName)) return undefined
+  if (!platformPackageInventory.includes(packageName)) return
   return platformPackageParents.find((parent) => packageName.startsWith(`${parent}-`))
 }
 

--- a/scripts/check-llms-surface.mjs
+++ b/scripts/check-llms-surface.mjs
@@ -1,0 +1,105 @@
+import { readFileSync } from "node:fs"
+import path from "node:path"
+import process from "node:process"
+import { pathToFileURL } from "node:url"
+
+import { llmsFiles, llmsSurfaceContract } from "./llms-surface-contract.mjs"
+
+export function normalize(text) {
+  return text.replaceAll(/\s+/gu, " ").trim()
+}
+
+function sectionFor(text, heading) {
+  const start = text.indexOf(heading)
+  if (start === -1) return ""
+  const nextHeading = text.indexOf("\n## ", start + heading.length)
+  return text.slice(start, nextHeading === -1 ? undefined : nextHeading)
+}
+
+function assertContains(text, expected, label) {
+  if (!normalize(text).includes(normalize(expected))) {
+    throw new Error(`${label} is missing required surface: ${expected}`)
+  }
+}
+
+function readManifest(read, manifestPath) {
+  try {
+    return JSON.parse(read(manifestPath))
+  } catch (error) {
+    throw new Error(`Could not read published package manifest ${manifestPath}: ${error.message}`, {
+      cause: error,
+    })
+  }
+}
+
+function verifyAuthority(read, surface) {
+  const { authority } = surface
+
+  if (authority.package) {
+    const manifest = readManifest(read, authority.package.manifest)
+    if (manifest.private || manifest.name !== authority.package.name) {
+      throw new Error(
+        `${surface.id}: ${authority.package.manifest} does not publish ${authority.package.name}`
+      )
+    }
+  }
+
+  if (authority.documentation) {
+    const documentation = read(authority.documentation.file)
+    for (const marker of authority.documentation.markers) {
+      assertContains(documentation, marker, `${surface.id}: ${authority.documentation.file}`)
+    }
+  }
+
+  if (authority.api) {
+    const api = read(authority.api.file)
+    for (const exportedName of authority.api.exports) {
+      assertContains(api, `export function ${exportedName}`, `${surface.id}: ${authority.api.file}`)
+    }
+  }
+
+  if (authority.cli) {
+    const cli = authority.cli
+    const documentation = read(cli.documentation)
+    const section = sectionFor(documentation, cli.heading)
+    if (!section) {
+      throw new Error(`${surface.id}: ${cli.documentation} is missing ${cli.heading}`)
+    }
+    assertContains(section, cli.command, `${surface.id}: ${cli.documentation}`)
+    for (const flag of cli.flags) {
+      assertContains(section, flag, `${surface.id}: ${cli.documentation}`)
+    }
+
+    const implementation = read(cli.implementation)
+    for (const marker of cli.implementationMarkers) {
+      assertContains(implementation, marker, `${surface.id}: ${cli.implementation}`)
+    }
+  }
+}
+
+function verifyDocuments(read, surface) {
+  for (const file of llmsFiles) {
+    const document = read(file)
+    for (const requiredSurface of surface.documents[file]) {
+      assertContains(document, requiredSurface, `${surface.id}: ${file}`)
+    }
+  }
+}
+
+export function checkLlmsSurface({ read } = {}) {
+  const readFile = read ?? ((file) => readFileSync(path.join(process.cwd(), file), "utf8"))
+  for (const surface of llmsSurfaceContract) {
+    verifyAuthority(readFile, surface)
+    verifyDocuments(readFile, surface)
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+  try {
+    checkLlmsSurface()
+    console.log(`LLMS surface is current across ${llmsSurfaceContract.length} contracts.`)
+  } catch (error) {
+    console.error(`check-llms-surface: ${error.message}`)
+    process.exitCode = 1
+  }
+}

--- a/scripts/check-llms-surface.test.mjs
+++ b/scripts/check-llms-surface.test.mjs
@@ -5,7 +5,6 @@ import test from "node:test"
 import { fileURLToPath } from "node:url"
 
 import { checkLlmsSurface } from "./check-llms-surface.mjs"
-import { llmsSurfaceContract } from "./llms-surface-contract.mjs"
 
 const root = path.join(path.dirname(fileURLToPath(import.meta.url)), "..")
 const source = new Map()
@@ -18,66 +17,64 @@ function read(file) {
 function withMutation(file, mutate) {
   const files = new Map(source)
   files.set(file, mutate(read(file)))
-  return () => files.get.bind(files)
+  return (requested) => files.get(requested) ?? read(requested)
+}
+
+function expectRejected(file, mutate, expected) {
+  assert.throws(() => checkLlmsSurface({ read: withMutation(file, mutate) }), expected)
 }
 
 test("accepts the checked-in public surface", () => {
   assert.doesNotThrow(() => checkLlmsSurface({ read }))
 })
 
-test("rejects every required llms surface when it is omitted", () => {
-  for (const surface of llmsSurfaceContract) {
-    for (const [file, required] of Object.entries(surface.documents)) {
-      const omitted = required[0]
-      assert.throws(
-        () =>
-          checkLlmsSurface({
-            read: withMutation(file, (text) => text.replaceAll(omitted, ""))(),
-          }),
-        new RegExp(`${surface.id}: ${file} is missing required surface`)
-      )
-    }
-  }
-})
-
-test("rejects stale command flags, package names, and Node API exports", () => {
-  assert.throws(
-    () =>
-      checkLlmsSurface({
-        read: withMutation("docs/cli.md", (text) => text.replaceAll("--check", "--changed"))(),
-      }),
-    /extraction-drift-check: docs\/cli\.md is missing required surface: --check/
-  )
-  assert.throws(
-    () =>
-      checkLlmsSurface({
-        read: withMutation("packages/eslint-plugin/package.json", (text) =>
-          text.replace("@palamedes/eslint-plugin", "@palamedes/renamed-plugin")
-        )(),
-      }),
-    /does not publish @palamedes\/eslint-plugin/
-  )
-  assert.throws(
-    () =>
-      checkLlmsSurface({
-        read: withMutation("packages/core-node/src/index.ts", (text) =>
-          text.replaceAll(
-            "export function listTranslationCandidates",
-            "function listTranslationCandidates"
-          )
-        )(),
-      }),
-    /translation-candidate-patches: packages\/core-node\/src\/index\.ts is missing required surface/
+test("rejects a renamed implemented lint flag", () => {
+  expectRejected(
+    "crates/palamedes-cli/src/commands/lint.rs",
+    (text) => text.replace("fail_on: LintFailOn", "threshold: LintFailOn"),
+    /missing required surface: --threshold/
   )
 })
 
-test("accepts harmless prose and whitespace around required context", () => {
+test("rejects an unclassified built-in command", () => {
+  expectRejected(
+    "crates/palamedes-cli/src/cli.rs",
+    (text) =>
+      text.replace("    Version,", "    Version,\n    /// Scan catalogs.\n    Scan(ScanOptions),"),
+    /Built-in pmds command inventory changed/
+  )
+})
+
+test("rejects a renamed published package outside the compact inventory", () => {
+  expectRejected(
+    "packages/react/package.json",
+    (text) => text.replace("@palamedes/react", "@palamedes/react-renamed"),
+    /Published package inventory changed/
+  )
+})
+
+test("rejects a removed translation patch type", () => {
+  expectRejected(
+    "packages/core-node/src/index.ts",
+    (text) => text.replace("export type TranslationPatch =", "type TranslationPatch ="),
+    /Translation candidate\/patch API inventory changed/
+  )
+})
+
+test("rejects a missing translation patch outcome from full context", () => {
+  expectRejected(
+    "llms-full.txt",
+    (text) => text.replaceAll("notApplied", ""),
+    /translation patch outcomes: llms-full\.txt is missing required surface: notApplied/
+  )
+})
+
+test("accepts harmless Markdown heading-layout changes", () => {
   assert.doesNotThrow(() =>
     checkLlmsSurface({
-      read: withMutation(
-        "llms.txt",
-        (text) => `Editorial note.\n\n${text.replace("pmds lint", "pmds\n    lint")}`
-      )(),
+      read: withMutation("docs/cli.md", (text) =>
+        text.replace("## `pmds lint`", "### Source lint")
+      ),
     })
   )
 })

--- a/scripts/check-llms-surface.test.mjs
+++ b/scripts/check-llms-surface.test.mjs
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict"
+import { readFileSync } from "node:fs"
+import path from "node:path"
+import test from "node:test"
+import { fileURLToPath } from "node:url"
+
+import { checkLlmsSurface } from "./check-llms-surface.mjs"
+import { llmsSurfaceContract } from "./llms-surface-contract.mjs"
+
+const root = path.join(path.dirname(fileURLToPath(import.meta.url)), "..")
+const source = new Map()
+
+function read(file) {
+  if (!source.has(file)) source.set(file, readFileSync(path.join(root, file), "utf8"))
+  return source.get(file)
+}
+
+function withMutation(file, mutate) {
+  const files = new Map(source)
+  files.set(file, mutate(read(file)))
+  return () => files.get.bind(files)
+}
+
+test("accepts the checked-in public surface", () => {
+  assert.doesNotThrow(() => checkLlmsSurface({ read }))
+})
+
+test("rejects every required llms surface when it is omitted", () => {
+  for (const surface of llmsSurfaceContract) {
+    for (const [file, required] of Object.entries(surface.documents)) {
+      const omitted = required[0]
+      assert.throws(
+        () =>
+          checkLlmsSurface({
+            read: withMutation(file, (text) => text.replaceAll(omitted, ""))(),
+          }),
+        new RegExp(`${surface.id}: ${file} is missing required surface`)
+      )
+    }
+  }
+})
+
+test("rejects stale command flags, package names, and Node API exports", () => {
+  assert.throws(
+    () =>
+      checkLlmsSurface({
+        read: withMutation("docs/cli.md", (text) => text.replaceAll("--check", "--changed"))(),
+      }),
+    /extraction-drift-check: docs\/cli\.md is missing required surface: --check/
+  )
+  assert.throws(
+    () =>
+      checkLlmsSurface({
+        read: withMutation("packages/eslint-plugin/package.json", (text) =>
+          text.replace("@palamedes/eslint-plugin", "@palamedes/renamed-plugin")
+        )(),
+      }),
+    /does not publish @palamedes\/eslint-plugin/
+  )
+  assert.throws(
+    () =>
+      checkLlmsSurface({
+        read: withMutation("packages/core-node/src/index.ts", (text) =>
+          text.replaceAll(
+            "export function listTranslationCandidates",
+            "function listTranslationCandidates"
+          )
+        )(),
+      }),
+    /translation-candidate-patches: packages\/core-node\/src\/index\.ts is missing required surface/
+  )
+})
+
+test("accepts harmless prose and whitespace around required context", () => {
+  assert.doesNotThrow(() =>
+    checkLlmsSurface({
+      read: withMutation(
+        "llms.txt",
+        (text) => `Editorial note.\n\n${text.replace("pmds lint", "pmds\n    lint")}`
+      )(),
+    })
+  )
+})

--- a/scripts/llms-surface-contract.mjs
+++ b/scripts/llms-surface-contract.mjs
@@ -1,134 +1,91 @@
 /*
- * The llms files are curated context, not generated API reference. This is the
- * deliberately small public surface that must be discoverable in both files.
- * Each authority entry is read from the implementation or published manifest;
- * each document entry describes the minimum useful context for that audience.
+ * `llms.txt` and `llms-full.txt` are edited context, not generated reference.
+ * This contract says which discovered public surfaces each audience covers:
+ * the concise file covers the workflow features called out below, while the
+ * full file covers every built-in command and non-platform published package.
+ * Keep an intentional inventory here when a public API is added or removed.
  */
 
-export const llmsFiles = ["llms.txt", "llms-full.txt"]
-
-export const llmsSurfaceContract = [
-  {
-    id: "source-lint",
-    authority: {
-      package: {
-        manifest: "packages/cli/package.json",
-        name: "@palamedes/cli",
-      },
-      cli: {
-        command: "pmds lint",
-        documentation: "docs/cli.md",
-        heading: "## `pmds lint`",
-        flags: ["--json", "--fail-on", "--no-cache"],
-        implementation: "crates/palamedes-cli/src/cli.rs",
-        implementationMarkers: ["Lint(LintOptions)"],
-      },
-    },
-    documents: {
-      "llms.txt": ["@palamedes/cli", "pmds lint", "non-mutating", "MDX"],
-      "llms-full.txt": ["@palamedes/cli", "pmds lint", "non-mutating", "MDX", "--fail-on warning"],
-    },
-  },
-  {
-    id: "eslint-oxlint-adapter",
-    authority: {
-      package: {
-        manifest: "packages/eslint-plugin/package.json",
-        name: "@palamedes/eslint-plugin",
-      },
-      documentation: {
-        file: "packages/eslint-plugin/README.md",
-        markers: ["Preview", "Oxlint", "MDX is not supported"],
-      },
-    },
-    documents: {
-      "llms.txt": ["@palamedes/eslint-plugin", "Preview", "ESLint/Oxlint", "pmds lint"],
-      "llms-full.txt": [
-        "@palamedes/eslint-plugin",
-        "Preview",
-        "ESLint/Oxlint",
-        "Oxlint's JavaScript plugin API is still alpha",
-        "MDX",
-        "pmds lint",
-      ],
-    },
-  },
-  {
-    id: "translation-candidate-patches",
-    authority: {
-      package: {
-        manifest: "packages/core-node/package.json",
-        name: "@palamedes/core-node",
-      },
-      api: {
-        file: "packages/core-node/src/index.ts",
-        exports: ["listTranslationCandidates", "applyTranslationPatches"],
-      },
-    },
-    documents: {
-      "llms.txt": [
-        "@palamedes/core-node",
-        "listTranslationCandidates",
-        "applyTranslationPatches",
-        "fingerprint",
-      ],
-      "llms-full.txt": [
-        "@palamedes/core-node",
-        "listTranslationCandidates",
-        "applyTranslationPatches",
-        "fingerprint",
-        "applied",
-        "unchanged",
-        "rejected",
-      ],
-    },
-  },
-  {
-    id: "extraction-drift-check",
-    authority: {
-      cli: {
-        command: "pmds extract",
-        documentation: "docs/cli.md",
-        heading: "## `pmds extract`",
-        flags: ["--check", "--json", "--no-cache"],
-        implementation: "crates/palamedes-cli/src/commands/extract/mod.rs",
-        implementationMarkers: ["check: bool", "json: bool", "no_cache: bool"],
-      },
-    },
-    documents: {
-      "llms.txt": ["pmds extract --check --json", "catalog", "--no-cache"],
-      "llms-full.txt": [
-        "pmds extract --check --json",
-        "without writing catalog files",
-        "--no-cache",
-        "cache",
-      ],
-    },
-  },
-  {
-    id: "deletion-aware-merge-driver",
-    authority: {
-      cli: {
-        command: "pmds catalog merge-driver",
-        documentation: "docs/cli.md",
-        heading: "## `pmds catalog merge`",
-        flags: ["--base", "--path", "--operation"],
-        implementation: "crates/palamedes-cli/src/commands/catalog/merge.rs",
-        implementationMarkers: ["pub struct MergeDriverOptions", "GitMergeOperation"],
-      },
-    },
-    documents: {
-      "llms.txt": [
-        "pmds catalog merge-driver %O %A %B %A --path %P",
-        "deletion-aware",
-        "three-way merge",
-      ],
-      "llms-full.txt": [
-        "pmds catalog merge-driver %O %A %B %A --path %P",
-        "deletion-aware three-way merge",
-        "rebase",
-        "use-first",
-      ],
-    },
-  },
+export const compactCommandInventory = [
+  "pmds extract",
+  "pmds lint",
+  "pmds catalog merge",
+  "pmds catalog merge-driver",
 ]
+
+export const compactPackageInventory = [
+  "@palamedes/cli",
+  "@palamedes/core-node",
+  "@palamedes/eslint-plugin",
+]
+
+// Every public package is intentionally enumerated. Platform binaries remain
+// discoverable through their parent package in the full context, while an
+// unexpected package name still fails the inventory check.
+export const publishedPackageInventory = [
+  "@palamedes/cli",
+  "@palamedes/config",
+  "@palamedes/core",
+  "@palamedes/core-node",
+  "@palamedes/eslint-plugin",
+  "@palamedes/extractor",
+  "@palamedes/next-plugin",
+  "@palamedes/react",
+  "@palamedes/remix",
+  "@palamedes/runtime",
+  "@palamedes/solid",
+  "@palamedes/transform",
+  "@palamedes/vite-plugin",
+  "create-palamedes",
+  "palamedes",
+]
+
+export const platformPackageParents = ["@palamedes/cli", "@palamedes/core-node"]
+
+export const platformPackageInventory = [
+  "@palamedes/cli-darwin-arm64",
+  "@palamedes/cli-linux-arm64-gnu",
+  "@palamedes/cli-linux-x64-gnu",
+  "@palamedes/cli-linux-x64-musl",
+  "@palamedes/cli-win32-x64-msvc",
+  "@palamedes/core-node-darwin-arm64",
+  "@palamedes/core-node-linux-arm64-gnu",
+  "@palamedes/core-node-linux-x64-gnu",
+  "@palamedes/core-node-linux-x64-musl",
+  "@palamedes/core-node-win32-x64-msvc",
+]
+
+// The candidate/patch API is a deliberately bounded public workflow. The
+// checker also discovers all matching exports, so additions need both an
+// inventory decision and full-context coverage.
+export const translationApiInventory = [
+  "applyTranslationPatches",
+  "listTranslationCandidates",
+  "TranslationCandidate",
+  "TranslationCandidateId",
+  "TranslationCandidateRequest",
+  "TranslationCandidateResult",
+  "TranslationPatch",
+  "TranslationPatchOutcome",
+  "TranslationPatchOutcomeStatus",
+  "TranslationPatchRequest",
+  "TranslationPatchResult",
+  "TranslationPatchWriteError",
+]
+
+export const translationPatchOutcomeInventory = ["applied", "unchanged", "rejected", "notApplied"]
+
+export const compactTranslationApiInventory = [
+  "listTranslationCandidates",
+  "applyTranslationPatches",
+  "TranslationPatch",
+  "fingerprint",
+]
+
+export const featureNarrative = {
+  lint: ["non-mutating", "MDX"],
+  eslintAdapter: ["Preview", "ESLint/Oxlint", "pmds lint"],
+  extractCheck: ["pmds extract --check --json", "--no-cache"],
+  mergeDriver: ["deletion-aware", "three-way merge"],
+  binaryPlugins: ["binary-only", "binary plugin protocol"],
+}

--- a/scripts/llms-surface-contract.mjs
+++ b/scripts/llms-surface-contract.mjs
@@ -1,0 +1,134 @@
+/*
+ * The llms files are curated context, not generated API reference. This is the
+ * deliberately small public surface that must be discoverable in both files.
+ * Each authority entry is read from the implementation or published manifest;
+ * each document entry describes the minimum useful context for that audience.
+ */
+
+export const llmsFiles = ["llms.txt", "llms-full.txt"]
+
+export const llmsSurfaceContract = [
+  {
+    id: "source-lint",
+    authority: {
+      package: {
+        manifest: "packages/cli/package.json",
+        name: "@palamedes/cli",
+      },
+      cli: {
+        command: "pmds lint",
+        documentation: "docs/cli.md",
+        heading: "## `pmds lint`",
+        flags: ["--json", "--fail-on", "--no-cache"],
+        implementation: "crates/palamedes-cli/src/cli.rs",
+        implementationMarkers: ["Lint(LintOptions)"],
+      },
+    },
+    documents: {
+      "llms.txt": ["@palamedes/cli", "pmds lint", "non-mutating", "MDX"],
+      "llms-full.txt": ["@palamedes/cli", "pmds lint", "non-mutating", "MDX", "--fail-on warning"],
+    },
+  },
+  {
+    id: "eslint-oxlint-adapter",
+    authority: {
+      package: {
+        manifest: "packages/eslint-plugin/package.json",
+        name: "@palamedes/eslint-plugin",
+      },
+      documentation: {
+        file: "packages/eslint-plugin/README.md",
+        markers: ["Preview", "Oxlint", "MDX is not supported"],
+      },
+    },
+    documents: {
+      "llms.txt": ["@palamedes/eslint-plugin", "Preview", "ESLint/Oxlint", "pmds lint"],
+      "llms-full.txt": [
+        "@palamedes/eslint-plugin",
+        "Preview",
+        "ESLint/Oxlint",
+        "Oxlint's JavaScript plugin API is still alpha",
+        "MDX",
+        "pmds lint",
+      ],
+    },
+  },
+  {
+    id: "translation-candidate-patches",
+    authority: {
+      package: {
+        manifest: "packages/core-node/package.json",
+        name: "@palamedes/core-node",
+      },
+      api: {
+        file: "packages/core-node/src/index.ts",
+        exports: ["listTranslationCandidates", "applyTranslationPatches"],
+      },
+    },
+    documents: {
+      "llms.txt": [
+        "@palamedes/core-node",
+        "listTranslationCandidates",
+        "applyTranslationPatches",
+        "fingerprint",
+      ],
+      "llms-full.txt": [
+        "@palamedes/core-node",
+        "listTranslationCandidates",
+        "applyTranslationPatches",
+        "fingerprint",
+        "applied",
+        "unchanged",
+        "rejected",
+      ],
+    },
+  },
+  {
+    id: "extraction-drift-check",
+    authority: {
+      cli: {
+        command: "pmds extract",
+        documentation: "docs/cli.md",
+        heading: "## `pmds extract`",
+        flags: ["--check", "--json", "--no-cache"],
+        implementation: "crates/palamedes-cli/src/commands/extract/mod.rs",
+        implementationMarkers: ["check: bool", "json: bool", "no_cache: bool"],
+      },
+    },
+    documents: {
+      "llms.txt": ["pmds extract --check --json", "catalog", "--no-cache"],
+      "llms-full.txt": [
+        "pmds extract --check --json",
+        "without writing catalog files",
+        "--no-cache",
+        "cache",
+      ],
+    },
+  },
+  {
+    id: "deletion-aware-merge-driver",
+    authority: {
+      cli: {
+        command: "pmds catalog merge-driver",
+        documentation: "docs/cli.md",
+        heading: "## `pmds catalog merge`",
+        flags: ["--base", "--path", "--operation"],
+        implementation: "crates/palamedes-cli/src/commands/catalog/merge.rs",
+        implementationMarkers: ["pub struct MergeDriverOptions", "GitMergeOperation"],
+      },
+    },
+    documents: {
+      "llms.txt": [
+        "pmds catalog merge-driver %O %A %B %A --path %P",
+        "deletion-aware",
+        "three-way merge",
+      ],
+      "llms-full.txt": [
+        "pmds catalog merge-driver %O %A %B %A --path %P",
+        "deletion-aware three-way merge",
+        "rebase",
+        "use-first",
+      ],
+    },
+  },
+]


### PR DESCRIPTION
## Summary

- Refresh `llms.txt` and `llms-full.txt` for source lint, the Preview ESLint/Oxlint adapter, typed translation candidate/patch APIs, extraction drift checks, and the deletion-aware Git merge driver.
- Add a curated-surface contract that verifies the current CLI docs/implementation, published package manifests, and Node API exports before checking each context-file level.
- Add mutation tests, CI coverage on full validation jobs, and contributor update guidance.

## Validation

- `pnpm lint`
- `pnpm format:check`
- `pnpm check:llms`
- `node --test ./scripts/check-llms-surface.test.mjs`
- `RUSTUP_TOOLCHAIN=1.97.1 pnpm build`
- `RUSTUP_TOOLCHAIN=1.97.1 pnpm test`
- `RUSTUP_TOOLCHAIN=1.97.1 pnpm check-types`
- `pnpm build:site`; verified both hosted files match the copy transform and retain all five surfaces

Closes #583

🔧 Emily Carter · Implementation Agent