### PR TITLE
ci: run React Router RSC isolation proof

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,10 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Install Playwright Chromium
+        if: matrix.os == 'ubuntu-24.04' && matrix.node == 24
+        run: pnpm exec playwright install --with-deps chromium
+
       - name: Check remix@next canary workflow contract
         if: matrix.os == 'ubuntu-24.04' && matrix.node == 24
         run: pnpm check:remix-next-canary
@@ -72,6 +76,10 @@ jobs:
       - name: Verify Next.js RSC request scope with Webpack
         if: matrix.os == 'ubuntu-24.04' && matrix.node == 24
         run: pnpm --filter @palamedes/example-nextjs-cookie test:rsc-scope:webpack
+
+      - name: Verify React Router RSC request scope
+        if: matrix.os == 'ubuntu-24.04' && matrix.node == 24
+        run: pnpm verify:react-router-rsc
 
       - name: Verify Next.js development catalog invalidation
         if: matrix.os == 'ubuntu-24.04' && matrix.node == 24

--- a/scripts/workflow-contracts.test.mjs
+++ b/scripts/workflow-contracts.test.mjs
@@ -60,6 +60,19 @@ describe("workflow contracts", () => {
     expect(vitePlugin.scripts.test).toBe("vitest run --globals")
   })
 
+  it("runs the React Router RSC request-isolation proof on Linux", async () => {
+    const ci = await readRepositoryFile(".github/workflows/ci.yml")
+    const validate = job(ci, "validate", "validate-rust")
+
+    expect(ci).toContain("- name: Verify React Router RSC request scope")
+    expect(ci).toContain("if: matrix.os == 'ubuntu-24.04' && matrix.node == 24")
+    expect(ci).toContain("run: pnpm verify:react-router-rsc")
+    expect(validate).toContain("- name: Install Playwright Chromium")
+    expect(validate.indexOf("run: pnpm exec playwright install --with-deps chromium")).toBeLessThan(
+      validate.indexOf("run: pnpm verify:react-router-rsc")
+    )
+  })
+
   it("requires locked Rust workspace tests before any release publishing", async () => {
     const publish = await readRepositoryFile(".github/workflows/publish.yml")
     const validateRelease = job(publish, "validate-release", "publish-native")


### PR DESCRIPTION
## Summary

- run the React Router RSC request-isolation proof on the Linux/Node 24 validation leg
- lock that coverage into the workflow contract test

Closes #636.

## Validation

- `pnpm vitest run scripts/workflow-contracts.test.mjs`
- `RUSTUP_TOOLCHAIN=1.97.1 pnpm build && RUSTUP_TOOLCHAIN=1.97.1 pnpm verify:react-router-rsc`
- `node_modules/.bin/oxfmt --check scripts/workflow-contracts.test.mjs`
- `git diff --check`