### PR TITLE
feat(remix): cover locale-scoped UI frames

### DIFF
--- a/docs/api/remix.md
+++ b/docs/api/remix.md
@@ -141,10 +141,25 @@ plain runtime calls with no per-request transform work. The cost moves from
 build time to process start and recurs per cold start — the same tradeoff Remix
 makes for its own TypeScript and JSX lowering via `oxc-transform`.
 
-Rich JSX message macros remain experimental for Remix v3 because Remix's
-default loader lowers JSX before the Palamedes register hook sees the module.
-Track the Remix UI adapter, rich-message, and Frames follow-up in
-[palamedes#357](https://github.com/sebastian-software/palamedes/issues/357).
+## Remix UI Frames and Rich Messages
+
+Server-rendered Remix UI Frames are supported. Put the full document and the
+endpoint used by each `<Frame>` inside `remixI18n.run()` (or middleware) so the
+initial stream and direct frame reload each establish request-local i18n state.
+The `remix-cookie` smoke test requests both `/frames` and
+`/frames/locale-summary` with a German locale and verifies the same translated
+frame content.
+
+Ordinary JavaScript macros, including `t`, remain supported in Remix UI
+components because they survive Remix's JSX lowering. Rich JSX macros, such as
+`<Trans>`, are deliberately unsupported: `remix/node-tsx` lowers JSX to
+`remix/ui/jsx-runtime` before the Palamedes loader sees it, so the transform can
+no longer read the original children and derive placeholders. The compiled
+`@palamedes/react` runtime also returns React elements, while Remix UI uses a
+different element model. Supporting rich messages needs a public pre-lowering
+transform hook plus a dedicated Remix UI runtime; there is no safe adapter to
+ship against the current public API. Client-side macro support remains tracked
+by [remix-run/remix#11580](https://github.com/remix-run/remix/issues/11580).
 
 ## Migration From The Experimental Cookie Example
 

--- a/examples/remix-cookie/app/actions/controller.ts
+++ b/examples/remix-cookie/app/actions/controller.ts
@@ -7,6 +7,7 @@ import {
   resolveLocaleFromRequest,
   serializeLocaleCookie,
 } from "../i18n.ts"
+import { renderFrameContent, renderFrameDocument } from "../frame-page.tsx"
 import { renderHomePage } from "../page.ts"
 import { routes } from "../routes.ts"
 
@@ -30,6 +31,43 @@ export default createController(routes, {
             }
           )
       )
+    },
+
+    frameDocument(context) {
+      return remixI18n.run(context, ({ locale }) => {
+        const normalizedLocale = normalizeLocale(locale)
+        return new Response(
+          renderFrameDocument({
+            locale: normalizedLocale,
+            localeLabel: getLocaleLabel(normalizedLocale),
+            request: context.request,
+          }),
+          {
+            headers: {
+              "content-type": "text/html; charset=utf-8",
+              "x-palamedes-locale": normalizedLocale,
+            },
+          }
+        )
+      })
+    },
+
+    frameLocaleSummary(context) {
+      return remixI18n.run(context, ({ locale }) => {
+        const normalizedLocale = normalizeLocale(locale)
+        return new Response(
+          renderFrameContent({
+            locale: normalizedLocale,
+            localeLabel: getLocaleLabel(normalizedLocale),
+          }),
+          {
+            headers: {
+              "content-type": "text/html; charset=utf-8",
+              "x-palamedes-locale": normalizedLocale,
+            },
+          }
+        )
+      })
     },
 
     async setLocale(context) {

--- a/examples/remix-cookie/app/frame-page.tsx
+++ b/examples/remix-cookie/app/frame-page.tsx
@@ -1,0 +1,72 @@
+import { t } from "@palamedes/core/macro"
+import { Frame } from "remix/ui"
+import { renderToStream } from "remix/ui/server"
+
+import type { Locale } from "./i18n.ts"
+
+type FramePageOptions = {
+  locale: Locale
+  localeLabel: string
+  request: Request
+}
+
+/**
+ * Renders a document with a streamed Remix UI Frame. The frame resolver runs
+ * under the document request's Palamedes scope; the route serving the same
+ * partial establishes its own equivalent scope for client-initiated reloads.
+ */
+export function renderFrameDocument({ locale, localeLabel, request }: FramePageOptions) {
+  const title = t`Remix v3 is rendering ${locale} with Palamedes`
+
+  return renderToStream(
+    <html lang={locale}>
+      <head>
+        <meta charSet="utf-8" />
+        <meta content="width=device-width, initial-scale=1" name="viewport" />
+        <title>{title}</title>
+      </head>
+      <body>
+        <main>
+          <p>
+            <code>@palamedes/remix</code>
+          </p>
+          <h1>{title}</h1>
+          <p>
+            Active document locale: <strong>{localeLabel}</strong>
+          </p>
+          <Frame
+            fallback={<p data-palamedes-frame-fallback="true">Loading locale summary…</p>}
+            name="locale-summary"
+            src="/frames/locale-summary"
+          />
+        </main>
+      </body>
+    </html>,
+    {
+      frameSrc: request.url,
+      signal: request.signal,
+      resolveFrame(src) {
+        const frameUrl = new URL(src, request.url)
+        if (frameUrl.pathname !== "/frames/locale-summary") {
+          throw new Error(`Unexpected Remix frame source: ${frameUrl.pathname}`)
+        }
+
+        return renderFrameContent({ locale, localeLabel })
+      },
+    }
+  )
+}
+
+export function renderFrameContent({ locale, localeLabel }: Omit<FramePageOptions, "request">) {
+  const description = t`This response was translated inside a request-scoped Remix handler.`
+
+  return renderToStream(
+    <section data-palamedes-frame="locale-summary">
+      <p>{description}</p>
+      <p>
+        Active frame locale: <strong>{localeLabel}</strong>
+      </p>
+      <p>Frame locale code: {locale}</p>
+    </section>
+  )
+}

--- a/examples/remix-cookie/app/routes.ts
+++ b/examples/remix-cookie/app/routes.ts
@@ -2,5 +2,7 @@ import { get, post, route } from "remix/routes"
 
 export const routes = route({
   home: get("/"),
+  frameDocument: get("/frames"),
+  frameLocaleSummary: get("/frames/locale-summary"),
   setLocale: post("/locale"),
 })

--- a/examples/remix-cookie/tsconfig.json
+++ b/examples/remix-cookie/tsconfig.json
@@ -6,6 +6,8 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "target": "ESNext",
+    "jsx": "react-jsx",
+    "jsxImportSource": "remix/ui",
     "allowImportingTsExtensions": true,
     "rewriteRelativeImportExtensions": true,
     "verbatimModuleSyntax": true,

--- a/packages/remix/README.md
+++ b/packages/remix/README.md
@@ -31,15 +31,15 @@ transform before Node executes the module.
 This integration is tested against `remix@3.0.0-beta.5` and supports
 server-loaded Remix modules:
 
-| Area                                                 | Status                                                                        |
-| ---------------------------------------------------- | ----------------------------------------------------------------------------- |
-| JS macros (`t`, `plural`, `select`, `selectOrdinal`) | Supported in server-loaded modules                                            |
-| `.po` catalog imports                                | Supported through the Palamedes register hook                                 |
-| Request-local i18n                                   | Supported through `createRemixI18nServer()` and middleware/request helpers    |
-| Locale strategies                                    | Cookie, route, subdomain, and TLD examples are covered by smoke tests         |
-| Server-rendered Remix UI Frames                       | Supported; document and direct frame requests retain their own locale scope   |
-| Rich JSX messages                                    | Not supported; the React `Trans` runtime is incompatible with Remix UI        |
-| Browser/client modules                               | Not supported yet; Remix's asset pipeline has no script transform hook        |
+| Area                                                 | Status                                                                      |
+| ---------------------------------------------------- | --------------------------------------------------------------------------- |
+| JS macros (`t`, `plural`, `select`, `selectOrdinal`) | Supported in server-loaded modules                                          |
+| `.po` catalog imports                                | Supported through the Palamedes register hook                               |
+| Request-local i18n                                   | Supported through `createRemixI18nServer()` and middleware/request helpers  |
+| Locale strategies                                    | Cookie, route, subdomain, and TLD examples are covered by smoke tests       |
+| Server-rendered Remix UI Frames                      | Supported; document and direct frame requests retain their own locale scope |
+| Rich JSX messages                                    | Not supported; the React `Trans` runtime is incompatible with Remix UI      |
+| Browser/client modules                               | Not supported yet; Remix's asset pipeline has no script transform hook      |
 
 The hook only reaches server-executed modules. Browser-delivered Remix v3 modules
 are compiled by Remix's asset pipeline, which does not currently expose a script

--- a/packages/remix/README.md
+++ b/packages/remix/README.md
@@ -37,7 +37,8 @@ server-loaded Remix modules:
 | `.po` catalog imports                                | Supported through the Palamedes register hook                                 |
 | Request-local i18n                                   | Supported through `createRemixI18nServer()` and middleware/request helpers    |
 | Locale strategies                                    | Cookie, route, subdomain, and TLD examples are covered by smoke tests         |
-| Rich JSX messages                                    | Not supported yet; Remix lowers JSX before the Palamedes hook sees the source |
+| Server-rendered Remix UI Frames                       | Supported; document and direct frame requests retain their own locale scope   |
+| Rich JSX messages                                    | Not supported; the React `Trans` runtime is incompatible with Remix UI        |
 | Browser/client modules                               | Not supported yet; Remix's asset pipeline has no script transform hook        |
 
 The hook only reaches server-executed modules. Browser-delivered Remix v3 modules
@@ -45,10 +46,46 @@ are compiled by Remix's asset pipeline, which does not currently expose a script
 transform hook for Palamedes macros. The upstream tracking request is
 [remix-run/remix#11580](https://github.com/remix-run/remix/issues/11580).
 
-Rich JSX message macros are still experimental for Remix v3 because Remix's
-loader lowers JSX to `remix/ui/jsx-runtime` calls before this hook runs. The
-follow-up for a Remix UI adapter, rich messages, and Frames is
-[palamedes#357](https://github.com/sebastian-software/palamedes/issues/357).
+## Remix UI, Frames, and Rich Messages
+
+Remix UI Frames are supported on the server. Render both the document and the
+frame endpoint inside `remixI18n.run()` so a streamed frame and a later,
+client-initiated frame reload independently resolve the same request locale:
+
+```tsx
+import { Frame } from "remix/ui"
+import { renderToStream } from "remix/ui/server"
+
+function renderDocument(request: Request, locale: string) {
+  return renderToStream(
+    <html lang={locale}>
+      <body>
+        <Frame name="locale-summary" src="/frames/locale-summary" fallback={<p>Loading…</p>} />
+      </body>
+    </html>,
+    {
+      frameSrc: request.url,
+      signal: request.signal,
+      resolveFrame: () => renderLocaleSummary(),
+    }
+  )
+}
+```
+
+The cookie example exercises both `/frames` and `/frames/locale-summary` with
+German translations. Use ordinary JavaScript macros such as `t` inside Remix UI
+components; those calls remain visible to the server loader after JSX lowering.
+
+Rich JSX macros such as `<Trans>` are not supported in Remix UI. This is a
+specific runtime boundary, rather than an untested adapter: `remix/node-tsx`
+lowers JSX to `remix/ui/jsx-runtime` before the Palamedes loader receives a
+module. Palamedes' rich-message transform requires the original JSX tree to
+derive message placeholders, and its compiled `@palamedes/react` `Trans`
+component produces React elements, while Remix UI renders its own element
+model. A supported adapter therefore needs both a pre-lowering transform hook
+and a dedicated Remix UI rich-message runtime; neither is a public Remix API
+today. Browser/client macro parity is separately blocked on the
+[asset-pipeline transform hook](https://github.com/remix-run/remix/issues/11580).
 
 ## Runtime Cost
 

--- a/scripts/example-matrix.mjs
+++ b/scripts/example-matrix.mjs
@@ -37,16 +37,6 @@ export const EXAMPLE_MATRIX = [
         path: "/",
         substrings: ["Deutsch", "Plätze frei"],
       },
-      {
-        headers: { "accept-language": "de" },
-        path: "/frames",
-        substrings: ["Diese Antwort", "Active frame locale", "Deutsch"],
-      },
-      {
-        headers: { "accept-language": "de" },
-        path: "/frames/locale-summary",
-        substrings: ["Diese Antwort", "Active frame locale", "Deutsch"],
-      },
     ],
   },
   {
@@ -235,6 +225,16 @@ export const EXAMPLE_MATRIX = [
         headers: { "accept-language": "de" },
         path: "/",
         substrings: ["Deutsch", "Plätze frei"],
+      },
+      {
+        headers: { "accept-language": "de" },
+        path: "/frames",
+        substrings: ["Diese Antwort", "Active frame locale", "Deutsch"],
+      },
+      {
+        headers: { "accept-language": "de" },
+        path: "/frames/locale-summary",
+        substrings: ["Diese Antwort", "Active frame locale", "Deutsch"],
       },
     ],
   },

--- a/scripts/example-matrix.mjs
+++ b/scripts/example-matrix.mjs
@@ -37,6 +37,16 @@ export const EXAMPLE_MATRIX = [
         path: "/",
         substrings: ["Deutsch", "Plätze frei"],
       },
+      {
+        headers: { "accept-language": "de" },
+        path: "/frames",
+        substrings: ["Diese Antwort", "Active frame locale", "Deutsch"],
+      },
+      {
+        headers: { "accept-language": "de" },
+        path: "/frames/locale-summary",
+        substrings: ["Diese Antwort", "Active frame locale", "Deutsch"],
+      },
     ],
   },
   {


### PR DESCRIPTION
## Summary

- add a Remix UI Frame document and direct frame endpoint to the cookie example
- verify document streaming and client-style partial reloads resolve the same request locale
- document server Frame support and the precise rich-JSX runtime boundary

Closes #357.

## Validation

- `pnpm --filter @palamedes/example-remix-cookie typecheck`
- `pnpm vitest run scripts/example-matrix-guard.test.mjs`
- `pnpm verify:examples:smoke -- --id remix-cookie`
- `pnpm build:site`
- `git diff --check`