### PR TITLE
fix(cli): harden pmds lint analysis

### DIFF
--- a/crates/palamedes-cli/src/commands/lint.rs
+++ b/crates/palamedes-cli/src/commands/lint.rs
@@ -294,17 +294,11 @@ impl CommentSyntax {
 #[derive(Default)]
 struct CommentScanState {
     javascript: Vec<JavascriptScanMode>,
+    javascript_regex_allowed: bool,
     quote: Option<char>,
     mdx_comment: Option<MdxComment>,
-}
-
-impl CommentScanState {
-    fn javascript_mode(&mut self) -> &mut Vec<JavascriptScanMode> {
-        if self.javascript.is_empty() {
-            self.javascript.push(JavascriptScanMode::Code);
-        }
-        &mut self.javascript
-    }
+    mdx_expression_depth: usize,
+    mdx_template: Vec<MdxTemplateMode>,
 }
 
 enum JavascriptScanMode {
@@ -314,6 +308,7 @@ enum JavascriptScanMode {
     SingleQuote,
     DoubleQuote,
     BlockComment { only_whitespace: bool },
+    Regex { character_class: bool },
 }
 
 #[derive(Clone, Copy)]
@@ -325,6 +320,14 @@ enum MdxCommentSyntax {
 struct MdxComment {
     syntax: MdxCommentSyntax,
     only_whitespace: bool,
+}
+
+enum MdxTemplateMode {
+    Raw,
+    Expression { braces: usize },
+    SingleQuote,
+    DoubleQuote,
+    BlockComment { only_whitespace: bool },
 }
 
 #[derive(Default)]
@@ -353,7 +356,7 @@ fn opening_fence(line: &str) -> Option<(char, usize)> {
     let content = commonmark_fence_content(line)?;
     for marker in ['`', '~'] {
         let width = fence_width(content, marker);
-        if width >= 3 {
+        if width >= 3 && (marker != '`' || !content[width..].contains('`')) {
             return Some((marker, width));
         }
     }
@@ -365,7 +368,11 @@ fn is_closing_fence(line: &str, marker: char, opening_width: usize) -> bool {
         return false;
     };
     let width = fence_width(content, marker);
-    width >= opening_width && content[width..].trim().is_empty()
+    width >= opening_width && content[width..].bytes().all(is_commonmark_line_whitespace)
+}
+
+const fn is_commonmark_line_whitespace(byte: u8) -> bool {
+    matches!(byte, b' ' | b'\t' | b'\r' | b'\n')
 }
 
 /// CommonMark permits up to three leading spaces before a fenced-code marker.
@@ -509,7 +516,12 @@ fn javascript_comment_openers(
     state: &mut CommentScanState,
 ) -> Vec<(usize, CommentSyntax)> {
     let mut openers = Vec::new();
-    let modes = state.javascript_mode();
+    if state.javascript.is_empty() {
+        state.javascript.push(JavascriptScanMode::Code);
+        state.javascript_regex_allowed = true;
+    }
+    let modes = &mut state.javascript;
+    let regex_allowed = &mut state.javascript_regex_allowed;
     let bytes = line.as_bytes();
     let mut index = 0usize;
     while index < bytes.len() {
@@ -538,6 +550,7 @@ fn javascript_comment_openers(
                     index += 1 + bytes.get(index + 1).map_or(0, |byte| char_width(*byte));
                 } else if bytes[index] == b'\'' {
                     modes.pop();
+                    *regex_allowed = false;
                     index += 1;
                 } else {
                     index += char_width(bytes[index]);
@@ -548,6 +561,7 @@ fn javascript_comment_openers(
                     index += 1 + bytes.get(index + 1).map_or(0, |byte| char_width(*byte));
                 } else if bytes[index] == b'"' {
                     modes.pop();
+                    *regex_allowed = false;
                     index += 1;
                 } else {
                     index += char_width(bytes[index]);
@@ -558,10 +572,29 @@ fn javascript_comment_openers(
                     index += 1 + bytes.get(index + 1).map_or(0, |byte| char_width(*byte));
                 } else if bytes[index] == b'`' {
                     modes.pop();
+                    *regex_allowed = false;
                     index += 1;
                 } else if line[index..].starts_with("${") {
                     modes.push(JavascriptScanMode::TemplateExpression { braces: 0 });
+                    *regex_allowed = true;
                     index += 2;
+                } else {
+                    index += char_width(bytes[index]);
+                }
+            }
+            JavascriptScanMode::Regex { character_class } => {
+                if bytes[index] == b'\\' {
+                    index += 1 + bytes.get(index + 1).map_or(0, |byte| char_width(*byte));
+                } else if *character_class && bytes[index] == b']' {
+                    *character_class = false;
+                    index += 1;
+                } else if !*character_class && bytes[index] == b'[' {
+                    *character_class = true;
+                    index += 1;
+                } else if !*character_class && bytes[index] == b'/' {
+                    modes.pop();
+                    *regex_allowed = false;
+                    index += 1;
                 } else {
                     index += char_width(bytes[index]);
                 }
@@ -590,20 +623,31 @@ fn javascript_comment_openers(
                 } else if bytes[index] == b'`' {
                     modes.push(JavascriptScanMode::TemplateRaw);
                     index += 1;
+                } else if bytes[index] == b'/' && *regex_allowed {
+                    modes.push(JavascriptScanMode::Regex {
+                        character_class: false,
+                    });
+                    index += 1;
                 } else if let JavascriptScanMode::TemplateExpression { braces } = modes
                     .last_mut()
                     .expect("JavaScript scanner has a base mode")
                 {
                     if bytes[index] == b'{' {
                         *braces += 1;
+                        *regex_allowed = true;
                     } else if bytes[index] == b'}' && *braces == 0 {
                         modes.pop();
+                        *regex_allowed = false;
                     } else if bytes[index] == b'}' {
                         *braces -= 1;
+                        *regex_allowed = false;
+                    } else {
+                        index += update_javascript_regex_context(line, index, regex_allowed);
+                        continue;
                     }
                     index += 1;
                 } else {
-                    index += char_width(bytes[index]);
+                    index += update_javascript_regex_context(line, index, regex_allowed);
                 }
             }
         }
@@ -611,11 +655,152 @@ fn javascript_comment_openers(
     openers
 }
 
+fn update_javascript_regex_context(line: &str, index: usize, regex_allowed: &mut bool) -> usize {
+    let bytes = line.as_bytes();
+    let byte = bytes[index];
+    if byte.is_ascii_whitespace() {
+        return 1;
+    }
+    if byte.is_ascii_alphabetic() || matches!(byte, b'_' | b'$') {
+        let end = line[index..]
+            .char_indices()
+            .find_map(|(offset, character)| {
+                (offset > 0
+                    && !(character.is_ascii_alphanumeric() || matches!(character, '_' | '$')))
+                .then_some(index + offset)
+            })
+            .unwrap_or(line.len());
+        *regex_allowed = matches!(
+            &line[index..end],
+            "case"
+                | "delete"
+                | "do"
+                | "else"
+                | "in"
+                | "instanceof"
+                | "new"
+                | "of"
+                | "return"
+                | "throw"
+                | "typeof"
+                | "void"
+                | "yield"
+                | "await"
+        );
+        return end - index;
+    }
+    if byte.is_ascii_digit() {
+        let end = line[index..]
+            .char_indices()
+            .find_map(|(offset, character)| {
+                (offset > 0 && !character.is_ascii_alphanumeric()).then_some(index + offset)
+            })
+            .unwrap_or(line.len());
+        *regex_allowed = false;
+        return end - index;
+    }
+    *regex_allowed = !matches!(byte, b')' | b']' | b'}');
+    char_width(byte)
+}
+
 fn mdx_comment_openers(line: &str, state: &mut CommentScanState) -> Vec<(usize, CommentSyntax)> {
     let mut openers = Vec::new();
     let bytes = line.as_bytes();
     let mut index = 0usize;
     while index < bytes.len() {
+        if let Some(mode) = state.mdx_template.last_mut() {
+            match mode {
+                MdxTemplateMode::Raw => {
+                    if bytes[index] == b'\\' {
+                        index += 1 + bytes.get(index + 1).map_or(0, |byte| char_width(*byte));
+                    } else if bytes[index] == b'`' {
+                        state.mdx_template.pop();
+                        index += 1;
+                    } else if line[index..].starts_with("${") {
+                        state
+                            .mdx_template
+                            .push(MdxTemplateMode::Expression { braces: 0 });
+                        index += 2;
+                    } else {
+                        index += char_width(bytes[index]);
+                    }
+                }
+                MdxTemplateMode::Expression { braces } => {
+                    if line[index..].starts_with("//") {
+                        let after_opener = &line[index + 2..];
+                        let whitespace = after_opener.len() - after_opener.trim_start().len();
+                        let directive = index + 2 + whitespace;
+                        if directive_start(line, directive) {
+                            openers.push((directive, CommentSyntax::Line));
+                        }
+                        break;
+                    }
+                    if line[index..].starts_with("/*") {
+                        state.mdx_template.push(MdxTemplateMode::BlockComment {
+                            only_whitespace: true,
+                        });
+                        index += 2;
+                    } else if bytes[index] == b'\'' {
+                        state.mdx_template.push(MdxTemplateMode::SingleQuote);
+                        index += 1;
+                    } else if bytes[index] == b'"' {
+                        state.mdx_template.push(MdxTemplateMode::DoubleQuote);
+                        index += 1;
+                    } else if bytes[index] == b'`' {
+                        state.mdx_template.push(MdxTemplateMode::Raw);
+                        index += 1;
+                    } else if bytes[index] == b'{' {
+                        *braces += 1;
+                        index += 1;
+                    } else if bytes[index] == b'}' && *braces == 0 {
+                        state.mdx_template.pop();
+                        index += 1;
+                    } else if bytes[index] == b'}' {
+                        *braces -= 1;
+                        index += 1;
+                    } else {
+                        index += char_width(bytes[index]);
+                    }
+                }
+                MdxTemplateMode::SingleQuote => {
+                    if bytes[index] == b'\\' {
+                        index += 1 + bytes.get(index + 1).map_or(0, |byte| char_width(*byte));
+                    } else if bytes[index] == b'\'' {
+                        state.mdx_template.pop();
+                        index += 1;
+                    } else {
+                        index += char_width(bytes[index]);
+                    }
+                }
+                MdxTemplateMode::DoubleQuote => {
+                    if bytes[index] == b'\\' {
+                        index += 1 + bytes.get(index + 1).map_or(0, |byte| char_width(*byte));
+                    } else if bytes[index] == b'"' {
+                        state.mdx_template.pop();
+                        index += 1;
+                    } else {
+                        index += char_width(bytes[index]);
+                    }
+                }
+                MdxTemplateMode::BlockComment { only_whitespace } => {
+                    if line[index..].starts_with("*/") {
+                        state.mdx_template.pop();
+                        index += 2;
+                    } else {
+                        if *only_whitespace {
+                            if directive_start(line, index) {
+                                openers.push((index, CommentSyntax::Block));
+                                *only_whitespace = false;
+                            } else if !line[index..].starts_with(char::is_whitespace) {
+                                *only_whitespace = false;
+                            }
+                        }
+                        index += char_width(bytes[index]);
+                    }
+                }
+            }
+            continue;
+        }
         if let Some(comment) = state.mdx_comment.as_mut() {
             let closes = match comment.syntax {
                 MdxCommentSyntax::Block => "*/",
@@ -654,7 +839,16 @@ fn mdx_comment_openers(line: &str, state: &mut CommentScanState) -> Vec<(usize, 
             }
             continue;
         }
-        if let Some(quote) = ['\'', '"']
+        if bytes[index] == b'{' {
+            state.mdx_expression_depth += 1;
+            index += 1;
+        } else if bytes[index] == b'}' && state.mdx_expression_depth > 0 {
+            state.mdx_expression_depth -= 1;
+            index += 1;
+        } else if bytes[index] == b'`' && state.mdx_expression_depth > 0 {
+            state.mdx_template.push(MdxTemplateMode::Raw);
+            index += 1;
+        } else if let Some(quote) = ['\'', '"']
             .into_iter()
             .find(|quote| line[index..].starts_with(*quote))
         {
@@ -889,6 +1083,22 @@ const trailing = 1; /* explanation palamedes-lint-disable-line pmds/no-placehold
     }
 
     #[test]
+    fn suppression_parser_enforces_commonmark_fence_whitespace_and_backtick_info() {
+        let nbsp_close = "```mdx\n```\u{a0}\n<!-- palamedes-lint-disable-next-line pmds/no-placeholder-only-message -->\n";
+        let (suppressions, diagnostics) = super::parse_suppressions(nbsp_close, "guide.mdx");
+        assert!(suppressions.is_empty());
+        assert!(diagnostics.is_empty());
+
+        let invalid_backtick_info = "```tsx`not-a-fence\n<!-- palamedes-lint-disable-next-line pmds/no-placeholder-only-message -->\n";
+        let (suppressions, diagnostics) =
+            super::parse_suppressions(invalid_backtick_info, "guide.mdx");
+        assert!(diagnostics.is_empty());
+        assert_eq!(suppressions.len(), 1);
+        assert_eq!(suppressions[0].primary.line, 2);
+        assert_eq!(suppressions[0].line, 3);
+    }
+
+    #[test]
     fn suppression_parser_allows_whitespace_only_multiline_comments() {
         let script = "/*\n \tpalamedes-lint-disable-line pmds/no-placeholder-only-message\n*/\n";
         let (suppressions, diagnostics) = super::parse_suppressions(script, "view.ts");
@@ -927,6 +1137,58 @@ const message = `outer ${tag`inner ${(
         assert_eq!(suppressions.len(), 1);
         assert_eq!(suppressions[0].primary.line, 3);
         assert_eq!(suppressions[0].line, 4);
+    }
+
+    #[test]
+    fn suppression_parser_ignores_regexp_braces_in_template_expressions() {
+        let source = r#"const escaped = `outer ${/\}/.test(status) ? (
+  // palamedes-lint-disable-next-line pmds/no-placeholder-only-message
+  t`${status}`
+) : ""}`;
+const character_class = `outer ${/[}]/.test(status) ? (
+  // palamedes-lint-disable-next-line pmds/no-placeholder-only-message
+  t`${status}`
+) : ""}`;
+const division = `outer ${status / 2 ? (
+  // palamedes-lint-disable-next-line pmds/no-placeholder-only-message
+  t`${status}`
+) : ""}`;
+"#;
+        let (suppressions, diagnostics) = super::parse_suppressions(source, "view.ts");
+
+        assert!(diagnostics.is_empty());
+        assert_eq!(suppressions.len(), 3);
+        assert_eq!(
+            suppressions
+                .iter()
+                .map(|suppression| (suppression.primary.line, suppression.line))
+                .collect::<Vec<_>>(),
+            vec![(2, 3), (6, 7), (10, 11)]
+        );
+    }
+
+    #[test]
+    fn suppression_parser_keeps_mdx_template_text_inert() {
+        let source = r#"{`raw <!-- palamedes-lint-disable-next-line pmds/no-placeholder-only-message --> ${(
+  // palamedes-lint-disable-next-line pmds/no-placeholder-only-message
+  t`${status}`
+)}`}
+{`nested ${`escaped \` <!-- palamedes-lint-disable-next-line pmds/no-placeholder-only-message --> ${(
+  /* palamedes-lint-disable-next-line pmds/prefer-trans-in-jsx */
+  t`${status}`
+)}`}`}
+"#;
+        let (suppressions, diagnostics) = super::parse_suppressions(source, "guide.mdx");
+
+        assert!(diagnostics.is_empty());
+        assert_eq!(suppressions.len(), 2);
+        assert_eq!(
+            suppressions
+                .iter()
+                .map(|suppression| (suppression.primary.line, suppression.line))
+                .collect::<Vec<_>>(),
+            vec![(2, 3), (6, 7)]
+        );
     }
 
     #[test]

--- a/crates/palamedes-cli/src/commands/lint.rs
+++ b/crates/palamedes-cli/src/commands/lint.rs
@@ -282,13 +282,6 @@ enum CommentSyntax {
 }
 
 impl CommentSyntax {
-    const fn opener_len(self) -> usize {
-        match self {
-            Self::Line | Self::Block => 2,
-            Self::Html => 4,
-        }
-    }
-
     fn directive_body(self, source: &str) -> &str {
         match self {
             Self::Line => source,
@@ -300,9 +293,38 @@ impl CommentSyntax {
 
 #[derive(Default)]
 struct CommentScanState {
+    javascript: Vec<JavascriptScanMode>,
     quote: Option<char>,
-    block_comment: bool,
-    html_comment: bool,
+    mdx_comment: Option<MdxComment>,
+}
+
+impl CommentScanState {
+    fn javascript_mode(&mut self) -> &mut Vec<JavascriptScanMode> {
+        if self.javascript.is_empty() {
+            self.javascript.push(JavascriptScanMode::Code);
+        }
+        &mut self.javascript
+    }
+}
+
+enum JavascriptScanMode {
+    Code,
+    TemplateRaw,
+    TemplateExpression { braces: usize },
+    SingleQuote,
+    DoubleQuote,
+    BlockComment { only_whitespace: bool },
+}
+
+#[derive(Clone, Copy)]
+enum MdxCommentSyntax {
+    Block,
+    Html,
+}
+
+struct MdxComment {
+    syntax: MdxCommentSyntax,
+    only_whitespace: bool,
 }
 
 #[derive(Default)]
@@ -313,22 +335,47 @@ struct MdxFenceState {
 impl MdxFenceState {
     /// Returns whether this line is within a fenced MDX example, including fence lines.
     fn contains(&mut self, line: &str) -> bool {
-        let trimmed = line.trim_start_matches([' ', '\t']);
         if let Some((marker, width)) = self.marker {
-            if fence_width(trimmed, marker) >= width {
+            if is_closing_fence(line, marker, width) {
                 self.marker = None;
             }
             return true;
         }
-        for marker in ['`', '~'] {
-            let width = fence_width(trimmed, marker);
-            if width >= 3 {
-                self.marker = Some((marker, width));
-                return true;
-            }
+        if let Some((marker, width)) = opening_fence(line) {
+            self.marker = Some((marker, width));
+            return true;
         }
         false
     }
+}
+
+fn opening_fence(line: &str) -> Option<(char, usize)> {
+    let content = commonmark_fence_content(line)?;
+    for marker in ['`', '~'] {
+        let width = fence_width(content, marker);
+        if width >= 3 {
+            return Some((marker, width));
+        }
+    }
+    None
+}
+
+fn is_closing_fence(line: &str, marker: char, opening_width: usize) -> bool {
+    let Some(content) = commonmark_fence_content(line) else {
+        return false;
+    };
+    let width = fence_width(content, marker);
+    width >= opening_width && content[width..].trim().is_empty()
+}
+
+/// CommonMark permits up to three leading spaces before a fenced-code marker.
+fn commonmark_fence_content(line: &str) -> Option<&str> {
+    let indent = line
+        .as_bytes()
+        .iter()
+        .take_while(|byte| **byte == b' ')
+        .count();
+    (indent <= 3).then_some(&line[indent..])
 }
 
 fn fence_width(line: &str, marker: char) -> usize {
@@ -386,10 +433,7 @@ fn parse_suppressions(source: &str, filename: &str) -> (Vec<Suppression>, Vec<So
             line_start += line.len();
             continue;
         }
-        for (comment_start, syntax) in comment_openers(line, file_kind, &mut comments) {
-            let after_opener = &line[comment_start + syntax.opener_len()..];
-            let leading_whitespace = after_opener.len() - after_opener.trim_start().len();
-            let directive_start = comment_start + syntax.opener_len() + leading_whitespace;
+        for (directive_start, syntax) in comment_openers(line, file_kind, &mut comments) {
             let directive_source = &line[directive_start..];
             let Some((directive, line_delta)) = DIRECTIVES
                 .iter()
@@ -451,89 +495,197 @@ fn comment_openers(
     file_kind: SuppressionFileKind,
     state: &mut CommentScanState,
 ) -> Vec<(usize, CommentSyntax)> {
-    let mut openers = Vec::new();
-    if file_kind == SuppressionFileKind::Unsupported {
-        return openers;
+    match file_kind {
+        SuppressionFileKind::Script | SuppressionFileKind::Jsx => {
+            javascript_comment_openers(line, state)
+        }
+        SuppressionFileKind::Mdx => mdx_comment_openers(line, state),
+        SuppressionFileKind::Unsupported => Vec::new(),
     }
+}
 
+fn javascript_comment_openers(
+    line: &str,
+    state: &mut CommentScanState,
+) -> Vec<(usize, CommentSyntax)> {
+    let mut openers = Vec::new();
+    let modes = state.javascript_mode();
     let bytes = line.as_bytes();
     let mut index = 0usize;
     while index < bytes.len() {
-        if state.block_comment {
-            if line[index..].starts_with("*/") {
-                state.block_comment = false;
-                index += 2;
-            } else {
-                index += char_width(bytes[index]);
+        match modes
+            .last_mut()
+            .expect("JavaScript scanner has a base mode")
+        {
+            JavascriptScanMode::BlockComment { only_whitespace } => {
+                if line[index..].starts_with("*/") {
+                    modes.pop();
+                    index += 2;
+                } else {
+                    if *only_whitespace {
+                        if directive_start(line, index) {
+                            openers.push((index, CommentSyntax::Block));
+                            *only_whitespace = false;
+                        } else if !line[index..].starts_with(char::is_whitespace) {
+                            *only_whitespace = false;
+                        }
+                    }
+                    index += char_width(bytes[index]);
+                }
             }
-            continue;
+            JavascriptScanMode::SingleQuote => {
+                if bytes[index] == b'\\' {
+                    index += 1 + bytes.get(index + 1).map_or(0, |byte| char_width(*byte));
+                } else if bytes[index] == b'\'' {
+                    modes.pop();
+                    index += 1;
+                } else {
+                    index += char_width(bytes[index]);
+                }
+            }
+            JavascriptScanMode::DoubleQuote => {
+                if bytes[index] == b'\\' {
+                    index += 1 + bytes.get(index + 1).map_or(0, |byte| char_width(*byte));
+                } else if bytes[index] == b'"' {
+                    modes.pop();
+                    index += 1;
+                } else {
+                    index += char_width(bytes[index]);
+                }
+            }
+            JavascriptScanMode::TemplateRaw => {
+                if bytes[index] == b'\\' {
+                    index += 1 + bytes.get(index + 1).map_or(0, |byte| char_width(*byte));
+                } else if bytes[index] == b'`' {
+                    modes.pop();
+                    index += 1;
+                } else if line[index..].starts_with("${") {
+                    modes.push(JavascriptScanMode::TemplateExpression { braces: 0 });
+                    index += 2;
+                } else {
+                    index += char_width(bytes[index]);
+                }
+            }
+            JavascriptScanMode::Code | JavascriptScanMode::TemplateExpression { .. } => {
+                if line[index..].starts_with("//") {
+                    let after_opener = &line[index + 2..];
+                    let whitespace = after_opener.len() - after_opener.trim_start().len();
+                    let directive = index + 2 + whitespace;
+                    if directive_start(line, directive) {
+                        openers.push((directive, CommentSyntax::Line));
+                    }
+                    break;
+                }
+                if line[index..].starts_with("/*") {
+                    modes.push(JavascriptScanMode::BlockComment {
+                        only_whitespace: true,
+                    });
+                    index += 2;
+                } else if bytes[index] == b'\'' {
+                    modes.push(JavascriptScanMode::SingleQuote);
+                    index += 1;
+                } else if bytes[index] == b'"' {
+                    modes.push(JavascriptScanMode::DoubleQuote);
+                    index += 1;
+                } else if bytes[index] == b'`' {
+                    modes.push(JavascriptScanMode::TemplateRaw);
+                    index += 1;
+                } else if let JavascriptScanMode::TemplateExpression { braces } = modes
+                    .last_mut()
+                    .expect("JavaScript scanner has a base mode")
+                {
+                    if bytes[index] == b'{' {
+                        *braces += 1;
+                    } else if bytes[index] == b'}' && *braces == 0 {
+                        modes.pop();
+                    } else if bytes[index] == b'}' {
+                        *braces -= 1;
+                    }
+                    index += 1;
+                } else {
+                    index += char_width(bytes[index]);
+                }
+            }
         }
-        if state.html_comment {
-            if line[index..].starts_with("-->") {
-                state.html_comment = false;
-                index += 3;
-            } else {
-                index += char_width(bytes[index]);
+    }
+    openers
+}
+
+fn mdx_comment_openers(line: &str, state: &mut CommentScanState) -> Vec<(usize, CommentSyntax)> {
+    let mut openers = Vec::new();
+    let bytes = line.as_bytes();
+    let mut index = 0usize;
+    while index < bytes.len() {
+        if let Some(comment) = state.mdx_comment.as_mut() {
+            let closes = match comment.syntax {
+                MdxCommentSyntax::Block => "*/",
+                MdxCommentSyntax::Html => "-->",
+            };
+            if line[index..].starts_with(closes) {
+                state.mdx_comment = None;
+                index += closes.len();
+                continue;
             }
+            if comment.only_whitespace {
+                if directive_start(line, index) {
+                    openers.push((
+                        index,
+                        match comment.syntax {
+                            MdxCommentSyntax::Block => CommentSyntax::Block,
+                            MdxCommentSyntax::Html => CommentSyntax::Html,
+                        },
+                    ));
+                    comment.only_whitespace = false;
+                } else if !line[index..].starts_with(char::is_whitespace) {
+                    comment.only_whitespace = false;
+                }
+            }
+            index += char_width(bytes[index]);
             continue;
         }
         if let Some(quote) = state.quote {
-            let width = char_width(bytes[index]);
             if bytes[index] == b'\\' {
-                index += width + bytes.get(index + width).map_or(0, |byte| char_width(*byte));
-                continue;
+                index += 1 + bytes.get(index + 1).map_or(0, |byte| char_width(*byte));
+            } else {
+                if line[index..].starts_with(quote) {
+                    state.quote = None;
+                }
+                index += char_width(bytes[index]);
             }
-            if line[index..].starts_with(quote) {
-                state.quote = None;
-            }
-            index += width;
             continue;
         }
-        if let Some(quote) = ['\'', '\"', '`']
+        if let Some(quote) = ['\'', '"']
             .into_iter()
             .find(|quote| line[index..].starts_with(*quote))
         {
             state.quote = Some(quote);
-            index += quote.len_utf8();
-            continue;
-        }
-
-        if matches!(
-            file_kind,
-            SuppressionFileKind::Script | SuppressionFileKind::Jsx
-        ) && line[index..].starts_with("//")
-        {
-            openers.push((index, CommentSyntax::Line));
-            break;
-        }
-        if matches!(
-            file_kind,
-            SuppressionFileKind::Script | SuppressionFileKind::Jsx
-        ) && line[index..].starts_with("/*")
-        {
-            openers.push((index, CommentSyntax::Block));
-            state.block_comment = true;
-            index += 2;
-            continue;
-        }
-        if file_kind == SuppressionFileKind::Mdx && line[index..].starts_with("<!--") {
-            openers.push((index, CommentSyntax::Html));
-            state.html_comment = true;
+            index += 1;
+        } else if line[index..].starts_with("<!--") {
+            state.mdx_comment = Some(MdxComment {
+                syntax: MdxCommentSyntax::Html,
+                only_whitespace: true,
+            });
             index += 4;
-            continue;
-        }
-        if file_kind == SuppressionFileKind::Mdx
-            && line[index..].starts_with("/*")
-            && is_jsx_comment_opener(line, index)
-        {
-            openers.push((index, CommentSyntax::Block));
-            state.block_comment = true;
+        } else if line[index..].starts_with("/*") && is_jsx_comment_opener(line, index) {
+            state.mdx_comment = Some(MdxComment {
+                syntax: MdxCommentSyntax::Block,
+                only_whitespace: true,
+            });
             index += 2;
-            continue;
+        } else {
+            index += char_width(bytes[index]);
         }
-        index += char_width(bytes[index]);
     }
     openers
+}
+
+fn directive_start(line: &str, index: usize) -> bool {
+    [
+        "palamedes-lint-disable-next-line",
+        "palamedes-lint-disable-line",
+    ]
+    .iter()
+    .any(|directive| line[index..].starts_with(directive))
 }
 
 fn is_jsx_comment_opener(line: &str, slash: usize) -> bool {
@@ -703,6 +855,78 @@ const trailing = 1; /* explanation palamedes-lint-disable-line pmds/no-placehold
         let (suppressions, diagnostics) = super::parse_suppressions(source, "guide.mdx");
         assert!(suppressions.is_empty());
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn suppression_parser_requires_real_commonmark_fence_closures() {
+        let source = concat!(
+            r#"````tsx
+<!-- palamedes-lint-disable-next-line pmds/no-placeholder-only-message -->
+~~~~
+<!-- palamedes-lint-disable-next-line pmds/no-placeholder-only-message -->
+``` trailing text
+<!-- palamedes-lint-disable-next-line pmds/no-placeholder-only-message -->
+````
+<!-- palamedes-lint-disable-next-line pmds/no-placeholder-only-message -->
+~~~~typescript
+<!-- palamedes-lint-disable-next-line pmds/no-placeholder-only-message -->
+~~~
+<!-- palamedes-lint-disable-next-line pmds/no-placeholder-only-message -->
+~~~~ trailing text
+<!-- palamedes-lint-disable-next-line pmds/no-placeholder-only-message -->
+"#,
+            "   ~~~~   \n",
+            "<!-- palamedes-lint-disable-next-line pmds/no-placeholder-only-message -->\n",
+        );
+        let (suppressions, diagnostics) = super::parse_suppressions(source, "guide.mdx");
+
+        assert!(diagnostics.is_empty());
+        assert_eq!(suppressions.len(), 2);
+        assert_eq!(suppressions[0].primary.line, 8);
+        assert_eq!(suppressions[0].line, 9);
+        assert_eq!(suppressions[1].primary.line, 16);
+        assert_eq!(suppressions[1].line, 17);
+    }
+
+    #[test]
+    fn suppression_parser_allows_whitespace_only_multiline_comments() {
+        let script = "/*\n \tpalamedes-lint-disable-line pmds/no-placeholder-only-message\n*/\n";
+        let (suppressions, diagnostics) = super::parse_suppressions(script, "view.ts");
+        assert!(diagnostics.is_empty());
+        assert_eq!(suppressions.len(), 1);
+        assert_eq!(suppressions[0].primary.line, 2);
+        assert_eq!(suppressions[0].line, 2);
+
+        let prose =
+            "/* explanation\n palamedes-lint-disable-line pmds/no-placeholder-only-message\n*/\n";
+        let (suppressions, diagnostics) = super::parse_suppressions(prose, "view.ts");
+        assert!(suppressions.is_empty());
+        assert!(diagnostics.is_empty());
+
+        let mdx = "<!--\n palamedes-lint-disable-line pmds/no-placeholder-only-message\n-->\n{/*\n palamedes-lint-disable-next-line pmds/prefer-trans-in-jsx\n*/}\n";
+        let (suppressions, diagnostics) = super::parse_suppressions(mdx, "guide.mdx");
+        assert!(diagnostics.is_empty());
+        assert_eq!(suppressions.len(), 2);
+        assert_eq!(suppressions[0].primary.line, 2);
+        assert_eq!(suppressions[0].line, 2);
+        assert_eq!(suppressions[1].primary.line, 5);
+        assert_eq!(suppressions[1].line, 6);
+    }
+
+    #[test]
+    fn suppression_parser_scans_template_expression_comments_not_raw_templates() {
+        let source = r#"const prose = `// palamedes-lint-disable-next-line pmds/no-placeholder-only-message`;
+const message = `outer ${tag`inner ${(
+  // palamedes-lint-disable-next-line pmds/no-placeholder-only-message
+  t`${status}`
+)}`}`;
+"#;
+        let (suppressions, diagnostics) = super::parse_suppressions(source, "view.ts");
+
+        assert!(diagnostics.is_empty());
+        assert_eq!(suppressions.len(), 1);
+        assert_eq!(suppressions[0].primary.line, 3);
+        assert_eq!(suppressions[0].line, 4);
     }
 
     #[test]

--- a/crates/palamedes-cli/src/commands/lint.rs
+++ b/crates/palamedes-cli/src/commands/lint.rs
@@ -5,8 +5,9 @@ use std::path::{Path, PathBuf};
 
 use clap::{Args, ValueEnum};
 use palamedes::{
-    analyze_source_file_cached, default_cache_path, ExtractCache, ExtractCatalogMessagesOptions,
-    SourceDiagnostic, SourceDiagnosticSeverity, SourceRange, SOURCE_DIAGNOSTIC_CODES,
+    analyze_source_files_cached, default_cache_path, ExtractCache, ExtractCatalogMessagesOptions,
+    SourceDiagnostic, SourceDiagnosticSeverity, SourceFileAnalysisRequest, SourceRange,
+    SOURCE_DIAGNOSTIC_CODES,
 };
 use serde::Serialize;
 
@@ -25,6 +26,9 @@ pub struct LintOptions {
     /// Fail on error or warning diagnostics.
     #[arg(long, default_value = "error")]
     fail_on: LintFailOn,
+    /// Worker threads for the parallel source-analysis pass.
+    #[arg(long)]
+    threads: Option<usize>,
     /// Ignore and do not write the shared source-analysis cache.
     #[arg(long)]
     no_cache: bool,
@@ -92,23 +96,34 @@ impl Command for LintOptions {
             )
         };
 
-        for path in &files {
-            let filename = display_source_path(path, &config.root_dir);
-            match analyze_source_file_cached(
-                &path.to_string_lossy(),
-                &filename,
-                &config.source_reference_root.to_string_lossy(),
-                &analysis_options,
-                &mut cache,
-            ) {
+        let analysis_files = files
+            .iter()
+            .map(|path| SourceFileAnalysisRequest {
+                path: path.to_string_lossy().into_owned(),
+                filename: display_source_path(path, &config.root_dir),
+            })
+            .collect::<Vec<_>>();
+        let analyses = analyze_source_files_cached(
+            &analysis_files,
+            &config.source_reference_root.to_string_lossy(),
+            &analysis_options,
+            self.threads.or(config.extract_threads),
+            &mut cache,
+        )?;
+
+        for (file, analysis) in analysis_files.iter().zip(analyses) {
+            match analysis {
                 Ok(result) => {
-                    let (mut file_diagnostics, file_suppressed) =
-                        apply_suppressions(&result.source, &filename, result.analysis.diagnostics);
+                    let (mut file_diagnostics, file_suppressed) = apply_suppressions(
+                        &result.source,
+                        &file.filename,
+                        result.analysis.diagnostics,
+                    );
                     diagnostics.append(&mut file_diagnostics);
                     suppressed += file_suppressed;
                 }
                 Err(error) => failed_files.push(LintFileFailure {
-                    file: filename,
+                    file: file.filename.clone(),
                     message: error.to_string(),
                 }),
             }
@@ -235,6 +250,93 @@ struct Suppression {
     primary: SourceRange,
 }
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum SuppressionFileKind {
+    Script,
+    Jsx,
+    Mdx,
+    Unsupported,
+}
+
+impl SuppressionFileKind {
+    fn from_filename(filename: &str) -> Self {
+        match Path::new(filename)
+            .extension()
+            .and_then(|extension| extension.to_str())
+            .map(str::to_ascii_lowercase)
+            .as_deref()
+        {
+            Some("js" | "ts") => Self::Script,
+            Some("jsx" | "tsx") => Self::Jsx,
+            Some("mdx") => Self::Mdx,
+            _ => Self::Unsupported,
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum CommentSyntax {
+    Line,
+    Block,
+    Html,
+}
+
+impl CommentSyntax {
+    const fn opener_len(self) -> usize {
+        match self {
+            Self::Line | Self::Block => 2,
+            Self::Html => 4,
+        }
+    }
+
+    fn directive_body(self, source: &str) -> &str {
+        match self {
+            Self::Line => source,
+            Self::Block => source.split_once("*/").map_or(source, |(body, _)| body),
+            Self::Html => source.split_once("-->").map_or(source, |(body, _)| body),
+        }
+    }
+}
+
+#[derive(Default)]
+struct CommentScanState {
+    quote: Option<char>,
+    block_comment: bool,
+    html_comment: bool,
+}
+
+#[derive(Default)]
+struct MdxFenceState {
+    marker: Option<(char, usize)>,
+}
+
+impl MdxFenceState {
+    /// Returns whether this line is within a fenced MDX example, including fence lines.
+    fn contains(&mut self, line: &str) -> bool {
+        let trimmed = line.trim_start_matches([' ', '\t']);
+        if let Some((marker, width)) = self.marker {
+            if fence_width(trimmed, marker) >= width {
+                self.marker = None;
+            }
+            return true;
+        }
+        for marker in ['`', '~'] {
+            let width = fence_width(trimmed, marker);
+            if width >= 3 {
+                self.marker = Some((marker, width));
+                return true;
+            }
+        }
+        false
+    }
+}
+
+fn fence_width(line: &str, marker: char) -> usize {
+    line.chars()
+        .take_while(|character| *character == marker)
+        .count()
+}
+
 fn apply_suppressions(
     source: &str,
     filename: &str,
@@ -276,30 +378,37 @@ fn parse_suppressions(source: &str, filename: &str) -> (Vec<Suppression>, Vec<So
     let mut suppressions = Vec::new();
     let mut diagnostics = Vec::new();
     let mut line_start = 0usize;
+    let file_kind = SuppressionFileKind::from_filename(filename);
+    let mut comments = CommentScanState::default();
+    let mut fences = MdxFenceState::default();
     for (line_index, line) in source.split_inclusive('\n').enumerate() {
-        for (directive, line_delta) in DIRECTIVES {
-            let Some(marker_index) = line.find(directive) else {
+        if file_kind == SuppressionFileKind::Mdx && fences.contains(line) {
+            line_start += line.len();
+            continue;
+        }
+        for (comment_start, syntax) in comment_openers(line, file_kind, &mut comments) {
+            let after_opener = &line[comment_start + syntax.opener_len()..];
+            let leading_whitespace = after_opener.len() - after_opener.trim_start().len();
+            let directive_start = comment_start + syntax.opener_len() + leading_whitespace;
+            let directive_source = &line[directive_start..];
+            let Some((directive, line_delta)) = DIRECTIVES
+                .iter()
+                .find(|(directive, _)| directive_source.starts_with(*directive))
+            else {
                 continue;
             };
-            if !["//", "{/*", "<!--"]
-                .iter()
-                .any(|comment| line[..marker_index].contains(comment))
-            {
-                continue;
-            }
-            let rest = line[marker_index + directive.len()..]
-                .trim()
-                .trim_end_matches(['*', '/', '}', '-', '>'])
+            let rest = syntax
+                .directive_body(&directive_source[directive.len()..])
                 .trim();
             let codes = rest
                 .split([',', ' ', '\t'])
                 .filter(|code| !code.is_empty())
                 .collect::<BTreeSet<_>>();
             let range = SourceRange {
-                start: line_start + marker_index,
-                end: line_start + marker_index + directive.len(),
+                start: line_start + directive_start,
+                end: line_start + directive_start + directive.len(),
                 line: line_index + 1,
-                column: line[..marker_index].chars().count() + 1,
+                column: line[..directive_start].chars().count() + 1,
             };
             if codes.is_empty() {
                 diagnostics.push(suppression_diagnostic(
@@ -332,6 +441,115 @@ fn parse_suppressions(source: &str, filename: &str) -> (Vec<Suppression>, Vec<So
         line_start += line.len();
     }
     (suppressions, diagnostics)
+}
+
+/// Finds supported comment openers outside strings and existing block comments.
+/// Directives are intentionally recognized only immediately after an opener
+/// (modulo whitespace), so prose examples and trailing comment text stay inert.
+fn comment_openers(
+    line: &str,
+    file_kind: SuppressionFileKind,
+    state: &mut CommentScanState,
+) -> Vec<(usize, CommentSyntax)> {
+    let mut openers = Vec::new();
+    if file_kind == SuppressionFileKind::Unsupported {
+        return openers;
+    }
+
+    let bytes = line.as_bytes();
+    let mut index = 0usize;
+    while index < bytes.len() {
+        if state.block_comment {
+            if line[index..].starts_with("*/") {
+                state.block_comment = false;
+                index += 2;
+            } else {
+                index += char_width(bytes[index]);
+            }
+            continue;
+        }
+        if state.html_comment {
+            if line[index..].starts_with("-->") {
+                state.html_comment = false;
+                index += 3;
+            } else {
+                index += char_width(bytes[index]);
+            }
+            continue;
+        }
+        if let Some(quote) = state.quote {
+            let width = char_width(bytes[index]);
+            if bytes[index] == b'\\' {
+                index += width + bytes.get(index + width).map_or(0, |byte| char_width(*byte));
+                continue;
+            }
+            if line[index..].starts_with(quote) {
+                state.quote = None;
+            }
+            index += width;
+            continue;
+        }
+        if let Some(quote) = ['\'', '\"', '`']
+            .into_iter()
+            .find(|quote| line[index..].starts_with(*quote))
+        {
+            state.quote = Some(quote);
+            index += quote.len_utf8();
+            continue;
+        }
+
+        if matches!(
+            file_kind,
+            SuppressionFileKind::Script | SuppressionFileKind::Jsx
+        ) && line[index..].starts_with("//")
+        {
+            openers.push((index, CommentSyntax::Line));
+            break;
+        }
+        if matches!(
+            file_kind,
+            SuppressionFileKind::Script | SuppressionFileKind::Jsx
+        ) && line[index..].starts_with("/*")
+        {
+            openers.push((index, CommentSyntax::Block));
+            state.block_comment = true;
+            index += 2;
+            continue;
+        }
+        if file_kind == SuppressionFileKind::Mdx && line[index..].starts_with("<!--") {
+            openers.push((index, CommentSyntax::Html));
+            state.html_comment = true;
+            index += 4;
+            continue;
+        }
+        if file_kind == SuppressionFileKind::Mdx
+            && line[index..].starts_with("/*")
+            && is_jsx_comment_opener(line, index)
+        {
+            openers.push((index, CommentSyntax::Block));
+            state.block_comment = true;
+            index += 2;
+            continue;
+        }
+        index += char_width(bytes[index]);
+    }
+    openers
+}
+
+fn is_jsx_comment_opener(line: &str, slash: usize) -> bool {
+    line[..slash].trim_end().ends_with('{')
+}
+
+const fn char_width(byte: u8) -> usize {
+    if byte < 0x80 {
+        1
+    } else if byte < 0xE0 {
+        2
+    } else if byte < 0xF0 {
+        3
+    } else {
+        4
+    }
 }
 
 fn suppression_diagnostic(
@@ -391,6 +609,7 @@ function View({ status }) {
             config: None,
             json: false,
             fail_on: LintFailOn::Error,
+            threads: None,
             no_cache: true,
         }
         .run(&Context::with_cwd(&app))
@@ -410,6 +629,80 @@ function View({ status }) {
         assert_eq!(diagnostics.len(), 2);
         assert_eq!(diagnostics[0].code, "pmds/invalid-suppression");
         assert_eq!(diagnostics[1].code, "pmds/unknown-suppression-code");
+    }
+
+    #[test]
+    fn suppression_parser_requires_a_real_immediate_comment_directive() {
+        let source = r#"const string = "// palamedes-lint-disable-line pmds/no-placeholder-only-message";
+// explanation: palamedes-lint-disable-line pmds/no-placeholder-only-message
+const trailing = 1; /* explanation palamedes-lint-disable-line pmds/no-placeholder-only-message */
+/* palamedes-lint-disable-line pmds/no-placeholder-only-message, pmds/prefer-trans-in-jsx */
+  //  palamedes-lint-disable-next-line pmds/no-empty-component-only-message
+"#;
+        let (suppressions, diagnostics) = super::parse_suppressions(source, "view.tsx");
+
+        assert!(diagnostics.is_empty());
+        assert_eq!(suppressions.len(), 3);
+        assert_eq!(suppressions[0].line, 4);
+        assert_eq!(suppressions[0].primary.line, 4);
+        assert_eq!(suppressions[0].primary.column, 4);
+        assert_eq!(suppressions[2].line, 6);
+    }
+
+    #[test]
+    fn suppression_parser_accepts_comment_openers_after_code_and_by_file_kind() {
+        let script =
+            "const value = 1; /* palamedes-lint-disable-line pmds/no-placeholder-only-message */\n";
+        let (suppressions, diagnostics) = super::parse_suppressions(script, "view.ts");
+        assert!(diagnostics.is_empty());
+        assert_eq!(suppressions.len(), 1);
+        assert_eq!(suppressions[0].line, 1);
+
+        let jsx =
+            "const view = <>{/* palamedes-lint-disable-line pmds/prefer-trans-in-jsx */}</>;\n";
+        let (suppressions, diagnostics) = super::parse_suppressions(jsx, "view.tsx");
+        assert!(diagnostics.is_empty());
+        assert_eq!(suppressions.len(), 1);
+
+        let (suppressions, diagnostics) = super::parse_suppressions(
+            "<!-- palamedes-lint-disable-line pmds/no-placeholder-only-message -->\n",
+            "view.ts",
+        );
+        assert!(suppressions.is_empty());
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn suppression_parser_uses_file_specific_mdx_comments_and_skips_examples() {
+        let source = r#"<!-- palamedes-lint-disable-next-line pmds/no-placeholder-only-message -->
+{/* palamedes-lint-disable-line pmds/prefer-trans-in-jsx */}
+// palamedes-lint-disable-line pmds/no-empty-component-only-message
+
+   ````tsx
+   // palamedes-lint-disable-next-line pmds/no-placeholder-only-message
+   {/* palamedes-lint-disable-line pmds/prefer-trans-in-jsx */}
+   ````
+~~~javascript
+<!-- palamedes-lint-disable-next-line pmds/no-empty-component-only-message -->
+~~~
+```
+<!-- palamedes-lint-disable-next-line pmds/no-placeholder-only-message -->
+"#;
+        let (suppressions, diagnostics) = super::parse_suppressions(source, "guide.mdx");
+
+        assert!(diagnostics.is_empty());
+        assert_eq!(suppressions.len(), 2);
+        assert_eq!(suppressions[0].line, 2);
+        assert_eq!(suppressions[1].line, 2);
+        assert_eq!(suppressions[1].primary.line, 2);
+    }
+
+    #[test]
+    fn suppression_parser_keeps_unmatched_mdx_fences_inert() {
+        let source = "# Guide\n\n  ~~~text\n  <!-- palamedes-lint-disable-next-line pmds/no-placeholder-only-message -->\n";
+        let (suppressions, diagnostics) = super::parse_suppressions(source, "guide.mdx");
+        assert!(suppressions.is_empty());
+        assert!(diagnostics.is_empty());
     }
 
     #[test]
@@ -439,6 +732,7 @@ catalogs:
             config: None,
             json: false,
             fail_on: LintFailOn::Error,
+            threads: None,
             no_cache: true,
         }
         .run(&Context::with_cwd(&app))
@@ -493,6 +787,7 @@ function View({ status }) { return <p>{t`${status}`}</p>; }
             config: None,
             json: true,
             fail_on: LintFailOn::Error,
+            threads: None,
             no_cache: false,
         }
         .run(&context)
@@ -501,6 +796,7 @@ function View({ status }) { return <p>{t`${status}`}</p>; }
             config: None,
             json: true,
             fail_on: LintFailOn::Error,
+            threads: None,
             no_cache: true,
         }
         .run(&context)
@@ -526,6 +822,7 @@ function View({ status }) { return <p>{t`${status}`}</p>; }
             config: None,
             json: false,
             fail_on: LintFailOn::Warning,
+            threads: None,
             no_cache: true,
         };
 

--- a/crates/palamedes-cli/src/error.rs
+++ b/crates/palamedes-cli/src/error.rs
@@ -8,6 +8,8 @@ use crate::config::ConfigError;
 
 /// Exit status used when `extract --check` finds catalog drift.
 pub const CATALOG_DRIFT_EXIT_CODE: u8 = 3;
+/// Exit status used when `lint` completes analysis but its requested threshold fails.
+pub const LINT_VERDICT_EXIT_CODE: u8 = 4;
 
 #[derive(Debug, Error)]
 pub enum CliError {
@@ -78,6 +80,9 @@ impl CliError {
     pub fn exit_code(&self) -> u8 {
         match self {
             Self::CatalogDrift { .. } => CATALOG_DRIFT_EXIT_CODE,
+            Self::LintFailedOnError { .. }
+            | Self::LintFailedOnWarning { .. }
+            | Self::LintAnalysisFailed { .. } => LINT_VERDICT_EXIT_CODE,
             _ => 1,
         }
     }

--- a/crates/palamedes-cli/tests/lint_exit.rs
+++ b/crates/palamedes-cli/tests/lint_exit.rs
@@ -1,0 +1,86 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[test]
+fn lint_verdicts_have_a_dedicated_exit_code() {
+    let fixture = fixture_dir("verdict");
+    fs::create_dir_all(fixture.join("src")).expect("create source directory");
+    fs::write(
+        fixture.join("palamedes.yaml"),
+        "locales: [en]\nsource-locale: en\ncatalogs:\n  - path: locales/{locale}/messages\n    include: [src]\n",
+    )
+    .expect("write config");
+    fs::write(
+        fixture.join("src/view.tsx"),
+        "import { t } from \"@palamedes/core/macro\";\nexport function Label({ status }) { return t`${status}`; }\n",
+    )
+    .expect("write source");
+
+    let warning = pmds(
+        &fixture,
+        &["lint", "--json", "--fail-on", "warning", "--threads", "1"],
+    );
+    assert_eq!(warning.status.code(), Some(4), "{warning:?}");
+    assert!(String::from_utf8_lossy(&warning.stdout).contains("pmds/no-placeholder-only-message"));
+
+    let default_threshold = pmds(&fixture, &["lint", "--json"]);
+    assert!(default_threshold.status.success(), "{default_threshold:?}");
+
+    let usage = pmds(&fixture, &["lint", "--fail-on", "info"]);
+    assert_eq!(usage.status.code(), Some(2), "{usage:?}");
+
+    fs::remove_dir_all(fixture).expect("cleanup fixture");
+}
+
+#[test]
+fn lint_analysis_failure_shares_the_dedicated_verdict_exit_code() {
+    let fixture = fixture_dir("analysis-failure");
+    fs::create_dir_all(fixture.join("src")).expect("create source directory");
+    fs::write(
+        fixture.join("palamedes.yaml"),
+        "locales: [en]\nsource-locale: en\ncatalogs:\n  - path: locales/{locale}/messages\n    include: [src]\n",
+    )
+    .expect("write config");
+    fs::write(
+        fixture.join("src/view.tsx"),
+        "import { t } from \"@palamedes/core/macro\";\nexport const label = t`${status}`;\n",
+    )
+    .expect("write invalid source");
+
+    let output = pmds(&fixture, &["lint", "--json"]);
+    assert_eq!(output.status.code(), Some(4), "{output:?}");
+
+    fs::remove_dir_all(fixture).expect("cleanup fixture");
+}
+
+#[test]
+fn lint_configuration_failures_keep_the_generic_exit_code() {
+    let fixture = fixture_dir("configuration-failure");
+    fs::create_dir_all(&fixture).expect("create fixture");
+
+    let output = pmds(&fixture, &["lint", "--json"]);
+    assert_eq!(output.status.code(), Some(1), "{output:?}");
+
+    fs::remove_dir_all(fixture).expect("cleanup fixture");
+}
+
+fn pmds(root: &Path, arguments: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_pmds"))
+        .args(arguments)
+        .current_dir(root)
+        .output()
+        .expect("run pmds")
+}
+
+fn fixture_dir(name: &str) -> PathBuf {
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time")
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "palamedes-cli-lint-exit-{name}-{}-{stamp}",
+        std::process::id()
+    ))
+}

--- a/crates/palamedes-cli/tests/lint_exit.rs
+++ b/crates/palamedes-cli/tests/lint_exit.rs
@@ -56,6 +56,68 @@ fn lint_analysis_failure_shares_the_dedicated_verdict_exit_code() {
 }
 
 #[test]
+fn lint_suppresses_an_inner_template_expression_comment_not_raw_template_text() {
+    let fixture = fixture_dir("template-expression-suppression");
+    fs::create_dir_all(fixture.join("src")).expect("create source directory");
+    fs::write(
+        fixture.join("palamedes.yaml"),
+        "locales: [en]\nsource-locale: en\ncatalogs:\n  - path: locales/{locale}/messages\n    include: [src]\n",
+    )
+    .expect("write config");
+    fs::write(
+        fixture.join("src/view.tsx"),
+        r#"import { t } from "@palamedes/core/macro";
+export function Label({ status }) {
+  const prose = `// palamedes-lint-disable-next-line pmds/no-placeholder-only-message`;
+  const label = `outer ${(
+    // palamedes-lint-disable-next-line pmds/no-placeholder-only-message
+    t`${status}`
+  )}`;
+  return <p>{label}</p>;
+}
+"#,
+    )
+    .expect("write source");
+
+    let output = pmds(
+        &fixture,
+        &["lint", "--json", "--fail-on", "warning", "--threads", "1"],
+    );
+    assert!(output.status.success(), "{output:?}");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("\"suppressed\": 1"), "{stdout}");
+
+    fs::remove_dir_all(fixture).expect("cleanup fixture");
+}
+
+#[test]
+fn lint_does_not_treat_raw_template_text_as_a_suppression() {
+    let fixture = fixture_dir("raw-template-prose");
+    fs::create_dir_all(fixture.join("src")).expect("create source directory");
+    fs::write(
+        fixture.join("palamedes.yaml"),
+        "locales: [en]\nsource-locale: en\ncatalogs:\n  - path: locales/{locale}/messages\n    include: [src]\n",
+    )
+    .expect("write config");
+    fs::write(
+        fixture.join("src/view.tsx"),
+        r#"import { t } from "@palamedes/core/macro";
+export function Label({ status }) {
+  const prose = `// palamedes-lint-disable-next-line pmds/no-placeholder-only-message`;
+  return t`${status}`;
+}
+"#,
+    )
+    .expect("write source");
+
+    let output = pmds(&fixture, &["lint", "--json", "--fail-on", "warning"]);
+    assert_eq!(output.status.code(), Some(4), "{output:?}");
+    assert!(String::from_utf8_lossy(&output.stdout).contains("pmds/no-placeholder-only-message"));
+
+    fs::remove_dir_all(fixture).expect("cleanup fixture");
+}
+
+#[test]
 fn lint_configuration_failures_keep_the_generic_exit_code() {
     let fixture = fixture_dir("configuration-failure");
     fs::create_dir_all(&fixture).expect("create fixture");

--- a/crates/palamedes-cli/tests/lint_exit.rs
+++ b/crates/palamedes-cli/tests/lint_exit.rs
@@ -118,6 +118,110 @@ export function Label({ status }) {
 }
 
 #[test]
+fn lint_keeps_commonmark_fence_edge_cases_on_the_public_path() {
+    let fixture = fixture_dir("commonmark-fence");
+    fs::create_dir_all(fixture.join("src")).expect("create source directory");
+    fs::write(
+        fixture.join("palamedes.yaml"),
+        "locales: [en]\nsource-locale: en\ncatalogs:\n  - path: locales/{locale}/messages\n    include: [src]\n",
+    )
+    .expect("write config");
+    fs::write(
+        fixture.join("src/nbsp-close.mdx"),
+        "```mdx\n```\u{a0}\n<!-- palamedes-lint-disable-next-line pmds/no-placeholder-only-message -->\n",
+    )
+    .expect("write NBSP fence source");
+    fs::write(
+        fixture.join("src/invalid-opener.mdx"),
+        "```tsx`not-a-fence\n<!-- palamedes-lint-disable-next-line pmds/no-placeholder-only-message -->\n",
+    )
+    .expect("write invalid opener source");
+
+    let output = pmds(&fixture, &["lint", "--json", "--fail-on", "warning"]);
+    assert_eq!(output.status.code(), Some(4), "{output:?}");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(
+        stdout.matches("pmds/unused-suppression").count(),
+        1,
+        "{stdout}"
+    );
+
+    fs::remove_dir_all(fixture).expect("cleanup fixture");
+}
+
+#[test]
+fn lint_suppresses_a_template_expression_comment_after_a_regexp_literal() {
+    let fixture = fixture_dir("regexp-template-expression-suppression");
+    fs::create_dir_all(fixture.join("src")).expect("create source directory");
+    fs::write(
+        fixture.join("palamedes.yaml"),
+        "locales: [en]\nsource-locale: en\ncatalogs:\n  - path: locales/{locale}/messages\n    include: [src]\n",
+    )
+    .expect("write config");
+    fs::write(
+        fixture.join("src/view.tsx"),
+        r#"import { t } from "@palamedes/core/macro";
+export function Label({ status }) {
+  const label = `outer ${/}/.test(status) ? (
+    // palamedes-lint-disable-next-line pmds/no-placeholder-only-message
+    t`${status}`
+  ) : ""}`;
+  return <p>{label}</p>;
+}
+"#,
+    )
+    .expect("write source");
+
+    let output = pmds(
+        &fixture,
+        &["lint", "--json", "--fail-on", "warning", "--threads", "1"],
+    );
+    assert!(output.status.success(), "{output:?}");
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("\"suppressed\": 1"),
+        "{output:?}"
+    );
+
+    fs::remove_dir_all(fixture).expect("cleanup fixture");
+}
+
+#[test]
+fn lint_treats_only_mdx_template_expression_comments_as_suppressions() {
+    let fixture = fixture_dir("mdx-template-expression-suppression");
+    fs::create_dir_all(fixture.join("src")).expect("create source directory");
+    fs::write(
+        fixture.join("palamedes.yaml"),
+        "locales: [en]\nsource-locale: en\ncatalogs:\n  - path: locales/{locale}/messages\n    include: [src]\n",
+    )
+    .expect("write config");
+    fs::write(
+        fixture.join("src/guide.mdx"),
+        r#"import { t } from "@palamedes/core/macro";
+
+{`raw <!-- palamedes-lint-disable-next-line pmds/no-placeholder-only-message --> ${(
+  // palamedes-lint-disable-next-line pmds/no-placeholder-only-message
+  t`${status}`
+)}`}
+"#,
+    )
+    .expect("write source");
+
+    let output = pmds(
+        &fixture,
+        &["lint", "--json", "--fail-on", "warning", "--threads", "1"],
+    );
+    assert_eq!(output.status.code(), Some(4), "{output:?}");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(
+        stdout.matches("pmds/unused-suppression").count(),
+        1,
+        "{stdout}"
+    );
+
+    fs::remove_dir_all(fixture).expect("cleanup fixture");
+}
+
+#[test]
 fn lint_configuration_failures_keep_the_generic_exit_code() {
     let fixture = fixture_dir("configuration-failure");
     fs::create_dir_all(&fixture).expect("create fixture");

--- a/crates/palamedes/src/extract.rs
+++ b/crates/palamedes/src/extract.rs
@@ -85,6 +85,19 @@ pub struct ExtractCatalogMessagesRequest {
     pub max_threads: Option<usize>,
 }
 
+/// One file to analyze as part of a source-analysis batch.
+///
+/// `path` identifies the file on disk and in [`ExtractCache`], while `filename`
+/// is the display path written into diagnostics. Keeping them separate lets a
+/// caller cache absolute paths while reporting stable project-relative paths.
+#[derive(Clone, Debug)]
+pub struct SourceFileAnalysisRequest {
+    /// Path to read and use as the cache key.
+    pub path: String,
+    /// Display filename for diagnostics produced from `path`.
+    pub filename: String,
+}
+
 /// Optional behavior for aggregated catalog extraction.
 #[derive(Clone, Debug)]
 pub struct ExtractCatalogMessagesOptions {
@@ -1735,58 +1748,172 @@ pub fn analyze_source_file_cached(
     options: &ExtractCatalogMessagesOptions,
     cache: &mut ExtractCache,
 ) -> PalamedesResult<SourceFileAnalysisResult> {
+    let mut results = analyze_source_files_cached(
+        &[SourceFileAnalysisRequest {
+            path: path.to_owned(),
+            filename: filename.to_owned(),
+        }],
+        root_dir,
+        options,
+        Some(1),
+        cache,
+    )?;
+    // The batch always returns exactly one outcome for every input file.
+    results
+        .pop()
+        .expect("one source-analysis request produces one outcome")
+}
+
+/// Analyze source files while reusing the cache shared with batch extraction.
+///
+/// Reading, cache validation, and parsing run in a bounded Rayon pool. The
+/// supplied cache is observed immutably by workers, then fresh results are
+/// inserted serially in request order. This keeps cache writes, diagnostics,
+/// and caller-side suppression processing deterministic while still avoiding
+/// serial parse work on cold trees.
+///
+/// The returned vector has one result per input, in input order. A bad file
+/// does not prevent independent files from being analyzed; its entry contains
+/// the original [`PalamedesError`]. A pool-construction failure applies to the
+/// whole batch and is returned from this function.
+pub fn analyze_source_files_cached(
+    files: &[SourceFileAnalysisRequest],
+    root_dir: &str,
+    options: &ExtractCatalogMessagesOptions,
+    max_threads: Option<usize>,
+    cache: &mut ExtractCache,
+) -> PalamedesResult<Vec<PalamedesResult<SourceFileAnalysisResult>>> {
     cache.reset_if_request_differs(root_dir, options);
-    let fingerprint = cache.fingerprint_before_read(path);
-    let source = std::fs::read_to_string(path).map_err(|source| PalamedesError::ReadFile {
-        path: PathBuf::from(path),
-        source,
-    })?;
-    if let Some((_relative_file, messages, diagnostics)) = cache.get_after_read(path, fingerprint) {
-        return Ok(SourceFileAnalysisResult {
-            source,
-            analysis: analysis_with_display_filename(
-                SourceAnalysisResult {
-                    messages,
-                    diagnostics,
-                },
+    let threads = resolve_extract_threads(max_threads, files.len());
+    let outcomes: Vec<SourceFileAnalysisOutcome> = if threads <= 1 {
+        files
+            .iter()
+            .map(|file| analyze_one_source_file_cached(file, options, cache))
+            .collect()
+    } else {
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(threads)
+            .build()
+            .map_err(|source| PalamedesError::ExtractionPool {
+                message: source.to_string(),
+            })?
+            .install(|| {
+                files
+                    .par_iter()
+                    .map(|file| analyze_one_source_file_cached(file, options, cache))
+                    .collect()
+            })
+    };
+
+    Ok(outcomes
+        .into_iter()
+        .map(|outcome| match outcome {
+            SourceFileAnalysisOutcome::Analyzed {
+                path,
                 filename,
-            ),
-        });
+                source,
+                analysis,
+                fresh,
+                fingerprint,
+            } => {
+                if fresh {
+                    cache.insert(
+                        path.clone(),
+                        relative_origin_file(Path::new(root_dir), &path),
+                        &analysis.messages,
+                        &analysis.diagnostics,
+                        fingerprint,
+                    );
+                }
+                Ok(SourceFileAnalysisResult {
+                    source,
+                    analysis: analysis_with_display_filename(analysis, &filename),
+                })
+            }
+            SourceFileAnalysisOutcome::Failed(error) => Err(error),
+        })
+        .collect())
+}
+
+/// Result of the parallel source-analysis phase before ordered cache insertion.
+enum SourceFileAnalysisOutcome {
+    Analyzed {
+        path: String,
+        filename: String,
+        source: String,
+        analysis: SourceAnalysisResult,
+        fresh: bool,
+        fingerprint: Option<ReadStartFingerprint>,
+    },
+    Failed(PalamedesError),
+}
+
+fn analyze_one_source_file_cached(
+    file: &SourceFileAnalysisRequest,
+    options: &ExtractCatalogMessagesOptions,
+    cache: &ExtractCache,
+) -> SourceFileAnalysisOutcome {
+    let fingerprint = cache.fingerprint_before_read(&file.path);
+    let source = match std::fs::read_to_string(&file.path) {
+        Ok(source) => source,
+        Err(source) => {
+            return SourceFileAnalysisOutcome::Failed(PalamedesError::ReadFile {
+                path: PathBuf::from(&file.path),
+                source,
+            });
+        }
+    };
+    if let Some((_relative_file, messages, diagnostics)) =
+        cache.get_after_read(&file.path, fingerprint)
+    {
+        return SourceFileAnalysisOutcome::Analyzed {
+            path: file.path.clone(),
+            filename: file.filename.clone(),
+            source,
+            analysis: SourceAnalysisResult {
+                messages,
+                diagnostics,
+            },
+            fresh: false,
+            fingerprint: None,
+        };
     }
 
-    let is_mdx = is_mdx_filename(path);
-    let analysis = if !is_mdx && !source.contains("@palamedes") && !source.contains("i18n") {
-        SourceAnalysisResult {
+    let analysis = if !is_mdx_filename(&file.path)
+        && !source.contains("@palamedes")
+        && !source.contains("i18n")
+    {
+        Ok(SourceAnalysisResult {
             messages: Vec::new(),
             diagnostics: Vec::new(),
-        }
+        })
     } else {
         EXTRACT_ARENA.with(|arena| {
             let mut arena = arena.borrow_mut();
             let analysis = analyze_source_in(
                 &arena,
                 &source,
-                path,
+                &file.path,
                 options.reference_scopes,
                 &options.mdx,
                 &options.rules,
             );
             arena.reset();
             analysis
-        })?
+        })
     };
 
-    cache.insert(
-        path.to_owned(),
-        relative_origin_file(Path::new(root_dir), path),
-        &analysis.messages,
-        &analysis.diagnostics,
-        fingerprint,
-    );
-    Ok(SourceFileAnalysisResult {
-        source,
-        analysis: analysis_with_display_filename(analysis, filename),
-    })
+    match analysis {
+        Ok(analysis) => SourceFileAnalysisOutcome::Analyzed {
+            path: file.path.clone(),
+            filename: file.filename.clone(),
+            source,
+            analysis,
+            fresh: true,
+            fingerprint,
+        },
+        Err(error) => SourceFileAnalysisOutcome::Failed(error),
+    }
 }
 
 fn analysis_with_display_filename(
@@ -2469,12 +2596,12 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     use super::{
-        analyze_source, analyze_source_file_cached, analyze_source_with_mdx_options,
-        analyze_source_with_options, extract_catalog_messages_cached,
-        extract_catalog_messages_from_files, extract_catalog_messages_from_files_with_options,
-        extract_messages as extract_messages_raw, resolve_extract_threads,
-        ExtractCatalogMessagesOptions, ExtractCatalogMessagesRequest, ExtractedMessageRecord,
-        DEFAULT_EXTRACT_THREADS,
+        analyze_source, analyze_source_file_cached, analyze_source_files_cached,
+        analyze_source_with_mdx_options, analyze_source_with_options,
+        extract_catalog_messages_cached, extract_catalog_messages_from_files,
+        extract_catalog_messages_from_files_with_options, extract_messages as extract_messages_raw,
+        resolve_extract_threads, ExtractCatalogMessagesOptions, ExtractCatalogMessagesRequest,
+        ExtractedMessageRecord, SourceFileAnalysisRequest, DEFAULT_EXTRACT_THREADS,
     };
     use crate::error::PalamedesResult;
     use crate::extract_cache::ExtractCache;
@@ -2789,6 +2916,105 @@ function Greeting() { return <p>{t`Hello`}</p>; }
             );
         }
 
+        fs::remove_dir_all(root).expect("cleanup");
+    }
+
+    #[test]
+    fn batch_source_analysis_keeps_order_and_cache_results_independent_of_threads() {
+        let root = temp_root("source-analysis-thread-count");
+        fs::create_dir_all(&root).expect("create root");
+        let mut files = Vec::new();
+        for index in 0..12 {
+            let path = root.join(format!("fixture-{index:02}.tsx"));
+            fs::write(
+                &path,
+                format!(
+                    "import {{ t }} from \"@palamedes/core/macro\";\nexport function Label{index}({{ status }}) {{ return t`${{status}}`; }}\n"
+                ),
+            )
+            .expect("write fixture");
+            fs::File::options()
+                .write(true)
+                .open(&path)
+                .expect("open fixture")
+                .set_modified(std::time::SystemTime::now() - std::time::Duration::from_secs(10))
+                .expect("age fixture");
+            files.push(SourceFileAnalysisRequest {
+                path: path.to_string_lossy().into_owned(),
+                filename: format!("src/fixture-{index:02}.tsx"),
+            });
+        }
+        // Duplicate inputs are reachable through library callers and must keep
+        // their caller-provided order even though cache insertion is serial.
+        files.push(files[3].clone());
+
+        let options = ExtractCatalogMessagesOptions {
+            rules: SourceRuleOptions::default(),
+            ..ExtractCatalogMessagesOptions::default()
+        };
+        let run = |threads, cache: &mut ExtractCache| {
+            analyze_source_files_cached(
+                &files,
+                &root.to_string_lossy(),
+                &options,
+                Some(threads),
+                cache,
+            )
+            .expect("batch source analysis")
+            .into_iter()
+            .map(|result| {
+                let result = result.expect("fixture analysis");
+                serde_json::to_vec(&(result.source, result.analysis))
+                    .expect("serialize deterministic analysis")
+            })
+            .collect::<Vec<_>>()
+        };
+
+        let mut uncached = ExtractCache::disabled();
+        let serial = run(1, &mut uncached);
+        for threads in [2, 4, 8] {
+            let mut cache = ExtractCache::disabled();
+            assert_eq!(serial, run(threads, &mut cache), "thread count {threads}");
+        }
+
+        let cache_path = root.join("cache.json");
+        let mut warm_cache =
+            ExtractCache::load_with_options(&cache_path, &root.to_string_lossy(), &options);
+        assert_eq!(serial, run(4, &mut warm_cache));
+        assert_eq!(warm_cache.len(), 12);
+        assert_eq!(serial, run(2, &mut warm_cache));
+
+        fs::remove_dir_all(root).expect("cleanup");
+    }
+
+    #[test]
+    fn batch_source_analysis_preserves_partial_failures_in_input_order() {
+        let root = temp_root("source-analysis-partial-failure");
+        fs::create_dir_all(&root).expect("create root");
+        let valid = root.join("valid.ts");
+        fs::write(&valid, "export const value = 1;\n").expect("write source");
+        let files = vec![
+            SourceFileAnalysisRequest {
+                path: valid.to_string_lossy().into_owned(),
+                filename: "src/valid.ts".to_owned(),
+            },
+            SourceFileAnalysisRequest {
+                path: root.join("missing.ts").to_string_lossy().into_owned(),
+                filename: "src/missing.ts".to_owned(),
+            },
+        ];
+        let mut cache = ExtractCache::disabled();
+        let outcomes = analyze_source_files_cached(
+            &files,
+            &root.to_string_lossy(),
+            &ExtractCatalogMessagesOptions::default(),
+            Some(4),
+            &mut cache,
+        )
+        .expect("batch executes");
+
+        assert!(outcomes[0].is_ok());
+        assert!(outcomes[1].is_err());
         fs::remove_dir_all(root).expect("cleanup");
     }
 

--- a/crates/palamedes/src/lib.rs
+++ b/crates/palamedes/src/lib.rs
@@ -85,12 +85,12 @@ pub use catalog_update::{
 pub use diagnostic::{CatalogDiagnostic, CatalogDiagnosticSeverity, CatalogDiagnosticSourceKey};
 pub use error::{PalamedesError, PalamedesResult};
 pub use extract::{
-    analyze_source, analyze_source_file_cached, analyze_source_with_mdx_options,
-    analyze_source_with_options, extract_catalog_messages_cached,
+    analyze_source, analyze_source_file_cached, analyze_source_files_cached,
+    analyze_source_with_mdx_options, analyze_source_with_options, extract_catalog_messages_cached,
     extract_catalog_messages_from_files, extract_catalog_messages_from_files_with_options,
     extract_messages, extract_messages_with_mdx_options, ExtractCatalogFileFailure,
     ExtractCatalogMessagesOptions, ExtractCatalogMessagesRequest, ExtractCatalogMessagesResult,
-    ExtractedMessageRecord,
+    ExtractedMessageRecord, SourceFileAnalysisRequest,
 };
 pub use extract_cache::{default_cache_path, ExtractCache};
 pub use mdx::{

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -150,10 +150,11 @@ not run.
 
 Suppressions are deliberately code-specific and line-scoped. A directive must
 start immediately after a supported comment opener, allowing whitespace but no
-other text. JS and TS accept `//` and `/* ... */`; JSX and TSX accept those
-forms including JSX `{/* ... */}`; MDX accepts HTML `<!-- ... -->` and JSX
-`{/* ... */}`. MDX fenced code blocks are always ignored so documentation
-examples cannot become unused suppressions.
+other text; in block and HTML comments, that whitespace may continue onto the
+directive's physical line. JS and TS accept `//` and `/* ... */`; JSX and TSX
+accept those forms including JSX `{/* ... */}`; MDX accepts HTML `<!-- ... -->`
+and JSX `{/* ... */}`. MDX fenced code blocks are always ignored so
+documentation examples cannot become unused suppressions.
 
 ```tsx
 // palamedes-lint-disable-next-line pmds/no-placeholder-only-message

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -153,8 +153,9 @@ start immediately after a supported comment opener, allowing whitespace but no
 other text; in block and HTML comments, that whitespace may continue onto the
 directive's physical line. JS and TS accept `//` and `/* ... */`; JSX and TSX
 accept those forms including JSX `{/* ... */}`; MDX accepts HTML `<!-- ... -->`
-and JSX `{/* ... */}`. MDX fenced code blocks are always ignored so
-documentation examples cannot become unused suppressions.
+and JSX `{/* ... */}`; JavaScript expressions in MDX also accept their native
+`//` and `/* ... */` forms. Raw MDX template text and fenced code blocks are
+always ignored so documentation examples cannot become unused suppressions.
 
 ```tsx
 // palamedes-lint-disable-next-line pmds/no-placeholder-only-message

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -101,12 +101,13 @@ pmds lint --fail-on warning
 
 Options:
 
-| Option                | Description                                               |
-| --------------------- | --------------------------------------------------------- |
-| `-c, --config <path>` | Use a specific config file.                               |
-| `--json`              | Print one deterministic result document.                  |
-| `--fail-on <level>`   | Fail on `error` or `warning`. Default: `error`.           |
-| `--no-cache`          | Ignore and do not write the shared source-analysis cache. |
+| Option                | Description                                                                                                         |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `-c, --config <path>` | Use a specific config file.                                                                                         |
+| `--json`              | Print one deterministic result document.                                                                            |
+| `--fail-on <level>`   | Fail on `error` or `warning`. Default: `error`.                                                                     |
+| `--threads <COUNT>`   | Worker threads for bounded parallel source analysis. Overrides `extract-threads`; defaults to `4`; `1` runs serial. |
+| `--no-cache`          | Ignore and do not write the shared source-analysis cache.                                                           |
 
 Human diagnostics contain file, line, column, severity, stable code, message,
 and actionable help. JSON contains `diagnostics`, `failedFiles`, and a
@@ -138,11 +139,21 @@ by file. The document shape is stable:
 }
 ```
 
-Exit code `0` means the configured threshold passed, `1` means diagnostics met
-the threshold or a file could not be analyzed, and `2` is reserved by Clap for
-invalid command-line usage.
+Exit code `0` means the configured threshold passed. Exit code `4` means lint
+completed and either diagnostics met the configured `--fail-on` threshold
+(whether errors alone or errors and warnings) or one or more source files could
+not be analyzed. Exit code `1` means configuration, I/O, or output execution
+failed before lint could produce its result. Exit code `2` remains reserved by
+Clap for invalid command-line usage. This mirrors `extract --check`: a completed
+verdict has a dedicated code that CI can distinguish from a command that could
+not run.
 
-Suppressions are deliberately code-specific and line-scoped:
+Suppressions are deliberately code-specific and line-scoped. A directive must
+start immediately after a supported comment opener, allowing whitespace but no
+other text. JS and TS accept `//` and `/* ... */`; JSX and TSX accept those
+forms including JSX `{/* ... */}`; MDX accepts HTML `<!-- ... -->` and JSX
+`{/* ... */}`. MDX fenced code blocks are always ignored so documentation
+examples cannot become unused suppressions.
 
 ```tsx
 // palamedes-lint-disable-next-line pmds/no-placeholder-only-message
@@ -155,6 +166,10 @@ Unknown codes, directives without a code, and valid suppressions that no longer
 match a finding are reported by `pmds lint`.
 The default `.palamedes/extract-cache.json` stores compatible messages and
 diagnostics together, so `extract` and `lint` can reuse the same native parse.
+Lint follows extraction's bounded parallel read/parse model. Workers only
+observe the immutable cache; results are suppressed, merged, and inserted into
+the cache serially in source-file order, so cold, warm, and repeated runs keep
+the same diagnostic output.
 
 ## `pmds audit`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -31,20 +31,20 @@ catalogs:
 
 ## Fields
 
-| Field                   | Required | Type                                   | Notes                                                                               |
-| ----------------------- | -------- | -------------------------------------- | ----------------------------------------------------------------------------------- |
-| `locales`               | Yes      | `string[]`                             | All locale codes known to the project. Must include `source-locale`.                |
-| `source-locale`         | Yes      | `string`                               | Locale used by source messages.                                                     |
-| `catalogs`              | Yes      | catalog array                          | Catalog locations and source scan patterns.                                         |
-| `fallback-locales`      | No       | `string[] \| Record<string, string[]>` | Shared or per-locale fallback chain.                                                |
-| `pseudo-locale`         | No       | `string`                               | Locale code used for pseudo-localized UI testing.                                   |
-| `source-reference-root` | No       | `git \| config \| lingui \| path`      | Root used for catalog source references. Defaults to nearest Git root, then config. |
-| `reference-scopes`      | No       | `boolean`                              | Adds stable source scopes to catalog references. Defaults to `true`.                |
-| `mdx`                   | No       | MDX options                            | Shared native MDX extraction and Vite compilation behavior.                         |
-| `lint`                  | No       | source lint options                    | Source-authoring rule levels used by `pmds lint`.                                   |
-| `plugins`               | No       | `(string \| [string, options])[]`      | Explicit CLI plugin packages. Never auto-discovered.                                |
-| `extract-threads`       | No       | `number`                               | Worker threads for the parallel extraction pass. Defaults to `4`; `1` runs serial.  |
-| `extract-cache`         | No       | `boolean`                              | Reuse the shared extraction/source-analysis cache. Defaults to `true`.              |
+| Field                   | Required | Type                                   | Notes                                                                                       |
+| ----------------------- | -------- | -------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `locales`               | Yes      | `string[]`                             | All locale codes known to the project. Must include `source-locale`.                        |
+| `source-locale`         | Yes      | `string`                               | Locale used by source messages.                                                             |
+| `catalogs`              | Yes      | catalog array                          | Catalog locations and source scan patterns.                                                 |
+| `fallback-locales`      | No       | `string[] \| Record<string, string[]>` | Shared or per-locale fallback chain.                                                        |
+| `pseudo-locale`         | No       | `string`                               | Locale code used for pseudo-localized UI testing.                                           |
+| `source-reference-root` | No       | `git \| config \| lingui \| path`      | Root used for catalog source references. Defaults to nearest Git root, then config.         |
+| `reference-scopes`      | No       | `boolean`                              | Adds stable source scopes to catalog references. Defaults to `true`.                        |
+| `mdx`                   | No       | MDX options                            | Shared native MDX extraction and Vite compilation behavior.                                 |
+| `lint`                  | No       | source lint options                    | Source-authoring rule levels used by `pmds lint`.                                           |
+| `plugins`               | No       | `(string \| [string, options])[]`      | Explicit CLI plugin packages. Never auto-discovered.                                        |
+| `extract-threads`       | No       | `number`                               | Worker threads for parallel extraction and lint analysis. Defaults to `4`; `1` runs serial. |
+| `extract-cache`         | No       | `boolean`                              | Reuse the shared extraction/source-analysis cache. Defaults to `true`.                      |
 
 The native CLI and JS config loader both accept snake_case aliases for these
 hyphenated config keys: `source_locale`, `fallback_locales`, `pseudo_locale`,
@@ -52,8 +52,8 @@ hyphenated config keys: `source_locale`, `fallback_locales`, `pseudo_locale`,
 
 `extract-threads` and `extract-cache` (and their `extract_threads` /
 `extract_cache` aliases) are read by the native `pmds` CLI only. They tune
-extraction, which the CLI owns; the JS config loader in `@palamedes/config`
-ignores them, and no bundler plugin reads them.
+extraction and lint source analysis, which the CLI owns; the JS config loader
+in `@palamedes/config` ignores them, and no bundler plugin reads them.
 
 `extract-threads` bounds the parallel read/parse pass. The default of `4` is a
 measured floor rather than a core count: extraction gets slower again above it,
@@ -61,7 +61,8 @@ because a one-shot `pmds extract` pays worker setup on every invocation and
 never amortizes it. Raise it only with a measurement on your own corpus and
 hardware; see
 [ADR-013](https://github.com/sebastian-software/palamedes/blob/main/adr/013-bounded-parallel-extraction.md)
-for the numbers. `--threads` on the command line overrides this value.
+for the numbers. `--threads` on `pmds extract` or `pmds lint` overrides this
+value.
 
 `extract-cache` controls whether extraction and source lint reuse their shared
 analysis for files that have not changed. The cache lives at

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -83,6 +83,7 @@ pnpm exec pmds extract --verbose
 pnpm exec pmds lint
 pnpm exec pmds lint --json
 pnpm exec pmds lint --fail-on warning
+pnpm exec pmds lint --threads 1
 pnpm exec pmds lint --no-cache
 pnpm exec pmds audit
 pnpm exec pmds audit --json
@@ -104,6 +105,11 @@ must fail CI; the default continues to fail only on errors.
 `pmds lint` is non-mutating and checks Palamedes authoring across the same
 configured sources as extraction. It supports stable human and JSON output,
 configured rule levels, code-specific line suppressions, and CI thresholds.
+Its verdict uses exit code `4` when diagnostics meet `--fail-on` or a source
+file cannot be analyzed; exit code `1` remains for configuration, I/O, and
+output failures, and `2` for invalid CLI usage. Lint source analysis uses the
+same bounded parallel worker policy as extraction; `--threads` overrides
+`extract-threads` and `1` runs it serially.
 
 `pmds extract --check` projects configured PO and FCL catalogs through the
 same extraction and serialization path without changing catalog files or


### PR DESCRIPTION
Closes #578

## Summary

- Parse lint suppressions only when a directive begins immediately after a supported comment opener; support JS/TS line and block comments, JSX comments, and MDX HTML/JSX comments while ignoring fenced MDX examples.
- Reserve exit code `4` for every completed lint failure report (threshold verdicts and per-file analysis failures); retain `1` for execution/configuration failures and `2` for Clap usage errors.
- Analyze lint files through a bounded Rayon batch using immutable cache reads, followed by serial in-order suppression application and cache insertion for byte-stable output and cache semantics.

## Validation

- Added adversarial suppression, exact exit-code, batch worker-count, duplicate-input, cold/warm-cache, and partial-failure coverage.
- Passed Rust 1.95 and stable workspace fmt, Clippy, and tests; `pnpm format:check`; and the CLI package test with stable Cargo.

🔧 Emily Carter · Implementation Agent