### PR TITLE
fix(core-node): harden native boundary contracts

### DIFF
--- a/adr/009-typed-napi-boundary-with-workflow-first-native-operations.md
+++ b/adr/009-typed-napi-boundary-with-workflow-first-native-operations.md
@@ -50,6 +50,19 @@ The preferred native workflow operations are:
 
 Standalone utilities may still exist when they are clearly useful outside a larger workflow. `parsePo()` is an example of an acceptable utility.
 
+Native Node operations are synchronous today. They perform filesystem and CPU
+work on the calling Node thread, so host adapters must invoke them only from
+their normal bounded build or module-hook work rather than request-time hot
+paths. In particular, the Vite plugin deliberately compiles catalog modules in
+Vite's host-side hooks; it does not claim those hooks are nonblocking.
+
+Adding `Async` variants would duplicate a broad workflow surface and introduce
+parallelism, cancellation, and result-ordering contracts that the current
+workloads have not demonstrated a need for. Revisit that decision when a
+representative host workload shows event-loop delay that cannot be bounded by
+existing build orchestration, or when a supported integration needs concurrent
+request-time native work with a defined cancellation contract.
+
 This does not mean Palamedes must collapse every operation into one giant "do everything" call. The rule is not "fewer functions at any cost." The rule is that each exported native function should represent a meaningful product operation, not a transport workaround.
 
 ## Alternatives Considered
@@ -77,3 +90,6 @@ Rejected because it would overfit the current host integrations and make the API
 - The Rust core remains `napi`-free; the binding crate is responsible for N-API bridge types and conversion.
 - Future performance work should first ask whether orchestration can remain inside an existing native workflow before adding new boundary crossings.
 - New utilities should be added sparingly and only when they are useful outside a larger workflow.
+- Node callers must treat the current native operations as synchronous and keep
+  them off latency-sensitive request paths; future async APIs require measured
+  event-loop pressure and an explicit lifecycle contract.

