### PR TITLE
fix(next): reuse installed client locale

### DIFF
--- a/packages/next-plugin/palamedes-loader.cjs
+++ b/packages/next-plugin/palamedes-loader.cjs
@@ -137,10 +137,13 @@ function clientMessageBootstrap(config, sourcePath, compiledIds, fragmentFailure
     `  import("@palamedes/core/compiled"),\n` +
     `  import("@palamedes/runtime"),\n` +
     `]);\n` +
-    `const ${identifier}_i18n = ${identifier}_modules[1].initializeClientI18n(\n` +
-    `  ${identifier}_locale,\n` +
-    `  ${identifier}_modules[0].createI18n,\n` +
-    `);\n`
+    `let ${identifier}_existingI18n;\n` +
+    `try {\n` +
+    `  ${identifier}_existingI18n = ${identifier}_modules[1].getI18n();\n` +
+    `} catch {\n` +
+    `  // No client i18n has been installed yet.\n` +
+    `}\n` +
+    `const ${identifier}_locale = ${identifier}_existingI18n?.locale ?? document.documentElement.lang;\n`
   const fragmentImports =
     fragmentFailureMode === "degrade"
       ? `await Promise.all(${identifier}_activeLoaders.map(async (load) => {\n` +
@@ -173,13 +176,24 @@ function clientMessageBootstrap(config, sourcePath, compiledIds, fragmentFailure
         `  ${identifier}_i18n.load(${identifier}_locale, messages);\n` +
         `}\n`
 
-  return `const ${identifier}_locale = document.documentElement.lang;
-const ${identifier}_loaderGroups = [${loaderGroups.join(", ")}];
+  const initialize = `const ${identifier}_i18n = ${identifier}_existingI18n ?? ${identifier}_modules[1].initializeClientI18n(
+  ${identifier}_locale,
+  ${identifier}_modules[0].createI18n,
+);
+`
+  const unsupportedLocale = `new Error(\`Palamedes client graph bootstrap does not support document locale "\${${identifier}_locale}". Configured locales: ${supportedLocales}.\`)`
+  const unsupportedLocaleHandling =
+    fragmentFailureMode === "degrade"
+      ? `try {\n  console.error(${unsupportedLocale});\n} catch {\n  // Logging must not prevent the client graph from hydrating.\n}\n`
+      : `throw ${unsupportedLocale};\n`
+
+  return `const ${identifier}_loaderGroups = [${loaderGroups.join(", ")}];
+${imports}
 const ${identifier}_activeLoaders = ${identifier}_loaderGroups.map((loaders) => loaders[${identifier}_locale]);
 if (${identifier}_activeLoaders.some((loader) => loader === undefined)) {
-  throw new Error(\`Palamedes client graph bootstrap does not support document locale "\${${identifier}_locale}". Configured locales: ${supportedLocales}.\`);
-}
-${imports}${fragmentImports}${fragmentRegistration}
+  ${unsupportedLocaleHandling}}
+else {
+${initialize}${fragmentImports}${fragmentRegistration}}
 `
 }
 

--- a/packages/next-plugin/src/palamedes-loader.test.ts
+++ b/packages/next-plugin/src/palamedes-loader.test.ts
@@ -211,7 +211,7 @@ describe("palamedes-loader.cjs", () => {
 
     const output = await runLoader({ clientMessageSplitting: true })
 
-    expect(output).toContain("_locale = document.documentElement.lang")
+    expect(output).toContain("_existingI18n?.locale ?? document.documentElement.lang")
     expect(output).toContain("_modules = await Promise.all")
     expect(output).toContain("_fragments = await Promise.all")
     expect(output).toContain('"en": () => import("./locales/en.po?palamedes-selected=')
@@ -294,6 +294,88 @@ describe("palamedes-loader.cjs", () => {
       restoreGlobal("document", originalDocument)
       restoreGlobal("__pmds_test_getI18n", originalGetI18n)
       restoreGlobal("__pmds_test_label", originalLabel)
+    }
+  })
+
+  it("uses the installed client locale when the document locale changes", async () => {
+    transformPalamedesMacros.mockReturnValue({
+      code: "globalThis.__pmds_test_body_ran = true;",
+      map: null,
+      compiledIds: ["id-a"],
+    })
+    const originalDocument = globalThis.document
+    const originalBodyRan = globalThis.__pmds_test_body_ran
+    const loaded: Array<{ locale: string; messages: Record<string, unknown> }> = []
+    const i18n = {
+      locale: "de",
+      load(locale: string, messages: Record<string, unknown>) {
+        loaded.push({ locale, messages })
+      },
+    }
+    const initializeClientI18n = vi.fn()
+
+    try {
+      globalThis.document = { documentElement: { lang: "fr" } } as Document
+      const output = await runLoader({
+        clientMessageSplitting: true,
+        clientFragmentFailureMode: "degrade",
+      })
+      await expect(
+        executeGeneratedClientModule(output, async (specifier) => {
+          if (specifier === "@palamedes/core/compiled") return { createI18n: vi.fn() }
+          if (specifier === "@palamedes/runtime")
+            return { getI18n: () => i18n, initializeClientI18n }
+          if (specifier.includes("./locales/de.po?palamedes-selected="))
+            return { messages: { id: "translated" } }
+          throw new Error(`Unexpected import: ${specifier}`)
+        })
+      ).resolves.toBeUndefined()
+      expect(globalThis.__pmds_test_body_ran).toBe(true)
+      expect(initializeClientI18n).not.toHaveBeenCalled()
+      expect(loaded).toEqual([{ locale: "de", messages: { id: "translated" } }])
+    } finally {
+      restoreGlobal("document", originalDocument)
+      restoreGlobal("__pmds_test_body_ran", originalBodyRan)
+    }
+  })
+
+  it("degrades an unsupported document locale before a client i18n is installed", async () => {
+    transformPalamedesMacros.mockReturnValue({
+      code: "globalThis.__pmds_test_body_ran = true;",
+      map: null,
+      compiledIds: ["id-a"],
+    })
+    const originalDocument = globalThis.document
+    const originalBodyRan = globalThis.__pmds_test_body_ran
+    const originalConsoleError = console.error
+    const errors: unknown[][] = []
+    try {
+      globalThis.document = { documentElement: { lang: "fr" } } as Document
+      console.error = (...args: unknown[]) => errors.push(args)
+      const output = await runLoader({
+        clientMessageSplitting: true,
+        clientFragmentFailureMode: "degrade",
+      })
+      await expect(
+        executeGeneratedClientModule(output, async (specifier) => {
+          if (specifier === "@palamedes/core/compiled") return { createI18n: vi.fn() }
+          if (specifier === "@palamedes/runtime")
+            return {
+              getI18n() {
+                throw new Error("No active client i18n")
+              },
+              initializeClientI18n: vi.fn(),
+            }
+          throw new Error(`Unexpected import: ${specifier}`)
+        })
+      ).resolves.toBeUndefined()
+      expect(globalThis.__pmds_test_body_ran).toBe(true)
+      expect(errors).toHaveLength(1)
+      expect(errors[0]?.[0]).toBeInstanceOf(Error)
+    } finally {
+      restoreGlobal("document", originalDocument)
+      restoreGlobal("__pmds_test_body_ran", originalBodyRan)
+      console.error = originalConsoleError
     }
   })
 


### PR DESCRIPTION
## Summary

- reuse an installed client i18n locale before reading `document.documentElement.lang`
- degrade an unsupported initial document locale in production without rejecting the client module
- add execution regressions for both DOM locale mutation paths

## Root cause

Every graph-split module read the mutable document locale at evaluation time. A browser translation or proxy-normalized locale could select no catalog and cause a top-level exception, even after a client i18n instance had been initialized.

## Validation

- `node_modules/.bin/vitest run --globals packages/next-plugin/src/palamedes-loader.test.ts`
- `node_modules/.bin/oxfmt --check packages/next-plugin/palamedes-loader.cjs packages/next-plugin/src/palamedes-loader.test.ts`
- `node_modules/.bin/oxlint packages/next-plugin/palamedes-loader.cjs packages/next-plugin/src/palamedes-loader.test.ts`

Fixes #632.