### PR TITLE
test(core-node): cover native panic conversion

### DIFF
--- a/crates/palamedes-node/src/catalog.rs
+++ b/crates/palamedes-node/src/catalog.rs
@@ -1765,6 +1765,13 @@ pub fn apply_translation_patches_with_injected_write_failure(
     )
 }
 
+#[cfg(feature = "test-support")]
+#[doc(hidden)]
+#[napi(catch_unwind)]
+pub fn panic_for_test_support() {
+    panic!("Palamedes test-support panic")
+}
+
 fn translation_patch_result_or_throw(
     env: Env,
     result: palamedes::PalamedesResult<palamedes::TranslationPatchResult>,

--- a/packages/core-node/src/index.test.ts
+++ b/packages/core-node/src/index.test.ts
@@ -683,6 +683,12 @@ msgstr ""
     await expect(readFile(secondPath, "utf8")).resolves.toBe(catalog)
   })
 
+  it("surfaces a native panic as a catchable JavaScript error", async () => {
+    const addon = await loadTestSupportAddon()
+
+    expect(() => addon.panicForTestSupport()).toThrowError(/Palamedes test-support panic/u)
+  })
+
   it("patches candidates listed with truncated origins using a stable fingerprint", async () => {
     const rootDir = await createTempDir()
     const catalogDir = path.join(rootDir, "locales", "de")
@@ -1080,6 +1086,7 @@ type TestSupportBindings = Pick<GeneratedNativeBindings, "listTranslationCandida
     request: GeneratedTranslationPatchRequest,
     failingPath: string
   ): GeneratedTranslationPatchResult
+  panicForTestSupport(): void
 }
 
 async function loadTestSupportAddon(): Promise<TestSupportBindings> {


### PR DESCRIPTION
## Summary

- expose a test-support-only N-API function that deliberately panics under `catch_unwind`
- prove the compiled addon exposes that panic as a catchable JavaScript `Error`

## Root cause

The existing source-level guard verified the N-API attributes but did not exercise the runtime behavior of a panic across a built native boundary.

## Validation

- `cargo fmt --check`
- `node_modules/.bin/oxfmt --check packages/core-node/src/index.test.ts`
- test-support addon built successfully with `RUSTUP_TOOLCHAIN=1.97.1`
- full local Core Node test runner is blocked after addon build by the pre-existing optional macOS binding version mismatch (`1.11.0` installed vs workspace `1.15.0`); CI rebuilds the binding cleanly

Fixes #629.