### PR TITLE
fix(core): validate singular translation ICU

### DIFF
--- a/crates/palamedes/src/translation_candidates.rs
+++ b/crates/palamedes/src/translation_candidates.rs
@@ -427,7 +427,7 @@ where
             continue;
         }
 
-        for message in validate_plural_translation_branches(&patch.translation) {
+        for message in validate_translation_icu(&patch.translation) {
             rejected.insert(index);
             diagnostics.push(workflow_diagnostic(
                 "translation.invalid_icu",
@@ -983,29 +983,38 @@ fn validate_patch_translation(
     }
 }
 
-fn validate_plural_translation_branches(value: &TranslationValue) -> Vec<String> {
-    let TranslationValue::Plural {
-        variable,
-        plural_kind,
-        values,
-        ..
-    } = value
-    else {
-        return Vec::new();
-    };
+fn validate_translation_icu(value: &TranslationValue) -> Vec<String> {
+    match value {
+        TranslationValue::Singular { value } => parse_runtime_icu(value)
+            .err()
+            .map(|source| vec![format!("Singular translation is not valid ICU: {source}")])
+            .unwrap_or_default(),
+        TranslationValue::Plural {
+            variable,
+            plural_kind,
+            values,
+            ..
+        } => values
+            .iter()
+            .filter_map(|(selector, branch)| {
+                parse_plural_branch(variable, *plural_kind, branch)
+                    .err()
+                    .map(|source| {
+                        format!(
+                            "Plural translation branch `translation.values.{selector}` is not valid ICU: {source}"
+                        )
+                    })
+            })
+            .collect(),
+    }
+}
 
-    values
-        .iter()
-        .filter_map(|(selector, branch)| {
-            parse_plural_branch(variable, *plural_kind, branch)
-                .err()
-                .map(|source| {
-                    format!(
-                        "Plural translation branch `translation.values.{selector}` is not valid ICU: {source}"
-                    )
-                })
-        })
-        .collect()
+fn parse_runtime_icu(value: &str) -> Result<IcuMessage, ferrocat_icu::IcuParseError> {
+    let canonical = ferrocat::canonicalize_icu_with_policy(
+        value,
+        ferrocat::IcuSyntaxPolicy::RuntimeLiteralApostrophes,
+    );
+    parse_icu(&canonical)
 }
 
 fn validate_machine_provenance(machine: &TranslationMachineProvenance) -> Result<(), &'static str> {
@@ -1124,7 +1133,7 @@ fn parse_plural_branch(
         TranslationPluralKind::Ordinal => "selectordinal",
     };
     let wrapped = format!("{{{variable}, {formatter}, other {{{value}}}}}");
-    let parsed = parse_icu(&wrapped)?;
+    let parsed = parse_runtime_icu(&wrapped)?;
     let [IcuNode::Plural { options, .. }] = parsed.nodes.as_slice() else {
         unreachable!("the generated plural wrapper always parses to one plural node");
     };
@@ -1984,6 +1993,66 @@ mod tests {
         assert!(output.contains("\tc=Greeting shown on the home page"));
         assert!(output.contains("Review me\t\tBitte prüfen"));
         assert!(output.contains("\tf=fuzzy\tf=x-custom"));
+    }
+
+    #[test]
+    fn rejects_invalid_singular_icu_as_a_per_patch_diagnostic_without_writing() {
+        let fixture = tempfile::tempdir().expect("fixture directory");
+        let path = fixture.path().join("messages/de.po");
+        write_po_fixture(&path, "de");
+        let listed = list_translation_candidates(&TranslationCandidateRequest {
+            config: po_config(fixture.path()),
+            locales: vec!["de".to_owned()],
+            targets: vec![id("messages/{locale}", "de", "Hello", None)],
+            max_origins: 8,
+        })
+        .expect("list singular patch candidate");
+        let hello = candidate(&listed.candidates, "Hello");
+        let before = fs::read_to_string(&path).expect("read catalog before invalid patch");
+
+        let result = apply_translation_patches(TranslationPatchRequest {
+            config: po_config(fixture.path()),
+            po: None,
+            patches: vec![singular_patch(hello, "Hallo {name")],
+        })
+        .expect("reject invalid singular ICU as a diagnostic");
+
+        assert!(!result.updated);
+        assert_eq!(
+            result.outcomes[0].status,
+            TranslationPatchOutcomeStatus::Rejected
+        );
+        assert!(result.diagnostics.iter().any(|diagnostic| {
+            diagnostic.code == "translation.invalid_icu"
+                && diagnostic.id.as_ref() == Some(&hello.id)
+                && diagnostic.message.contains("Singular translation")
+        }));
+        assert_eq!(fs::read_to_string(&path).unwrap(), before);
+    }
+
+    #[test]
+    fn accepts_singular_icu_with_runtime_literal_apostrophes() {
+        let fixture = tempfile::tempdir().expect("fixture directory");
+        let path = fixture.path().join("messages/de.po");
+        write_po_fixture(&path, "de");
+        let listed = list_translation_candidates(&TranslationCandidateRequest {
+            config: po_config(fixture.path()),
+            locales: vec!["de".to_owned()],
+            targets: vec![id("messages/{locale}", "de", "Hello", None)],
+            max_origins: 8,
+        })
+        .expect("list singular patch candidate");
+        let hello = candidate(&listed.candidates, "Hello");
+
+        let result = apply_translation_patches(TranslationPatchRequest {
+            config: po_config(fixture.path()),
+            po: None,
+            patches: vec![singular_patch(hello, "L'{name} est prêt")],
+        })
+        .expect("accept a singular translation using runtime apostrophe semantics");
+
+        assert!(result.updated);
+        assert!(result.diagnostics.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- validate singular translation patches as ICU before persisting them
- align singular and plural validation with runtime apostrophe semantics
- cover invalid singular ICU and valid literal-apostrophe syntax

## Root cause

Only plural branches were parsed before catalog writes, allowing malformed singular ICU strings to be reported as applied.

## Validation

- `cargo fmt --check`
- `rustup run 1.97.1 cargo test -p palamedes`

Fixes #628.