### PR TITLE
fix(cli): reserve lint plugin namespace

### DIFF
--- a/adr/017-cli-plugin-execution-boundary.md
+++ b/adr/017-cli-plugin-execution-boundary.md
@@ -23,8 +23,10 @@ longer needs a JavaScript host.
 Use one native command boundary:
 
 1. The Rust `pmds` executable owns built-in and plugin command dispatch.
-2. Built-in namespaces (`extract`, `lint`, `audit`, `report`, `catalog`, and
-   `version`) execute before configuration or plugin resolution.
+2. Built-in feature commands (`extract`, `lint`, `audit`, `report`, `catalog`,
+   and `version`) execute before configuration or plugin resolution. The current
+   reserved plugin namespace tokens are those commands plus Clap's `help`
+   subcommand; visible and hidden aliases of any root command are also reserved.
 3. Any other namespace is resolved only from the explicit `plugins` list in a
    Palamedes data config (`yaml`, `yml`, `json`, or `toml`). JavaScript and
    TypeScript files are not CLI configuration.

--- a/adr/017-cli-plugin-execution-boundary.md
+++ b/adr/017-cli-plugin-execution-boundary.md
@@ -23,8 +23,8 @@ longer needs a JavaScript host.
 Use one native command boundary:
 
 1. The Rust `pmds` executable owns built-in and plugin command dispatch.
-2. Built-in namespaces (`extract`, `audit`, `report`, `catalog`, and `version`)
-   execute before configuration or plugin resolution.
+2. Built-in namespaces (`extract`, `lint`, `audit`, `report`, `catalog`, and
+   `version`) execute before configuration or plugin resolution.
 3. Any other namespace is resolved only from the explicit `plugins` list in a
    Palamedes data config (`yaml`, `yml`, `json`, or `toml`). JavaScript and
    TypeScript files are not CLI configuration.

--- a/crates/palamedes-cli/src/main.rs
+++ b/crates/palamedes-cli/src/main.rs
@@ -3,7 +3,7 @@
 //! Built-in commands live here and are compiled into the binary. They are
 //! reached without loading configuration or resolving plugins (ADR 017), which
 //! is what guarantees that a missing or broken plugin can never affect
-//! `extract`, `audit`, `report`, `catalog`, or `version`.
+//! `extract`, `lint`, `audit`, `report`, `catalog`, or `version`.
 
 mod cli;
 mod command;

--- a/crates/palamedes-cli/src/plugins.rs
+++ b/crates/palamedes-cli/src/plugins.rs
@@ -25,7 +25,7 @@ use serde_json::{json, Value};
 use crate::command::Context;
 use crate::config::{ConfigPluginDeclaration, LoadedConfig};
 
-const BUILT_IN_NAMESPACES: &[&str] = &["extract", "audit", "report", "catalog", "version"];
+const BUILT_IN_NAMESPACES: &[&str] = &["extract", "lint", "audit", "report", "catalog", "version"];
 const PROTOCOL_VERSION: u64 = palamedes_plugin::PROTOCOL_VERSION;
 const NATIVE_EXECUTABLE_ENV: &str = palamedes_plugin::NATIVE_EXECUTABLE_ENV;
 
