### PR TITLE
fix(eslint-plugin): report native analysis failures once

### DIFF
--- a/crates/palamedes/src/translation_scope.rs
+++ b/crates/palamedes/src/translation_scope.rs
@@ -152,7 +152,7 @@ fn identifier_name<'a>(expression: &'a Expression<'a>) -> Option<(&'a str, (u32,
     }
 }
 
-/// Formats a byte offset as a one-based filename, line, and column location.
+/// Formats a byte offset as a one-based filename, line, and Unicode-scalar column location.
 pub(crate) fn source_location(source: &str, filename: &str, offset: usize) -> String {
     let mut line = 1usize;
     let mut line_start = 0usize;
@@ -167,7 +167,20 @@ pub(crate) fn source_location(source: &str, filename: &str, offset: usize) -> St
         }
     }
 
-    let column = offset.saturating_sub(line_start) + 1;
+    let column = source[line_start..offset].chars().count() + 1;
 
     format!("{filename}:{line}:{column}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::source_location;
+
+    #[test]
+    fn source_locations_use_unicode_scalar_columns() {
+        let source = "const label = \"😀\"; t`Hello`";
+        let offset = source.find("t`Hello`").expect("translation macro offset");
+
+        assert_eq!(source_location(source, "view.tsx", offset), "view.tsx:1:20");
+    }
 }

--- a/docs/research/oxlint-eslint-adapter.md
+++ b/docs/research/oxlint-eslint-adapter.md
@@ -48,6 +48,20 @@ per unchanged file. A source edit changes the fingerprint and invalidates the
 entry. Tests exercise the coordinator with distinct source objects to cover
 hosts that create a separate context for each enabled rule.
 
+Fatal native analysis errors take a separate path. The coordinator records the
+first reporting facade in a `WeakSet` keyed by the host `SourceCode` object, so
+an error is emitted once per parse even if cached analysis is visited by several
+rules. A new `SourceCode` identity is a new editor parse and may report again;
+the weak key does not retain editor source objects. ESLint-compatible APIs bind
+the displayed rule ID to the rule calling `report`, so no neutral coordinator
+ID can be emitted without adding a separately enabled public rule. The adapter
+therefore uses the first visiting enabled facade and prefixes the diagnostic as
+`Palamedes native analysis failed`, rather than presenting it as that semantic
+rule's result. Native authoring errors' explicit `at file:line:column` and
+`Location: file:line:column` locations are converted from one-based Unicode
+scalar coordinates to host UTF-16 positions; malformed or absent locations use
+the deterministic file-start fallback.
+
 ## Rule Mapping
 
 | Native code                            | ESLint/Oxlint rule                          | Recommended                                          |

--- a/docs/research/oxlint-eslint-adapter.md
+++ b/docs/research/oxlint-eslint-adapter.md
@@ -49,10 +49,11 @@ entry. Tests exercise the coordinator with distinct source objects to cover
 hosts that create a separate context for each enabled rule.
 
 Fatal native analysis errors take a separate path. The coordinator records the
-first reporting facade in a `WeakSet` keyed by the host `SourceCode` object, so
-an error is emitted once per parse even if cached analysis is visited by several
-rules. A new `SourceCode` identity is a new editor parse and may report again;
-the weak key does not retain editor source objects. ESLint-compatible APIs bind
+first facade's claim in a `WeakMap<SourceCodeLike, true>` keyed by the host
+`SourceCode` object, so an error is emitted once per parse even if cached
+analysis is visited by several rules. A new `SourceCode` identity is a new
+editor parse and may report again; the weak key does not retain editor source
+objects. ESLint-compatible APIs bind
 the displayed rule ID to the rule calling `report`, so no neutral coordinator
 ID can be emitted without adding a separately enabled public rule. The adapter
 therefore uses the first visiting enabled facade and prefixes the diagnostic as

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -80,6 +80,17 @@ repeat native parsing. UTF-8 byte ranges from Rust are converted to the UTF-16
 indices expected by JavaScript linters before `SourceCode#getLocFromIndex` maps
 them to editor locations.
 
