### PR TITLE
fix(examples): synchronize Waku document locale

### DIFF
--- a/examples/waku-cookie/src/lib/i18n.ts
+++ b/examples/waku-cookie/src/lib/i18n.ts
@@ -70,6 +70,7 @@ export function initializeClientI18n(locale: Locale) {
   clientI18n.activate(locale)
 
   if (typeof window !== "undefined") {
+    document.documentElement.lang = locale
     setClientI18n(clientI18n)
   }
 }

--- a/examples/waku-cookie/src/pages/_root.tsx
+++ b/examples/waku-cookie/src/pages/_root.tsx
@@ -1,13 +1,9 @@
 import type { ReactNode } from "react"
 import "@palamedes/example-ui/styles.css"
-import { unstable_getHeaders } from "waku/router/server"
-import { resolveCookieLocale } from "../lib/i18n"
 
-export default async function Root({ children }: { children: ReactNode }) {
-  const { locale } = resolveCookieLocale(unstable_getHeaders())
-
+export default function Root({ children }: { children: ReactNode }) {
   return (
-    <html lang={locale}>
+    <html lang="en">
       <head>
         <meta charSet="utf-8" />
         <meta content="width=device-width, initial-scale=1" name="viewport" />

--- a/examples/waku-route/src/lib/i18n.ts
+++ b/examples/waku-route/src/lib/i18n.ts
@@ -54,6 +54,7 @@ export function initializeClientI18n(locale: Locale) {
   clientI18n.activate(locale)
 
   if (typeof window !== "undefined") {
+    document.documentElement.lang = locale
     setClientI18n(clientI18n)
   }
 

--- a/examples/waku-subdomain/src/lib/i18n.ts
+++ b/examples/waku-subdomain/src/lib/i18n.ts
@@ -52,6 +52,7 @@ export function initializeClientI18n(locale: Locale) {
   clientI18n.activate(locale)
 
   if (typeof window !== "undefined") {
+    document.documentElement.lang = locale
     setClientI18n(clientI18n)
   }
 

--- a/examples/waku-tld/src/lib/i18n.ts
+++ b/examples/waku-tld/src/lib/i18n.ts
@@ -56,6 +56,7 @@ export function initializeClientI18n(locale: Locale) {
   clientI18n.activate(locale)
 
   if (typeof window !== "undefined") {
+    document.documentElement.lang = locale
     setClientI18n(clientI18n)
   }
 

--- a/tests/examples-browser/examples.browser.test.js
+++ b/tests/examples-browser/examples.browser.test.js
@@ -56,14 +56,6 @@ function hasClientLocaleProbe(example) {
   return ["solidstart-cookie", "tanstack-cookie", "waku-cookie"].includes(example.id)
 }
 
-function hasServerDocumentLocale(example) {
-  return example.id !== "waku-cookie"
-}
-
-function documentLocale(example, locale) {
-  return hasServerDocumentLocale(example) ? locale : "en"
-}
-
 function isHydrationMismatch(message) {
   return (
     /\b(?:hydration|hydrate|hydrated)\b.*\b(?:mismatch|failed|error)/iu.test(message) ||
@@ -239,7 +231,7 @@ test("matrix example browser contract", async () => {
     .toMatch(example.strategy === "cookie" ? /español/iu : /english/iu)
   await expect
     .poll(() => page.locator("html").getAttribute("lang"))
-    .toBe(documentLocale(example, example.strategy === "cookie" ? "es" : "en"))
+    .toBe(example.strategy === "cookie" ? "es" : "en")
   await waitForClientReady(page)
   expect(pageErrors).toEqual([])
   if (hasClientLocaleProbe(example)) {
@@ -257,9 +249,7 @@ test("matrix example browser contract", async () => {
       .click({ force: true, noWaitAfter: true, timeout: 15_000 })
     await navigation
 
-    await expect
-      .poll(() => page.locator("html").getAttribute("lang"))
-      .toBe(documentLocale(example, "de"))
+    await expect.poll(() => page.locator("html").getAttribute("lang")).toBe("de")
     await expect.poll(() => currentServerLocale(page)).toContain("Deutsch")
 
     await waitForClientReady(page)


### PR DESCRIPTION
## Summary

- synchronize `document.documentElement.lang` whenever each Waku example activates its client locale
- remove the ineffective Waku cookie root-locale code
- make browser examples assert the actual document locale for every cookie example, including Waku

## Root cause

Waku's static document shell did not apply the route-root locale to the served document. The client already knows the resolved locale, but never updated the document element; the browser test consequently encoded a Waku-only exception.

## Validation

- `node_modules/.bin/oxfmt --write` for changed Waku sources and browser test
- `node_modules/.bin/oxlint` for changed Waku sources and browser test

Fixes #635.