@@ -1230,6 +1230,7 @@ mod tests {
     use std::path::Path;
     use std::time::{SystemTime, UNIX_EPOCH};
 
+    use clap::CommandFactory;
     use serde_json::json;
 
     use std::collections::BTreeMap;
@@ -1237,8 +1238,20 @@ mod tests {
     use super::{
         finish_run, is_kebab_name, matches_constraint, parse_event, resolve_binary_plugin,
         validate_manifest, BinaryInvocation, ManifestCommand, PluginEvent, PluginInvocation,
-        PluginManifest, ResolvedPlugin, PROTOCOL_VERSION,
+        PluginManifest, ResolvedPlugin, BUILT_IN_NAMESPACES, PROTOCOL_VERSION,
     };
+    use crate::cli::Cli;
+
+    #[test]
+    fn built_in_namespaces_match_the_clap_command_tree() {
+        let cli = Cli::command();
+        let commands = cli
+            .get_subcommands()
+            .map(|command| command.get_name())
+            .collect::<Vec<_>>();
+
+        assert_eq!(BUILT_IN_NAMESPACES, commands);
+    }
 
     #[test]
     fn parses_reserved_plugin_options_and_passthrough() {
@@ -1400,12 +1413,15 @@ mod tests {
                 .code,
             "PLUGIN_INVALID"
         );
-        assert_eq!(
-            validate_manifest(&resolved, &manifest("extract", PROTOCOL_VERSION))
-                .expect_err("built-in collision rejected")
-                .code,
-            "PLUGIN_NAMESPACE_COLLISION"
-        );
+        for namespace in BUILT_IN_NAMESPACES {
+            assert_eq!(
+                validate_manifest(&resolved, &manifest(namespace, PROTOCOL_VERSION))
+                    .expect_err("built-in collision rejected")
+                    .code,
+                "PLUGIN_NAMESPACE_COLLISION",
+                "for built-in namespace {namespace}",
+            );
+        }
 
         let mut invalid_command = manifest("acme", PROTOCOL_VERSION);
         invalid_command

--- a/crates/palamedes-cli/src/plugins.rs
+++ b/crates/palamedes-cli/src/plugins.rs
@@ -5,7 +5,7 @@
 //! described over the versioned stdio protocol, and then run as child
 //! processes. No JavaScript module or executable config is loaded here.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::env;
 use std::fs;
 use std::io::{self, BufRead, BufReader, IsTerminal, Write};
@@ -19,15 +19,30 @@ use std::sync::atomic::{AtomicI32, Ordering};
 use std::sync::Once;
 use std::thread;
 
+use clap::CommandFactory;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
 use crate::command::Context;
 use crate::config::{ConfigPluginDeclaration, LoadedConfig};
 
-const BUILT_IN_NAMESPACES: &[&str] = &["extract", "lint", "audit", "report", "catalog", "version"];
 const PROTOCOL_VERSION: u64 = palamedes_plugin::PROTOCOL_VERSION;
 const NATIVE_EXECUTABLE_ENV: &str = palamedes_plugin::NATIVE_EXECUTABLE_ENV;
+
+fn reserved_plugin_namespaces() -> BTreeSet<String> {
+    command_namespace_tokens(&mut crate::cli::Cli::command())
+}
+
+fn command_namespace_tokens(command: &mut clap::Command) -> BTreeSet<String> {
+    command.build();
+    command
+        .get_subcommands()
+        .flat_map(|subcommand| {
+            std::iter::once(subcommand.get_name()).chain(subcommand.get_all_aliases())
+        })
+        .map(str::to_owned)
+        .collect()
+}
 
 /// Dispatches one external Clap subcommand through the binary plugin host.
 pub fn run(args: &[String], context: &Context) -> u8 {
@@ -271,6 +286,14 @@ fn validate_manifest(
     resolved: &ResolvedPlugin,
     manifest: &PluginManifest,
 ) -> Result<(), PluginFailure> {
+    validate_manifest_with_reserved_namespaces(resolved, manifest, &reserved_plugin_namespaces())
+}
+
+fn validate_manifest_with_reserved_namespaces(
+    resolved: &ResolvedPlugin,
+    manifest: &PluginManifest,
+    reserved_namespaces: &BTreeSet<String>,
+) -> Result<(), PluginFailure> {
     if manifest.protocol_version != PROTOCOL_VERSION {
         return Err(PluginFailure::new(
             "PLUGIN_PROTOCOL_INCOMPATIBLE",
@@ -289,7 +312,7 @@ fn validate_manifest(
             ),
         ));
     }
-    if BUILT_IN_NAMESPACES.contains(&manifest.name.as_str()) {
+    if reserved_namespaces.contains(&manifest.name) {
         return Err(PluginFailure::new(
             "PLUGIN_NAMESPACE_COLLISION",
             format!(
@@ -1230,27 +1253,81 @@ mod tests {
     use std::path::Path;
     use std::time::{SystemTime, UNIX_EPOCH};
 
-    use clap::CommandFactory;
+    use clap::Command;
     use serde_json::json;
 
-    use std::collections::BTreeMap;
+    use std::collections::{BTreeMap, BTreeSet};
 
     use super::{
-        finish_run, is_kebab_name, matches_constraint, parse_event, resolve_binary_plugin,
-        validate_manifest, BinaryInvocation, ManifestCommand, PluginEvent, PluginInvocation,
-        PluginManifest, ResolvedPlugin, BUILT_IN_NAMESPACES, PROTOCOL_VERSION,
+        command_namespace_tokens, finish_run, is_kebab_name, matches_constraint, parse_event,
+        reserved_plugin_namespaces, resolve_binary_plugin, validate_manifest,
+        validate_manifest_with_reserved_namespaces, BinaryInvocation, ManifestCommand, PluginEvent,
+        PluginInvocation, PluginManifest, ResolvedPlugin, PROTOCOL_VERSION,
     };
-    use crate::cli::Cli;
 
     #[test]
-    fn built_in_namespaces_match_the_clap_command_tree() {
-        let cli = Cli::command();
-        let commands = cli
-            .get_subcommands()
-            .map(|command| command.get_name())
-            .collect::<Vec<_>>();
+    fn reserved_plugin_namespaces_match_the_built_clap_command_tree() {
+        assert_eq!(
+            reserved_plugin_namespaces(),
+            BTreeSet::from_iter(
+                ["extract", "lint", "audit", "report", "catalog", "version", "help"]
+                    .map(str::to_owned)
+            )
+        );
+    }
 
-        assert_eq!(BUILT_IN_NAMESPACES, commands);
+    #[test]
+    fn reserved_plugin_namespaces_include_aliases_without_an_order_contract() {
+        let expected = BTreeSet::from_iter(
+            [
+                "audit",
+                "check",
+                "help",
+                "internal-check",
+                "report",
+                "summary",
+            ]
+            .map(str::to_owned),
+        );
+        let mut audit_first = Command::new("pmds")
+            .subcommand(
+                Command::new("audit")
+                    .visible_alias("check")
+                    .alias("internal-check"),
+            )
+            .subcommand(Command::new("report").visible_alias("summary"));
+        let mut report_first = Command::new("pmds")
+            .subcommand(Command::new("report").visible_alias("summary"))
+            .subcommand(
+                Command::new("audit")
+                    .visible_alias("check")
+                    .alias("internal-check"),
+            );
+
+        assert_eq!(command_namespace_tokens(&mut audit_first), expected);
+        assert_eq!(command_namespace_tokens(&mut report_first), expected);
+
+        let resolved = ResolvedPlugin {
+            specifier: "@acme/plugin".to_owned(),
+            binary_path: "/fixture/plugin".into(),
+        };
+        for namespace in ["check", "internal-check", "summary"] {
+            let manifest = PluginManifest {
+                name: namespace.to_owned(),
+                protocol_version: PROTOCOL_VERSION,
+                commands: BTreeMap::from([(
+                    "inspect".to_owned(),
+                    ManifestCommand { description: None },
+                )]),
+            };
+            assert_eq!(
+                validate_manifest_with_reserved_namespaces(&resolved, &manifest, &expected)
+                    .expect_err("alias collision rejected")
+                    .code,
+                "PLUGIN_NAMESPACE_COLLISION",
+                "for alias {namespace}"
+            );
+        }
     }
 
     #[test]
@@ -1413,9 +1490,9 @@ mod tests {
                 .code,
             "PLUGIN_INVALID"
         );
-        for namespace in BUILT_IN_NAMESPACES {
+        for namespace in reserved_plugin_namespaces() {
             assert_eq!(
-                validate_manifest(&resolved, &manifest(namespace, PROTOCOL_VERSION))
+                validate_manifest(&resolved, &manifest(&namespace, PROTOCOL_VERSION))
                     .expect_err("built-in collision rejected")
                     .code,
                 "PLUGIN_NAMESPACE_COLLISION",

--- a/crates/palamedes-cli/tests/help_dispatch.rs
+++ b/crates/palamedes-cli/tests/help_dispatch.rs
@@ -1,0 +1,19 @@
+use std::process::Command;
+
+#[test]
+fn help_is_owned_by_clap_before_plugin_dispatch() {
+    let output = Command::new(env!("CARGO_BIN_EXE_pmds"))
+        .arg("help")
+        .output()
+        .expect("run pmds help");
+
+    assert!(output.status.success(), "{output:?}");
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("Usage: pmds"),
+        "{output:?}"
+    );
+    assert!(
+        !String::from_utf8_lossy(&output.stdout).contains("PLUGIN_"),
+        "{output:?}"
+    );
+}

--- a/crates/palamedes-plugin/src/lib.rs
+++ b/crates/palamedes-plugin/src/lib.rs
@@ -321,7 +321,7 @@ impl CommandContext<'_> {
     }
 
     /// A prepared subprocess invocation of a documented built-in command
-    /// (`extract`, `audit`, `report`, `catalog`, `version`), or `None` when
+    /// (`extract`, `lint`, `audit`, `report`, `catalog`, `version`), or `None` when
     /// the host did not provide the sidecar path. The plugin decides how to
     /// run it; with `--json` it should capture the output instead of letting
     /// it reach the plugin's own stdout.

--- a/docs/api/cli-binary-plugin.md
+++ b/docs/api/cli-binary-plugin.md
@@ -71,9 +71,11 @@ The plugin answers with exactly one manifest event:
 }
 ```
 
-Namespaces and commands must be lowercase kebab-case. Plugin namespaces cannot
-collide with built-ins (`extract`, `lint`, `audit`, `report`, `catalog`,
-`version`) or another configured plugin.
+Namespaces and commands must be lowercase kebab-case. The six built-in feature
+commands are `extract`, `lint`, `audit`, `report`, `catalog`, and `version`.
+Plugin namespaces cannot use those tokens, Clap's `help` subcommand, or any
+visible or hidden alias of a root command; they also cannot collide with another
+configured plugin.
 
 A `run` request carries the invocation and resolved project context:
 

--- a/docs/api/cli-binary-plugin.md
+++ b/docs/api/cli-binary-plugin.md
@@ -72,8 +72,8 @@ The plugin answers with exactly one manifest event:
 ```
 
 Namespaces and commands must be lowercase kebab-case. Plugin namespaces cannot
-collide with built-ins (`extract`, `audit`, `report`, `catalog`, `version`) or
-another configured plugin.
+collide with built-ins (`extract`, `lint`, `audit`, `report`, `catalog`,
+`version`) or another configured plugin.
 
 A `run` request carries the invocation and resolved project context:
 


### PR DESCRIPTION
## Summary

- Reserve `lint` as a built-in plugin namespace and reject it with `PLUGIN_NAMESPACE_COLLISION`.
- Add a test that keeps the reserved namespace constant aligned with the Clap command tree.
- Correct the complete built-in command contract in ADR 017, the binary-plugin protocol, and related Rust API documentation.

## Issue

Closes #576

## Validation

- `cargo fmt --all --check`
- `cargo +1.95 test -p palamedes-cli plugins::tests`
- `cargo +1.95 clippy -p palamedes-cli --all-targets -- -D warnings`
- `cargo +1.95 clippy --workspace --all-targets --locked -- -D warnings`
- `cargo +1.95 test --workspace --locked`
- `pnpm check:llms`

## Follow-up

None.

🔧 Emily Carter · Implementation Agent