### PR TITLE
fix(core-node): preserve prototype getter snapshots

### DIFF
--- a/packages/core-node/src/index.test.ts
+++ b/packages/core-node/src/index.test.ts
@@ -115,6 +115,17 @@ describe("@palamedes/core-node", () => {
         new Map([["message", ["valid", "\ud800"]]]),
       ])
     ).toThrow(/renderCatalogModule\.argument\[0\]\.get\(message\)\[1\]/u)
+
+    const isWellFormed = Object.getOwnPropertyDescriptor(String.prototype, "isWellFormed")
+    Object.defineProperty(String.prototype, "isWellFormed", {
+      configurable: true,
+      value: undefined,
+    })
+    try {
+      expect(() => parsePo("\ud800")).toThrow(/parsePo\.argument\[0\]/u)
+    } finally {
+      if (isWellFormed) Object.defineProperty(String.prototype, "isWellFormed", isWellFormed)
+    }
   })
 
   it("passes the single validated accessor and Proxy snapshot to native bindings", () => {
@@ -207,6 +218,15 @@ describe("@palamedes/core-node", () => {
       public message = "from class"
     }
     expect(renderCatalogModule(new ClassBackedMessages())).toContain("from class")
+
+    class PrototypeGetterMessages implements Record<string, string> {
+      [key: string]: string
+
+      get message() {
+        return "from prototype getter"
+      }
+    }
+    expect(renderCatalogModule(new PrototypeGetterMessages())).toContain("from prototype getter")
 
     const nonEnumerableMessages: Record<string, string> = {}
     Object.defineProperty(nonEnumerableMessages, "hidden", {

--- a/packages/core-node/src/index.test.ts
+++ b/packages/core-node/src/index.test.ts
@@ -116,15 +116,12 @@ describe("@palamedes/core-node", () => {
       ])
     ).toThrow(/renderCatalogModule\.argument\[0\]\.get\(message\)\[1\]/u)
 
-    const isWellFormed = Object.getOwnPropertyDescriptor(String.prototype, "isWellFormed")
-    Object.defineProperty(String.prototype, "isWellFormed", {
-      configurable: true,
-      value: undefined,
-    })
+    const isWellFormed = Reflect.getOwnPropertyDescriptor(String.prototype, "isWellFormed")
+    Reflect.deleteProperty(String.prototype, "isWellFormed")
     try {
       expect(() => parsePo("\ud800")).toThrow(/parsePo\.argument\[0\]/u)
     } finally {
-      if (isWellFormed) Object.defineProperty(String.prototype, "isWellFormed", isWellFormed)
+      if (isWellFormed) Reflect.defineProperty(String.prototype, "isWellFormed", isWellFormed)
     }
   })
 
@@ -222,8 +219,8 @@ describe("@palamedes/core-node", () => {
     class PrototypeGetterMessages implements Record<string, string> {
       [key: string]: string
 
-      get message() {
-        return "from prototype getter"
+      public get message() {
+        return ["from prototype getter"].join("")
       }
     }
     expect(renderCatalogModule(new PrototypeGetterMessages())).toContain("from prototype getter")

--- a/packages/core-node/src/native-loader.ts
+++ b/packages/core-node/src/native-loader.ts
@@ -384,6 +384,14 @@ function nativeVisiblePropertyNames(
   }
 }
 
+function enumerablePropertyNames(value: object, argumentPath: NativeArgumentPath): string[] {
+  try {
+    return Object.keys(value)
+  } catch (error) {
+    throw nativeBoundaryReadError(argumentPath, error)
+  }
+}
+
 function defineSnapshotProperty(target: object, key: string, value: unknown): void {
   Object.defineProperty(target, key, {
     configurable: true,

--- a/packages/core-node/src/native-loader.ts
+++ b/packages/core-node/src/native-loader.ts
@@ -114,6 +114,7 @@ function isWellFormed(value: string): boolean {
   for (let index = 0; index < value.length; index += 1) {
     const codeUnit = value.charCodeAt(index)
     if (codeUnit >= 55_296 && codeUnit <= 56_319) {
+      if (index + 1 >= value.length) return false
       const next = value.charCodeAt(index + 1)
       if (next < 56_320 || next > 57_343) return false
       index += 1
@@ -252,7 +253,7 @@ export function snapshotNativeArguments(operation: string, arguments_: unknown[]
     const recordSnapshot: Record<string, unknown> = {}
     snapshots.set(value, recordSnapshot)
     current.assign(recordSnapshot)
-    for (const key of enumerablePropertyNames(value, currentPath).reverse()) {
+    for (const key of nativeVisiblePropertyNames(value, classification, currentPath).reverse()) {
       const propertyPath = appendNativeArgumentPath(currentPath, `.${key}`)
       assertWellFormedPropertyName(key, propertyPath)
       pending.push({
@@ -320,7 +321,7 @@ function arrayPropertyPath(key: string): string {
 type SnapshotObjectClassification =
   | { kind: "array"; length: number }
   | { kind: "map" }
-  | { kind: "record" }
+  | { kind: "record"; prototype: object | null }
 
 function classifySnapshotObject(
   value: object,
@@ -331,7 +332,8 @@ function classifySnapshotObject(
       return { kind: "array", length: readArrayLength(value) }
     }
 
-    return isMapPrototype(Object.getPrototypeOf(value)) ? { kind: "map" } : { kind: "record" }
+    const prototype = Object.getPrototypeOf(value)
+    return isMapPrototype(prototype) ? { kind: "map" } : { kind: "record", prototype }
   } catch (error) {
     throw nativeBoundaryReadError(argumentPath, error)
   }
@@ -352,9 +354,31 @@ function isMapPrototype(prototype: object | null): boolean {
   return false
 }
 
-function enumerablePropertyNames(value: object, argumentPath: NativeArgumentPath): string[] {
+function nativeVisiblePropertyNames(
+  value: object,
+  classification: SnapshotObjectClassification,
+  argumentPath: NativeArgumentPath
+): string[] {
   try {
-    return Object.keys(value)
+    if (
+      classification.kind !== "record" ||
+      classification.prototype === null ||
+      classification.prototype === Object.prototype
+    ) {
+      return Object.keys(value)
+    }
+
+    const names = new Set(Object.getOwnPropertyNames(value))
+    for (
+      let prototype = classification.prototype;
+      prototype !== null && prototype !== Object.prototype;
+      prototype = Object.getPrototypeOf(prototype)
+    ) {
+      for (const name of Object.getOwnPropertyNames(prototype)) {
+        if (name !== "constructor") names.add(name)
+      }
+    }
+    return [...names]
   } catch (error) {
     throw nativeBoundaryReadError(argumentPath, error)
   }


### PR DESCRIPTION
## Summary

- preserve non-enumerable prototype getter values when snapshotting class instances
- reject a trailing lone high surrogate in the fallback Unicode validator
- add regression coverage for both cases

## Root cause

The snapshot layer used own enumerable keys only, unlike N-API's named-property reads, and its legacy Unicode fallback treated a missing low surrogate as valid.

## Validation

- `node_modules/.bin/oxfmt --check packages/core-node/src/native-loader.ts packages/core-node/src/index.test.ts`
- `CI=true RUSTUP_TOOLCHAIN=1.97.1 pnpm --filter @palamedes/core-node test` (blocked locally by an existing optional Darwin binding version mismatch; CI rebuilds the matching binding)

Fixes #630.