--- a/crates/palamedes-node/src/catalog_config.rs
+++ b/crates/palamedes-node/src/catalog_config.rs
@@ -10,7 +10,13 @@ use napi_derive::napi;
 pub struct CatalogArtifactCatalogConfig {
     pub path: String,
     pub format: Option<CatalogConfigFormat>,
-    pub include: Vec<String>,
+    /// Host-side source selection only. Native catalog workflows do not apply
+    /// these patterns; adapters such as the Vite plugin filter source modules
+    /// before invoking the native operation.
+    pub include: Option<Vec<String>>,
+    /// Host-side source selection only. Native catalog workflows do not apply
+    /// these patterns; adapters such as the Vite plugin filter source modules
+    /// before invoking the native operation.
     pub exclude: Option<Vec<String>>,
 }
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -39,11 +39,11 @@
     "access": "public"
   },
   "optionalDependencies": {
-    "@palamedes/cli-darwin-arm64": "workspace:^",
-    "@palamedes/cli-linux-arm64-gnu": "workspace:^",
-    "@palamedes/cli-linux-x64-gnu": "workspace:^",
-    "@palamedes/cli-linux-x64-musl": "workspace:^",
-    "@palamedes/cli-win32-x64-msvc": "workspace:^"
+    "@palamedes/cli-darwin-arm64": "workspace:*",
+    "@palamedes/cli-linux-arm64-gnu": "workspace:*",
+    "@palamedes/cli-linux-x64-gnu": "workspace:*",
+    "@palamedes/cli-linux-x64-musl": "workspace:*",
+    "@palamedes/cli-win32-x64-msvc": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "^24.0.0",

--- a/packages/cli/scripts/smoke.mjs
+++ b/packages/cli/scripts/smoke.mjs
@@ -83,6 +83,19 @@ try {
   if (Object.hasOwn(installedManifest.scripts ?? {}, "postinstall")) {
     throw new Error("The packed @palamedes/cli package still declares a postinstall script.")
   }
+  const platformDependencyVersions = Object.entries(
+    installedManifest.optionalDependencies ?? {}
+  ).filter(([name]) => name.startsWith("@palamedes/cli-"))
+  if (platformDependencyVersions.length !== 5) {
+    throw new Error("The packed @palamedes/cli manifest is missing a platform dependency.")
+  }
+  for (const [name, version] of platformDependencyVersions) {
+    if (version !== installedManifest.version) {
+      throw new Error(
+        `The packed @palamedes/cli manifest must pin ${name} to ${installedManifest.version}, found ${version}.`
+      )
+    }
+  }
 
   const copiedSidecar = path.join(
     cliInstallDir,

--- a/packages/core-node/package.json
+++ b/packages/core-node/package.json
@@ -38,7 +38,7 @@
     "generate-native-types": "node ./scripts/generate-native-types.mjs",
     "check-native-types": "node ./scripts/generate-native-types.mjs --check",
     "build": "unbuild",
-    "test": "vitest run --globals src/index.test.ts",
+    "test": "vitest run --globals src/index.test.ts && node --test ./scripts/package.test.mjs",
     "stub": "unbuild --stub"
   },
   "engines": {
@@ -48,11 +48,11 @@
     "access": "public"
   },
   "optionalDependencies": {
-    "@palamedes/core-node-darwin-arm64": "workspace:^",
-    "@palamedes/core-node-linux-arm64-gnu": "workspace:^",
-    "@palamedes/core-node-linux-x64-gnu": "workspace:^",
-    "@palamedes/core-node-linux-x64-musl": "workspace:^",
-    "@palamedes/core-node-win32-x64-msvc": "workspace:^"
+    "@palamedes/core-node-darwin-arm64": "workspace:*",
+    "@palamedes/core-node-linux-arm64-gnu": "workspace:*",
+    "@palamedes/core-node-linux-x64-gnu": "workspace:*",
+    "@palamedes/core-node-linux-x64-musl": "workspace:*",
+    "@palamedes/core-node-win32-x64-msvc": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "^24.0.0",

--- a/packages/core-node/scripts/package.test.mjs
+++ b/packages/core-node/scripts/package.test.mjs
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict"
+import { execFileSync } from "node:child_process"
+import { mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import test from "node:test"
+
+const packageDir = path.resolve(import.meta.dirname, "..")
+
+test("the packed wrapper pins every native optional dependency exactly", (context) => {
+  const archiveDir = mkdtempSync(path.join(os.tmpdir(), "palamedes-core-node-pack-"))
+  context.after(() => rmSync(archiveDir, { recursive: true, force: true }))
+
+  const packageManager = process.platform === "win32" ? "pnpm.cmd" : "pnpm"
+  execFileSync(packageManager, ["pack", "--pack-destination", archiveDir], {
+    cwd: packageDir,
+    env: { ...process.env, npm_config_cache: path.join(archiveDir, "npm-cache") },
+    shell: process.platform === "win32",
+    stdio: "pipe",
+  })
+  const archive = readdirSync(archiveDir).find((entry) => entry.endsWith(".tgz"))
+  assert.ok(archive, "npm pack did not produce an archive")
+
+  const manifest = JSON.parse(
+    execFileSync("tar", ["-xOzf", path.join(archiveDir, archive), "package/package.json"], {
+      encoding: "utf8",
+    })
+  )
+  const platformPackages = Object.entries(manifest.optionalDependencies).filter(([name]) =>
+    name.startsWith("@palamedes/core-node-")
+  )
+  assert.equal(platformPackages.length, 5)
+  for (const [name, version] of platformPackages) {
+    assert.equal(version, manifest.version, `${name} must be pinned in the packed manifest`)
+  }
+
+  assert.equal(
+    readFileSync(path.join(packageDir, "package.json"), "utf8").includes("workspace:*"),
+    true
+  )
+})

--- a/packages/core-node/src/generated/palamedes-node-types.ts
+++ b/packages/core-node/src/generated/palamedes-node-types.ts
@@ -369,7 +369,17 @@ export interface CatalogModuleResult {
 export interface CatalogArtifactCatalogConfig {
   path: string;
   format?: CatalogConfigFormat;
-  include: Array<string>;
+  /**
+   * Host-side source selection only. Native catalog workflows do not apply
+   * these patterns; adapters such as the Vite plugin filter source modules
+   * before invoking the native operation.
+   */
+  include?: Array<string>;
+  /**
+   * Host-side source selection only. Native catalog workflows do not apply
+   * these patterns; adapters such as the Vite plugin filter source modules
+   * before invoking the native operation.
+   */
   exclude?: Array<string>;
 }
 export type CatalogConfigFormat = "Po" | "Fcl"

--- a/packages/core-node/src/index.test.ts
+++ b/packages/core-node/src/index.test.ts
@@ -32,6 +32,7 @@ import {
   assertNativeBindingVersion,
   assertWellFormedNativeArguments,
   loadNativeBindings,
+  snapshotNativeArguments,
 } from "./native-loader"
 
 type SourceMapLike = {
@@ -110,6 +111,89 @@ describe("@palamedes/core-node", () => {
         new Map([["message", ["valid", "\ud800"]]]),
       ])
     ).toThrow(/renderCatalogModule\.argument\[0\]\.get\(message\)\[1\]/u)
+  })
+
+  it("passes the single validated accessor and Proxy snapshot to native bindings", () => {
+    let accessorReads = 0
+    const accessorMessages: Record<string, string> = {}
+    Object.defineProperty(accessorMessages, "message", {
+      enumerable: true,
+      get() {
+        accessorReads += 1
+        return accessorReads === 1 ? "from accessor" : "\ud800"
+      },
+    })
+
+    const accessorRendered = renderCatalogModule(accessorMessages)
+    expect(accessorReads).toBe(1)
+    expect(accessorRendered).toContain("from accessor")
+    expect(accessorRendered).not.toContain("�")
+
+    let proxyReads = 0
+    const proxyMessages = new Proxy(
+      { message: "unused" },
+      {
+        get(target, property, receiver) {
+          if (property === "message") {
+            proxyReads += 1
+            return proxyReads === 1 ? "from proxy" : "\udc00"
+          }
+          return Reflect.get(target, property, receiver)
+        },
+      }
+    )
+    const proxyRendered = renderCatalogModule(proxyMessages)
+    expect(proxyReads).toBe(1)
+    expect(proxyRendered).toContain("from proxy")
+    expect(proxyRendered).not.toContain("�")
+  })
+
+  it("snapshots nested accessors, arrays, Maps, and getter failures deterministically", () => {
+    let nestedReads = 0
+    const nested: { config: { locales: string[] } } = { config: {} as { locales: string[] } }
+    Object.defineProperty(nested.config, "locales", {
+      enumerable: true,
+      get() {
+        nestedReads += 1
+        return nestedReads === 1 ? ["en", "cafe\u0301", "😀"] : ["\ud800"]
+      },
+    })
+    const map = new Map([["request", nested]])
+    const snapshot = snapshotNativeArguments("compileCatalogModule", [map])
+    const snapshotMap = snapshot[0] as Map<string, { config: { locales: string[] } }>
+
+    expect(nestedReads).toBe(1)
+    expect(snapshotMap).not.toBe(map)
+    expect(snapshotMap.get("request")).toStrictEqual({
+      config: { locales: ["en", "cafe\u0301", "😀"] },
+    })
+    expect(nested.config.locales).toStrictEqual(["\ud800"])
+
+    const cyclic: { message: string; self?: unknown } = { message: "cycle" }
+    cyclic.self = cyclic
+    const cyclicSnapshot = snapshotNativeArguments("renderCatalogModule", [cyclic])[0] as {
+      self: unknown
+    }
+    expect(cyclicSnapshot.self).toBe(cyclicSnapshot)
+
+    const failure = new Error("fixture getter failure")
+    const throwingRequest = {}
+    Object.defineProperty(throwingRequest, "locale", {
+      enumerable: true,
+      get() {
+        throw failure
+      },
+    })
+    try {
+      snapshotNativeArguments("compileCatalogModule", [throwingRequest])
+      throw new Error("Expected a throwing getter to fail the native boundary snapshot.")
+    } catch (error) {
+      expect(error).toMatchObject({ cause: failure })
+      expect(error).toHaveProperty(
+        "message",
+        expect.stringMatching(/could not read compileCatalogModule\.argument\[0\]\.locale/u)
+      )
+    }
   })
 
   it("loads native bindings and exposes version information", () => {

--- a/packages/core-node/src/index.test.ts
+++ b/packages/core-node/src/index.test.ts
@@ -12,6 +12,7 @@ import {
   analyzeSourceNative,
   applyTranslationPatches,
   compileCatalogArtifact,
+  compileCatalogArtifactSelected,
   compileCatalogModule,
   extractMessagesNative,
   getNativeInfo,
@@ -192,6 +193,84 @@ describe("@palamedes/core-node", () => {
       expect(error).toHaveProperty(
         "message",
         expect.stringMatching(/could not read compileCatalogModule\.argument\[0\]\.locale/u)
+      )
+    }
+  })
+
+  it("preserves native-visible class and enumerable record semantics", () => {
+    class ClassBackedMessages implements Record<string, string> {
+      [key: string]: string
+
+      public message = "from class"
+    }
+    expect(renderCatalogModule(new ClassBackedMessages())).toContain("from class")
+
+    const nonEnumerableMessages: Record<string, string> = {}
+    Object.defineProperty(nonEnumerableMessages, "hidden", {
+      configurable: true,
+      value: "not native-visible",
+      writable: true,
+    })
+    expect(renderCatalogModule(nonEnumerableMessages)).not.toContain("not native-visible")
+  })
+
+  it("classifies Proxy metadata once and translates prototype and length errors", () => {
+    let prototypeReads = 0
+    const stablePrototypeProxy = new Proxy(
+      { message: "one prototype read" },
+      {
+        getPrototypeOf(target) {
+          prototypeReads += 1
+          return Reflect.getPrototypeOf(target)
+        },
+      }
+    )
+    expect(renderCatalogModule(stablePrototypeProxy)).toContain("one prototype read")
+    expect(prototypeReads).toBe(1)
+
+    const prototypeFailure = new Error("fixture prototype failure")
+    const throwingPrototypeProxy = new Proxy(
+      { message: "unreachable" },
+      {
+        getPrototypeOf() {
+          throw prototypeFailure
+        },
+      }
+    )
+    try {
+      renderCatalogModule(throwingPrototypeProxy)
+      throw new Error(
+        "Expected a throwing getPrototypeOf trap to fail the native boundary snapshot."
+      )
+    } catch (error) {
+      expect(error).toMatchObject({ cause: prototypeFailure })
+      expect(error).toHaveProperty(
+        "message",
+        expect.stringMatching(/could not read renderCatalogModule\.argument\[0\]/u)
+      )
+    }
+
+    const lengthFailure = new Error("fixture length failure")
+    const throwingLengthProxy = new Proxy(["message"], {
+      get(target, property, receiver) {
+        if (property === "length") throw lengthFailure
+        return Reflect.get(target, property, receiver)
+      },
+    })
+    try {
+      compileCatalogArtifactSelected(
+        { rootDir: ".", locales: ["en"], sourceLocale: "en", catalogs: [] },
+        "fixture.po",
+        throwingLengthProxy
+      )
+      throw new Error("Expected a throwing length trap to fail the native boundary snapshot.")
+    } catch (error) {
+      expect(error).toMatchObject({ cause: lengthFailure })
+      expect(error).toHaveProperty(
+        "message",
+        expect.stringMatching(
+          /could not read compileCatalogArtifactSelected\.argument\[0\]\.compiledIds/u
+        )
       )
     }
   })

--- a/packages/core-node/src/index.test.ts
+++ b/packages/core-node/src/index.test.ts
@@ -28,6 +28,11 @@ import type {
   TranslationPatchRequest as GeneratedTranslationPatchRequest,
   TranslationPatchResult as GeneratedTranslationPatchResult,
 } from "./generated/palamedes-node-types"
+import {
+  assertNativeBindingVersion,
+  assertWellFormedNativeArguments,
+  loadNativeBindings,
+} from "./native-loader"
 
 type SourceMapLike = {
   mappings?: string
@@ -47,6 +52,66 @@ afterEach(async () => {
 })
 
 describe("@palamedes/core-node", () => {
+  it("rejects a mismatched platform binding before exposing the native surface", () => {
+    expect(() =>
+      assertNativeBindingVersion("1.14.0", "@palamedes/core-node-linux-x64-gnu", {
+        palamedesVersion: "1.15.0",
+        ferrocatVersion: "0.1.0",
+      })
+    ).toThrow(
+      "@palamedes/core-node@1.14.0 loaded @palamedes/core-node-linux-x64-gnu with native version 1.15.0"
+    )
+    expect(() =>
+      assertNativeBindingVersion("1.14.0", "@palamedes/core-node-linux-x64-gnu", {
+        palamedesVersion: "1.14.0",
+        ferrocatVersion: "0.1.0",
+      })
+    ).not.toThrow()
+
+    const fixtureBindings = {
+      getNativeInfo: () => ({ palamedesVersion: "1.15.0", ferrocatVersion: "0.1.0" }),
+    }
+    expect(() =>
+      loadNativeBindings({
+        packageDir: "/fixture/core-node",
+        nativePackageName: "@palamedes/core-node-win32-x64-msvc",
+        require(specifier) {
+          return specifier.endsWith("package.json") ? { version: "1.14.0" } : fixtureBindings
+        },
+      })
+    ).toThrow("@palamedes/core-node-win32-x64-msvc with native version 1.15.0")
+  })
+
+  it("rejects lone surrogates without changing well-formed nested request data", () => {
+    const validRequest = {
+      config: {
+        rootDir: "café",
+        locales: ["en", "de", "emoji-😀"],
+        sourceLocale: "en",
+        fallbackLocales: { de: ["en"] },
+        catalogs: [{ path: "locales/{locale}", include: ["src/e\u0301.ts"] }],
+      },
+      compiledIds: ["hello"],
+    }
+    const before = structuredClone(validRequest)
+
+    expect(() =>
+      assertWellFormedNativeArguments("compileCatalogArtifactSelected", [validRequest])
+    ).not.toThrow()
+    expect(validRequest).toStrictEqual(before)
+    expect(() => parsePo("\ud800")).toThrow(/parsePo\.argument\[0\]/u)
+    expect(() =>
+      assertWellFormedNativeArguments("compileCatalogModule", [
+        { config: { locales: ["en", "\udc00"] } },
+      ])
+    ).toThrow(/compileCatalogModule\.argument\[0\]\.config\.locales\[1\]/u)
+    expect(() =>
+      assertWellFormedNativeArguments("renderCatalogModule", [
+        new Map([["message", ["valid", "\ud800"]]]),
+      ])
+    ).toThrow(/renderCatalogModule\.argument\[0\]\.get\(message\)\[1\]/u)
+  })
+
   it("loads native bindings and exposes version information", () => {
     const info = getNativeInfo()
 

--- a/packages/core-node/src/index.ts
+++ b/packages/core-node/src/index.ts
@@ -1,6 +1,3 @@
-import path from "node:path"
-import { createRequire } from "node:module"
-import { fileURLToPath } from "node:url"
 import type {
   CatalogAuditCheckOptions as GeneratedCatalogAuditCheckOptions,
   CatalogAuditDiagnostic as GeneratedCatalogAuditDiagnostic,
@@ -76,6 +73,7 @@ import type {
   TranslationPatchResult as GeneratedTranslationPatchResult,
   TranslationValue as GeneratedTranslationValue,
 } from "./generated/palamedes-node-types"
+import { loadNativeBindings } from "./native-loader"
 
 export type NativeInfo = GeneratedNativeInfo
 export type ParsedPoItem = GeneratedParsedPoItem
@@ -369,97 +367,6 @@ type NativeCatalogUpdateRequest = GeneratedCatalogUpdateRequest
 type NativeCatalogParseRequest = GeneratedCatalogParseRequest
 type NativeTranslationCandidateRequest = GeneratedTranslationCandidateRequest
 type NativeTranslationPatchRequest = GeneratedTranslationPatchRequest
-
-function detectLinuxLibc(): "gnu" | "musl" | null {
-  if (process.platform !== "linux") {
-    return null
-  }
-
-  const report = process.report?.getReport?.() as
-    | { header?: { glibcVersionRuntime?: string }; sharedObjects?: string[] }
-    | undefined
-  const header = report?.header
-  const glibcVersion = header?.glibcVersionRuntime
-
-  if (typeof glibcVersion === "string" && glibcVersion.length > 0) {
-    return "gnu"
-  }
-
-  const sharedObjects = Array.isArray(report?.sharedObjects) ? report.sharedObjects : []
-
-  if (sharedObjects.some((sharedObject) => sharedObject.includes("musl"))) {
-    return "musl"
-  }
-
-  if (
-    sharedObjects.some(
-      (sharedObject) => sharedObject.includes("libc.so.6") || sharedObject.includes("ld-linux")
-    )
-  ) {
-    return "gnu"
-  }
-
-  return null
-}
-
-const SUPPORTED_NATIVE_PACKAGES = [
-  "@palamedes/core-node-darwin-arm64",
-  "@palamedes/core-node-linux-arm64-gnu",
-  "@palamedes/core-node-linux-x64-gnu",
-  "@palamedes/core-node-linux-x64-musl",
-  "@palamedes/core-node-win32-x64-msvc",
-] as const
-
-function getPlatformTriple(): string {
-  const libc = detectLinuxLibc()
-  return libc
-    ? `${process.platform}-${process.arch}-${libc}`
-    : `${process.platform}-${process.arch}`
-}
-
-function getNativePackageName(): string {
-  const linuxLibc = detectLinuxLibc()
-
-  if (process.platform === "darwin" && process.arch === "arm64") {
-    return "@palamedes/core-node-darwin-arm64"
-  }
-
-  if (process.platform === "linux" && process.arch === "x64" && linuxLibc === "gnu") {
-    return "@palamedes/core-node-linux-x64-gnu"
-  }
-
-  if (process.platform === "linux" && process.arch === "x64" && linuxLibc === "musl") {
-    return "@palamedes/core-node-linux-x64-musl"
-  }
-
-  if (process.platform === "linux" && process.arch === "arm64" && linuxLibc === "gnu") {
-    return "@palamedes/core-node-linux-arm64-gnu"
-  }
-
-  if (process.platform === "win32" && process.arch === "x64") {
-    return "@palamedes/core-node-win32-x64-msvc"
-  }
-
-  throw new Error(
-    `No Palamedes native bindings package is available for ${getPlatformTriple()}. Supported packages: ${SUPPORTED_NATIVE_PACKAGES.join(", ")}. If you need to build from source, run \`cargo build --workspace\` in the Palamedes repository.`
-  )
-}
-
-function loadNativeBindings(): NativeBindings {
-  const require = createRequire(import.meta.url)
-  const packageDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
-  const nativePackageName = getNativePackageName()
-
-  try {
-    return require(nativePackageName) as NativeBindings
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error)
-    throw new Error(
-      `Failed to load Palamedes native bindings from ${nativePackageName} for ${getPlatformTriple()} in package ${packageDir}: ${message}. Supported packages: ${SUPPORTED_NATIVE_PACKAGES.join(", ")}.`,
-      { cause: error }
-    )
-  }
-}
 
 const native = loadNativeBindings()
 

--- a/packages/core-node/src/native-loader.ts
+++ b/packages/core-node/src/native-loader.ts
@@ -190,7 +190,8 @@ export function snapshotNativeArguments(operation: string, arguments_: unknown[]
       continue
     }
 
-    if (value instanceof Map) {
+    const classification = classifySnapshotObject(value, currentPath)
+    if (classification.kind === "map") {
       const mapSnapshot = new Map<unknown, unknown>()
       snapshots.set(value, mapSnapshot)
       current.assign(mapSnapshot)
@@ -227,13 +228,12 @@ export function snapshotNativeArguments(operation: string, arguments_: unknown[]
       }
       continue
     }
-    if (Array.isArray(value)) {
+    if (classification.kind === "array") {
       const arraySnapshot: unknown[] = []
-      arraySnapshot.length = value.length
+      arraySnapshot.length = classification.length
       snapshots.set(value, arraySnapshot)
       current.assign(arraySnapshot)
-      for (const key of ownPropertyNames(value, currentPath).reverse()) {
-        if (key === "length") continue
+      for (const key of enumerablePropertyNames(value, currentPath).reverse()) {
         const propertyPath = appendNativeArgumentPath(currentPath, arrayPropertyPath(key))
         assertWellFormedPropertyName(key, propertyPath)
         pending.push({
@@ -249,16 +249,10 @@ export function snapshotNativeArguments(operation: string, arguments_: unknown[]
       continue
     }
 
-    const prototype = objectPrototype(value, currentPath)
-    if (prototype !== Object.prototype && prototype !== null) {
-      throw new TypeError(
-        `Palamedes native boundary requires a plain object at ${formatNativeArgumentPath(currentPath)}; copy class instances into request data before calling ${operation}.`
-      )
-    }
-    const snapshot = Object.create(prototype) as Record<string, unknown>
-    snapshots.set(value, snapshot)
-    current.assign(snapshot)
-    for (const key of ownPropertyNames(value, currentPath).reverse()) {
+    const recordSnapshot: Record<string, unknown> = {}
+    snapshots.set(value, recordSnapshot)
+    current.assign(recordSnapshot)
+    for (const key of enumerablePropertyNames(value, currentPath).reverse()) {
       const propertyPath = appendNativeArgumentPath(currentPath, `.${key}`)
       assertWellFormedPropertyName(key, propertyPath)
       pending.push({
@@ -267,7 +261,7 @@ export function snapshotNativeArguments(operation: string, arguments_: unknown[]
         key,
         path: propertyPath,
         assign(snapshotValue: unknown) {
-          defineSnapshotProperty(snapshot, key, snapshotValue)
+          defineSnapshotProperty(recordSnapshot, key, snapshotValue)
         },
       })
     }
@@ -323,17 +317,44 @@ function arrayPropertyPath(key: string): string {
   return /^(?:0|[1-9]\d*)$/u.test(key) ? `[${key}]` : `.${key}`
 }
 
-function ownPropertyNames(value: object, argumentPath: NativeArgumentPath): string[] {
+type SnapshotObjectClassification =
+  | { kind: "array"; length: number }
+  | { kind: "map" }
+  | { kind: "record" }
+
+function classifySnapshotObject(
+  value: object,
+  argumentPath: NativeArgumentPath
+): SnapshotObjectClassification {
   try {
-    return Object.getOwnPropertyNames(value)
+    if (Array.isArray(value)) {
+      return { kind: "array", length: readArrayLength(value) }
+    }
+
+    return isMapPrototype(Object.getPrototypeOf(value)) ? { kind: "map" } : { kind: "record" }
   } catch (error) {
     throw nativeBoundaryReadError(argumentPath, error)
   }
 }
 
-function objectPrototype(value: object, argumentPath: NativeArgumentPath): object | null {
+function readArrayLength(value: object): number {
+  const length = Reflect.get(value, "length")
+  if (typeof length !== "number" || !Number.isSafeInteger(length) || length < 0) {
+    throw new TypeError("Array length must be a non-negative safe integer.")
+  }
+  return length
+}
+
+function isMapPrototype(prototype: object | null): boolean {
+  for (let current = prototype; current !== null; current = Object.getPrototypeOf(current)) {
+    if (current === Map.prototype) return true
+  }
+  return false
+}
+
+function enumerablePropertyNames(value: object, argumentPath: NativeArgumentPath): string[] {
   try {
-    return Object.getPrototypeOf(value)
+    return Object.keys(value)
   } catch (error) {
     throw nativeBoundaryReadError(argumentPath, error)
   }

--- a/packages/core-node/src/native-loader.ts
+++ b/packages/core-node/src/native-loader.ts
@@ -125,17 +125,48 @@ function isWellFormed(value: string): boolean {
 }
 
 export function assertWellFormedNativeArguments(operation: string, arguments_: unknown[]): void {
-  const seen = new WeakSet<object>()
-  const pending = arguments_
+  snapshotNativeArguments(operation, arguments_)
+}
+
+/**
+ * Read, validate, and normalize arguments before the N-API boundary. The
+ * binding receives only this snapshot, so an accessor or Proxy cannot return a
+ * different string after it has passed Unicode validation.
+ */
+export function snapshotNativeArguments(operation: string, arguments_: unknown[]): unknown[] {
+  const snapshots = new Map<object, unknown>()
+  const result: unknown[] = Array.from({ length: arguments_.length })
+  const pending: SnapshotTask[] = arguments_
     .map((value, index) => ({
+      kind: "value" as const,
       value,
       path: { segment: `${operation}.argument[${index}]` },
+      assign(snapshot: unknown) {
+        result[index] = snapshot
+      },
     }))
     .reverse()
 
   while (pending.length > 0) {
     const current = pending.pop()
     if (!current) continue
+
+    if (current.kind === "property") {
+      let propertyValue: unknown
+      try {
+        propertyValue = Reflect.get(current.source, current.key)
+      } catch (error) {
+        throw nativeBoundaryReadError(current.path, error)
+      }
+      pending.push({
+        kind: "value",
+        value: propertyValue,
+        path: current.path,
+        assign: current.assign,
+      })
+      continue
+    }
+
     const { path: currentPath, value } = current
 
     if (typeof value === "string") {
@@ -145,42 +176,120 @@ export function assertWellFormedNativeArguments(operation: string, arguments_: u
           `Palamedes native boundary rejected malformed Unicode in ${field}; replace the unpaired UTF-16 surrogate before calling ${operation}.`
         )
       }
+      current.assign(value)
       continue
     }
-    if (value === null || typeof value !== "object" || seen.has(value)) {
+    if (value === null || typeof value !== "object") {
+      current.assign(value)
       continue
     }
 
-    seen.add(value)
+    const existingSnapshot = snapshots.get(value)
+    if (existingSnapshot !== undefined) {
+      current.assign(existingSnapshot)
+      continue
+    }
+
     if (value instanceof Map) {
-      const mapEntries = [...value.entries()]
+      const mapSnapshot = new Map<unknown, unknown>()
+      snapshots.set(value, mapSnapshot)
+      current.assign(mapSnapshot)
+      let mapEntries: Array<[unknown, unknown]>
+      try {
+        mapEntries = [...Map.prototype.entries.call(value)]
+      } catch (error) {
+        throw nativeBoundaryReadError(currentPath, error)
+      }
       for (let index = mapEntries.length - 1; index >= 0; index -= 1) {
         const [key, entry] = mapEntries[index] ?? []
+        const pair: { key?: unknown; value?: unknown } = {}
+        const setEntry = () => {
+          if ("key" in pair && "value" in pair) mapSnapshot.set(pair.key, pair.value)
+        }
         pending.push({
+          kind: "value",
           value: entry,
           path: appendNativeArgumentPath(currentPath, mapValuePath(key)),
+          assign(snapshotValue: unknown) {
+            pair.value = snapshotValue
+            setEntry()
+          },
         })
-        pending.push({ value: key, path: appendNativeArgumentPath(currentPath, ".<key>") })
+        pending.push({
+          kind: "value",
+          value: key,
+          path: appendNativeArgumentPath(currentPath, ".<key>"),
+          assign(snapshotKey: unknown) {
+            pair.key = snapshotKey
+            setEntry()
+          },
+        })
       }
       continue
     }
     if (Array.isArray(value)) {
-      for (let index = value.length - 1; index >= 0; index -= 1) {
+      const arraySnapshot: unknown[] = []
+      arraySnapshot.length = value.length
+      snapshots.set(value, arraySnapshot)
+      current.assign(arraySnapshot)
+      for (const key of ownPropertyNames(value, currentPath).reverse()) {
+        if (key === "length") continue
+        const propertyPath = appendNativeArgumentPath(currentPath, arrayPropertyPath(key))
+        assertWellFormedPropertyName(key, propertyPath)
         pending.push({
-          value: value[index],
-          path: appendNativeArgumentPath(currentPath, `[${index}]`),
+          kind: "property",
+          source: value,
+          key,
+          path: propertyPath,
+          assign(snapshotValue: unknown) {
+            defineSnapshotProperty(arraySnapshot, key, snapshotValue)
+          },
         })
       }
       continue
     }
-    const objectEntries = Object.entries(value)
-    for (let index = objectEntries.length - 1; index >= 0; index -= 1) {
-      const [key, entry] = objectEntries[index] ?? []
-      pending.push({ value: entry, path: appendNativeArgumentPath(currentPath, `.${key}`) })
-      pending.push({ value: key, path: appendNativeArgumentPath(currentPath, ".<key>") })
+
+    const prototype = objectPrototype(value, currentPath)
+    if (prototype !== Object.prototype && prototype !== null) {
+      throw new TypeError(
+        `Palamedes native boundary requires a plain object at ${formatNativeArgumentPath(currentPath)}; copy class instances into request data before calling ${operation}.`
+      )
+    }
+    const snapshot = Object.create(prototype) as Record<string, unknown>
+    snapshots.set(value, snapshot)
+    current.assign(snapshot)
+    for (const key of ownPropertyNames(value, currentPath).reverse()) {
+      const propertyPath = appendNativeArgumentPath(currentPath, `.${key}`)
+      assertWellFormedPropertyName(key, propertyPath)
+      pending.push({
+        kind: "property",
+        source: value,
+        key,
+        path: propertyPath,
+        assign(snapshotValue: unknown) {
+          defineSnapshotProperty(snapshot, key, snapshotValue)
+        },
+      })
     }
   }
+
+  return result
 }
+
+type SnapshotTask =
+  | {
+      kind: "value"
+      value: unknown
+      path: NativeArgumentPath
+      assign: (snapshot: unknown) => void
+    }
+  | {
+      kind: "property"
+      source: object
+      key: string
+      path: NativeArgumentPath
+      assign: (snapshot: unknown) => void
+    }
 
 type NativeArgumentPath = {
   parent?: NativeArgumentPath
@@ -210,6 +319,50 @@ function mapValuePath(key: unknown): string {
   return ".<map value>"
 }
 
+function arrayPropertyPath(key: string): string {
+  return /^(?:0|[1-9]\d*)$/u.test(key) ? `[${key}]` : `.${key}`
+}
+
+function ownPropertyNames(value: object, argumentPath: NativeArgumentPath): string[] {
+  try {
+    return Object.getOwnPropertyNames(value)
+  } catch (error) {
+    throw nativeBoundaryReadError(argumentPath, error)
+  }
+}
+
+function objectPrototype(value: object, argumentPath: NativeArgumentPath): object | null {
+  try {
+    return Object.getPrototypeOf(value)
+  } catch (error) {
+    throw nativeBoundaryReadError(argumentPath, error)
+  }
+}
+
+function defineSnapshotProperty(target: object, key: string, value: unknown): void {
+  Object.defineProperty(target, key, {
+    configurable: true,
+    enumerable: true,
+    value,
+    writable: true,
+  })
+}
+
+function assertWellFormedPropertyName(key: string, argumentPath: NativeArgumentPath): void {
+  if (!isWellFormed(key)) {
+    throw new TypeError(
+      `Palamedes native boundary rejected malformed Unicode in ${formatNativeArgumentPath(argumentPath)}.<key>; replace the unpaired UTF-16 surrogate in the property name.`
+    )
+  }
+}
+
+function nativeBoundaryReadError(argumentPath: NativeArgumentPath, cause: unknown): TypeError {
+  return new TypeError(
+    `Palamedes native boundary could not read ${formatNativeArgumentPath(argumentPath)}; accessors and Proxies must return a stable value.`,
+    { cause }
+  )
+}
+
 function guardNativeBindings(bindings: NativeBindings): NativeBindings {
   return new Proxy(bindings, {
     get(target, property, receiver) {
@@ -217,10 +370,8 @@ function guardNativeBindings(bindings: NativeBindings): NativeBindings {
       if (typeof property !== "string" || typeof value !== "function") {
         return value
       }
-      return (...arguments_: unknown[]) => {
-        assertWellFormedNativeArguments(property, arguments_)
-        return Reflect.apply(value, target, arguments_)
-      }
+      return (...arguments_: unknown[]) =>
+        Reflect.apply(value, target, snapshotNativeArguments(property, arguments_))
     },
   })
 }

--- a/packages/core-node/src/native-loader.ts
+++ b/packages/core-node/src/native-loader.ts
@@ -1,0 +1,251 @@
+import { createRequire } from "node:module"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+import type { NativeBindings, NativeInfo } from "./generated/palamedes-node-types"
+
+const SUPPORTED_NATIVE_PACKAGES = [
+  "@palamedes/core-node-darwin-arm64",
+  "@palamedes/core-node-linux-arm64-gnu",
+  "@palamedes/core-node-linux-x64-gnu",
+  "@palamedes/core-node-linux-x64-musl",
+  "@palamedes/core-node-win32-x64-msvc",
+] as const
+
+function detectLinuxLibc(): "gnu" | "musl" | null {
+  if (process.platform !== "linux") {
+    return null
+  }
+
+  const report = process.report?.getReport?.() as
+    | { header?: { glibcVersionRuntime?: string }; sharedObjects?: string[] }
+    | undefined
+  const glibcVersion = report?.header?.glibcVersionRuntime
+
+  if (typeof glibcVersion === "string" && glibcVersion.length > 0) {
+    return "gnu"
+  }
+
+  const sharedObjects = Array.isArray(report?.sharedObjects) ? report.sharedObjects : []
+  if (sharedObjects.some((sharedObject) => sharedObject.includes("musl"))) {
+    return "musl"
+  }
+  if (
+    sharedObjects.some(
+      (sharedObject) => sharedObject.includes("libc.so.6") || sharedObject.includes("ld-linux")
+    )
+  ) {
+    return "gnu"
+  }
+
+  return null
+}
+
+function getPlatformTriple(): string {
+  const libc = detectLinuxLibc()
+  return libc
+    ? `${process.platform}-${process.arch}-${libc}`
+    : `${process.platform}-${process.arch}`
+}
+
+function getNativePackageName(): string {
+  const linuxLibc = detectLinuxLibc()
+
+  if (process.platform === "darwin" && process.arch === "arm64") {
+    return "@palamedes/core-node-darwin-arm64"
+  }
+  if (process.platform === "linux" && process.arch === "x64" && linuxLibc === "gnu") {
+    return "@palamedes/core-node-linux-x64-gnu"
+  }
+  if (process.platform === "linux" && process.arch === "x64" && linuxLibc === "musl") {
+    return "@palamedes/core-node-linux-x64-musl"
+  }
+  if (process.platform === "linux" && process.arch === "arm64" && linuxLibc === "gnu") {
+    return "@palamedes/core-node-linux-arm64-gnu"
+  }
+  if (process.platform === "win32" && process.arch === "x64") {
+    return "@palamedes/core-node-win32-x64-msvc"
+  }
+
+  throw new Error(
+    `No Palamedes native bindings package is available for ${getPlatformTriple()}. Supported packages: ${SUPPORTED_NATIVE_PACKAGES.join(", ")}. If you need to build from source, run \`cargo build --workspace\` in the Palamedes repository.`
+  )
+}
+
+type ModuleLoader = (specifier: string) => unknown
+
+export type LoadNativeBindingsOptions = {
+  packageDir?: string
+  nativePackageName?: string
+  require?: ModuleLoader
+}
+
+function packageVersion(require: ModuleLoader, packageDir: string): string {
+  const manifest = require(path.join(packageDir, "package.json")) as { version?: unknown }
+  if (typeof manifest.version !== "string" || manifest.version.length === 0) {
+    throw new Error(`Unable to read the @palamedes/core-node version from ${packageDir}.`)
+  }
+  return manifest.version
+}
+
+export function assertNativeBindingVersion(
+  wrapperVersion: string,
+  nativePackageName: string,
+  nativeInfo: NativeInfo
+): void {
+  const nativeVersion = nativeInfo.palamedesVersion
+  if (nativeVersion === wrapperVersion) {
+    return
+  }
+
+  throw new Error(
+    `Palamedes native binding version mismatch: @palamedes/core-node@${wrapperVersion} loaded ${nativePackageName} with native version ${nativeVersion || "<missing>"}. Reinstall @palamedes/core-node so its exact optional platform dependency is refreshed, or install matching ${nativePackageName}@${wrapperVersion}.`
+  )
+}
+
+function isWellFormed(value: string): boolean {
+  const nativeIsWellFormed = (
+    String.prototype as unknown as { isWellFormed?: (this: string) => boolean }
+  ).isWellFormed
+  if (typeof nativeIsWellFormed === "function") {
+    return nativeIsWellFormed.call(value)
+  }
+
+  for (let index = 0; index < value.length; index += 1) {
+    const codeUnit = value.charCodeAt(index)
+    if (codeUnit >= 55_296 && codeUnit <= 56_319) {
+      const next = value.charCodeAt(index + 1)
+      if (next < 56_320 || next > 57_343) return false
+      index += 1
+    } else if (codeUnit >= 56_320 && codeUnit <= 57_343) {
+      return false
+    }
+  }
+  return true
+}
+
+export function assertWellFormedNativeArguments(operation: string, arguments_: unknown[]): void {
+  const seen = new WeakSet<object>()
+  const pending = arguments_
+    .map((value, index) => ({
+      value,
+      path: { segment: `${operation}.argument[${index}]` },
+    }))
+    .reverse()
+
+  while (pending.length > 0) {
+    const current = pending.pop()
+    if (!current) continue
+    const { path: currentPath, value } = current
+
+    if (typeof value === "string") {
+      if (!isWellFormed(value)) {
+        const field = formatNativeArgumentPath(currentPath)
+        throw new TypeError(
+          `Palamedes native boundary rejected malformed Unicode in ${field}; replace the unpaired UTF-16 surrogate before calling ${operation}.`
+        )
+      }
+      continue
+    }
+    if (value === null || typeof value !== "object" || seen.has(value)) {
+      continue
+    }
+
+    seen.add(value)
+    if (value instanceof Map) {
+      const mapEntries = [...value.entries()]
+      for (let index = mapEntries.length - 1; index >= 0; index -= 1) {
+        const [key, entry] = mapEntries[index] ?? []
+        pending.push({
+          value: entry,
+          path: appendNativeArgumentPath(currentPath, mapValuePath(key)),
+        })
+        pending.push({ value: key, path: appendNativeArgumentPath(currentPath, ".<key>") })
+      }
+      continue
+    }
+    if (Array.isArray(value)) {
+      for (let index = value.length - 1; index >= 0; index -= 1) {
+        pending.push({
+          value: value[index],
+          path: appendNativeArgumentPath(currentPath, `[${index}]`),
+        })
+      }
+      continue
+    }
+    const objectEntries = Object.entries(value)
+    for (let index = objectEntries.length - 1; index >= 0; index -= 1) {
+      const [key, entry] = objectEntries[index] ?? []
+      pending.push({ value: entry, path: appendNativeArgumentPath(currentPath, `.${key}`) })
+      pending.push({ value: key, path: appendNativeArgumentPath(currentPath, ".<key>") })
+    }
+  }
+}
+
+type NativeArgumentPath = {
+  parent?: NativeArgumentPath
+  segment: string
+}
+
+function appendNativeArgumentPath(parent: NativeArgumentPath, segment: string): NativeArgumentPath {
+  return { parent, segment }
+}
+
+function formatNativeArgumentPath(argumentPath: NativeArgumentPath): string {
+  const segments: string[] = []
+  for (
+    let current: NativeArgumentPath | undefined = argumentPath;
+    current;
+    current = current.parent
+  ) {
+    segments.push(current.segment)
+  }
+  return segments.reverse().join("")
+}
+
+function mapValuePath(key: unknown): string {
+  if (typeof key === "string") {
+    return `.get(${key})`
+  }
+  return ".<map value>"
+}
+
+function guardNativeBindings(bindings: NativeBindings): NativeBindings {
+  return new Proxy(bindings, {
+    get(target, property, receiver) {
+      const value = Reflect.get(target, property, receiver)
+      if (typeof property !== "string" || typeof value !== "function") {
+        return value
+      }
+      return (...arguments_: unknown[]) => {
+        assertWellFormedNativeArguments(property, arguments_)
+        return Reflect.apply(value, target, arguments_)
+      }
+    },
+  })
+}
+
+export function loadNativeBindings(options: LoadNativeBindingsOptions = {}): NativeBindings {
+  const require = options.require ?? createRequire(import.meta.url)
+  const packageDir =
+    options.packageDir ?? path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
+  const nativePackageName = options.nativePackageName ?? getNativePackageName()
+  let bindings: NativeBindings
+
+  try {
+    bindings = require(nativePackageName) as NativeBindings
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(
+      `Failed to load Palamedes native bindings from ${nativePackageName} for ${getPlatformTriple()} in package ${packageDir}: ${message}. Supported packages: ${SUPPORTED_NATIVE_PACKAGES.join(", ")}.`,
+      { cause: error }
+    )
+  }
+
+  assertNativeBindingVersion(
+    packageVersion(require, packageDir),
+    nativePackageName,
+    bindings.getNativeInfo()
+  )
+  return guardNativeBindings(bindings)
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1331,19 +1331,19 @@ importers:
         version: 6.0.3
     optionalDependencies:
       '@palamedes/cli-darwin-arm64':
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../cli-darwin-arm64
       '@palamedes/cli-linux-arm64-gnu':
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../cli-linux-arm64-gnu
       '@palamedes/cli-linux-x64-gnu':
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../cli-linux-x64-gnu
       '@palamedes/cli-linux-x64-musl':
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../cli-linux-x64-musl
       '@palamedes/cli-win32-x64-msvc':
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../cli-win32-x64-msvc
 
   packages/cli-darwin-arm64: {}
@@ -1409,19 +1409,19 @@ importers:
         version: 4.1.10(@edge-runtime/vm@3.2.0)(@types/node@24.13.3)(jsdom@30.0.1(@noble/hashes@2.2.0))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
     optionalDependencies:
       '@palamedes/core-node-darwin-arm64':
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../core-node-darwin-arm64
       '@palamedes/core-node-linux-arm64-gnu':
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../core-node-linux-arm64-gnu
       '@palamedes/core-node-linux-x64-gnu':
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../core-node-linux-x64-gnu
       '@palamedes/core-node-linux-x64-musl':
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../core-node-linux-x64-musl
       '@palamedes/core-node-win32-x64-msvc':
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../core-node-win32-x64-msvc
 
   packages/core-node-darwin-arm64: {}

--- a/scripts/check-release-set.mjs
+++ b/scripts/check-release-set.mjs
@@ -3,6 +3,7 @@ import path from "node:path"
 
 const root = process.cwd()
 const nativePackagePattern = /^@palamedes\/(?:core-node|cli)-.+/
+const nativeWrapperPackageNames = new Set(["@palamedes/core-node", "@palamedes/cli"])
 
 function readJson(file) {
   return JSON.parse(readFileSync(path.join(root, file), "utf8"))
@@ -190,6 +191,20 @@ for (const packageInfo of publicPackages) {
     }
   } else if (!workflowFilters.has(packageInfo.name)) {
     fail(`${packageInfo.name} is missing from the JavaScript publish filters`)
+  }
+
+  if (nativeWrapperPackageNames.has(packageInfo.name)) {
+    const platformDependencies = Object.entries(
+      readJson(path.join(packageInfo.path, "package.json")).optionalDependencies ?? {}
+    ).filter(([name]) => name.startsWith(`${packageInfo.name}-`))
+    if (platformDependencies.length !== 5) {
+      fail(`${packageInfo.name} must declare all five native platform dependencies`)
+    }
+    for (const [name, version] of platformDependencies) {
+      if (version !== "workspace:*") {
+        fail(`${packageInfo.name} must use workspace:* for ${name}, found ${version}`)
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Closes #582

## Boundary contract changes

- Uses `workspace:*` for core-node and CLI platform optional dependencies, which pnpm publishes as exact same-release pins. The core-node loader now verifies `getNativeInfo().palamedesVersion` before exposing the binding and gives a versioned reinstall/remediation error on skew.
- Makes generated catalog `include` optional and documents both `include` and `exclude` as host-side-only fields. Vite keeps applying its existing source filter before native compilation.
- Guards every call through the Node binding with a linear, non-mutating well-formed-Unicode traversal. Lone UTF-16 surrogates fail with the operation and field path; valid pairs, combining text, nested arrays, records, and Maps remain accepted.
- Records the synchronous N-API decision in ADR-009: calls can block the Node thread, Vite uses them in bounded host hooks, and async variants need measured event-loop pressure plus an explicit lifecycle contract.

## Validation

- `RUSTUP_TOOLCHAIN=1.95 pnpm build`
- `RUSTUP_TOOLCHAIN=1.95 pnpm check-types`
- `pnpm lint` and `pnpm format:check`
- Core-node Unicode/version-fixture/packed-manifest tests; CLI platform and packed-manifest smoke tests; Vite host-filtering tests (46 passing)
- `pnpm check:release-set` and generated native type check
- `RUSTUP_TOOLCHAIN=1.95 cargo fmt --all --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, and `cargo test --workspace --locked`

🔧 Emily Carter · Implementation Agent