### PR TITLE
test(waku): rendezvous cookie requests inside scope

### DIFF
--- a/examples/waku-cookie/src/pages/_interceptors/test-barrier.server.ts
+++ b/examples/waku-cookie/src/pages/_interceptors/test-barrier.server.ts
@@ -1,0 +1,12 @@
+import { waitForServerI18nTestBarrier } from "@palamedes/runtime/server/test"
+import { unstable_getRequest, type HandlerInterceptor } from "waku/router/server"
+
+// fsRouter registers interceptor files in lexical order. This filename follows
+// palamedes.server.ts, so reduceRight runs this barrier inside the Palamedes
+// request scope after i18n activation and before page rendering begins.
+const testBarrierInterceptor: HandlerInterceptor = async (next) => {
+  await waitForServerI18nTestBarrier(unstable_getRequest())
+  return await next()
+}
+
+export default testBarrierInterceptor

--- a/examples/waku-cookie/src/waku.server.ts
+++ b/examples/waku-cookie/src/waku.server.ts
@@ -1,9 +1,6 @@
 import { fsRouter } from "waku"
 import adapter from "waku/adapters/default"
-import {
-  markServerI18nTestBarrierReached,
-  waitForServerI18nTestBarrier,
-} from "@palamedes/runtime/server/test"
+import { markServerI18nTestBarrierReached } from "@palamedes/runtime/server/test"
 
 // Glob keys must keep the `pages/` prefix so fsRouter's default `pagesDir: "pages"`
 // matches them. Globbing from `/src` and stripping the leading `/src/` yields
@@ -21,9 +18,9 @@ export default adapter(fsRouter(modules), {
   middlewareFns: [
     () => async (context, next) => {
       const request = context.req.raw
-      await waitForServerI18nTestBarrier(request)
+      const result = await next()
       markServerI18nTestBarrierReached(request, context.res.headers)
-      return await next()
+      return result
     },
   ],
 })


### PR DESCRIPTION
## Summary

- add a later-registered Waku interceptor that waits at the test barrier inside the Palamedes i18n scope
- retain the barrier response marker in adapter middleware after router processing
- make Waku cookie's concurrent locale isolation proof deterministic

Closes #639.

## Validation

- `pnpm verify:examples:smoke -- --id waku-cookie`
- `node_modules/.bin/oxfmt --check examples/waku-cookie/src/waku.server.ts examples/waku-cookie/src/pages/_interceptors/test-barrier.server.ts`
- `git diff --check`