### PR TITLE
fix(waku): resolve packed runtime locally

### DIFF
--- a/packages/waku/scripts/packed-consumer.test.mjs
+++ b/packages/waku/scripts/packed-consumer.test.mjs
@@ -42,6 +42,10 @@ try {
       2
     )}\n`
   )
+  writeFileSync(
+    path.join(consumerRoot, "pnpm-workspace.yaml"),
+    `overrides:\n  "@palamedes/runtime": "file:${runtimeArchive}"\n`
+  )
   runPackageManager(consumerRoot, ["install", "--ignore-scripts"])
 
   const installedWaku = path.join(consumerRoot, "node_modules", "@palamedes", "waku")


### PR DESCRIPTION
## Summary

Pins the packed-consumer fixture’s transitive `@palamedes/runtime` resolution to the locally packed runtime tarball. This keeps the external-consumer tarball/import coverage intact and lets the gate pass at the unreleased `1.15.0` version.

������ Emily Carter · Implementation Agent

## Issue

Closes #626

## Validation

- `pnpm --filter @palamedes/waku test`
- `pnpm --filter @palamedes/waku exec tsc --noEmit -p tsconfig.json`
- `pnpm exec oxfmt --check packages/waku/scripts/packed-consumer.test.mjs`
- `pnpm check:release-set`

## Follow-up

The referenced Publish run’s Waku regression is addressed here. Its existing core-node test timeout is tracked separately and intentionally outside this PR’s scope.