### PR TITLE
ci: cache Rust example verification builds

### DIFF
--- a/.github/workflows/example-verification.yml
+++ b/.github/workflows/example-verification.yml
@@ -86,6 +86,9 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
@@ -105,6 +108,7 @@ jobs:
       - name: Browser-test 21 browser-capable examples
         if: github.event_name == 'schedule' || inputs.run_browser
         env:
+          PALAMEDES_BROWSER_RETRY: ${{ github.event_name == 'schedule' && '1' || '0' }}
           PALAMEDES_SCREENSHOT_DIR: artifacts/example-screenshots
         run: pnpm verify:examples:browser -- --capture-screenshots
 

--- a/.github/workflows/remix-next-canary.yml
+++ b/.github/workflows/remix-next-canary.yml
@@ -53,6 +53,11 @@ jobs:
           git worktree add --detach "$canary_dir" "$GITHUB_SHA"
           echo "path=$canary_dir" >> "$GITHUB_OUTPUT"
 
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ${{ steps.canary-worktree.outputs.path }} -> target
+
       - name: Install locked dependencies
         id: install-dependencies
         working-directory: ${{ steps.canary-worktree.outputs.path }}

--- a/scripts/check-remix-next-canary.mjs
+++ b/scripts/check-remix-next-canary.mjs
@@ -49,6 +49,10 @@ function assertSetupBootstrap(steps) {
   const node = steps.find((step) => step.name === "Set up Node.js")
   const corepack = steps.find((step) => step.name === "Enable Corepack")
   const cache = steps.find((step) => step.name === "Set up pnpm cache")
+  const rust = steps.find((step) => step.name === "Set up Rust")
+  const worktree = findStep(steps, "canary-worktree")
+  const rustCache = steps.find((step) => step.name === "Cache Rust build artifacts")
+  const installDependencies = findStep(steps, "install-dependencies")
 
   assert.equal(node?.uses, "actions/setup-node@v7", "Node setup must use setup-node@v7")
   assert.equal(node?.with?.["node-version"], 24, "Node setup must select Node 24")
@@ -64,6 +68,19 @@ function assertSetupBootstrap(steps) {
   assert.ok(
     steps.indexOf(node) < steps.indexOf(corepack) && steps.indexOf(corepack) < steps.indexOf(cache),
     "Node setup, Corepack, and pnpm cache setup must run in that order"
+  )
+  assert.equal(rust?.uses, "dtolnay/rust-toolchain@stable", "Rust setup must use stable")
+  assert.equal(rustCache?.uses, "Swatinem/rust-cache@v2", "Rust build artifacts must be cached")
+  assert.equal(
+    rustCache?.with?.workspaces,
+    `${CANARY_WORKTREE} -> target`,
+    "Rust cache must target the isolated canary workspace"
+  )
+  assert.ok(
+    steps.indexOf(rust) < steps.indexOf(worktree) &&
+      steps.indexOf(worktree) < steps.indexOf(rustCache) &&
+      steps.indexOf(rustCache) < steps.indexOf(installDependencies),
+    "Rust setup, canary workspace, Rust cache, and install must run in that order"
   )
 }
 

--- a/scripts/check-remix-next-canary.test.mjs
+++ b/scripts/check-remix-next-canary.test.mjs
@@ -68,6 +68,21 @@ test("rejects cache setup before Corepack", () => {
   })
 })
 
+test("rejects missing or misconfigured Rust cache", () => {
+  assertRejected((workflow) => {
+    const steps = stepsFor(workflow)
+    steps.splice(
+      steps.findIndex((step) => step.name === "Cache Rust build artifacts"),
+      1
+    )
+  })
+
+  assertRejected((workflow) => {
+    stepsFor(workflow).find((step) => step.name === "Cache Rust build artifacts").with.workspaces =
+      ". -> target"
+  })
+})
+
 test("rejects every missing or incorrectly bound canary phase", () => {
   for (const id of ORDERED_STEP_IDS) {
     assertRejected((workflow) => {

--- a/scripts/workflow-contracts.test.mjs
+++ b/scripts/workflow-contracts.test.mjs
@@ -73,6 +73,20 @@ describe("workflow contracts", () => {
     )
   })
 
+  it("caches Rust example builds and retries only scheduled browser verification", async () => {
+    const [exampleVerification, browserConfig] = await Promise.all([
+      readRepositoryFile(".github/workflows/example-verification.yml"),
+      readRepositoryFile("vitest.examples.config.mjs"),
+    ])
+
+    expect(exampleVerification).toContain("- name: Cache Rust build artifacts")
+    expect(exampleVerification).toContain("uses: Swatinem/rust-cache@v2")
+    expect(exampleVerification).toContain(
+      "PALAMEDES_BROWSER_RETRY: ${{ github.event_name == 'schedule' && '1' || '0' }}"
+    )
+    expect(browserConfig).toContain('retry: process.env.PALAMEDES_BROWSER_RETRY === "1" ? 1 : 0')
+  })
+
   it("requires locked Rust workspace tests before any release publishing", async () => {
     const publish = await readRepositoryFile(".github/workflows/publish.yml")
     const validateRelease = job(publish, "validate-release", "publish-native")

--- a/vitest.examples.config.mjs
+++ b/vitest.examples.config.mjs
@@ -3,6 +3,7 @@ import { defineConfig } from "vitest/config"
 export default defineConfig({
   test: {
     include: ["tests/examples-browser/examples.browser.test.js"],
+    retry: process.env.PALAMEDES_BROWSER_RETRY === "1" ? 1 : 0,
     testTimeout: 60_000,
   },
 })


### PR DESCRIPTION
## Summary

- cache Rust build artifacts for example verification and the isolated Remix canary worktree
- retry scheduled browser verification once without masking local or manually dispatched flakes
- cover both workflow contracts with tests

Closes #641.

## Validation

- `pnpm check:remix-next-canary`
- `pnpm vitest run scripts/workflow-contracts.test.mjs`
- `node_modules/.bin/oxfmt --check vitest.examples.config.mjs scripts/check-remix-next-canary.mjs scripts/check-remix-next-canary.test.mjs scripts/workflow-contracts.test.mjs`
- `git diff --check`