### PR TITLE
fix(core): preserve live macro imports

### DIFF
--- a/crates/palamedes/src/extract.rs
+++ b/crates/palamedes/src/extract.rs
@@ -1933,7 +1933,7 @@ fn analyze_source_in(
         });
     }
 
-    validate_translation_macro_scopes(&parsed.program, filename, source, |local_name| {
+    validate_translation_macro_scopes(&parsed.program, filename, source, |local_name, _| {
         collector
             .imported_macros
             .get(local_name)

--- a/crates/palamedes/src/source_macros.rs
+++ b/crates/palamedes/src/source_macros.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use oxc_ast::ast::{ImportDeclaration, ImportDeclarationSpecifier};
+use oxc_ast::ast::{ImportDeclaration, ImportDeclarationSpecifier, ImportOrExportKind};
 
 pub(crate) const PALAMEDES_MACRO_PACKAGES: [&str; 3] = [
     "@palamedes/core/macro",
@@ -35,6 +35,11 @@ pub(crate) fn record_macro_import_declaration(
     if let Some(specifiers) = &declaration.specifiers {
         for specifier in specifiers {
             if let ImportDeclarationSpecifier::ImportSpecifier(specifier) = specifier {
+                if declaration.import_kind != ImportOrExportKind::Value
+                    || specifier.import_kind != ImportOrExportKind::Value
+                {
+                    continue;
+                }
                 let imported_name = specifier.imported.name().to_string();
                 if matches!(imported_name.as_str(), "msg" | "defineMessage")
                     && removed_macro_import.is_none()

--- a/crates/palamedes/src/transform/imports.rs
+++ b/crates/palamedes/src/transform/imports.rs
@@ -1,18 +1,22 @@
 use std::collections::{HashMap, HashSet};
 
-use crate::source_macros::record_macro_import_declaration;
 pub(super) use crate::source_macros::ImportedMacro;
+use crate::{source_macros::record_macro_import_declaration, transform::Replacement};
 use oxc_ast::ast::{
     BindingIdentifier, IdentifierReference, ImportDeclaration, ImportDeclarationSpecifier,
     ImportOrExportKind, JSXIdentifier,
 };
 use oxc_ast_visit::{walk, Visit};
+use oxc_semantic::Semantic;
+use oxc_span::GetSpan;
+use oxc_syntax::symbol::SymbolId;
 
 pub(super) struct ImportCollector {
     runtime_module: String,
     runtime_import_name: String,
     pub macro_imports: HashMap<String, ImportedMacro>,
-    pub macro_import_ranges: Vec<(usize, usize)>,
+    macro_specifiers: Vec<MacroImportSpecifier>,
+    reference_symbols: HashMap<(u32, u32), SymbolId>,
     pub removed_macro_import: Option<(String, usize)>,
     pub has_reusable_runtime_import: bool,
     /// Number of bindings that could shadow calls through the configured local name.
@@ -28,7 +32,8 @@ impl ImportCollector {
             runtime_module: runtime_module.to_string(),
             runtime_import_name: runtime_import_name.to_string(),
             macro_imports: HashMap::new(),
-            macro_import_ranges: Vec::new(),
+            macro_specifiers: Vec::new(),
+            reference_symbols: HashMap::new(),
             removed_macro_import: None,
             has_reusable_runtime_import: false,
             runtime_import_binding_count: 0,
@@ -36,6 +41,194 @@ impl ImportCollector {
             trans_import_sources: HashSet::new(),
         }
     }
+
+    /// Resolve macro references from the same native OXC semantic analysis used
+    /// for transform decisions. Missing facts intentionally make a binding
+    /// ineligible for removal.
+    pub(super) fn resolve_macro_references(&mut self, semantic: &Semantic<'_>) {
+        for specifier in &self.macro_specifiers {
+            let Some(symbol_id) = specifier.symbol_id else {
+                continue;
+            };
+            for reference in semantic.scoping().get_resolved_references(symbol_id) {
+                let span = semantic.nodes().get_node(reference.node_id()).span();
+                self.reference_symbols
+                    .insert((span.start, span.end), symbol_id);
+            }
+        }
+    }
+
+    /// Returns a macro only if this exact use resolves to its imported binding.
+    pub(super) fn macro_at(
+        &self,
+        local_name: &str,
+        span: (u32, u32),
+    ) -> Option<(ImportedMacro, SymbolId)> {
+        let macro_info = self.macro_imports.get(local_name)?;
+        let symbol_id = *self.reference_symbols.get(&span)?;
+        self.macro_specifiers
+            .iter()
+            .any(|specifier| {
+                specifier.local_name == local_name && specifier.symbol_id == Some(symbol_id)
+            })
+            .then(|| (macro_info.clone(), symbol_id))
+    }
+
+    pub(super) fn macro_import_cleanup_replacements(
+        &self,
+        source: &str,
+        semantic: &Semantic<'_>,
+        consumed_binding_ranges: &[(SymbolId, usize, usize)],
+    ) -> Vec<Replacement> {
+        let mut removable = HashSet::new();
+        for (index, specifier) in self.macro_specifiers.iter().enumerate() {
+            let Some(symbol_id) = specifier.symbol_id else {
+                continue;
+            };
+            let all_value_references_consumed = semantic
+                .scoping()
+                .get_resolved_references(symbol_id)
+                .filter(|reference| reference.is_value())
+                .all(|reference| {
+                    let span = semantic.nodes().get_node(reference.node_id()).span();
+                    consumed_binding_ranges
+                        .iter()
+                        .any(|(consumed_symbol, start, end)| {
+                            *consumed_symbol == symbol_id
+                                && *start <= span.start as usize
+                                && span.end as usize <= *end
+                        })
+                });
+            if all_value_references_consumed {
+                removable.insert(index);
+            }
+        }
+
+        let mut replacements = Vec::new();
+        let mut declarations = HashMap::<(usize, usize), Vec<usize>>::new();
+        for index in removable {
+            let specifier = &self.macro_specifiers[index];
+            declarations
+                .entry(specifier.declaration_range)
+                .or_default()
+                .push(index);
+        }
+
+        for (declaration_range, removed) in declarations {
+            let all_macro_specifiers = self
+                .macro_specifiers
+                .iter()
+                .filter(|specifier| specifier.declaration_range == declaration_range)
+                .count();
+            if removed.len() == all_macro_specifiers
+                && all_macro_specifiers == declaration_specifier_count(source, declaration_range)
+            {
+                replacements.push(Replacement {
+                    start: declaration_range.0,
+                    end: declaration_range.1,
+                    text: String::new(),
+                });
+                continue;
+            }
+
+            for index in removed {
+                let specifier = &self.macro_specifiers[index];
+                if let Some((start, end)) =
+                    removable_specifier_range(source, declaration_range, specifier.specifier_range)
+                {
+                    replacements.push(Replacement {
+                        start,
+                        end,
+                        text: String::new(),
+                    });
+                }
+            }
+        }
+
+        replacements
+    }
+
+    pub(super) fn has_surviving_value_reference(
+        &self,
+        semantic: &Semantic<'_>,
+        symbol_id: SymbolId,
+        consumed_binding_ranges: &[(SymbolId, usize, usize)],
+    ) -> bool {
+        semantic
+            .scoping()
+            .get_resolved_references(symbol_id)
+            .filter(|reference| reference.is_value())
+            .any(|reference| {
+                let span = semantic.nodes().get_node(reference.node_id()).span();
+                !consumed_binding_ranges
+                    .iter()
+                    .any(|(consumed_symbol, start, end)| {
+                        *consumed_symbol == symbol_id
+                            && *start <= span.start as usize
+                            && span.end as usize <= *end
+                    })
+            })
+    }
+}
+
+#[derive(Debug)]
+struct MacroImportSpecifier {
+    local_name: String,
+    symbol_id: Option<SymbolId>,
+    declaration_range: (usize, usize),
+    specifier_range: (usize, usize),
+}
+
+fn declaration_specifier_count(source: &str, declaration_range: (usize, usize)) -> usize {
+    let declaration = &source[declaration_range.0..declaration_range.1];
+    let Some(brace_start) = declaration.find('{') else {
+        return usize::MAX;
+    };
+    if !declaration["import".len()..brace_start].trim().is_empty() {
+        return usize::MAX;
+    }
+    if declaration.contains("/*")
+        || declaration.contains("//")
+        || declaration.contains('*')
+        || declaration.contains("import type")
+        || declaration.contains("{ type ")
+    {
+        return usize::MAX;
+    }
+    declaration
+        .get(brace_start + 1..)
+        .and_then(|rest| rest.split('}').next())
+        .map(|specifiers| {
+            specifiers
+                .split(',')
+                .filter(|specifier| !specifier.trim().is_empty())
+                .count()
+        })
+        .unwrap_or(usize::MAX)
+}
+
+fn removable_specifier_range(
+    source: &str,
+    declaration_range: (usize, usize),
+    specifier_range: (usize, usize),
+) -> Option<(usize, usize)> {
+    let mut after = specifier_range.1;
+    while after < declaration_range.1 && source.as_bytes()[after].is_ascii_whitespace() {
+        after += 1;
+    }
+    if source.as_bytes().get(after) == Some(&b',') {
+        return Some((specifier_range.0, after + 1));
+    }
+
+    let mut before = specifier_range.0;
+    while before > declaration_range.0 && source.as_bytes()[before - 1].is_ascii_whitespace() {
+        before -= 1;
+    }
+    if before > declaration_range.0 && source.as_bytes()[before - 1] == b',' {
+        return Some((before - 1, specifier_range.1));
+    }
+
+    None
 }
 
 impl<'a> Visit<'a> for ImportCollector {
@@ -60,13 +253,32 @@ impl<'a> Visit<'a> for ImportCollector {
 
     fn visit_import_declaration(&mut self, it: &ImportDeclaration<'a>) {
         let source = it.source.value.as_str();
-
-        record_macro_import_declaration(
+        let is_macro_import = record_macro_import_declaration(
             it,
             &mut self.macro_imports,
             &mut self.removed_macro_import,
-            Some(&mut self.macro_import_ranges),
+            None,
         );
+
+        if is_macro_import && it.import_kind == ImportOrExportKind::Value {
+            if let Some(specifiers) = &it.specifiers {
+                for specifier in specifiers {
+                    if let ImportDeclarationSpecifier::ImportSpecifier(specifier) = specifier {
+                        if specifier.import_kind == ImportOrExportKind::Value {
+                            self.macro_specifiers.push(MacroImportSpecifier {
+                                local_name: specifier.local.name.to_string(),
+                                symbol_id: specifier.local.symbol_id.get(),
+                                declaration_range: (it.span.start as usize, it.span.end as usize),
+                                specifier_range: (
+                                    specifier.span.start as usize,
+                                    specifier.span.end as usize,
+                                ),
+                            });
+                        }
+                    }
+                }
+            }
+        }
 
         if source == self.runtime_module && it.import_kind == ImportOrExportKind::Value {
             if let Some(specifiers) = &it.specifiers {

--- a/crates/palamedes/src/transform/imports.rs
+++ b/crates/palamedes/src/transform/imports.rs
@@ -23,7 +23,8 @@ pub(super) struct ImportCollector {
     pub runtime_import_binding_count: usize,
     /// All authored identifiers that a generated import alias must not capture.
     pub used_identifier_names: HashSet<String>,
-    pub trans_import_sources: HashSet<String>,
+    binding_symbols: HashMap<String, HashSet<SymbolId>>,
+    reusable_trans_import_sources: HashSet<String>,
 }
 
 impl ImportCollector {
@@ -38,7 +39,8 @@ impl ImportCollector {
             has_reusable_runtime_import: false,
             runtime_import_binding_count: 0,
             used_identifier_names: HashSet::new(),
-            trans_import_sources: HashSet::new(),
+            binding_symbols: HashMap::new(),
+            reusable_trans_import_sources: HashSet::new(),
         }
     }
 
@@ -85,10 +87,9 @@ impl ImportCollector {
             let Some(symbol_id) = specifier.symbol_id else {
                 continue;
             };
-            let all_value_references_consumed = semantic
+            let all_references_consumed = semantic
                 .scoping()
                 .get_resolved_references(symbol_id)
-                .filter(|reference| reference.is_value())
                 .all(|reference| {
                     let span = semantic.nodes().get_node(reference.node_id()).span();
                     consumed_binding_ranges
@@ -99,7 +100,7 @@ impl ImportCollector {
                                 && span.end as usize <= *end
                         })
                 });
-            if all_value_references_consumed {
+            if all_references_consumed {
                 removable.insert(index);
             }
         }
@@ -148,7 +149,7 @@ impl ImportCollector {
         replacements
     }
 
-    pub(super) fn has_surviving_value_reference(
+    pub(super) fn has_surviving_reference(
         &self,
         semantic: &Semantic<'_>,
         symbol_id: SymbolId,
@@ -157,7 +158,6 @@ impl ImportCollector {
         semantic
             .scoping()
             .get_resolved_references(symbol_id)
-            .filter(|reference| reference.is_value())
             .any(|reference| {
                 let span = semantic.nodes().get_node(reference.node_id()).span();
                 !consumed_binding_ranges
@@ -168,6 +168,16 @@ impl ImportCollector {
                             && span.end as usize <= *end
                     })
             })
+    }
+
+    pub(super) fn has_other_binding_named(&self, name: &str, symbol_id: SymbolId) -> bool {
+        self.binding_symbols
+            .get(name)
+            .is_some_and(|symbols| symbols.iter().any(|other| *other != symbol_id))
+    }
+
+    pub(super) fn has_reusable_trans_import(&self, module: &str) -> bool {
+        self.reusable_trans_import_sources.contains(module)
     }
 }
 
@@ -237,6 +247,12 @@ impl<'a> Visit<'a> for ImportCollector {
         if name == self.runtime_import_name {
             self.runtime_import_binding_count += 1;
         }
+        if let Some(symbol_id) = it.symbol_id.get() {
+            self.binding_symbols
+                .entry(name.clone())
+                .or_default()
+                .insert(symbol_id);
+        }
         self.used_identifier_names.insert(name);
         walk::walk_binding_identifier(self, it);
     }
@@ -297,16 +313,18 @@ impl<'a> Visit<'a> for ImportCollector {
 
         if matches!(
             source,
-            "@palamedes/react"
-                | "@palamedes/react/compiled"
-                | "@palamedes/solid"
-                | "@palamedes/solid/compiled"
-        ) {
+            "@palamedes/react/compiled" | "@palamedes/solid/compiled"
+        ) && it.import_kind == ImportOrExportKind::Value
+        {
             if let Some(specifiers) = &it.specifiers {
                 for specifier in specifiers {
                     if let ImportDeclarationSpecifier::ImportSpecifier(specifier) = specifier {
-                        if specifier.local.name == "Trans" {
-                            self.trans_import_sources.insert(source.to_string());
+                        if specifier.import_kind == ImportOrExportKind::Value
+                            && specifier.imported.name() == "Trans"
+                            && specifier.local.name == "Trans"
+                        {
+                            self.reusable_trans_import_sources
+                                .insert(source.to_string());
                         }
                     }
                 }

--- a/crates/palamedes/src/transform/imports.rs
+++ b/crates/palamedes/src/transform/imports.rs
@@ -9,7 +9,7 @@ use oxc_ast::ast::{
 use oxc_ast_visit::{walk, Visit};
 use oxc_semantic::Semantic;
 use oxc_span::GetSpan;
-use oxc_syntax::symbol::SymbolId;
+use oxc_syntax::{scope::ScopeId, symbol::SymbolId};
 
 pub(super) struct ImportCollector {
     runtime_module: String,
@@ -17,14 +17,14 @@ pub(super) struct ImportCollector {
     pub macro_imports: HashMap<String, ImportedMacro>,
     macro_specifiers: Vec<MacroImportSpecifier>,
     reference_symbols: HashMap<(u32, u32), SymbolId>,
+    reference_scopes: HashMap<(u32, u32), ScopeId>,
     pub removed_macro_import: Option<(String, usize)>,
     pub has_reusable_runtime_import: bool,
     /// Number of bindings that could shadow calls through the configured local name.
     pub runtime_import_binding_count: usize,
     /// All authored identifiers that a generated import alias must not capture.
     pub used_identifier_names: HashSet<String>,
-    binding_symbols: HashMap<String, HashSet<SymbolId>>,
-    reusable_trans_import_sources: HashSet<String>,
+    reusable_trans_import_symbols: HashMap<String, SymbolId>,
 }
 
 impl ImportCollector {
@@ -35,12 +35,12 @@ impl ImportCollector {
             macro_imports: HashMap::new(),
             macro_specifiers: Vec::new(),
             reference_symbols: HashMap::new(),
+            reference_scopes: HashMap::new(),
             removed_macro_import: None,
             has_reusable_runtime_import: false,
             runtime_import_binding_count: 0,
             used_identifier_names: HashSet::new(),
-            binding_symbols: HashMap::new(),
-            reusable_trans_import_sources: HashSet::new(),
+            reusable_trans_import_symbols: HashMap::new(),
         }
     }
 
@@ -56,6 +56,8 @@ impl ImportCollector {
                 let span = semantic.nodes().get_node(reference.node_id()).span();
                 self.reference_symbols
                     .insert((span.start, span.end), symbol_id);
+                self.reference_scopes
+                    .insert((span.start, span.end), reference.scope_id());
             }
         }
     }
@@ -170,14 +172,36 @@ impl ImportCollector {
             })
     }
 
-    pub(super) fn has_other_binding_named(&self, name: &str, symbol_id: SymbolId) -> bool {
-        self.binding_symbols
-            .get(name)
-            .is_some_and(|symbols| symbols.iter().any(|other| *other != symbol_id))
+    pub(super) fn can_reuse_trans_import_at(
+        &self,
+        semantic: &Semantic<'_>,
+        module: &str,
+        reference_span: (u32, u32),
+    ) -> bool {
+        let Some(&import_symbol) = self.reusable_trans_import_symbols.get(module) else {
+            return false;
+        };
+        let Some(&scope_id) = self.reference_scopes.get(&reference_span) else {
+            return false;
+        };
+
+        semantic.scoping().find_binding(scope_id, "Trans".into()) == Some(import_symbol)
     }
 
-    pub(super) fn has_reusable_trans_import(&self, module: &str) -> bool {
-        self.reusable_trans_import_sources.contains(module)
+    pub(super) fn can_use_generated_trans_import_at(
+        &self,
+        semantic: &Semantic<'_>,
+        macro_symbol: SymbolId,
+        reference_span: (u32, u32),
+    ) -> bool {
+        let Some(&scope_id) = self.reference_scopes.get(&reference_span) else {
+            return false;
+        };
+
+        semantic
+            .scoping()
+            .find_binding(scope_id, "Trans".into())
+            .is_none_or(|symbol_id| symbol_id == macro_symbol)
     }
 }
 
@@ -246,12 +270,6 @@ impl<'a> Visit<'a> for ImportCollector {
         let name = it.name.to_string();
         if name == self.runtime_import_name {
             self.runtime_import_binding_count += 1;
-        }
-        if let Some(symbol_id) = it.symbol_id.get() {
-            self.binding_symbols
-                .entry(name.clone())
-                .or_default()
-                .insert(symbol_id);
         }
         self.used_identifier_names.insert(name);
         walk::walk_binding_identifier(self, it);
@@ -323,8 +341,10 @@ impl<'a> Visit<'a> for ImportCollector {
                             && specifier.imported.name() == "Trans"
                             && specifier.local.name == "Trans"
                         {
-                            self.reusable_trans_import_sources
-                                .insert(source.to_string());
+                            if let Some(symbol_id) = specifier.local.symbol_id.get() {
+                                self.reusable_trans_import_symbols
+                                    .insert(source.to_string(), symbol_id);
+                            }
                         }
                     }
                 }

--- a/crates/palamedes/src/transform/mod.rs
+++ b/crates/palamedes/src/transform/mod.rs
@@ -303,7 +303,7 @@ pub fn transform_macros(
     let mut trans_imports = visitor.trans_imports.iter().cloned().collect::<Vec<_>>();
     trans_imports.sort();
     for (module, local_name) in trans_imports {
-        if local_name != "Trans" || !collector.has_reusable_trans_import(&module) {
+        if local_name != "Trans" || !visitor.reused_trans_imports.contains(&module) {
             if local_name == "Trans" {
                 let _ = writeln!(prefix, "import {{ Trans }} from \"{module}\";");
             } else {

--- a/crates/palamedes/src/transform/mod.rs
+++ b/crates/palamedes/src/transform/mod.rs
@@ -12,6 +12,7 @@ use std::fmt::Write as _;
 use oxc_allocator::Allocator;
 use oxc_ast_visit::Visit;
 use oxc_parser::Parser;
+use oxc_semantic::SemanticBuilder;
 use oxc_span::SourceType;
 use serde::{Deserialize, Serialize};
 use string_wizard::{Hires, MagicString, SourceMapOptions};
@@ -181,8 +182,14 @@ pub fn transform_macros(
         });
     }
 
+    let semantic = SemanticBuilder::new()
+        .with_build_nodes(true)
+        .build(&parsed.program)
+        .semantic;
+
     let mut collector = ImportCollector::new(&runtime_module, &runtime_import_name);
     collector.visit_program(&parsed.program);
+    collector.resolve_macro_references(&semantic);
 
     let runtime_import_name_is_unsafe = if collector.has_reusable_runtime_import {
         collector.runtime_import_binding_count > 1
@@ -212,20 +219,25 @@ pub fn transform_macros(
     }
 
     if !collector.macro_imports.is_empty() {
-        validate_translation_macro_scopes(&parsed.program, filename, source, |local_name| {
-            collector
-                .macro_imports
-                .get(local_name)
-                .map(|macro_info| macro_info.imported_name.clone())
-        })?;
+        validate_translation_macro_scopes(
+            &parsed.program,
+            filename,
+            source,
+            |local_name, span| {
+                collector
+                    .macro_at(local_name, span)
+                    .map(|(macro_info, _)| macro_info.imported_name)
+            },
+        )?;
     }
 
-    let mut visitor = TransformVisitor::new(filename, source, &collector.macro_imports, &options);
+    let mut visitor = TransformVisitor::new(filename, source, &collector, &options);
     visitor.visit_program(&parsed.program);
 
     if let Some(error) = visitor.error {
         return Err(error);
     }
+    visitor.rebind_surviving_trans(&semantic);
 
     let mut server_function_transform = options.server_functions.as_ref().map(|_| {
         ServerFunctionTransform::run(
@@ -245,13 +257,11 @@ pub fn transform_macros(
 
     let mut replacements = visitor.replacements;
     if !replacements.is_empty() {
-        for (start, end) in collector.macro_import_ranges {
-            replacements.push(Replacement {
-                start,
-                end,
-                text: String::new(),
-            });
-        }
+        replacements.extend(collector.macro_import_cleanup_replacements(
+            source,
+            &semantic,
+            &visitor.consumed_binding_ranges,
+        ));
     }
     if let Some(transform) = &server_function_transform {
         replacements.extend(transform.replacements.iter().cloned());
@@ -290,15 +300,18 @@ pub fn transform_macros(
         }
     }
 
-    let mut trans_modules = visitor
-        .trans_import_modules
-        .iter()
-        .cloned()
-        .collect::<Vec<_>>();
-    trans_modules.sort();
-    for module in trans_modules {
-        if !collector.trans_import_sources.contains(&module) {
-            let _ = writeln!(prefix, "import {{ Trans }} from \"{module}\";");
+    let mut trans_imports = visitor.trans_imports.iter().cloned().collect::<Vec<_>>();
+    trans_imports.sort();
+    for (module, local_name) in trans_imports {
+        if local_name != "Trans" || !collector.trans_import_sources.contains(&module) {
+            if local_name == "Trans" {
+                let _ = writeln!(prefix, "import {{ Trans }} from \"{module}\";");
+            } else {
+                let _ = writeln!(
+                    prefix,
+                    "import {{ Trans as {local_name} }} from \"{module}\";"
+                );
+            }
         }
     }
 

--- a/crates/palamedes/src/transform/mod.rs
+++ b/crates/palamedes/src/transform/mod.rs
@@ -303,7 +303,7 @@ pub fn transform_macros(
     let mut trans_imports = visitor.trans_imports.iter().cloned().collect::<Vec<_>>();
     trans_imports.sort();
     for (module, local_name) in trans_imports {
-        if local_name != "Trans" || !collector.trans_import_sources.contains(&module) {
+        if local_name != "Trans" || !collector.has_reusable_trans_import(&module) {
             if local_name == "Trans" {
                 let _ = writeln!(prefix, "import {{ Trans }} from \"{module}\";");
             } else {

--- a/crates/palamedes/src/transform/tests.rs
+++ b/crates/palamedes/src/transform/tests.rs
@@ -682,6 +682,27 @@ const view = <MacroTrans>Upload failed</MacroTrans>;
 }
 
 #[test]
+fn aliases_reused_trans_when_it_is_shadowed_at_the_macro_site() {
+    let source = r#"import { Trans as MacroTrans } from "@palamedes/react/macro";
+import { Trans } from "@palamedes/react/compiled";
+function Example() {
+  const Trans = () => "authored-shadow";
+  return <MacroTrans>Upload failed</MacroTrans>;
+}
+"#;
+
+    let result = transform_macros(source, "test.tsx", None).expect("transform should succeed");
+
+    assert!(result
+        .code
+        .contains(r#"import { Trans as __palamedesTrans } from "@palamedes/react/compiled";"#));
+    assert!(result
+        .code
+        .contains("const Trans = () => \"authored-shadow\""));
+    assert!(result.code.contains("return <__palamedesTrans id="));
+}
+
+#[test]
 fn aliases_injected_runtime_import_when_local_name_is_taken_by_another_module() {
     let source = r#"import { t } from "@palamedes/core/macro";
 import { getI18n } from "@palamedes/runtime";

--- a/crates/palamedes/src/transform/tests.rs
+++ b/crates/palamedes/src/transform/tests.rs
@@ -497,6 +497,109 @@ fn transforms_tagged_templates() {
 }
 
 #[test]
+fn preserves_macro_binding_for_mixed_runtime_uses() {
+    let source = r#"import { t as translate, plural as count } from "@palamedes/core/macro";
+function Example() {
+  const label = translate`Upload failed`;
+  useEffect(() => {}, [translate]);
+  consume({ translate, count });
+  console.log(count);
+  return label;
+}
+"#;
+
+    let result = transform_macros(source, "test.ts", None).expect("transform should succeed");
+
+    assert!(result
+        .code
+        .contains(r#"import { t as translate, plural as count } from "@palamedes/core/macro";"#));
+    assert!(result.code.contains("[translate]"));
+    assert!(result.code.contains("{ translate, count }"));
+    assert!(result.code.contains("console.log(count)"));
+    assert!(!result.code.contains("translate`Upload failed`"));
+}
+
+#[test]
+fn removes_only_fully_consumed_macro_specifiers() {
+    let source = r#"import { t as translate, plural as count } from "@palamedes/core/macro";
+function Example() {
+  const label = translate`Upload failed`;
+  return count;
+}
+"#;
+
+    let result = transform_macros(source, "test.ts", None).expect("transform should succeed");
+
+    assert!(!result.code.contains("t as translate"));
+    assert!(result.code.contains("plural as count"));
+    assert!(result.code.contains("return count"));
+}
+
+#[test]
+fn does_not_transform_shadowed_macro_locals() {
+    let source = r#"import { t } from "@palamedes/core/macro";
+function Example() {
+  const label = t`Upload failed`;
+  return ((t) => t`runtime tag`)(runtimeTag) && label;
+}
+"#;
+
+    let result = transform_macros(source, "test.ts", None).expect("transform should succeed");
+
+    assert!(!result.code.contains("@palamedes/core/macro"));
+    assert!(result.code.contains("t`runtime tag`"));
+    assert!(result.code.contains("getI18n()._("));
+}
+
+#[test]
+fn removes_value_macro_without_retaining_type_only_specifiers() {
+    let source = r#"import { t, type Trans } from "@palamedes/react/macro";
+function Example(): Trans {
+  return t`Upload failed`;
+}
+"#;
+
+    let result = transform_macros(source, "test.tsx", None).expect("transform should succeed");
+
+    assert!(result
+        .code
+        .contains(r#"import {  type Trans } from "@palamedes/react/macro";"#));
+    assert!(!result.code.contains("import { t,"));
+}
+
+#[test]
+fn rebinds_trans_when_its_macro_binding_survives() {
+    let source = r#"import { Trans } from "@palamedes/react/macro";
+function Example() {
+  const compiled = <Trans>Upload failed</Trans>;
+  return { compiled, component: Trans };
+}
+"#;
+
+    let result = transform_macros(source, "test.tsx", None).expect("transform should succeed");
+
+    assert!(result
+        .code
+        .contains(r#"import { Trans } from "@palamedes/react/macro";"#));
+    assert!(result
+        .code
+        .contains(r#"import { Trans as __palamedesTrans } from "@palamedes/react/compiled";"#));
+    assert!(result.code.contains("<__palamedesTrans id="));
+    assert!(result.code.contains("component: Trans"));
+    assert!(!result
+        .code
+        .contains(r#"import { Trans } from "@palamedes/react/compiled";"#));
+
+    let allocator = Allocator::default();
+    let parsed = Parser::new(&allocator, &result.code, SourceType::tsx()).parse();
+    assert!(
+        parsed.diagnostics.is_empty(),
+        "Trans rebinding should emit valid TSX: {:?}",
+        parsed.diagnostics
+    );
+}
+
+#[test]
 fn aliases_injected_runtime_import_when_local_name_is_taken_by_another_module() {
     let source = r#"import { t } from "@palamedes/core/macro";
 import { getI18n } from "@palamedes/runtime";

--- a/crates/palamedes/src/transform/tests.rs
+++ b/crates/palamedes/src/transform/tests.rs
@@ -520,6 +520,24 @@ function Example() {
 }
 
 #[test]
+fn preserves_macro_binding_for_same_binding_type_queries() {
+    let source = r#"import { t } from "@palamedes/core/macro";
+type MacroValue = typeof t;
+function Example() {
+  return t`Upload failed`;
+}
+"#;
+
+    let result = transform_macros(source, "test.ts", None).expect("transform should succeed");
+
+    assert!(result
+        .code
+        .contains(r#"import { t } from "@palamedes/core/macro";"#));
+    assert!(result.code.contains("type MacroValue = typeof t"));
+    assert!(!result.code.contains("t`Upload failed`"));
+}
+
+#[test]
 fn removes_only_fully_consumed_macro_specifiers() {
     let source = r#"import { t as translate, plural as count } from "@palamedes/core/macro";
 function Example() {
@@ -597,6 +615,70 @@ function Example() {
         "Trans rebinding should emit valid TSX: {:?}",
         parsed.diagnostics
     );
+}
+
+#[test]
+fn aliases_compiled_trans_when_an_authored_trans_binding_is_reserved() {
+    let source = r#"import { Trans as MacroTrans } from "@palamedes/react/macro";
+const Trans = () => null;
+const view = <MacroTrans>Upload failed</MacroTrans>;
+"#;
+
+    let result = transform_macros(source, "test.tsx", None).expect("transform should succeed");
+
+    assert!(result
+        .code
+        .contains(r#"import { Trans as __palamedesTrans } from "@palamedes/react/compiled";"#));
+    assert!(result.code.contains("const Trans = () => null"));
+    assert!(result.code.contains("<__palamedesTrans id="));
+    assert!(!result
+        .code
+        .contains(r#"import { Trans } from "@palamedes/react/compiled";"#));
+}
+
+#[test]
+fn reuses_only_exact_value_trans_imports() {
+    let cases = [
+        (
+            r#"import type { Trans } from "@palamedes/react/compiled";"#,
+            "type-only import",
+        ),
+        (
+            r#"import { Fragment as Trans } from "@palamedes/react/compiled";"#,
+            "renamed import",
+        ),
+    ];
+
+    for (compiled_import, case_name) in cases {
+        let source = format!(
+            "import {{ Trans as MacroTrans }} from \"@palamedes/react/macro\";\n{compiled_import}\nconst view = <MacroTrans>Upload failed</MacroTrans>;\n"
+        );
+        let result = transform_macros(&source, "test.tsx", None)
+            .unwrap_or_else(|_| panic!("{case_name} should transform"));
+
+        assert!(
+            result.code.contains(
+                r#"import { Trans as __palamedesTrans } from "@palamedes/react/compiled";"#
+            ),
+            "{case_name} must not suppress the generated value import"
+        );
+        assert!(result.code.contains("<__palamedesTrans id="));
+    }
+
+    let source = r#"import { Trans as MacroTrans } from "@palamedes/react/macro";
+import { Trans } from "@palamedes/react/compiled";
+const view = <MacroTrans>Upload failed</MacroTrans>;
+"#;
+    let result = transform_macros(source, "test.tsx", None).expect("transform should succeed");
+
+    assert_eq!(
+        result
+            .code
+            .matches(r#"from "@palamedes/react/compiled""#)
+            .count(),
+        1
+    );
+    assert!(result.code.contains("<Trans id="));
 }
 
 #[test]

--- a/crates/palamedes/src/transform/visitor.rs
+++ b/crates/palamedes/src/transform/visitor.rs
@@ -88,11 +88,13 @@ impl<'a> TransformVisitor<'a> {
         let mut aliases = HashMap::<SymbolId, String>::new();
         let mut reserved = self.imports.used_identifier_names.clone();
         for (symbol_id, module, replacement_index) in self.trans_replacements.clone() {
-            let local_name = if self.imports.has_surviving_value_reference(
+            let needs_alias = self.imports.has_surviving_reference(
                 semantic,
                 symbol_id,
                 &self.consumed_binding_ranges,
-            ) {
+            ) || (!self.imports.has_reusable_trans_import(&module)
+                && self.imports.has_other_binding_named("Trans", symbol_id));
+            let local_name = if needs_alias {
                 aliases
                     .entry(symbol_id)
                     .or_insert_with(|| unique_identifier("__palamedesTrans", &mut reserved))

--- a/crates/palamedes/src/transform/visitor.rs
+++ b/crates/palamedes/src/transform/visitor.rs
@@ -1,30 +1,34 @@
 use std::collections::{HashMap, HashSet};
 
 use oxc_ast::ast::{
-    CallExpression, JSXChild, JSXElement, JSXOpeningElement, TaggedTemplateExpression,
+    CallExpression, Expression, JSXChild, JSXElement, JSXOpeningElement, TaggedTemplateExpression,
 };
 use oxc_ast_visit::{walk, Visit};
+use oxc_semantic::Semantic;
+use oxc_span::GetSpan;
 
 use crate::error::PalamedesError;
 use crate::translation_scope::source_location;
 
-use super::imports::ImportedMacro;
-use super::messages::identifier_name;
+use super::imports::ImportCollector;
 use super::runtime::{
     transform_choice_call, transform_choice_jsx_element, transform_descriptor_call,
     transform_tagged_template, transform_trans_element,
 };
 use super::{NativeTransformOptions, Replacement};
+use oxc_syntax::symbol::SymbolId;
 
 pub(super) struct TransformVisitor<'a> {
     filename: &'a str,
     source: &'a str,
-    macro_imports: &'a HashMap<String, ImportedMacro>,
+    imports: &'a ImportCollector,
     options: &'a NativeTransformOptions,
     pub replacements: Vec<Replacement>,
     pub compiled_ids: Vec<String>,
     pub needs_runtime_import: bool,
-    pub trans_import_modules: HashSet<String>,
+    pub trans_imports: HashSet<(String, String)>,
+    trans_replacements: Vec<(SymbolId, String, usize)>,
+    pub consumed_binding_ranges: Vec<(SymbolId, usize, usize)>,
     pub error: Option<PalamedesError>,
     jsx_child_element_spans: Vec<(usize, usize)>,
 }
@@ -33,18 +37,20 @@ impl<'a> TransformVisitor<'a> {
     pub(super) fn new(
         filename: &'a str,
         source: &'a str,
-        macro_imports: &'a HashMap<String, ImportedMacro>,
+        imports: &'a ImportCollector,
         options: &'a NativeTransformOptions,
     ) -> Self {
         Self {
             filename,
             source,
-            macro_imports,
+            imports,
             options,
             replacements: Vec::new(),
             compiled_ids: Vec::new(),
             needs_runtime_import: false,
-            trans_import_modules: HashSet::new(),
+            trans_imports: HashSet::new(),
+            trans_replacements: Vec::new(),
+            consumed_binding_ranges: Vec::new(),
             error: None,
             jsx_child_element_spans: Vec::new(),
         }
@@ -72,6 +78,35 @@ impl<'a> TransformVisitor<'a> {
             location: source_location(self.source, self.filename, start),
             detail: "the macro could not be statically transformed; use a supported literal, template, descriptor, or choice shape".to_string(),
         });
+    }
+
+    fn record_consumed_binding(&mut self, symbol_id: SymbolId, start: usize, end: usize) {
+        self.consumed_binding_ranges.push((symbol_id, start, end));
+    }
+
+    pub(super) fn rebind_surviving_trans(&mut self, semantic: &Semantic<'_>) {
+        let mut aliases = HashMap::<SymbolId, String>::new();
+        let mut reserved = self.imports.used_identifier_names.clone();
+        for (symbol_id, module, replacement_index) in self.trans_replacements.clone() {
+            let local_name = if self.imports.has_surviving_value_reference(
+                semantic,
+                symbol_id,
+                &self.consumed_binding_ranges,
+            ) {
+                aliases
+                    .entry(symbol_id)
+                    .or_insert_with(|| unique_identifier("__palamedesTrans", &mut reserved))
+                    .clone()
+            } else {
+                "Trans".to_string()
+            };
+            if local_name != "Trans" {
+                self.replacements[replacement_index].text = self.replacements[replacement_index]
+                    .text
+                    .replacen("<Trans ", &format!("<{local_name} "), 1);
+            }
+            self.trans_imports.insert((module, local_name));
+        }
     }
 
     fn is_current_jsx_child_element(&self, element: &JSXElement<'_>) -> bool {
@@ -116,7 +151,13 @@ impl<'a> Visit<'a> for TransformVisitor<'a> {
             return;
         };
 
-        let Some(macro_info) = self.macro_imports.get(tag_name.as_str()).cloned() else {
+        let Some((macro_info, macro_symbol_id)) = self.imports.macro_at(
+            tag_name.as_str(),
+            (
+                it.opening_element.name.span().start,
+                it.opening_element.name.span().end,
+            ),
+        ) else {
             walk::walk_jsx_element(self, it);
             return;
         };
@@ -125,8 +166,7 @@ impl<'a> Visit<'a> for TransformVisitor<'a> {
             macro_info.imported_name.as_str(),
             "Trans" | "Plural" | "Select" | "SelectOrdinal"
         ) {
-            if let Some(nested_start) =
-                nested_message_macro_in_children(&it.children, self.macro_imports)
+            if let Some(nested_start) = nested_message_macro_in_children(&it.children, self.imports)
             {
                 self.fail(PalamedesError::NestedMessageMacro {
                     location: source_location(self.source, self.filename, nested_start),
@@ -180,11 +220,19 @@ impl<'a> Visit<'a> for TransformVisitor<'a> {
                     text,
                 });
                 self.push_compiled_id(&compiled_id);
+                self.record_consumed_binding(
+                    macro_symbol_id,
+                    it.span.start as usize,
+                    it.span.end as usize,
+                );
 
                 if macro_info.imported_name == "Trans" {
                     if let Some(module) = macro_info.source.strip_suffix("/macro") {
-                        self.trans_import_modules
-                            .insert(format!("{module}/compiled"));
+                        self.trans_replacements.push((
+                            macro_symbol_id,
+                            format!("{module}/compiled"),
+                            self.replacements.len() - 1,
+                        ));
                     }
                 } else {
                     self.needs_runtime_import = true;
@@ -215,12 +263,13 @@ impl<'a> Visit<'a> for TransformVisitor<'a> {
             return;
         }
 
-        let Some(local_name) = identifier_name(&it.tag) else {
+        let Some((local_name, tag_span)) = identifier_name_and_span(&it.tag) else {
             walk::walk_tagged_template_expression(self, it);
             return;
         };
 
-        let Some(macro_info) = self.macro_imports.get(local_name).cloned() else {
+        let Some((macro_info, macro_symbol_id)) = self.imports.macro_at(local_name, tag_span)
+        else {
             walk::walk_tagged_template_expression(self, it);
             return;
         };
@@ -238,6 +287,11 @@ impl<'a> Visit<'a> for TransformVisitor<'a> {
                     text,
                 });
                 self.push_compiled_id(&compiled_id);
+                self.record_consumed_binding(
+                    macro_symbol_id,
+                    it.span.start as usize,
+                    it.span.end as usize,
+                );
                 self.needs_runtime_import = true;
             }
             Ok(None) => {
@@ -258,12 +312,13 @@ impl<'a> Visit<'a> for TransformVisitor<'a> {
             return;
         }
 
-        let Some(local_name) = identifier_name(&it.callee) else {
+        let Some((local_name, callee_span)) = identifier_name_and_span(&it.callee) else {
             walk::walk_call_expression(self, it);
             return;
         };
 
-        let Some(macro_info) = self.macro_imports.get(local_name).cloned() else {
+        let Some((macro_info, macro_symbol_id)) = self.imports.macro_at(local_name, callee_span)
+        else {
             walk::walk_call_expression(self, it);
             return;
         };
@@ -285,6 +340,11 @@ impl<'a> Visit<'a> for TransformVisitor<'a> {
                             text,
                         });
                         self.push_compiled_id(&compiled_id);
+                        self.record_consumed_binding(
+                            macro_symbol_id,
+                            it.span.start as usize,
+                            it.span.end as usize,
+                        );
                         self.needs_runtime_import = true;
                     }
                     Ok(None) => {
@@ -315,6 +375,11 @@ impl<'a> Visit<'a> for TransformVisitor<'a> {
                             text,
                         });
                         self.push_compiled_id(&compiled_id);
+                        self.record_consumed_binding(
+                            macro_symbol_id,
+                            it.span.start as usize,
+                            it.span.end as usize,
+                        );
                         self.needs_runtime_import = true;
                     }
                     Ok(None) => {
@@ -342,23 +407,20 @@ impl<'a> Visit<'a> for TransformVisitor<'a> {
 
 fn nested_message_macro_in_children<'a>(
     children: &'a [JSXChild<'a>],
-    macro_imports: &HashMap<String, ImportedMacro>,
+    imports: &ImportCollector,
 ) -> Option<usize> {
-    NestedMessageMacroFinder::find_in_children(children, macro_imports)
+    NestedMessageMacroFinder::find_in_children(children, imports)
 }
 
 struct NestedMessageMacroFinder<'a> {
-    macro_imports: &'a HashMap<String, ImportedMacro>,
+    imports: &'a ImportCollector,
     nested_start: Option<usize>,
 }
 
 impl<'a> NestedMessageMacroFinder<'a> {
-    fn find_in_children(
-        children: &[JSXChild<'a>],
-        macro_imports: &'a HashMap<String, ImportedMacro>,
-    ) -> Option<usize> {
+    fn find_in_children(children: &[JSXChild<'a>], imports: &'a ImportCollector) -> Option<usize> {
         let mut finder = Self {
-            macro_imports,
+            imports,
             nested_start: None,
         };
 
@@ -379,7 +441,7 @@ impl<'a> Visit<'a> for NestedMessageMacroFinder<'a> {
             return;
         }
 
-        if is_jsx_message_macro(it, self.macro_imports) {
+        if is_jsx_message_macro(it, self.imports) {
             self.nested_start = Some(it.span.start as usize);
             return;
         }
@@ -393,20 +455,47 @@ impl<'a> Visit<'a> for NestedMessageMacroFinder<'a> {
     }
 }
 
-fn is_jsx_message_macro(
-    element: &JSXElement<'_>,
-    macro_imports: &HashMap<String, ImportedMacro>,
-) -> bool {
+fn is_jsx_message_macro(element: &JSXElement<'_>, imports: &ImportCollector) -> bool {
     let Some(tag_name) = element.opening_element.name.get_identifier_name() else {
         return false;
     };
 
-    macro_imports
-        .get(tag_name.as_str())
-        .is_some_and(|macro_info| {
+    imports
+        .macro_at(
+            tag_name.as_str(),
+            (
+                element.opening_element.name.span().start,
+                element.opening_element.name.span().end,
+            ),
+        )
+        .is_some_and(|(macro_info, _)| {
             matches!(
                 macro_info.imported_name.as_str(),
                 "Trans" | "Plural" | "Select" | "SelectOrdinal"
             )
         })
+}
+
+fn identifier_name_and_span<'a>(expression: &'a Expression<'a>) -> Option<(&'a str, (u32, u32))> {
+    match expression.without_parentheses() {
+        Expression::Identifier(identifier) => Some((
+            identifier.name.as_str(),
+            (identifier.span.start, identifier.span.end),
+        )),
+        _ => None,
+    }
+}
+
+fn unique_identifier(base: &str, reserved: &mut HashSet<String>) -> String {
+    if reserved.insert(base.to_string()) {
+        return base.to_string();
+    }
+    let mut counter = 2;
+    loop {
+        let candidate = format!("{base}{counter}");
+        if reserved.insert(candidate.clone()) {
+            return candidate;
+        }
+        counter += 1;
+    }
 }

--- a/crates/palamedes/src/transform/visitor.rs
+++ b/crates/palamedes/src/transform/visitor.rs
@@ -27,7 +27,8 @@ pub(super) struct TransformVisitor<'a> {
     pub compiled_ids: Vec<String>,
     pub needs_runtime_import: bool,
     pub trans_imports: HashSet<(String, String)>,
-    trans_replacements: Vec<(SymbolId, String, usize)>,
+    pub reused_trans_imports: HashSet<String>,
+    trans_replacements: Vec<(SymbolId, String, usize, (u32, u32))>,
     pub consumed_binding_ranges: Vec<(SymbolId, usize, usize)>,
     pub error: Option<PalamedesError>,
     jsx_child_element_spans: Vec<(usize, usize)>,
@@ -49,6 +50,7 @@ impl<'a> TransformVisitor<'a> {
             compiled_ids: Vec::new(),
             needs_runtime_import: false,
             trans_imports: HashSet::new(),
+            reused_trans_imports: HashSet::new(),
             trans_replacements: Vec::new(),
             consumed_binding_ranges: Vec::new(),
             error: None,
@@ -87,13 +89,22 @@ impl<'a> TransformVisitor<'a> {
     pub(super) fn rebind_surviving_trans(&mut self, semantic: &Semantic<'_>) {
         let mut aliases = HashMap::<SymbolId, String>::new();
         let mut reserved = self.imports.used_identifier_names.clone();
-        for (symbol_id, module, replacement_index) in self.trans_replacements.clone() {
+        for (symbol_id, module, replacement_index, reference_span) in
+            self.trans_replacements.clone()
+        {
+            let reuses_trans_import =
+                self.imports
+                    .can_reuse_trans_import_at(semantic, &module, reference_span);
             let needs_alias = self.imports.has_surviving_reference(
                 semantic,
                 symbol_id,
                 &self.consumed_binding_ranges,
-            ) || (!self.imports.has_reusable_trans_import(&module)
-                && self.imports.has_other_binding_named("Trans", symbol_id));
+            ) || (!reuses_trans_import
+                && !self.imports.can_use_generated_trans_import_at(
+                    semantic,
+                    symbol_id,
+                    reference_span,
+                ));
             let local_name = if needs_alias {
                 aliases
                     .entry(symbol_id)
@@ -106,6 +117,8 @@ impl<'a> TransformVisitor<'a> {
                 self.replacements[replacement_index].text = self.replacements[replacement_index]
                     .text
                     .replacen("<Trans ", &format!("<{local_name} "), 1);
+            } else if reuses_trans_import {
+                self.reused_trans_imports.insert(module.clone());
             }
             self.trans_imports.insert((module, local_name));
         }
@@ -234,6 +247,10 @@ impl<'a> Visit<'a> for TransformVisitor<'a> {
                             macro_symbol_id,
                             format!("{module}/compiled"),
                             self.replacements.len() - 1,
+                            (
+                                it.opening_element.name.span().start,
+                                it.opening_element.name.span().end,
+                            ),
                         ));
                     }
                 } else {

--- a/crates/palamedes/src/translation_scope.rs
+++ b/crates/palamedes/src/translation_scope.rs
@@ -1,6 +1,7 @@
 use oxc_ast::ast::{CallExpression, Expression, JSXElement, Program, TaggedTemplateExpression};
 use oxc_ast::ast_kind::AstKind;
 use oxc_ast_visit::{walk, Visit};
+use oxc_span::GetSpan;
 
 use crate::error::{PalamedesError, PalamedesResult};
 
@@ -14,7 +15,7 @@ pub(crate) fn validate_translation_macro_scopes<'a, F>(
     imported_macro_name: F,
 ) -> PalamedesResult<()>
 where
-    F: Fn(&str) -> Option<String>,
+    F: Fn(&str, (u32, u32)) -> Option<String>,
 {
     let mut validator = TranslationScopeValidator {
         filename,
@@ -41,14 +42,20 @@ struct TranslationScopeValidator<'a, F> {
 
 impl<F> TranslationScopeValidator<'_, F>
 where
-    F: Fn(&str) -> Option<String>,
+    F: Fn(&str, (u32, u32)) -> Option<String>,
 {
-    fn validate_macro(&mut self, local_name: &str, expected: &[&str], offset: usize) {
+    fn validate_macro(
+        &mut self,
+        local_name: &str,
+        span: (u32, u32),
+        expected: &[&str],
+        offset: usize,
+    ) {
         if self.error.is_some() || self.function_depth > 0 {
             return;
         }
 
-        let Some(macro_name) = (self.imported_macro_name)(local_name) else {
+        let Some(macro_name) = (self.imported_macro_name)(local_name, span) else {
             return;
         };
         if !expected.contains(&macro_name.as_str()) {
@@ -64,7 +71,7 @@ where
 
 impl<'a, F> Visit<'a> for TranslationScopeValidator<'_, F>
 where
-    F: Fn(&str) -> Option<String>,
+    F: Fn(&str, (u32, u32)) -> Option<String>,
 {
     fn enter_node(&mut self, kind: AstKind<'a>) {
         if matches!(
@@ -92,6 +99,10 @@ where
         if let Some(local_name) = it.opening_element.name.get_identifier_name() {
             self.validate_macro(
                 local_name.as_str(),
+                (
+                    it.opening_element.name.span().start,
+                    it.opening_element.name.span().end,
+                ),
                 &EAGER_JSX_MACROS,
                 it.span.start as usize,
             );
@@ -107,8 +118,8 @@ where
             return;
         }
 
-        if let Some(local_name) = identifier_name(&it.tag) {
-            self.validate_macro(local_name, &["t"], it.span.start as usize);
+        if let Some((local_name, span)) = identifier_name(&it.tag) {
+            self.validate_macro(local_name, span, &["t"], it.span.start as usize);
         }
 
         if self.error.is_none() {
@@ -121,8 +132,8 @@ where
             return;
         }
 
-        if let Some(local_name) = identifier_name(&it.callee) {
-            self.validate_macro(local_name, &EAGER_JS_MACROS, it.span.start as usize);
+        if let Some((local_name, span)) = identifier_name(&it.callee) {
+            self.validate_macro(local_name, span, &EAGER_JS_MACROS, it.span.start as usize);
         }
 
         if self.error.is_none() {
@@ -131,9 +142,12 @@ where
     }
 }
 
-fn identifier_name<'a>(expression: &'a Expression<'a>) -> Option<&'a str> {
+fn identifier_name<'a>(expression: &'a Expression<'a>) -> Option<(&'a str, (u32, u32))> {
     match expression.without_parentheses() {
-        Expression::Identifier(identifier) => Some(identifier.name.as_str()),
+        Expression::Identifier(identifier) => Some((
+            identifier.name.as_str(),
+            (identifier.span.start, identifier.span.end),
+        )),
         _ => None,
     }
 }

--- a/packages/core-node/src/index.test.ts
+++ b/packages/core-node/src/index.test.ts
@@ -4,7 +4,9 @@ import { copyFile, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promi
 import os from "node:os"
 import path from "node:path"
 import { fileURLToPath } from "node:url"
+import { runInNewContext } from "node:vm"
 
+import ts from "typescript"
 import { afterEach, describe, expect, it } from "vitest"
 
 import {
@@ -745,6 +747,49 @@ function message(name) {
       sourcesContent: [source],
     })
     expect(map.mappings).not.toBe("")
+  })
+
+  it("executes transformed Trans through the compiled import when an authored local shadows it", () => {
+    const source = `import { Trans as MacroTrans } from "@palamedes/react/macro";
+import { Trans } from "@palamedes/react/compiled";
+function Example() {
+  const Trans = () => "authored-shadow"
+  return <MacroTrans>Hello</MacroTrans>
+}`
+    const result = transformMacrosNative(source, "sample.tsx")
+
+    expect(result.code).toContain(
+      'import { Trans as __palamedesTrans } from "@palamedes/react/compiled";'
+    )
+    expect(result.code).toContain("return <__palamedesTrans id=")
+
+    const executable = result.code
+      .replace(
+        'import { Trans as __palamedesTrans } from "@palamedes/react/compiled";',
+        'const __palamedesTrans = () => "compiled-component";'
+      )
+      .replace(
+        'import { Trans } from "@palamedes/react/compiled";',
+        'const Trans = () => "top-level-import";'
+      )
+    const output = ts.transpileModule(executable, {
+      compilerOptions: {
+        jsx: ts.JsxEmit.React,
+        jsxFactory: "jsx",
+        module: ts.ModuleKind.None,
+        target: ts.ScriptTarget.ES2022,
+      },
+    }).outputText
+    const context: {
+      Example?: () => { type: () => string }
+      jsx: (type: () => string) => { type: () => string }
+    } = {
+      jsx: (type) => ({ type }),
+    }
+
+    runInNewContext(output, context)
+
+    expect(context.Example?.().type()).toBe("compiled-component")
   })
 
   it.each(["react", "solid"] as const)(

--- a/packages/core-node/src/index.test.ts
+++ b/packages/core-node/src/index.test.ts
@@ -566,11 +566,14 @@ msgstr ""
         catalogPath: diagnostic.catalogPath?.replaceAll("\\", "/"),
       }))
     ).toStrictEqual([
-      expect.objectContaining({
+      {
         code: "translation.missing_catalog",
+        message:
+          `Translation catalog for locale \`fr\` is missing at \`${rootDir}${path.sep}locales/fr/messages.po\`. ` +
+          "Run `pmds extract` to create it before requesting this locale explicitly.",
         locale: "fr",
         catalogPath: path.join(rootDir, "locales", "fr", "messages.po").replaceAll("\\", "/"),
-      }),
+      },
     ])
 
     const sourceResult = listTranslationCandidates({ config, locales: ["en"] })


### PR DESCRIPTION
## Summary

Make macro cleanup binding-aware with the shared native OXC semantic facts. Transformed bindings are removed only after every value reference is consumed; live aliases/specifiers stay imported. `Trans` uses a collision-free compiled alias when its macro binding remains live.

## Issue

Closes #599

## Validation

- `cargo +1.95 fmt --all --check`
- `cargo +1.95 clippy --workspace --all-targets --locked -- -D warnings`
- `cargo +1.95 test --workspace --locked`
- `RUSTUP_TOOLCHAIN=1.95 pnpm build`
- `RUSTUP_TOOLCHAIN=1.95 pnpm check-types`
- `RUSTUP_TOOLCHAIN=1.95 pnpm test`
- `pnpm format:check` and `pnpm lint`
- Public native transform reproduction

## Follow-up

None.

🔧 Emily Carter · Implementation Agent