+Fatal native analysis failures are also emitted once per host parse, even when
+several Palamedes rules are enabled. The coordinator owns that one-shot state
+with the host `SourceCode` identity, so a later editor re-parse reports the
+failure again while an unchanged parse never duplicates it. ESLint-compatible
+hosts require diagnostics to be reported by an enabled rule, so the host
+`ruleId` is the first enabled Palamedes facade; the message explicitly identifies
+the diagnostic as a shared native-analysis failure, not a finding from that rule.
+When a native error contains Palamedes' structured `at file:line:column` or
+`Location: file:line:column` form, the adapter uses that source location;
+otherwise it safely falls back to the start of the file.
+
 There are no fixes in this version. `pmds lint` suppressions are intentionally
 separate from ESLint/Oxlint directives and are only consumed by the CLI.
 

--- a/packages/eslint-plugin/src/analysis.ts
+++ b/packages/eslint-plugin/src/analysis.ts
@@ -55,7 +55,7 @@ export function createAnalysisCoordinator(analyze: AnalyzeSource = analyzeSource
   const byFilename = new Map<string, CachedAnalysis>()
   // Deliberately separate from the analysis cache: a new SourceCode instance is
   // a new host parse, even when it can reuse a cached native result.
-  const reportedFailures = new WeakSet<SourceCodeLike>()
+  const reportedFailures = new WeakMap<SourceCodeLike, true>()
   let nativeCalls = 0
 
   function analyzeContext(context: AnalysisContext): CachedAnalysis {
@@ -93,16 +93,16 @@ export function createAnalysisCoordinator(analyze: AnalyzeSource = analyzeSource
 
   /**
    * Return a fatal native failure only to the first facade for this SourceCode.
-   * WeakSet ownership makes this atomic with respect to interleaved rule visits
+   * WeakMap ownership makes this atomic with respect to interleaved rule visits
    * without retaining host parse objects between editor runs.
    */
   function takeUnreportedFailure(context: AnalysisContext): NativeFailure | undefined {
     const result = analyzeContext(context)
-    if (!result.failure || reportedFailures.has(context.sourceCode)) {
+    if (!result.failure || reportedFailures.get(context.sourceCode)) {
       return undefined
     }
 
-    reportedFailures.add(context.sourceCode)
+    reportedFailures.set(context.sourceCode, true)
     return result.failure
   }
 

--- a/packages/eslint-plugin/src/analysis.ts
+++ b/packages/eslint-plugin/src/analysis.ts
@@ -24,7 +24,18 @@ export type AnalyzeSource = (
 type CachedAnalysis = {
   fingerprint: string
   diagnostics: SourceDiagnostic[]
-  failure?: string
+  failure?: NativeFailure
+}
+
+export type NativeFailure = {
+  message: string
+  location?: NativeFailureLocation
+}
+
+/** A one-based native source location, before conversion to a host location. */
+export type NativeFailureLocation = {
+  line: number
+  column: number
 }
 
 const ALL_RULES: SourceAnalysisOptions = {
@@ -42,6 +53,9 @@ export function mightContainPalamedesSource(source: string): boolean {
 export function createAnalysisCoordinator(analyze: AnalyzeSource = analyzeSourceNative) {
   const bySourceCode = new WeakMap<SourceCodeLike, CachedAnalysis>()
   const byFilename = new Map<string, CachedAnalysis>()
+  // Deliberately separate from the analysis cache: a new SourceCode instance is
+  // a new host parse, even when it can reuse a cached native result.
+  const reportedFailures = new WeakSet<SourceCodeLike>()
   let nativeCalls = 0
 
   function analyzeContext(context: AnalysisContext): CachedAnalysis {
@@ -69,7 +83,7 @@ export function createAnalysisCoordinator(analyze: AnalyzeSource = analyzeSource
       cached = {
         fingerprint,
         diagnostics: [],
-        failure: error instanceof Error ? error.message : String(error),
+        failure: nativeFailureFromError(error),
       }
     }
     bySourceCode.set(context.sourceCode, cached)
@@ -77,10 +91,83 @@ export function createAnalysisCoordinator(analyze: AnalyzeSource = analyzeSource
     return cached
   }
 
+  /**
+   * Return a fatal native failure only to the first facade for this SourceCode.
+   * WeakSet ownership makes this atomic with respect to interleaved rule visits
+   * without retaining host parse objects between editor runs.
+   */
+  function takeUnreportedFailure(context: AnalysisContext): NativeFailure | undefined {
+    const result = analyzeContext(context)
+    if (!result.failure || reportedFailures.has(context.sourceCode)) {
+      return undefined
+    }
+
+    reportedFailures.add(context.sourceCode)
+    return result.failure
+  }
+
   return {
     analyzeContext,
+    takeUnreportedFailure,
     nativeCallCount: () => nativeCalls,
   }
+}
+
+function nativeFailureFromError(error: unknown): NativeFailure {
+  const message = error instanceof Error ? error.message : String(error)
+  return {
+    message,
+    location: parseNativeFailureLocation(message),
+  }
+}
+
+/**
+ * Native authoring errors deliberately format a source location after either
+ * `at ` or `Location: `. Restrict parsing to those templates so an arbitrary
+ * colon in an explanatory or multi-line message cannot become a false location.
+ */
+export function parseNativeFailureLocation(message: string): NativeFailureLocation | undefined {
+  const match = /(?:\bat |\bLocation: )(.+):(\d+):(\d+)(?=[:.\n]|$)/.exec(message)
+  if (!match) {
+    return undefined
+  }
+
+  const line = Number(match[2])
+  const column = Number(match[3])
+  return Number.isSafeInteger(line) && line >= 1 && Number.isSafeInteger(column) && column >= 1
+    ? { line, column }
+    : undefined
+}
+
+/**
+ * Convert Palamedes' one-based Unicode-scalar coordinates to the UTF-16 index
+ * consumed by ESLint and Oxlint. Invalid or out-of-range locations are not
+ * trustworthy and intentionally fall back to the start of the file.
+ */
+export function nativeFailureLocationToUtf16Index(
+  source: string,
+  location: NativeFailureLocation
+): number | undefined {
+  if (location.line < 1 || location.column < 1) {
+    return undefined
+  }
+
+  const lines = source.split("\n")
+  const line = lines[location.line - 1]
+  if (line === undefined) {
+    return undefined
+  }
+
+  const characters = [...line]
+  if (location.column > characters.length + 1) {
+    return undefined
+  }
+
+  let index = 0
+  for (let lineIndex = 0; lineIndex < location.line - 1; lineIndex += 1) {
+    index += lines[lineIndex].length + 1
+  }
+  return index + characters.slice(0, location.column - 1).join("").length
 }
 
 function sourceFingerprint(source: string): string {

--- a/packages/eslint-plugin/src/index.test.ts
+++ b/packages/eslint-plugin/src/index.test.ts
@@ -8,7 +8,12 @@ import { fileURLToPath } from "node:url"
 import { ESLint } from "eslint"
 
 import plugin from "./index"
-import { createAnalysisCoordinator, utf8ByteOffsetToUtf16Index } from "./analysis"
+import {
+  createAnalysisCoordinator,
+  nativeFailureLocationToUtf16Index,
+  parseNativeFailureLocation,
+  utf8ByteOffsetToUtf16Index,
+} from "./analysis"
 
 function eslintFor(rules: Record<string, "warn" | "error">): ESLint {
   return new ESLint({
@@ -53,6 +58,106 @@ describe("native Palamedes lint adapter", () => {
     })
     expect(analyze).toHaveBeenCalledTimes(2)
   })
+
+  it("claims a cached native failure once per SourceCode identity", () => {
+    const analyze = vi.fn(() => {
+      throw new Error("Translation macro `t` must be used inside a function at view.tsx:2:1.")
+    })
+    const coordinator = createAnalysisCoordinator(analyze)
+    const firstParse = { text: "import { t } from '@palamedes/core/macro'\nconst value = t`Hello`" }
+
+    expect(
+      coordinator.takeUnreportedFailure({ filename: "view.tsx", sourceCode: firstParse })
+    ).toMatchObject({
+      message: expect.stringContaining("must be used inside a function"),
+      location: { line: 2, column: 1 },
+    })
+    expect(
+      coordinator.takeUnreportedFailure({ filename: "view.tsx", sourceCode: firstParse })
+    ).toBeUndefined()
+
+    const reparsed = { text: firstParse.text }
+    expect(
+      coordinator.takeUnreportedFailure({ filename: "view.tsx", sourceCode: reparsed })
+    ).toMatchObject({ location: { line: 2, column: 1 } })
+    expect(analyze).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not carry a failed parse into a later successful source", () => {
+    const analyze = vi.fn((source: string) => {
+      if (source === "broken") {
+        throw new Error("Parse error: malformed native parser output")
+      }
+      return { diagnostics: [] }
+    })
+    const coordinator = createAnalysisCoordinator(analyze)
+
+    expect(
+      coordinator.takeUnreportedFailure({ filename: "view.tsx", sourceCode: { text: "broken" } })
+    ).toMatchObject({ message: "Parse error: malformed native parser output" })
+    expect(
+      coordinator.takeUnreportedFailure({ filename: "view.tsx", sourceCode: { text: "fixed" } })
+    ).toBeUndefined()
+    expect(
+      coordinator.analyzeContext({ filename: "view.tsx", sourceCode: { text: "fixed" } })
+        .diagnostics
+    ).toStrictEqual([])
+    expect(analyze).toHaveBeenCalledTimes(2)
+  })
+
+  it("uses only native location templates and converts Unicode coordinates", () => {
+    expect(
+      parseNativeFailureLocation(
+        "Unsupported `t` macro usage at C:\\repo:with:colon\\view.tsx:2:3: invalid descriptor\nkeep this detail"
+      )
+    ).toStrictEqual({ line: 2, column: 3 })
+    expect(
+      parseNativeFailureLocation(
+        "Translation macro `t` must be used inside a function at /repo/view.tsx:1:1. Wrap it."
+      )
+    ).toStrictEqual({ line: 1, column: 1 })
+    expect(
+      parseNativeFailureLocation("detail C:\\repo\\view.tsx:2:3 is not a native location")
+    ).toBeUndefined()
+    expect(parseNativeFailureLocation("Location: view.tsx:1:0.")).toBeUndefined()
+    expect(nativeFailureLocationToUtf16Index("😀x\ntext", { line: 1, column: 2 })).toBe(2)
+    expect(nativeFailureLocationToUtf16Index("😀x", { line: 1, column: 0 })).toBeUndefined()
+    expect(nativeFailureLocationToUtf16Index("x", { line: 2, column: 1 })).toBeUndefined()
+  })
+
+  it.each([
+    {
+      name: "dynamic descriptor",
+      source: `import { t } from "@palamedes/core/macro"
+function View() { return t({ message }) }`,
+      line: 2,
+      column: 26,
+    },
+    {
+      name: "macro outside a function",
+      source: `import { t } from "@palamedes/core/macro"
+const message = t\`Hello\``,
+      line: 2,
+      column: 17,
+    },
+  ])(
+    "reports one native $name failure through enabled ESLint facades",
+    async ({ source, line, column }) => {
+      const [result] = await eslintFor({
+        "palamedes/no-placeholder-only-message": "warn",
+        "palamedes/no-empty-component-only-message": "warn",
+        "palamedes/prefer-trans-in-jsx": "warn",
+      }).lintText(source, { filePath: "view.jsx" })
+
+      expect(result.messages).toHaveLength(1)
+      expect(result.messages[0]).toMatchObject({
+        ruleId: "palamedes/no-placeholder-only-message",
+        line,
+        column,
+        message: expect.stringContaining("Palamedes native analysis failed"),
+      })
+    }
+  )
 
   it.each(["react", "solid"])(
     "reports aliased %s macros through separate ESLint rule names at the exact Unicode range",
@@ -143,6 +248,58 @@ function View({ status }: { status: string }) {
       expect(output.diagnostics).toHaveLength(1)
       expect(output.diagnostics[0].code).toBe("palamedes(prefer-trans-in-jsx)")
       expect(output.diagnostics[0].labels[0].span).toMatchObject({ line: 4, column: 14 })
+    } finally {
+      rmSync(directory, { recursive: true, force: true })
+    }
+  })
+
+  it("reports one native authoring failure through Oxlint at its native location", () => {
+    const directory = mkdtempSync(path.join(tmpdir(), "palamedes-oxlint-native-failure-"))
+    try {
+      const pluginPath = fileURLToPath(new URL("../dist/index.mjs", import.meta.url))
+      const sourcePath = path.join(directory, "view.jsx")
+      const configPath = path.join(directory, ".oxlintrc.json")
+      writeFileSync(
+        sourcePath,
+        `import { t } from "@palamedes/core/macro"
+function View() { return t({ message }) }`
+      )
+      writeFileSync(
+        configPath,
+        JSON.stringify({
+          categories: { correctness: "off" },
+          jsPlugins: [{ name: "palamedes", specifier: pluginPath }],
+          rules: {
+            "palamedes/no-placeholder-only-message": "warn",
+            "palamedes/no-empty-component-only-message": "warn",
+            "palamedes/prefer-trans-in-jsx": "warn",
+          },
+        })
+      )
+
+      const require = createRequire(import.meta.url)
+      const oxlintEntry = require.resolve("oxlint")
+      const oxlintBin = path.resolve(path.dirname(oxlintEntry), "../bin/oxlint")
+      const run = spawnSync(
+        process.execPath,
+        [oxlintBin, "--config", configPath, "--format", "json", "--threads", "1", sourcePath],
+        { cwd: directory, encoding: "utf8" }
+      )
+
+      expect(run).toMatchObject({ status: 0 })
+      const output = JSON.parse(run.stdout) as {
+        diagnostics: Array<{
+          code: string
+          labels: Array<{ span: { line: number; column: number } }>
+          message: string
+        }>
+      }
+      expect(output.diagnostics).toHaveLength(1)
+      expect(output.diagnostics[0]).toMatchObject({
+        code: "palamedes(no-placeholder-only-message)",
+        message: expect.stringContaining("Palamedes native analysis failed"),
+      })
+      expect(output.diagnostics[0].labels[0].span).toMatchObject({ line: 2, column: 26 })
     } finally {
       rmSync(directory, { recursive: true, force: true })
     }

--- a/packages/eslint-plugin/src/index.test.ts
+++ b/packages/eslint-plugin/src/index.test.ts
@@ -7,7 +7,7 @@ import { fileURLToPath } from "node:url"
 
 import { ESLint } from "eslint"
 
-import plugin from "./index"
+import plugin, { configs } from "./index"
 import {
   createAnalysisCoordinator,
   nativeFailureLocationToUtf16Index,
@@ -59,7 +59,7 @@ describe("native Palamedes lint adapter", () => {
     expect(analyze).toHaveBeenCalledTimes(2)
   })
 
-  it("claims a cached native failure once per SourceCode identity", () => {
+  it("uses weak source claims while reusing a cached native failure across fresh parses", () => {
     const analyze = vi.fn(() => {
       throw new Error("Translation macro `t` must be used inside a function at view.tsx:2:1.")
     })
@@ -158,6 +158,34 @@ const message = t\`Hello\``,
       })
     }
   )
+
+  it("reports recommended ESLint failures once per file and once again after a fresh parse", async () => {
+    const eslint = eslintFor(configs.recommended.rules)
+    const failures = ["first", "second"].map((name) => ({
+      filePath: `${name}.jsx`,
+      source: `import { t } from "@palamedes/core/macro"
+function ${name}View() { return t({ message: ${name}Message }) }`,
+    }))
+
+    const firstPass = await Promise.all(
+      failures.map(({ filePath, source }) => eslint.lintText(source, { filePath }))
+    )
+    for (const [index, [result]] of firstPass.entries()) {
+      expect(result.messages).toHaveLength(1)
+      expect(result.messages[0]).toMatchObject({
+        ruleId: "palamedes/no-placeholder-only-message",
+        message: expect.stringContaining(`Palamedes native analysis failed`),
+        line: 2,
+        column: failures[index].source.split("\n")[1].indexOf("t({") + 1,
+      })
+    }
+
+    const [freshResult] = await eslint.lintText(failures[0].source, {
+      filePath: failures[0].filePath,
+    })
+    expect(freshResult.messages).toHaveLength(1)
+    expect(freshResult.messages[0]?.message).toContain("Palamedes native analysis failed")
+  })
 
   it.each(["react", "solid"])(
     "reports aliased %s macros through separate ESLint rule names at the exact Unicode range",
@@ -300,6 +328,107 @@ function View() { return t({ message }) }`
         message: expect.stringContaining("Palamedes native analysis failed"),
       })
       expect(output.diagnostics[0].labels[0].span).toMatchObject({ line: 2, column: 26 })
+    } finally {
+      rmSync(directory, { recursive: true, force: true })
+    }
+  })
+
+  it("reports each native failure once across multiple Oxlint files in one worker", () => {
+    const directory = mkdtempSync(path.join(tmpdir(), "palamedes-oxlint-multi-failure-"))
+    try {
+      const pluginPath = fileURLToPath(new URL("../dist/index.mjs", import.meta.url))
+      const failures = Array.from({ length: 6 }, (_, index) => ({
+        filename: `f${index}.jsx`,
+        source: `import { t } from "@palamedes/core/macro"
+function View${index}() { const prefix${index} = ${index}; return t({ message: message${index} }) }`,
+      }))
+      const semanticFilename = "semantic.jsx"
+      const semanticSource = `import { t } from "@palamedes/core/macro"
+function SemanticView({ status }) {
+  return <p>{t\`${"${status}"}\`}</p>
+}`
+      const configPath = path.join(directory, ".oxlintrc.json")
+      const sourcePaths = failures.map(({ filename, source }, index) => {
+        const sourcePath = path.join(directory, filename)
+        writeFileSync(sourcePath, source)
+        return index === 1 ? [sourcePath, path.join(directory, semanticFilename)] : [sourcePath]
+      })
+      writeFileSync(path.join(directory, semanticFilename), semanticSource)
+      writeFileSync(
+        configPath,
+        JSON.stringify({
+          categories: { correctness: "off" },
+          jsPlugins: [{ name: "palamedes", specifier: pluginPath }],
+          rules: {
+            "palamedes/no-placeholder-only-message": "warn",
+            "palamedes/no-empty-component-only-message": "warn",
+            "palamedes/prefer-trans-in-jsx": "warn",
+          },
+        })
+      )
+
+      const require = createRequire(import.meta.url)
+      const oxlintEntry = require.resolve("oxlint")
+      const oxlintBin = path.resolve(path.dirname(oxlintEntry), "../bin/oxlint")
+      const run = spawnSync(
+        process.execPath,
+        [
+          oxlintBin,
+          "--config",
+          configPath,
+          "--format",
+          "json",
+          "--threads",
+          "1",
+          ...sourcePaths.flat(),
+        ],
+        { cwd: directory, encoding: "utf8" }
+      )
+
+      expect(run).toMatchObject({ status: 0 })
+      const output = JSON.parse(run.stdout) as {
+        diagnostics: Array<{
+          code: string
+          labels: Array<{ span: { line: number; column: number } }>
+          message: string
+        }>
+      }
+      const nativeDiagnostics = output.diagnostics.filter((diagnostic) =>
+        diagnostic.message.startsWith("Palamedes native analysis failed:")
+      )
+      expect(nativeDiagnostics).toHaveLength(failures.length)
+      for (const failure of failures) {
+        const diagnostic = nativeDiagnostics.filter((candidate) =>
+          candidate.message.includes(failure.filename)
+        )
+        expect(diagnostic).toHaveLength(1)
+        expect(diagnostic[0]).toMatchObject({
+          code: "palamedes(no-placeholder-only-message)",
+          message: expect.stringContaining("descriptor `message` must be a string literal"),
+          labels: [
+            {
+              span: {
+                line: 2,
+                column: failure.source.split("\n")[1].indexOf("t({") + 1,
+              },
+            },
+          ],
+        })
+      }
+
+      const semanticDiagnostics = output.diagnostics.filter(
+        (diagnostic) => !diagnostic.message.startsWith("Palamedes native analysis failed:")
+      )
+      expect(semanticDiagnostics.map(({ code }) => code).sort()).toStrictEqual([
+        "palamedes(no-placeholder-only-message)",
+        "palamedes(prefer-trans-in-jsx)",
+      ])
+      for (const diagnostic of semanticDiagnostics) {
+        expect(diagnostic.labels[0]?.span).toMatchObject({
+          line: 3,
+          column: semanticSource.split("\n")[2].indexOf("t`") + 1,
+        })
+      }
     } finally {
       rmSync(directory, { recursive: true, force: true })
     }

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -4,6 +4,7 @@ import type { ESLint } from "eslint"
 import {
   createAnalysisCoordinator,
   mightContainPalamedesSource,
+  nativeFailureLocationToUtf16Index,
   utf8ByteOffsetToUtf16Index,
 } from "./analysis"
 
@@ -37,20 +38,31 @@ function createFacade(code: DiagnosticCode, description: string): Rule {
         },
         Program() {
           const filename = context.filename ?? context.getFilename?.() ?? "<input>"
-          const result = analysis.analyzeContext({
+          const analysisContext = {
             filename,
             sourceCode: context.sourceCode,
-          })
-          if (result.failure) {
+          }
+          const failure = analysis.takeUnreportedFailure(analysisContext)
+          if (failure) {
+            const failureStart = failure.location
+              ? nativeFailureLocationToUtf16Index(context.sourceCode.text, failure.location)
+              : undefined
+            const start = failureStart ?? 0
             context.report({
               loc: {
-                start: { line: 1, column: 0 },
-                end: { line: 1, column: Math.min(1, context.sourceCode.text.length) },
+                start: context.sourceCode.getLocFromIndex(start),
+                end: context.sourceCode.getLocFromIndex(
+                  nextCodePointIndex(context.sourceCode.text, start)
+                ),
               },
-              message: `Palamedes native analysis failed: ${result.failure}`,
+              // ESLint-compatible rule APIs derive ruleId from the active
+              // facade; the message makes clear this is not a rule finding.
+              message: `Palamedes native analysis failed: ${failure.message}`,
             })
             return
           }
+
+          const result = analysis.analyzeContext(analysisContext)
 
           for (const diagnostic of result.diagnostics) {
             if (diagnostic.code !== code) continue
@@ -71,6 +83,11 @@ function createFacade(code: DiagnosticCode, description: string): Rule {
       }
     },
   }
+}
+
+function nextCodePointIndex(source: string, index: number): number {
+  const codePoint = source.codePointAt(index)
+  return Math.min(source.length, index + (codePoint !== undefined && codePoint > 0xff_ff ? 2 : 1))
 }
 
 const rules = {


### PR DESCRIPTION
## Summary

Closes #577.

- Move native-failure reporting ownership into the shared analysis coordinator, using a WeakSet keyed by each host SourceCode object. Cached failures therefore report once per parse and report again after a fresh editor re-parse.
- Keep the semantic rule facades unchanged for normal diagnostics. ESLint-compatible host APIs derive ruleId from the first visiting enabled facade, so the failure message explicitly identifies itself as a shared Palamedes native-analysis error rather than a semantic-rule finding.
- Extract only Palamedes structured source locations (including Windows paths), convert native Unicode-scalar coordinates to host UTF-16 positions, and deterministically fall back to file start for missing or malformed locations.
- Correct module-scope macro native locations to Unicode-scalar columns.

## Host coverage

ESLint and Oxlint integration tests enable all three adapter rules and assert a single native dynamic-descriptor failure at the native location. ESLint also covers a macro outside a function; coordinator tests cover cached failures, a fresh SourceCode re-lint, parse-failure fallback, malformed/absent locations, Windows/colon paths, and Unicode conversion.

## Validation

- `RUSTUP_TOOLCHAIN=1.95 pnpm build`
- `RUSTUP_TOOLCHAIN=1.95 pnpm test`
- `RUSTUP_TOOLCHAIN=1.95 pnpm check-types`
- `RUSTUP_TOOLCHAIN=1.95 pnpm check:native-types`
- `pnpm check:published-types`
- `pnpm check:release-set`
- `pnpm lint`
- `pnpm format:check`
- `RUSTUP_TOOLCHAIN=1.95 cargo test -p palamedes source_locations_use_unicode_scalar_columns`

🔧 Emily Carter · Implementation Agent