### PR TITLE
fix(tanstack): brand resolver failures

### DIFF
--- a/docs/api/tanstack.md
+++ b/docs/api/tanstack.md
@@ -43,12 +43,39 @@ this example; Start removes that branch from the client build.
 The resolver receives the original Fetch `Request`, including headers and
 cookies. It owns locale negotiation, catalog loading, and creation of a fresh
 i18n instance; Palamedes owns activation and cleanup. An initializer failure
-stops the server function and propagates as a server error.
+stops the server function and throws an error beginning `Palamedes TanStack
+i18n initialization failed`, with the original cause attached.
 
 Start invokes this boundary before decoding and invoking a server function. The
 scope stays active through awaited `next()`, including validation, handler work,
 and synchronous, asynchronous, or cross-module helpers that call translated
 code.
+
+## SSR page rendering
+
+TanStack Start does not run request middleware for page SSR or server routes.
+Wrap the server entry with a request-local scope using the same resolver:
+
+```ts
+import { createStartHandler, defaultStreamHandler } from "@tanstack/react-start/server"
+import { createServerI18nScope } from "@palamedes/runtime/server"
+import { createServerI18nFromRequest } from "./lib/i18n.server"
+
+const handler = createStartHandler(defaultStreamHandler)
+const ssrI18nScope = createServerI18nScope()
+
+export default {
+  async fetch(request: Request, options?: never) {
+    return await ssrI18nScope.run(await createServerI18nFromRequest(request), () =>
+      handler(request, options)
+    )
+  },
+}
+```
+
+The outer entry scope supplies SSR. If you also register the global request
+middleware, its fresh nested scope for server functions is intentional: it
+starts before Start decodes the function request.
 
 ## Composable server-function middleware
 

--- a/docs/framework-example-notes.md
+++ b/docs/framework-example-notes.md
@@ -26,7 +26,8 @@ The `tanstack-cookie`, `tanstack-route`, `tanstack-subdomain`, and
 `tanstack-tld` examples verify:
 
 - Vite-based Palamedes integration in TanStack Start
-- SSR plus localized server functions through `@palamedes/tanstack` request middleware
+- request-local SSR through each fixture's explicit server-entry scope
+- localized server functions through `@palamedes/tanstack` request middleware in `tanstack-cookie`
 - `.po` loading through `@palamedes/vite-plugin`
 - cookie-derived, route-derived, subdomain-derived, and tld-derived locale flows
 
@@ -52,7 +53,7 @@ The `waku-cookie`, `waku-route`, `waku-subdomain`, and `waku-tld` examples verif
 
 - Waku file-based `src/pages` routing with the default adapter path
 - Waku-native SSR with provider-free Palamedes rendering
-- localized server actions through `@palamedes/waku` request-scoped interceptor coverage
+- request-scoped server-action interceptor coverage through `@palamedes/waku` in `waku-cookie`
 - `.po` loading through the Vite plugin path exposed via `waku.config.ts`
 - cookie-derived, route-derived, subdomain-derived, and tld-derived locale flows
 

--- a/examples/tanstack-cookie/src/server.ts
+++ b/examples/tanstack-cookie/src/server.ts
@@ -10,6 +10,8 @@ const handler = createStartHandler(defaultStreamHandler)
 
 export default {
   async fetch(request: Request, options?: never) {
+    // This outer scope owns SSR. The request middleware in start.ts deliberately
+    // creates a fresh nested scope for server functions before Start decodes them.
     const { locale } = locales.resolve({
       strategy: "cookie",
       acceptLanguageHeader: request.headers.get("accept-language"),

--- a/packages/tanstack/README.md
+++ b/packages/tanstack/README.md
@@ -43,6 +43,36 @@ does not activate i18n for page rendering or server routes. It starts before
 Start decodes and invokes a server function, and keeps the request-local scope
 active until its awaited `next()` completes.
 
+If the resolver fails, the server function does not run and the middleware
+throws an error beginning `Palamedes TanStack i18n initialization failed`, with
+the original cause attached.
+
+## SSR page rendering
+
+TanStack Start invokes request middleware only for server functions. Scope SSR
+in the server entry separately, using the same request-to-i18n resolver:
+
+```ts
+import { createStartHandler, defaultStreamHandler } from "@tanstack/react-start/server"
+import { createServerI18nScope } from "@palamedes/runtime/server"
+import { createServerI18nFromRequest } from "./lib/i18n.server"
+
+const handler = createStartHandler(defaultStreamHandler)
+const ssrI18nScope = createServerI18nScope()
+
+export default {
+  async fetch(request: Request, options?: never) {
+    return await ssrI18nScope.run(await createServerI18nFromRequest(request), () =>
+      handler(request, options)
+    )
+  },
+}
+```
+
+When this entry scope and the request middleware are both registered, the
+nested initialization is intentional: the outer scope handles SSR, while the
+middleware starts a fresh scope before Start decodes a server function.
+
 ## Per-function middleware
 
 Use `createTanStackI18nMiddleware()` when only selected server functions need

--- a/packages/tanstack/src/index.test.ts
+++ b/packages/tanstack/src/index.test.ts
@@ -61,8 +61,9 @@ describe("TanStack i18n request scope", () => {
   it("does not invoke the handler when initialization fails and restores an outer scope", async () => {
     const outerScope = createServerI18nScope<I18nInstance>()
     const outerI18n = createTestI18n("en")
+    const failure = new Error("catalog is unavailable")
     const runner = createScopedTanStackI18nRunner(async () => {
-      throw new Error("Palamedes TanStack i18n initialization failed")
+      throw failure
     })
 
     await outerScope.run(outerI18n, async () => {
@@ -70,7 +71,11 @@ describe("TanStack i18n request scope", () => {
         runner.run(new Request("https://example.test/_serverFn/probe"), async () => {
           throw new Error("handler must not run")
         })
-      ).rejects.toThrow("Palamedes TanStack i18n initialization failed")
+      ).rejects.toMatchObject({
+        message:
+          "Palamedes TanStack i18n initialization failed before server-function dispatch ran.",
+        cause: failure,
+      })
       expect(getI18n()).toBe(outerI18n)
     })
   })

--- a/packages/tanstack/src/scope.ts
+++ b/packages/tanstack/src/scope.ts
@@ -15,7 +15,15 @@ export function createScopedTanStackI18nRunner<T extends I18nInstance>(
 
   return {
     async run(request, next) {
-      const i18n = await resolveI18n(request)
+      let i18n: T
+      try {
+        i18n = await resolveI18n(request)
+      } catch (error) {
+        throw new Error(
+          "Palamedes TanStack i18n initialization failed before server-function dispatch ran.",
+          { cause: error }
+        )
+      }
       return await scope.run(i18n, async () => await next())
     },
     scope,


### PR DESCRIPTION
## Summary

- wrap TanStack resolver failures with a branded initialization error and preserve their cause
- replace the test-authored failure branding with a real regression assertion
- document the explicit SSR entry scope, intentional nested cookie-example setup, and accurate framework coverage

Closes #638.

## Validation

- `pnpm --filter @palamedes/tanstack test`
- `node_modules/.bin/oxfmt --check packages/tanstack/src/scope.ts packages/tanstack/src/index.test.ts examples/tanstack-cookie/src/server.ts`
- `git diff --check`

The local site build/typecheck regenerates an unrelated stale route entry, which is intentionally excluded. The clean CI checkout remains the authoritative full site gate.