### PR TITLE
fix(next): degrade invalid catalog fragments

### DIFF
--- a/packages/next-plugin/palamedes-loader.cjs
+++ b/packages/next-plugin/palamedes-loader.cjs
@@ -143,9 +143,12 @@ function clientMessageBootstrap(config, sourcePath, compiledIds, fragmentFailure
     `);\n`
   const fragmentImports =
     fragmentFailureMode === "degrade"
-      ? `const ${identifier}_fragments = await Promise.all(${identifier}_activeLoaders.map(async (load) => {\n` +
+      ? `await Promise.all(${identifier}_activeLoaders.map(async (load) => {\n` +
         `  try {\n` +
-        `    return await load();\n` +
+        `    const fragment = await load();\n` +
+        `    if (fragment === null) return;\n` +
+        `    const { messages } = fragment;\n` +
+        `    ${identifier}_i18n.load(${identifier}_locale, messages);\n` +
         `  } catch (error) {\n` +
         `    try {\n` +
         `      console.error(\n` +
@@ -157,10 +160,18 @@ function clientMessageBootstrap(config, sourcePath, compiledIds, fragmentFailure
         `    } catch {\n` +
         `      // Logging must not prevent the client graph from hydrating.\n` +
         `    }\n` +
-        `    return null;\n` +
         `  }\n` +
         `}));\n`
       : `const ${identifier}_fragments = await Promise.all(${identifier}_activeLoaders.map((load) => load()));\n`
+
+  const fragmentRegistration =
+    fragmentFailureMode === "degrade"
+      ? ""
+      : `for (const fragment of ${identifier}_fragments) {\n` +
+        `  if (fragment === null) continue;\n` +
+        `  const { messages } = fragment;\n` +
+        `  ${identifier}_i18n.load(${identifier}_locale, messages);\n` +
+        `}\n`
 
   return `const ${identifier}_locale = document.documentElement.lang;
 const ${identifier}_loaderGroups = [${loaderGroups.join(", ")}];
@@ -168,11 +179,7 @@ const ${identifier}_activeLoaders = ${identifier}_loaderGroups.map((loaders) => 
 if (${identifier}_activeLoaders.some((loader) => loader === undefined)) {
   throw new Error(\`Palamedes client graph bootstrap does not support document locale "\${${identifier}_locale}". Configured locales: ${supportedLocales}.\`);
 }
-${imports}${fragmentImports}for (const fragment of ${identifier}_fragments) {
-  if (fragment === null) continue;
-  const { messages } = fragment;
-  ${identifier}_i18n.load(${identifier}_locale, messages);
-}
+${imports}${fragmentImports}${fragmentRegistration}
 `
 }
 

--- a/packages/next-plugin/src/palamedes-loader.test.ts
+++ b/packages/next-plugin/src/palamedes-loader.test.ts
@@ -384,6 +384,67 @@ describe("palamedes-loader.cjs", () => {
     }
   })
 
+  it("degrades an invalid resolved production catalog fragment and hydrates the module", async () => {
+    transformPalamedesMacros.mockReturnValue({
+      code: "globalThis.__pmds_test_body_ran = true;",
+      map: null,
+      compiledIds: ["id-a"],
+    })
+
+    const originalDocument = globalThis.document
+    const originalBodyRan = globalThis.__pmds_test_body_ran
+    const originalConsoleError = console.error
+    const errors: unknown[][] = []
+    const catalogError = new TypeError("Expected compiled catalog messages")
+    const loaded: Array<{ locale: string; messages: Record<string, unknown> }> = []
+    const i18n = {
+      load(locale: string, messages: Record<string, unknown> | undefined) {
+        if (messages === undefined) {
+          throw catalogError
+        }
+        loaded.push({ locale, messages })
+      },
+    }
+
+    try {
+      globalThis.document = { documentElement: { lang: "de" } } as Document
+      console.error = (...args: unknown[]) => errors.push(args)
+
+      const output = await runLoader({
+        clientMessageSplitting: true,
+        clientFragmentFailureMode: "degrade",
+      })
+      const modulePromise = executeGeneratedClientModule(output, async (specifier) => {
+        if (specifier === "@palamedes/core/compiled") {
+          return { createI18n: () => i18n }
+        }
+        if (specifier === "@palamedes/runtime") {
+          return { initializeClientI18n: () => i18n }
+        }
+        if (specifier.includes("./locales/de.po?palamedes-selected=")) {
+          return { default: "not a catalog" }
+        }
+        throw new Error(`Unexpected import: ${specifier}`)
+      })
+
+      await expect(modulePromise).resolves.toBeUndefined()
+      expect(globalThis.__pmds_test_body_ran).toBe(true)
+      expect(loaded).toEqual([])
+      expect(errors).toEqual([
+        [
+          "Palamedes client graph message splitting failed to load a catalog fragment for src/page.tsx (",
+          "de",
+          "). Continuing without that fragment.",
+          catalogError,
+        ],
+      ])
+    } finally {
+      restoreGlobal("document", originalDocument)
+      restoreGlobal("__pmds_test_body_ran", originalBodyRan)
+      console.error = originalConsoleError
+    }
+  })
+
   it("continues production hydration when diagnostic logging throws", async () => {
     transformPalamedesMacros.mockReturnValue({
       code: "globalThis.__pmds_test_body_ran = true;",


### PR DESCRIPTION
## Summary

- register each client catalog fragment inside its existing production degrade guard
- continue hydrating when a resolved fragment has no valid `messages` export
- add an execution regression test for a resolved non-catalog module

## Root cause

Only the dynamic import was guarded. A resolved module with an invalid catalog export could still make `i18n.load()` reject outside the degrade path and prevent client-module hydration.

## Validation

- `node_modules/.bin/vitest run --globals packages/next-plugin/src/palamedes-loader.test.ts`
- `node_modules/.bin/oxfmt --check packages/next-plugin/palamedes-loader.cjs packages/next-plugin/src/palamedes-loader.test.ts`
- `node_modules/.bin/oxlint packages/next-plugin/palamedes-loader.cjs packages/next-plugin/src/palamedes-loader.test.ts`

Fixes #631.