### PR TITLE
fix(transform): instrument server action const aliases

### DIFF
--- a/crates/palamedes/src/transform/server_functions.rs
+++ b/crates/palamedes/src/transform/server_functions.rs
@@ -346,6 +346,17 @@ fn record_exported_initializer_functions(
     semantic: &Semantic<'_>,
     spans: &mut HashSet<(u32, u32)>,
 ) {
+    if let Expression::Identifier(identifier) = expression.get_inner_expression() {
+        if let Some(span) = identifier
+            .reference_id
+            .get()
+            .and_then(|reference_id| semantic.scoping().get_reference(reference_id).symbol_id())
+            .and_then(|symbol_id| local_async_function_spans.get(&symbol_id))
+        {
+            spans.insert(*span);
+        }
+    }
+
     let mut collector = ExportedInitializerFunctionCollector {
         spans,
         local_async_function_spans,

--- a/crates/palamedes/src/transform/tests.rs
+++ b/crates/palamedes/src/transform/tests.rs
@@ -112,6 +112,26 @@ export default save;
 }
 
 #[test]
+fn instruments_async_functions_exported_by_const_alias_identifier() {
+    let source = r#""use server";
+async function saveHandler() { await persist(); }
+export const save = saveHandler;
+export const later = laterHandler;
+async function laterHandler() { await archive(); }
+"#;
+    let result = transform_macros_raw(source, "actions.ts", Some(server_function_options()))
+        .expect("const-aliased local Server Functions should be instrumented");
+
+    assert_eq!(
+        result
+            .code
+            .matches("await __palamedesServerFunctionInitializer();")
+            .count(),
+        2
+    );
+}
+
+#[test]
 fn instruments_async_callbacks_inside_exported_action_initializers() {
     let source = r#""use server";
 const hidden = withAuth(async () => hide());


### PR DESCRIPTION
## Summary

- resolve direct exported const aliases to local async Server Function handlers
- cover aliases declared before and after their local handler

## Root cause

The transform only resolved local handler identifiers when they appeared as call arguments, not as a direct exported initializer.

## Validation

- `cargo fmt --check`
- `rustup run 1.97.1 cargo test -p palamedes`

Fixes #634.