### PR TITLE
fix(next): harden split catalog caches

### DIFF
--- a/crates/palamedes/src/catalog_artifact/cache.rs
+++ b/crates/palamedes/src/catalog_artifact/cache.rs
@@ -161,6 +161,24 @@ impl CatalogCompilationCache {
 
     fn insert_ready(&self, key: CompilationCacheKey, compiled: Arc<CachedCompilation>) {
         let mut state = lock_unpoison(&self.state);
+        let superseded = state
+            .ready
+            .keys()
+            .filter(|existing| {
+                existing != &&key
+                    && existing.files.len() == key.files.len()
+                    && existing
+                        .files
+                        .iter()
+                        .zip(&key.files)
+                        .all(|(left, right)| left.path == right.path)
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        for stale in superseded {
+            state.ready.remove(&stale);
+            state.last_used.remove(&stale);
+        }
         if state.ready.len() >= self.capacity {
             if let Some(oldest) = state
                 .last_used

--- a/crates/palamedes/src/catalog_artifact/tests.rs
+++ b/crates/palamedes/src/catalog_artifact/tests.rs
@@ -677,6 +677,11 @@ fn selected_catalog_cache_invalidates_equal_mtime_content_replacement() {
         Some("Guten Tag")
     );
     assert_eq!(
+        cache.ready_len(),
+        1,
+        "a changed catalog must replace, rather than retain, its superseded cache generation"
+    );
+    assert_eq!(
         cache.statistics(),
         super::cache::CacheStatistics {
             parses: 5,

--- a/packages/next-plugin/palamedes-loader.cjs
+++ b/packages/next-plugin/palamedes-loader.cjs
@@ -1,7 +1,7 @@
 "use strict"
 
 const { createHash } = require("node:crypto")
-const { realpathSync, statSync } = require("node:fs")
+const { readFileSync, realpathSync, statSync } = require("node:fs")
 const path = require("node:path")
 const { decode, encode } = require("@jridgewell/sourcemap-codec")
 const { loadPalamedesConfigSync } = require("@palamedes/config")
@@ -29,7 +29,10 @@ function loadConfigCached(configPath) {
   const cached = configCache.get(key)
   if (cached) {
     try {
-      if (statSync(cached.config.configPath).mtimeMs === cached.mtimeMs) {
+      if (
+        createHash("sha256").update(readFileSync(cached.config.configPath)).digest("hex") ===
+        cached.digest
+      ) {
         return cached.config
       }
     } catch {
@@ -41,7 +44,7 @@ function loadConfigCached(configPath) {
   try {
     configCache.set(key, {
       config,
-      mtimeMs: statSync(config.configPath).mtimeMs,
+      digest: createHash("sha256").update(readFileSync(config.configPath)).digest("hex"),
     })
   } catch {
     // Tests and virtual configs may not have a stat-able config file.
@@ -82,7 +85,7 @@ function catalogResourcePath(config, catalog, locale) {
       `Palamedes Next message splitting currently supports PO catalogs only. Catalog ${catalog.path} uses format ${extension}.`
     )
   }
-  const configuredPath = path.resolve(config.rootDir, catalog.path.replace("{locale}", locale))
+  const configuredPath = path.resolve(config.rootDir, catalog.path.replaceAll("{locale}", locale))
   const parsed = path.parse(configuredPath)
   return path.format({ dir: parsed.dir, name: parsed.name, ext: `.${extension}` })
 }
@@ -309,7 +312,9 @@ function shiftedGeneratedPosition(position, insertionPosition, insertion, metric
     return position
   }
   if (metrics.addedLines === 0) {
-    return { line: position.line, column: position.column + insertion.length }
+    return position.line === insertionPosition.line
+      ? { line: position.line, column: position.column + insertion.length }
+      : position
   }
   return {
     line: position.line + metrics.addedLines,

--- a/packages/next-plugin/palamedes-po-loader.cjs
+++ b/packages/next-plugin/palamedes-po-loader.cjs
@@ -1,6 +1,7 @@
 "use strict"
 
-const { statSync } = require("node:fs")
+const { createHash } = require("node:crypto")
+const { readFileSync } = require("node:fs")
 const path = require("node:path")
 const { loadPalamedesConfig } = require("@palamedes/config")
 const { compileCatalogArtifactSelected, compileCatalogModule } = require("@palamedes/core-node")
@@ -12,7 +13,7 @@ const SELECTED_MESSAGES_QUERY = "palamedes-selected"
 /*
  * Loading the config walks the filesystem upward and parses the file; doing
  * that once per .po file per rebuild is wasteful. Cache per requested path
- * and invalidate on config-file mtime changes, so webpack rebuilds triggered
+ * and invalidate on config-file content changes, so webpack rebuilds triggered
  * by the addDependency below observe the edited config.
  */
 const configCache = new Map()
@@ -22,7 +23,10 @@ async function loadConfigCached(configPath) {
   const cached = configCache.get(key)
   if (cached) {
     try {
-      if (statSync(cached.cfg.configPath).mtimeMs === cached.mtimeMs) {
+      if (
+        createHash("sha256").update(readFileSync(cached.cfg.configPath)).digest("hex") ===
+        cached.digest
+      ) {
         return cached.cfg
       }
     } catch {
@@ -31,7 +35,10 @@ async function loadConfigCached(configPath) {
   }
   const cfg = await loadPalamedesConfig({ configPath })
   try {
-    configCache.set(key, { cfg, mtimeMs: statSync(cfg.configPath).mtimeMs })
+    configCache.set(key, {
+      cfg,
+      digest: createHash("sha256").update(readFileSync(cfg.configPath)).digest("hex"),
+    })
   } catch {
     // Config not stat-able (e.g. stubbed in tests) — serve it uncached.
   }


### PR DESCRIPTION
## Summary

- hash Next loader configs by content instead of trusting their modification times
- replace every `{locale}` path placeholder and preserve later source-map columns for single-line insertions
- evict superseded selected-catalog cache generations with the same dependency file set

## Root cause

The JavaScript loaders could serve stale configuration after an equal-mtime replacement, generated imports disagreed with Rust for repeated locale placeholders, and catalog edits accumulated obsolete full snapshots in the native-process cache.

## Validation

- `node_modules/.bin/vitest run --globals packages/next-plugin/src/palamedes-loader.test.ts`
- `node_modules/.bin/oxfmt --check packages/next-plugin/palamedes-loader.cjs packages/next-plugin/palamedes-po-loader.cjs`
- `node_modules/.bin/oxlint packages/next-plugin/palamedes-loader.cjs packages/next-plugin/palamedes-po-loader.cjs`
- `rustup run 1.97.1 cargo test -p palamedes catalog_artifact::tests::selected_catalog_cache_invalidates_equal_mtime_content_replacement`

Fixes #633.