### PR TITLE
fix: resolve the 2026-08-09 audit findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,13 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   validate:
     name: validate (${{ matrix.os }}, Node ${{ matrix.node }})
@@ -42,8 +49,19 @@ jobs:
       - name: Enable Corepack
         run: corepack enable
 
+      - name: Restore pnpm cache
+        uses: actions/setup-node@v7
+        with:
+          node-version: ${{ matrix.node }}
+          cache: pnpm
+
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
+
+      # `pnpm build` shells out to cargo for the native packages, so every
+      # validate leg would otherwise rebuild the oxc workspace from scratch.
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -135,13 +153,27 @@ jobs:
         run: pnpm check-types
 
   validate-rust:
-    runs-on: ubuntu-24.04
+    name: validate-rust (${{ matrix.os }}, Rust ${{ matrix.toolchain }})
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        toolchain:
-          - stable
-          - "1.95"
+        # The core reads and writes project files, so its path handling ships on
+        # Windows and macOS too. Format and lint are platform-independent and
+        # stay on the Linux legs; only the tests fan out.
+        include:
+          - os: ubuntu-24.04
+            toolchain: stable
+            lint: true
+          - os: ubuntu-24.04
+            toolchain: "1.95"
+            lint: true
+          - os: windows-2025
+            toolchain: stable
+            lint: false
+          - os: macos-14
+            toolchain: stable
+            lint: false
 
     steps:
       - name: Check out repository
@@ -162,9 +194,11 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Check Rust formatting
+        if: ${{ matrix.lint }}
         run: cargo fmt --all --check
 
       - name: Run Rust lints
+        if: ${{ matrix.lint }}
         run: cargo clippy --workspace --all-targets --locked -- -D warnings
 
       - name: Run Rust tests

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -1,0 +1,121 @@
+name: Dependency Audit
+
+# Advisories are published independently of this repository's changes, so this
+# runs on a schedule rather than per pull request: a newly disclosed CVE in a
+# build dependency should open a tracking issue, not block unrelated work.
+on:
+  schedule:
+    - cron: "23 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: dependency-audit-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  audit:
+    name: audit
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Restore pnpm cache
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # The curated `overrides` block in pnpm-workspace.yaml is the repository's
+      # mechanism for pinning patched transitive versions. This report is what
+      # tells maintainers when that list has fallen behind.
+      - name: Audit npm dependencies
+        id: npm-audit
+        continue-on-error: true
+        run: |
+          {
+            echo '## npm advisories'
+            echo
+            echo '```'
+            pnpm audit --audit-level=high 2>&1 || true
+            echo '```'
+          } >> audit-report.md
+
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked
+
+      - name: Audit Rust dependencies
+        id: cargo-audit
+        continue-on-error: true
+        run: |
+          {
+            echo
+            echo '## Rust advisories'
+            echo
+            echo '```'
+            cargo audit 2>&1 || true
+            echo '```'
+          } >> audit-report.md
+
+      - name: Upload audit report
+        uses: actions/upload-artifact@v7
+        with:
+          name: dependency-audit
+          path: audit-report.md
+
+      # One long-lived issue that is refreshed in place, so a weekly cron cannot
+      # accumulate a backlog of near-identical reports.
+      - name: Open or refresh the tracking issue
+        if: steps.npm-audit.outcome == 'failure' || steps.cargo-audit.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TITLE: "chore(deps): dependency audit findings"
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          {
+            echo "The scheduled dependency audit reported findings."
+            echo
+            echo "Triage each entry against the curated \`overrides\` block in"
+            echo "\`pnpm-workspace.yaml\`, and pin the patched version where the parent"
+            echo "dependency line permits it."
+            echo
+            cat audit-report.md
+            echo
+            echo "Run: $RUN_URL"
+          } > issue-body.md
+
+          existing="$(gh issue list --state open --label dependencies --search "$TITLE" --json number,title \
+            --jq "[.[] | select(.title == \"$TITLE\")] | first | .number // empty")"
+
+          if [ -n "$existing" ]; then
+            gh issue edit "$existing" --body-file issue-body.md
+          else
+            gh issue create --title "$TITLE" --body-file issue-body.md --label dependencies
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,8 @@ well-scoped changes are easiest to review.
 
 - Node.js `>=22.22`
 - pnpm via Corepack
-- Rust stable toolchain
+- Rust — `rust-toolchain.toml` pins the workspace MSRV, so `rustup` installs it
+  on the first `cargo` invocation; make sure `rustup` itself is up to date
 - GitHub CLI if you work on issue or PR automation locally
 
 ```bash

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -14,6 +14,7 @@ expected to use directly.
 - [`@palamedes/config`](./config.md)
 - [`@palamedes/cli`](./cli.md)
 - [`pmds` binary plugin protocol](./cli-binary-plugin.md)
+- [`@palamedes/eslint-plugin`](./eslint-plugin.md)
 - [`@palamedes/vite-plugin`](./vite-plugin.md)
 - [`@palamedes/next-plugin`](./next-plugin.md)
 - [`@palamedes/core-node`](./core-node.md)

--- a/docs/api/eslint-plugin.md
+++ b/docs/api/eslint-plugin.md
@@ -1,0 +1,100 @@
+# `@palamedes/eslint-plugin`
+
+`@palamedes/eslint-plugin` surfaces Palamedes' native source diagnostics inside
+ESLint and Oxlint. The rules are thin facades: the plugin does not re-implement
+macro analysis in JavaScript, it forwards one native Core analysis per file.
+
+This package is Preview. Oxlint's JavaScript plugin API is still alpha, so
+[`pmds lint`](../cli.md#lint) remains the stable CI and MDX interface.
+
+## Installation
+
+```sh
+pnpm add -D @palamedes/eslint-plugin eslint
+# or
+pnpm add -D @palamedes/eslint-plugin oxlint
+```
+
+Keep optional dependencies enabled so `@palamedes/core-node` can install the
+native package for the current platform.
+
+## ESLint flat config
+
+```js
+import palamedes from "@palamedes/eslint-plugin"
+
+export default [
+  {
+    files: ["**/*.{js,jsx,ts,tsx}"],
+    plugins: { palamedes },
+    rules: {
+      "palamedes/no-placeholder-only-message": "warn",
+      "palamedes/prefer-trans-in-jsx": "warn",
+    },
+  },
+]
+```
+
+`configs.recommended` enables `no-placeholder-only-message` and
+`prefer-trans-in-jsx` as warnings.
+
+## Oxlint
+
+```json
+{
+  "jsPlugins": [{ "name": "palamedes", "specifier": "@palamedes/eslint-plugin" }],
+  "rules": {
+    "palamedes/no-placeholder-only-message": "warn",
+    "palamedes/prefer-trans-in-jsx": "warn"
+  }
+}
+```
+
+## Rules
+
+| Rule                                        | In `configs.recommended` | Purpose                                                                                |
+| ------------------------------------------- | ------------------------ | -------------------------------------------------------------------------------------- |
+| `palamedes/no-placeholder-only-message`     | warning                  | Reject messages made only of runtime values.                                           |
+| `palamedes/no-empty-component-only-message` | off                      | Reject a single empty component placeholder; opt in when that policy fits the project. |
+| `palamedes/prefer-trans-in-jsx`             | warning                  | Suggest `Trans` for safe direct JSX render positions; `t` remains supported.           |
+
+There are no autofixes in this version. Each host owns rule severity.
+
+## Suppressions differ from the CLI
+
+The adapter leaves suppression handling to its host, so findings are silenced
+with the host's own directive:
+
+```tsx
+// eslint-disable-next-line palamedes/no-placeholder-only-message
+const eslintLabel = t`${status}`
+
+// oxlint-disable-next-line palamedes/no-placeholder-only-message
+const oxlintLabel = t`${status}`
+```
+
+`pmds lint` does not read those directives, and this plugin does not read
+`palamedes-lint-disable-*`. A project running both lanes needs the directive
+each lane understands, and the rule names differ as well: the CLI reports the
+native diagnostic codes (`pmds/no-placeholder-only-message`), while the plugin
+exposes the same diagnostic under its host plugin namespace
+(`palamedes/no-placeholder-only-message`). See
+[the CLI suppression reference](../cli.md#lint) for the `pmds lint` side.
+
+## Coverage and limits
+
+- **One analysis per file.** Every native diagnostic is enabled in a single
+  analysis, cached by filename and source fingerprint, so several enabled
+  facades never repeat native parsing. UTF-8 byte ranges from Rust are converted
+  to UTF-16 indices before the host maps them to editor locations.
+- **Native failures are reported once per host parse.** ESLint-compatible hosts
+  require a diagnostic to come from an enabled rule, so the reported `ruleId` is
+  the first enabled Palamedes facade; the message states that it is a shared
+  native-analysis failure rather than a finding from that rule. A later editor
+  re-parse reports it again; an unchanged parse does not duplicate it.
+- **MDX is not supported here.** Oxlint JavaScript plugins cannot register
+  custom parsers or file formats. Use `pmds lint` for MDX.
+
+The implementation rationale, benchmark, packaging risks, and reproducible LSP
+verification live in
+[Native diagnostics through ESLint and Oxlint](../research/oxlint-eslint-adapter.md).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -168,6 +168,16 @@ const inline = t`${status}` // palamedes-lint-disable-line pmds/no-placeholder-o
 
 Unknown codes, directives without a code, and valid suppressions that no longer
 match a finding are reported by `pmds lint`.
+
+`palamedes-lint-disable-*` directives are consumed by `pmds lint` only. The
+ESLint and Oxlint adapter in [`@palamedes/eslint-plugin`](./api/eslint-plugin.md)
+leaves suppression handling to its host, so the same finding is silenced with
+`eslint-disable-next-line palamedes/<rule>` or
+`oxlint-disable-next-line palamedes/<rule>` there. The two forms do not
+transfer: a project running both lanes needs the directive each lane
+understands. The rule names differ too — the CLI reports the native diagnostic
+codes (`pmds/...`), while the adapter exposes them under its host plugin
+namespace (`palamedes/...`).
 The default `.palamedes/extract-cache.json` stores compatible messages and
 diagnostics together, so `extract` and `lint` can reuse the same native parse.
 Lint follows extraction's bounded parallel read/parse model. Workers only

--- a/docs/framework-example-notes.md
+++ b/docs/framework-example-notes.md
@@ -62,6 +62,18 @@ Palamedes-side fixes already baked into these examples:
 - server-side activation for client widgets rendered during SSR, so no
   locale-local fallback copy maps are needed
 
+Current framework note:
+
+- **the served document always carries `<html lang="en">`.** Waku pre-renders
+  `src/pages/_root.tsx` once as a static shell, so it has no access to the
+  request and cannot emit a per-request locale. All four examples apply the
+  active locale to `document.documentElement.lang` from the client bootstrap in
+  `src/lib/i18n.ts` instead, which means a client without JavaScript — including
+  a crawler that does not execute it — still sees `lang="en"` on a non-English
+  document. This is a Waku constraint, not a Palamedes one; the other framework
+  families render `lang` on the server. Revisit if Waku exposes a dynamic root
+  or document-shell API.
+
 ## React Router
 
 The `react-router-cookie`, `react-router-route`, `react-router-subdomain`, and

--- a/examples/react-router-rsc-cookie/app/root.tsx
+++ b/examples/react-router-rsc-cookie/app/root.tsx
@@ -1,8 +1,13 @@
+import { getI18n } from "@palamedes/runtime"
 import { Links, Meta, Outlet } from "react-router"
 
 export function Layout({ children }: { children: React.ReactNode }) {
+  // The custom RSC entry runs this render inside the request scope, so the
+  // active instance carries the locale this document was negotiated for.
+  const { locale } = getI18n()
+
   return (
-    <html lang="en">
+    <html lang={locale}>
       <head>
         <meta charSet="utf-8" />
         <meta content="width=device-width, initial-scale=1" name="viewport" />

--- a/examples/react-router-rsc-cookie/app/root.tsx
+++ b/examples/react-router-rsc-cookie/app/root.tsx
@@ -1,13 +1,17 @@
 import { getI18n } from "@palamedes/runtime"
 import { Links, Meta, Outlet } from "react-router"
 
-export function Layout({ children }: { children: React.ReactNode }) {
-  // The custom RSC entry runs this render inside the request scope, so the
-  // active instance carries the locale this document was negotiated for.
-  const { locale } = getI18n()
+// React Router bundles the root layout into the client graph as well, and this
+// fixture installs i18n on the server only. So the locale comes from the active
+// request scope while rendering, and from the attribute that render produced
+// while hydrating — same value on both sides, and no client i18n required.
+function documentLocale() {
+  return typeof document === "undefined" ? getI18n().locale : document.documentElement.lang
+}
 
+export function Layout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang={locale}>
+    <html lang={documentLocale()}>
       <head>
         <meta charSet="utf-8" />
         <meta content="width=device-width, initial-scale=1" name="viewport" />

--- a/examples/waku-cookie/src/pages/_root.tsx
+++ b/examples/waku-cookie/src/pages/_root.tsx
@@ -1,6 +1,10 @@
 import type { ReactNode } from "react"
 import "@palamedes/example-ui/styles.css"
 
+// Waku pre-renders this document shell once, so it cannot carry a per-request
+// locale. The active locale is applied to `document.documentElement.lang` by
+// the client bootstrap in `src/lib/i18n.ts` instead; see the waku section of
+// `docs/framework-example-notes.md`.
 export default function Root({ children }: { children: ReactNode }) {
   return (
     <html lang="en">

--- a/examples/waku-route/src/pages/_root.tsx
+++ b/examples/waku-route/src/pages/_root.tsx
@@ -1,6 +1,10 @@
 import type { ReactNode } from "react"
 import "@palamedes/example-ui/styles.css"
 
+// Waku pre-renders this document shell once, so it cannot carry a per-request
+// locale. The active locale is applied to `document.documentElement.lang` by
+// the client bootstrap in `src/lib/i18n.ts` instead; see the waku section of
+// `docs/framework-example-notes.md`.
 export default function Root({ children }: { children: ReactNode }) {
   return (
     <html lang="en">

--- a/examples/waku-subdomain/src/pages/_root.tsx
+++ b/examples/waku-subdomain/src/pages/_root.tsx
@@ -1,6 +1,10 @@
 import type { ReactNode } from "react"
 import "@palamedes/example-ui/styles.css"
 
+// Waku pre-renders this document shell once, so it cannot carry a per-request
+// locale. The active locale is applied to `document.documentElement.lang` by
+// the client bootstrap in `src/lib/i18n.ts` instead; see the waku section of
+// `docs/framework-example-notes.md`.
 export default function Root({ children }: { children: ReactNode }) {
   return (
     <html lang="en">

--- a/examples/waku-tld/src/pages/_root.tsx
+++ b/examples/waku-tld/src/pages/_root.tsx
@@ -1,6 +1,10 @@
 import type { ReactNode } from "react"
 import "@palamedes/example-ui/styles.css"
 
+// Waku pre-renders this document shell once, so it cannot carry a per-request
+// locale. The active locale is applied to `document.documentElement.lang` by
+// the client bootstrap in `src/lib/i18n.ts` instead; see the waku section of
+// `docs/framework-example-notes.md`.
 export default function Root({ children }: { children: ReactNode }) {
   return (
     <html lang="en">

--- a/packages/core-node/src/index.test.ts
+++ b/packages/core-node/src/index.test.ts
@@ -110,10 +110,8 @@ describe("@palamedes/core-node", () => {
       ])
     ).toThrow(/compileCatalogModule\.argument\[0\]\.config\.locales\[1\]/u)
     expect(() =>
-      assertWellFormedNativeArguments("renderCatalogModule", [
-        new Map([["message", ["valid", "\ud800"]]]),
-      ])
-    ).toThrow(/renderCatalogModule\.argument\[0\]\.get\(message\)\[1\]/u)
+      assertWellFormedNativeArguments("renderCatalogModule", [{ message: ["valid", "\ud800"] }])
+    ).toThrow(/renderCatalogModule\.argument\[0\]\.message\[1\]/u)
 
     const isWellFormed = Reflect.getOwnPropertyDescriptor(String.prototype, "isWellFormed")
     Reflect.deleteProperty(String.prototype, "isWellFormed")
@@ -159,7 +157,7 @@ describe("@palamedes/core-node", () => {
     expect(proxyRendered).not.toContain("�")
   })
 
-  it("snapshots nested accessors, arrays, Maps, and getter failures deterministically", () => {
+  it("snapshots nested accessors, arrays, and getter failures deterministically", () => {
     let nestedReads = 0
     const nested: { config: { locales: string[] } } = { config: {} as { locales: string[] } }
     Object.defineProperty(nested.config, "locales", {
@@ -169,13 +167,13 @@ describe("@palamedes/core-node", () => {
         return nestedReads === 1 ? ["en", "cafe\u0301", "😀"] : ["\ud800"]
       },
     })
-    const map = new Map([["request", nested]])
-    const snapshot = snapshotNativeArguments("compileCatalogModule", [map])
-    const snapshotMap = snapshot[0] as Map<string, { config: { locales: string[] } }>
+    const request = { request: nested }
+    const snapshot = snapshotNativeArguments("compileCatalogModule", [request])
+    const snapshotRequest = snapshot[0] as { request: { config: { locales: string[] } } }
 
     expect(nestedReads).toBe(1)
-    expect(snapshotMap).not.toBe(map)
-    expect(snapshotMap.get("request")).toStrictEqual({
+    expect(snapshotRequest).not.toBe(request)
+    expect(snapshotRequest.request).toStrictEqual({
       config: { locales: ["en", "cafe\u0301", "😀"] },
     })
     expect(nested.config.locales).toStrictEqual(["\ud800"])
@@ -224,6 +222,28 @@ describe("@palamedes/core-node", () => {
     }
     expect(renderCatalogModule(new PrototypeGetterMessages())).toContain("from prototype getter")
 
+    // A prototype method is a data property holding a function. Snapshotting it
+    // would push a function across the boundary, so it must stay out — the
+    // getter above is the only prototype member the binding sees. The declared
+    // parameter type rules such a class out, so the cast stands in for the
+    // untyped JavaScript caller the boundary has to survive.
+    class MethodBackedMessages {
+      public message = "from class with a method"
+
+      public format() {
+        return "helper"
+      }
+
+      public toString() {
+        return "helper"
+      }
+    }
+    const methodBacked = renderCatalogModule(
+      new MethodBackedMessages() as unknown as Record<string, string>
+    )
+    expect(methodBacked).toContain("from class with a method")
+    expect(methodBacked).not.toContain("format")
+
     const nonEnumerableMessages: Record<string, string> = {}
     Object.defineProperty(nonEnumerableMessages, "hidden", {
       configurable: true,
@@ -231,6 +251,29 @@ describe("@palamedes/core-node", () => {
       writable: true,
     })
     expect(renderCatalogModule(nonEnumerableMessages)).not.toContain("not native-visible")
+
+    // The same exclusion applies to a class instance, so the two record shapes
+    // cannot disagree about which own properties are native-visible.
+    const nonEnumerableInstance = new ClassBackedMessages()
+    Object.defineProperty(nonEnumerableInstance, "hidden", {
+      configurable: true,
+      value: "not native-visible",
+      writable: true,
+    })
+    expect(renderCatalogModule(nonEnumerableInstance)).not.toContain("not native-visible")
+  })
+
+  it("rejects a Map instead of silently rendering an empty catalog", () => {
+    expect(() => renderCatalogModule(new Map([["greeting", "hi"]]) as never)).toThrow(
+      /rejected a Map in renderCatalogModule\.argument\[0\]/u
+    )
+
+    class MessageMap extends Map<string, string> {}
+    expect(() => renderCatalogModule(new MessageMap([["greeting", "hi"]]) as never)).toThrow(
+      /rejected a Map in renderCatalogModule\.argument\[0\]/u
+    )
+
+    expect(renderCatalogModule(Object.fromEntries(new Map([["greeting", "hi"]])))).toContain("hi")
   })
 
   it("classifies Proxy metadata once and translates prototype and length errors", () => {

--- a/packages/core-node/src/native-loader.ts
+++ b/packages/core-node/src/native-loader.ts
@@ -193,41 +193,7 @@ export function snapshotNativeArguments(operation: string, arguments_: unknown[]
 
     const classification = classifySnapshotObject(value, currentPath)
     if (classification.kind === "map") {
-      const mapSnapshot = new Map<unknown, unknown>()
-      snapshots.set(value, mapSnapshot)
-      current.assign(mapSnapshot)
-      let mapEntries: Array<[unknown, unknown]>
-      try {
-        mapEntries = [...Map.prototype.entries.call(value)]
-      } catch (error) {
-        throw nativeBoundaryReadError(currentPath, error)
-      }
-      for (let index = mapEntries.length - 1; index >= 0; index -= 1) {
-        const [key, entry] = mapEntries[index] ?? []
-        const pair: { key?: unknown; value?: unknown } = {}
-        const setEntry = () => {
-          if ("key" in pair && "value" in pair) mapSnapshot.set(pair.key, pair.value)
-        }
-        pending.push({
-          kind: "value",
-          value: entry,
-          path: appendNativeArgumentPath(currentPath, mapValuePath(key)),
-          assign(snapshotValue: unknown) {
-            pair.value = snapshotValue
-            setEntry()
-          },
-        })
-        pending.push({
-          kind: "value",
-          value: key,
-          path: appendNativeArgumentPath(currentPath, ".<key>"),
-          assign(snapshotKey: unknown) {
-            pair.key = snapshotKey
-            setEntry()
-          },
-        })
-      }
-      continue
+      throw nativeBoundaryUnsupportedMapError(currentPath)
     }
     if (classification.kind === "array") {
       const arraySnapshot: unknown[] = []
@@ -307,13 +273,6 @@ function formatNativeArgumentPath(argumentPath: NativeArgumentPath): string {
   return segments.reverse().join("")
 }
 
-function mapValuePath(key: unknown): string {
-  if (typeof key === "string") {
-    return `.get(${key})`
-  }
-  return ".<map value>"
-}
-
 function arrayPropertyPath(key: string): string {
   return /^(?:0|[1-9]\d*)$/u.test(key) ? `[${key}]` : `.${key}`
 }
@@ -354,31 +313,44 @@ function isMapPrototype(prototype: object | null): boolean {
   return false
 }
 
+/**
+ * The property set the binding receives: own enumerable keys, plus getters
+ * declared on the prototype chain. Class getters are non-enumerable, so
+ * `Object.keys` alone would drop a class that computes its messages; every
+ * other prototype member stays out, because a prototype method is a function
+ * and functions do not cross the boundary. Own non-enumerable properties are
+ * excluded for every record, class instance or plain object alike.
+ */
 function nativeVisiblePropertyNames(
   value: object,
   classification: SnapshotObjectClassification,
   argumentPath: NativeArgumentPath
 ): string[] {
   try {
+    const names = Object.keys(value)
     if (
       classification.kind !== "record" ||
       classification.prototype === null ||
       classification.prototype === Object.prototype
     ) {
-      return Object.keys(value)
+      return names
     }
 
-    const names = new Set(Object.getOwnPropertyNames(value))
+    const seen = new Set(names)
     for (
       let prototype = classification.prototype;
       prototype !== null && prototype !== Object.prototype;
       prototype = Object.getPrototypeOf(prototype)
     ) {
       for (const name of Object.getOwnPropertyNames(prototype)) {
-        if (name !== "constructor") names.add(name)
+        if (name === "constructor" || seen.has(name)) continue
+        const descriptor = Object.getOwnPropertyDescriptor(prototype, name)
+        if (typeof descriptor?.get !== "function") continue
+        seen.add(name)
+        names.push(name)
       }
     }
-    return [...names]
+    return names
   } catch (error) {
     throw nativeBoundaryReadError(argumentPath, error)
   }
@@ -407,6 +379,17 @@ function assertWellFormedPropertyName(key: string, argumentPath: NativeArgumentP
       `Palamedes native boundary rejected malformed Unicode in ${formatNativeArgumentPath(argumentPath)}.<key>; replace the unpaired UTF-16 surrogate in the property name.`
     )
   }
+}
+
+/**
+ * No native signature accepts a JS `Map`: the bindings build their maps from an
+ * object's properties, so a `Map` would convert to an empty one and produce a
+ * silently untranslated result. Reject it here instead.
+ */
+function nativeBoundaryUnsupportedMapError(argumentPath: NativeArgumentPath): TypeError {
+  return new TypeError(
+    `Palamedes native boundary rejected a Map in ${formatNativeArgumentPath(argumentPath)}; the native bindings read plain objects, so pass a record such as Object.fromEntries(map).`
+  )
 }
 
 function nativeBoundaryReadError(argumentPath: NativeArgumentPath, cause: unknown): TypeError {

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -92,7 +92,12 @@ When a native error contains Palamedes' structured `at file:line:column` or
 otherwise it safely falls back to the start of the file.
 
 There are no fixes in this version. `pmds lint` suppressions are intentionally
-separate from ESLint/Oxlint directives and are only consumed by the CLI.
+separate from ESLint/Oxlint directives and are only consumed by the CLI: this
+plugin does not read `palamedes-lint-disable-*`, and `pmds lint` does not read
+host directives, so a project running both lanes needs the directive each lane
+understands. The rule names differ as well — the CLI reports the native
+diagnostic codes (`pmds/...`) while this plugin exposes them under its host
+plugin namespace (`palamedes/...`).
 
 MDX is not supported through the adapter because Oxlint JavaScript plugins do
 not currently support custom parsers or file formats. Use `pmds lint` for MDX.

--- a/packages/next-plugin/palamedes-loader.cjs
+++ b/packages/next-plugin/palamedes-loader.cjs
@@ -147,34 +147,45 @@ function clientMessageBootstrap(config, sourcePath, compiledIds, fragmentFailure
     `  // No client i18n has been installed yet.\n` +
     `}\n` +
     `const ${identifier}_locale = ${identifier}_existingI18n?.locale ?? document.documentElement.lang;\n`
+  // Fragments are imported in parallel but registered in loader-group order, so
+  // two catalogs carrying the same message id resolve to the same winner in
+  // both failure modes. Degrading isolates a failure; it does not reorder.
+  const reportFragmentFailure =
+    `const ${identifier}_reportFragmentFailure = (error) => {\n` +
+    `  try {\n` +
+    `    console.error(\n` +
+    `      ${fragmentFailurePrefix},\n` +
+    `      ${identifier}_locale,\n` +
+    `      ${fragmentFailureSuffix},\n` +
+    `      error,\n` +
+    `    );\n` +
+    `  } catch {\n` +
+    `    // Logging must not prevent the client graph from hydrating.\n` +
+    `  }\n` +
+    `};\n`
   const fragmentImports =
     fragmentFailureMode === "degrade"
-      ? `await Promise.all(${identifier}_activeLoaders.map(async (load) => {\n` +
+      ? `${reportFragmentFailure}const ${identifier}_fragments = await Promise.all(${identifier}_activeLoaders.map(async (load) => {\n` +
         `  try {\n` +
-        `    const fragment = await load();\n` +
-        `    if (fragment === null) return;\n` +
-        `    const { messages } = fragment;\n` +
-        `    ${identifier}_i18n.load(${identifier}_locale, messages);\n` +
+        `    return await load();\n` +
         `  } catch (error) {\n` +
-        `    try {\n` +
-        `      console.error(\n` +
-        `        ${fragmentFailurePrefix},\n` +
-        `        ${identifier}_locale,\n` +
-        `        ${fragmentFailureSuffix},\n` +
-        `        error,\n` +
-        `      );\n` +
-        `    } catch {\n` +
-        `      // Logging must not prevent the client graph from hydrating.\n` +
-        `    }\n` +
+        `    ${identifier}_reportFragmentFailure(error);\n` +
+        `    return null;\n` +
         `  }\n` +
         `}));\n`
       : `const ${identifier}_fragments = await Promise.all(${identifier}_activeLoaders.map((load) => load()));\n`
 
   const fragmentRegistration =
     fragmentFailureMode === "degrade"
-      ? ""
-      : `for (const fragment of ${identifier}_fragments) {\n` +
+      ? `for (const fragment of ${identifier}_fragments) {\n` +
         `  if (fragment === null) continue;\n` +
+        `  try {\n` +
+        `    ${identifier}_i18n.load(${identifier}_locale, fragment.messages);\n` +
+        `  } catch (error) {\n` +
+        `    ${identifier}_reportFragmentFailure(error);\n` +
+        `  }\n` +
+        `}\n`
+      : `for (const fragment of ${identifier}_fragments) {\n` +
         `  const { messages } = fragment;\n` +
         `  ${identifier}_i18n.load(${identifier}_locale, messages);\n` +
         `}\n`

--- a/packages/next-plugin/src/palamedes-loader.test.ts
+++ b/packages/next-plugin/src/palamedes-loader.test.ts
@@ -527,6 +527,68 @@ describe("palamedes-loader.cjs", () => {
     }
   })
 
+  it.each(["degrade", "throw"] as const)(
+    "registers catalog fragments in loader-group order (%s mode)",
+    async (clientFragmentFailureMode) => {
+      transformPalamedesMacros.mockReturnValue({
+        code: "globalThis.__pmds_test_body_ran = true;",
+        map: null,
+        compiledIds: ["id-a"],
+      })
+      loadPalamedesConfigSync.mockReturnValue({
+        configPath: "/repo/palamedes.yaml",
+        rootDir: "/repo",
+        locales: ["en", "de"],
+        sourceLocale: "en",
+        catalogs: [
+          { path: "src/locales/{locale}", include: ["src/**/*.tsx"] },
+          { path: "src/overrides/{locale}", include: ["src/**/*.tsx"] },
+        ],
+      })
+
+      const originalDocument = globalThis.document
+      const originalBodyRan = globalThis.__pmds_test_body_ran
+      const loaded: Array<Record<string, unknown>> = []
+      const i18n = {
+        load(_locale: string, messages: Record<string, unknown>) {
+          loaded.push(messages)
+        },
+      }
+
+      try {
+        globalThis.document = { documentElement: { lang: "de" } } as Document
+        const output = await runLoader({
+          clientMessageSplitting: true,
+          clientFragmentFailureMode,
+        })
+        await expect(
+          executeGeneratedClientModule(output, async (specifier) => {
+            if (specifier === "@palamedes/core/compiled") return { createI18n: () => i18n }
+            if (specifier === "@palamedes/runtime") return { initializeClientI18n: () => i18n }
+            // The first loader group resolves last, so a registration order that
+            // followed resolution order would invert the two catalogs.
+            if (specifier.includes("./locales/de.po?palamedes-selected=")) {
+              await new Promise((resolve) => setTimeout(resolve, 10))
+              return { messages: { greeting: "from the base catalog" } }
+            }
+            if (specifier.includes("./overrides/de.po?palamedes-selected=")) {
+              return { messages: { greeting: "from the override catalog" } }
+            }
+            throw new Error(`Unexpected import: ${specifier}`)
+          })
+        ).resolves.toBeUndefined()
+
+        expect(loaded).toEqual([
+          { greeting: "from the base catalog" },
+          { greeting: "from the override catalog" },
+        ])
+      } finally {
+        restoreGlobal("document", originalDocument)
+        restoreGlobal("__pmds_test_body_ran", originalBodyRan)
+      }
+    }
+  )
+
   it("continues production hydration when diagnostic logging throws", async () => {
     transformPalamedesMacros.mockReturnValue({
       code: "globalThis.__pmds_test_body_ran = true;",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -58,7 +58,7 @@
   ],
   "scripts": {
     "build": "unbuild",
-    "test": "vitest run --globals src/index.test.ts src/server.test.ts src/server-unavailable.test.ts",
+    "test": "vitest run --globals src/index.test.ts src/server.test.ts src/server-test.test.ts src/server-unavailable.test.ts",
     "stub": "unbuild --stub"
   },
   "engines": {

--- a/packages/runtime/src/server-test.test.ts
+++ b/packages/runtime/src/server-test.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import {
+  SERVER_I18N_TEST_BARRIER_REACHED_HEADER,
+  markServerI18nTestBarrierReached,
+  waitForServerI18nTestBarrier,
+} from "./server-test"
+
+const TEST_BARRIER_HEADER = "x-palamedes-i18n-test-barrier"
+const TEST_BARRIERS_KEY = Symbol.for("palamedes.runtime.serverI18nTestBarriers")
+
+function barrierRequest(barrierId?: string): Request {
+  return new Request("https://example.test/", {
+    headers: barrierId ? { [TEST_BARRIER_HEADER]: barrierId } : {},
+  })
+}
+
+function enableBarrier(): void {
+  vi.stubEnv("PALAMEDES_I18N_TEST_BARRIER", "1")
+}
+
+/** Captures a rejection immediately, so the timer can fire unattended. */
+function settle(pending: Promise<void> | undefined): Promise<unknown> {
+  return Promise.resolve(pending).then(
+    (value) => value,
+    (error: unknown) => error
+  )
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  vi.useRealTimers()
+  delete (globalThis as Record<symbol, unknown>)[TEST_BARRIERS_KEY]
+})
+
+describe("server i18n test barrier", () => {
+  it("stays inert unless both the environment opt-in and the header are present", () => {
+    // A production server must never be able to park a request here, so both
+    // gates are checked independently.
+    expect(waitForServerI18nTestBarrier(barrierRequest("only-header"))).toBeUndefined()
+
+    enableBarrier()
+    expect(waitForServerI18nTestBarrier(barrierRequest())).toBeUndefined()
+
+    vi.stubEnv("PALAMEDES_I18N_TEST_BARRIER", "true")
+    expect(waitForServerI18nTestBarrier(barrierRequest("wrong-opt-in"))).toBeUndefined()
+
+    expect((globalThis as Record<symbol, unknown>)[TEST_BARRIERS_KEY]).toBeUndefined()
+  })
+
+  it("releases both requests only once the second one arrives", async () => {
+    enableBarrier()
+
+    let firstSettled = false
+    const first = waitForServerI18nTestBarrier(barrierRequest("pair"))
+    expect(first).toBeInstanceOf(Promise)
+    void first?.then(() => {
+      firstSettled = true
+    })
+
+    await Promise.resolve()
+    expect(firstSettled).toBe(false)
+
+    const second = waitForServerI18nTestBarrier(barrierRequest("pair"))
+    await expect(second).resolves.toBeUndefined()
+    await expect(first).resolves.toBeUndefined()
+    expect(firstSettled).toBe(true)
+  })
+
+  it("rejects a request that never finds a partner", async () => {
+    vi.useFakeTimers()
+    enableBarrier()
+
+    // The rejection is captured before the clock moves, so the timer can fire
+    // without an unhandled rejection in between.
+    const lonely = settle(waitForServerI18nTestBarrier(barrierRequest("lonely")))
+    await vi.advanceTimersByTimeAsync(5e3)
+
+    expect(await lonely).toMatchObject({
+      message: expect.stringMatching(
+        /Timed out waiting for a second server i18n test request in barrier "lonely"/u
+      ),
+    })
+  })
+
+  it("does not let a third request reuse a completed rendezvous", async () => {
+    vi.useFakeTimers()
+    enableBarrier()
+
+    const first = waitForServerI18nTestBarrier(barrierRequest("triple"))
+    const second = waitForServerI18nTestBarrier(barrierRequest("triple"))
+    await expect(Promise.all([first, second])).resolves.toEqual([undefined, undefined])
+
+    // The completed barrier is gone, so a late third request starts a fresh
+    // rendezvous and fails loudly rather than passing through unsynchronised.
+    const third = settle(waitForServerI18nTestBarrier(barrierRequest("triple")))
+    await vi.advanceTimersByTimeAsync(5e3)
+
+    expect(await third).toMatchObject({
+      message: expect.stringMatching(/Timed out waiting for a second/u),
+    })
+  })
+
+  it("keeps separate barrier ids independent", async () => {
+    vi.useFakeTimers()
+    enableBarrier()
+
+    const alone = settle(waitForServerI18nTestBarrier(barrierRequest("alpha")))
+    const firstBeta = waitForServerI18nTestBarrier(barrierRequest("beta"))
+    const secondBeta = waitForServerI18nTestBarrier(barrierRequest("beta"))
+
+    await expect(Promise.all([firstBeta, secondBeta])).resolves.toEqual([undefined, undefined])
+    await vi.advanceTimersByTimeAsync(5e3)
+
+    expect(await alone).toMatchObject({ message: expect.stringMatching(/barrier "alpha"/u) })
+  })
+
+  it("marks the response only for requests the barrier actually governs", () => {
+    const headers = new Headers()
+
+    markServerI18nTestBarrierReached(barrierRequest("marked"), headers)
+    expect(headers.get(SERVER_I18N_TEST_BARRIER_REACHED_HEADER)).toBeNull()
+
+    enableBarrier()
+    markServerI18nTestBarrierReached(barrierRequest(), headers)
+    expect(headers.get(SERVER_I18N_TEST_BARRIER_REACHED_HEADER)).toBeNull()
+
+    // The verifier requires this marker, so an adapter that never registers its
+    // barrier cannot report a false-positive isolation result.
+    markServerI18nTestBarrierReached(barrierRequest("marked"), headers)
+    expect(headers.get(SERVER_I18N_TEST_BARRIER_REACHED_HEADER)).toBe("marked")
+  })
+})

--- a/packages/runtime/src/server-test.ts
+++ b/packages/runtime/src/server-test.ts
@@ -10,7 +10,6 @@ const TEST_BARRIERS_KEY = Symbol.for("palamedes.runtime.serverI18nTestBarriers")
 
 type Barrier = {
   arrivals: number
-  reject(error: Error): void
   resolve(): void
   timeout: ReturnType<typeof setTimeout>
 }
@@ -69,7 +68,6 @@ export function waitForServerI18nTestBarrier(request: Request): Promise<void> | 
   return new Promise((resolve, reject) => {
     const barrier: Barrier = {
       arrivals: 1,
-      reject,
       resolve,
       timeout: setTimeout(() => {
         if (barriers.get(barrierId) !== barrier) return

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,8 @@
+# Pins the toolchain to the workspace MSRV declared in Cargo.toml, so a local
+# `cargo build` installs it instead of failing with a resolver error listing
+# every oxc crate. CI keeps its explicit toolchains: dtolnay/rust-toolchain sets
+# RUSTUP_TOOLCHAIN, which takes precedence over this file, so the `stable` legs
+# still exercise stable.
+[toolchain]
+channel = "1.95"
+components = ["clippy", "rustfmt"]

--- a/scripts/check-published-types.mjs
+++ b/scripts/check-published-types.mjs
@@ -1,4 +1,13 @@
-import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs"
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs"
 import os from "node:os"
 import path from "node:path"
 import process from "node:process"
@@ -7,6 +16,128 @@ import ts from "typescript"
 const root = process.cwd()
 const fixtureRoot = mkdtempSync(path.join(os.tmpdir(), "palamedes-published-types-"))
 const scopeDirectory = path.join(fixtureRoot, "node_modules", "@palamedes")
+
+/*
+ * Published packages that carry no `types` field, with the reason each one is
+ * outside this gate. Every other published package is linked and resolved
+ * below, so adding a package to the release set adds it here automatically
+ * instead of silently skipping it — that omission is how #637 shipped.
+ */
+const UNTYPED_PACKAGES = new Map([
+  ["@palamedes/cli", "npm launcher for the pmds binary; no TypeScript surface"],
+  ["@palamedes/cli-darwin-arm64", "prebuilt binary shim"],
+  ["@palamedes/cli-linux-arm64-gnu", "prebuilt binary shim"],
+  ["@palamedes/cli-linux-x64-gnu", "prebuilt binary shim"],
+  ["@palamedes/cli-linux-x64-musl", "prebuilt binary shim"],
+  ["@palamedes/cli-win32-x64-msvc", "prebuilt binary shim"],
+  ["@palamedes/core-node-darwin-arm64", "prebuilt native addon"],
+  ["@palamedes/core-node-linux-arm64-gnu", "prebuilt native addon"],
+  ["@palamedes/core-node-linux-x64-gnu", "prebuilt native addon"],
+  ["@palamedes/core-node-linux-x64-musl", "prebuilt native addon"],
+  ["@palamedes/core-node-win32-x64-msvc", "prebuilt native addon"],
+  ["create-palamedes", "scaffold placeholder; ships a bin only"],
+  ["palamedes", "meta package; re-exports nothing itself"],
+])
+
+/** Export subpaths that resolve to bundler plugin files rather than modules. */
+const UNTYPED_SUBPATHS = new Map([
+  ["@palamedes/next-plugin", new Set(["./palamedes-loader", "./palamedes-po-loader"])],
+])
+
+function readPackages() {
+  const packages = []
+  for (const directory of readdirSync(path.join(root, "packages")).sort()) {
+    const manifestPath = path.join(root, "packages", directory, "package.json")
+    let manifest
+    try {
+      manifest = JSON.parse(readFileSync(manifestPath, "utf8"))
+    } catch {
+      continue
+    }
+    if (manifest.private) continue
+    packages.push({ directory, manifest })
+  }
+  return packages
+}
+
+function typedSubpaths({ manifest }) {
+  const skipped = UNTYPED_SUBPATHS.get(manifest.name) ?? new Set()
+  return Object.entries(manifest.exports ?? { ".": {} })
+    .filter(([subpath, condition]) => !skipped.has(subpath) && typeof condition === "object")
+    .map(([subpath, condition]) => ({
+      specifier: subpath === "." ? manifest.name : `${manifest.name}${subpath.slice(1)}`,
+      // A `require` condition promises a CommonJS consumer can resolve this
+      // entry, so each one is checked from a `.cts` fixture as well.
+      dual: JSON.stringify(condition).includes('"require"'),
+    }))
+}
+
+function assertEveryPublishedPackageIsCovered(packages) {
+  const problems = []
+  for (const { manifest } of packages) {
+    const excluded = UNTYPED_PACKAGES.has(manifest.name)
+    if (manifest.types && excluded) {
+      problems.push(
+        `${manifest.name} declares "types" but is listed in UNTYPED_PACKAGES; remove the exclusion.`
+      )
+    }
+    if (!manifest.types && !excluded) {
+      problems.push(
+        `${manifest.name} is published without "types" and is not listed in UNTYPED_PACKAGES; add it with a reason or ship declarations.`
+      )
+    }
+  }
+  for (const name of UNTYPED_PACKAGES.keys()) {
+    if (!packages.some(({ manifest }) => manifest.name === name)) {
+      problems.push(`UNTYPED_PACKAGES lists ${name}, which is no longer published.`)
+    }
+  }
+  if (problems.length > 0) {
+    throw new Error(problems.join("\n"))
+  }
+}
+
+function exportTargets(condition, targets) {
+  if (typeof condition === "string") {
+    if (condition.startsWith("./")) targets.add(condition)
+    return targets
+  }
+  if (Array.isArray(condition)) {
+    for (const entry of condition) exportTargets(entry, targets)
+    return targets
+  }
+  if (condition && typeof condition === "object") {
+    for (const entry of Object.values(condition)) exportTargets(entry, targets)
+  }
+  return targets
+}
+
+/*
+ * Type resolution stops at the first matching `types` condition, so it cannot
+ * see that a `require` condition points at a build output that is never
+ * emitted — the shape of #637. Check the advertised files instead. Scoped to
+ * the typed packages: the platform-specific native shims only carry their
+ * `.node` artifact on their own host, so they are verified by the publish
+ * workflow instead. Requires `pnpm build` to have run.
+ */
+function assertExportTargetsExist(packages) {
+  const problems = []
+  for (const { directory, manifest } of packages) {
+    const targets = exportTargets(manifest.exports ?? {}, new Set())
+    for (const field of ["main", "module", "types"]) {
+      if (typeof manifest[field] === "string") targets.add(manifest[field])
+    }
+    for (const target of [...targets].sort()) {
+      if (existsSync(path.join(root, "packages", directory, target))) continue
+      problems.push(
+        `${manifest.name} advertises ${target}, which is missing after a build; drop the condition or emit the file.`
+      )
+    }
+  }
+  if (problems.length > 0) {
+    throw new Error(problems.join("\n"))
+  }
+}
 
 function linkPackage(name) {
   const packageDirectory = path.join(root, "packages", name)
@@ -39,12 +170,51 @@ function checkProgram(fileName, compilerOptions) {
 
 try {
   mkdirSync(scopeDirectory, { recursive: true })
-  linkPackage("core")
-  linkPackage("eslint-plugin")
-  linkPackage("next-plugin")
-  linkPackage("waku")
-  linkPackage("tanstack")
-  linkPackage("vite-plugin")
+  const packages = readPackages()
+  assertEveryPublishedPackageIsCovered(packages)
+
+  const typedPackages = packages.filter(({ manifest }) => manifest.types)
+  assertExportTargetsExist(typedPackages)
+  for (const { directory } of typedPackages) {
+    linkPackage(directory)
+  }
+
+  /*
+   * Every typed package resolves from a consumer, for every export subpath and
+   * every module mode it advertises. This is the breadth pass; the hand-written
+   * fixtures below additionally pin the call signatures teams depend on.
+   */
+  const entries = typedPackages.flatMap((entry) => typedSubpaths(entry))
+  const resolutionEsmFixture = path.join(fixtureRoot, "resolution.mts")
+  writeFileSync(
+    resolutionEsmFixture,
+    entries
+      .map(
+        ({ specifier }, index) =>
+          `import type * as namespace${index} from ${JSON.stringify(specifier)}\nexport type Entry${index} = typeof namespace${index}\n`
+      )
+      .join("")
+  )
+  checkProgram(resolutionEsmFixture, {
+    module: ts.ModuleKind.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+  })
+
+  const resolutionCommonJsFixture = path.join(fixtureRoot, "resolution.cts")
+  writeFileSync(
+    resolutionCommonJsFixture,
+    entries
+      .filter(({ dual }) => dual)
+      .map(
+        ({ specifier }, index) =>
+          `import namespace${index} = require(${JSON.stringify(specifier)})\nexport type Entry${index} = typeof namespace${index}\n`
+      )
+      .join("")
+  )
+  checkProgram(resolutionCommonJsFixture, {
+    module: ts.ModuleKind.NodeNext,
+    moduleResolution: ts.ModuleResolutionKind.NodeNext,
+  })
 
   const esmFixture = path.join(fixtureRoot, "consumer.mts")
   writeFileSync(

--- a/scripts/example-matrix-guard.mjs
+++ b/scripts/example-matrix-guard.mjs
@@ -74,4 +74,25 @@ export function assertExampleMatrix(matrix) {
     0,
     "Vite has no screenshot artifact"
   )
+
+  /*
+   * The browser layer runs on a weekly cron, so the smoke checks are what
+   * asserts the served document locale on a pull request. Requiring the key to
+   * be present — `null` for a response that has no document element — keeps a
+   * client-only regression from hiding as one more check that simply omitted
+   * it, which is how the waku families drifted (#635, #667).
+   */
+  for (const example of matrix) {
+    for (const check of example.smokeChecks ?? []) {
+      assert.ok(
+        Object.hasOwn(check, "htmlLang"),
+        `${example.id} smoke check ${check.path} must declare htmlLang (use null for a non-document response)`
+      )
+      assert.ok(
+        check.htmlLang === null ||
+          (typeof check.htmlLang === "string" && check.htmlLang.length > 0),
+        `${example.id} smoke check ${check.path} must set htmlLang to a locale or null`
+      )
+    }
+  }
 }

--- a/scripts/example-matrix-guard.test.mjs
+++ b/scripts/example-matrix-guard.test.mjs
@@ -53,6 +53,25 @@ describe("example matrix guard", () => {
     expect(() => assertExampleMatrix(duplicatedPort)).toThrow(/ports must be unique/)
   })
 
+  it("rejects a smoke check that omits or empties its document locale", () => {
+    const omitted = cloneMatrix()
+    const withChecks = omitted.findIndex((example) => example.smokeChecks.length > 0)
+    omitted[withChecks] = {
+      ...omitted[withChecks],
+      smokeChecks: omitted[withChecks].smokeChecks.map(
+        ({ htmlLang: _htmlLang, ...check }) => check
+      ),
+    }
+    expect(() => assertExampleMatrix(omitted)).toThrow(/must declare htmlLang/)
+
+    const emptied = cloneMatrix()
+    emptied[withChecks] = {
+      ...emptied[withChecks],
+      smokeChecks: emptied[withChecks].smokeChecks.map((check) => ({ ...check, htmlLang: "" })),
+    }
+    expect(() => assertExampleMatrix(emptied)).toThrow(/must set htmlLang to a locale or null/)
+  })
+
   it("keeps Vite as the single client-only browser proof", () => {
     const misplacedVite = cloneMatrix()
     const viteIndex = misplacedVite.findIndex((example) => example.id === "vite-mdx")

--- a/scripts/example-matrix.mjs
+++ b/scripts/example-matrix.mjs
@@ -35,6 +35,7 @@ export const EXAMPLE_MATRIX = [
       {
         headers: { "accept-language": "de" },
         path: "/",
+        htmlLang: "de",
         substrings: ["Deutsch", "Plätze frei"],
       },
     ],
@@ -51,11 +52,13 @@ export const EXAMPLE_MATRIX = [
       {
         headers: { "accept-language": "de" },
         path: "/en",
+        htmlLang: "en",
         substrings: ["currently rendering", "Switch to the recommended locale"],
       },
       {
         headers: { host: "de.lvh.me:4011" },
         path: "/en",
+        htmlLang: "en",
         substrings: ["This host is mapped to Deutsch"],
       },
     ],
@@ -166,11 +169,13 @@ export const EXAMPLE_MATRIX = [
       {
         headers: { "accept-language": "de" },
         path: "/en",
+        htmlLang: "en",
         substrings: ["currently rendering", "Switch to the recommended locale"],
       },
       {
         headers: { host: "de.lvh.me:4041" },
         path: "/en",
+        htmlLang: "en",
         substrings: ["This host is mapped to Deutsch"],
       },
     ],
@@ -203,11 +208,13 @@ export const EXAMPLE_MATRIX = [
       {
         headers: { "accept-language": "de" },
         path: "/",
+        htmlLang: "de",
         substrings: ["Deutsch", "Plätze frei"],
       },
       {
         headers: { "accept-language": "en" },
         path: "/",
+        htmlLang: "en",
         substrings: ["English", "seats left"],
       },
     ],
@@ -224,15 +231,20 @@ export const EXAMPLE_MATRIX = [
       {
         headers: { "accept-language": "de" },
         path: "/",
+        htmlLang: "de",
         substrings: ["Deutsch", "Plätze frei"],
       },
       {
         headers: { "accept-language": "de" },
+        htmlLang: "de",
         path: "/frames",
         substrings: ["Diese Antwort", "Active frame locale", "Deutsch"],
       },
       {
+        // The frame endpoint streams the partial on its own, so this response
+        // has no document element to carry a lang attribute.
         headers: { "accept-language": "de" },
+        htmlLang: null,
         path: "/frames/locale-summary",
         substrings: ["Diese Antwort", "Active frame locale", "Deutsch"],
       },
@@ -250,10 +262,12 @@ export const EXAMPLE_MATRIX = [
       {
         headers: { "accept-language": "de" },
         path: "/en",
+        htmlLang: "en",
         substrings: ["currently rendering", "Switch to the recommended locale"],
       },
       {
         path: "/de",
+        htmlLang: "de",
         substrings: ["Deutsch", "Plätze frei"],
       },
     ],
@@ -270,11 +284,13 @@ export const EXAMPLE_MATRIX = [
       {
         headers: { host: "de.lvh.me:4062" },
         path: "/",
+        htmlLang: "de",
         substrings: ["Deutsch", "Plätze frei"],
       },
       {
         headers: { host: "en.lvh.me:4062", "accept-language": "de" },
         path: "/",
+        htmlLang: "en",
         substrings: ["currently rendering", "Switch to the recommended locale"],
       },
     ],
@@ -291,11 +307,13 @@ export const EXAMPLE_MATRIX = [
       {
         headers: { host: "remix.example.de:4063" },
         path: "/",
+        htmlLang: "de",
         substrings: ["Deutsch", "Plätze frei"],
       },
       {
         headers: { host: "remix.example.com:4063", "accept-language": "de" },
         path: "/",
+        htmlLang: "en",
         substrings: ["currently rendering", "Switch to the recommended locale"],
       },
     ],
@@ -339,11 +357,13 @@ export const EXAMPLE_MATRIX = [
       {
         headers: { host: "de.lvh.me:4012" },
         path: "/",
+        htmlLang: "de",
         substrings: ["Deutsch", "Plätze frei"],
       },
       {
         headers: { host: "en.lvh.me:4012", "accept-language": "de" },
         path: "/",
+        htmlLang: "en",
         substrings: ["currently rendering", "Switch to the recommended locale"],
       },
     ],
@@ -395,11 +415,13 @@ export const EXAMPLE_MATRIX = [
       {
         headers: { host: "de.lvh.me:4042" },
         path: "/",
+        htmlLang: "de",
         substrings: ["Deutsch", "Plätze frei"],
       },
       {
         headers: { host: "en.lvh.me:4042", "accept-language": "de" },
         path: "/",
+        htmlLang: "en",
         substrings: ["currently rendering", "Switch to the recommended locale"],
       },
     ],
@@ -443,11 +465,13 @@ export const EXAMPLE_MATRIX = [
       {
         headers: { host: "palamedes-i18n.de:4013" },
         path: "/",
+        htmlLang: "de",
         substrings: ["Deutsch", "Plätze frei"],
       },
       {
         headers: { host: "palamedes-i18n.fr:4013" },
         path: "/",
+        htmlLang: "fr",
         substrings: ["français", "places restantes"],
       },
       {
@@ -455,6 +479,7 @@ export const EXAMPLE_MATRIX = [
         // wins over the browser preference (Accept-Language `de`).
         headers: { host: "palamedes-i18n.com:4013", "accept-language": "de" },
         path: "/",
+        htmlLang: "en",
         substrings: ["English", "seats left"],
       },
     ],
@@ -514,11 +539,13 @@ export const EXAMPLE_MATRIX = [
       {
         headers: { host: "palamedes-i18n.de:4043" },
         path: "/",
+        htmlLang: "de",
         substrings: ["Deutsch", "Plätze frei"],
       },
       {
         headers: { host: "palamedes-i18n.fr:4043" },
         path: "/",
+        htmlLang: "fr",
         substrings: ["français", "places restantes"],
       },
       {
@@ -526,6 +553,7 @@ export const EXAMPLE_MATRIX = [
         // wins over the browser preference (Accept-Language `de`).
         headers: { host: "palamedes-i18n.com:4043", "accept-language": "de" },
         path: "/",
+        htmlLang: "en",
         substrings: ["English", "seats left"],
       },
     ],

--- a/scripts/verify-react-router-rsc.mjs
+++ b/scripts/verify-react-router-rsc.mjs
@@ -53,6 +53,19 @@ async function expectMultiCookieLocale() {
   if (!response.ok || !html.includes("Server-Rendern bestätigte Sprache.")) {
     throw new Error("A production request with session and locale cookies did not render German.")
   }
+  // This fixture sits outside EXAMPLE_MATRIX, so its served document locale is
+  // asserted here rather than by the matrix smoke checks.
+  if (!/<html[^>]*\slang="de"/u.test(html)) {
+    throw new Error("A German document was served without a matching html lang attribute.")
+  }
+}
+
+async function expectDefaultDocumentLocale() {
+  const response = await fetch(baseUrl, { headers: { "accept-language": "en" } })
+  const html = await response.text()
+  if (!response.ok || !/<html[^>]*\slang="en"/u.test(html)) {
+    throw new Error("An English document was served without a matching html lang attribute.")
+  }
 }
 
 async function addServerFunctionBarrier(page, barrierId) {
@@ -83,6 +96,7 @@ const server = spawn("pnpm", ["--filter", "@palamedes/example-react-router-rsc-c
 try {
   await waitForServer()
   await expectMultiCookieLocale()
+  await expectDefaultDocumentLocale()
   const browser = await chromium.launch({ headless: true })
   try {
     const [deContext, enContext] = await Promise.all([browser.newContext(), browser.newContext()])

--- a/scripts/workflow-contracts.test.mjs
+++ b/scripts/workflow-contracts.test.mjs
@@ -60,6 +60,36 @@ describe("workflow contracts", () => {
     expect(vitePlugin.scripts.test).toBe("vitest run --globals")
   })
 
+  it("keeps the hot CI lane cancellable, least-privileged, and cached", async () => {
+    const ci = await readRepositoryFile(".github/workflows/ci.yml")
+    const validate = job(ci, "validate", "validate-rust")
+
+    expect(ci).toContain("permissions:\n  contents: read")
+    expect(ci).toContain("cancel-in-progress: ${{ github.event_name == 'pull_request' }}")
+    // Both caches sit in the validate job because `pnpm build` drives cargo.
+    expect(validate).toContain("cache: pnpm")
+    expect(validate).toContain("uses: Swatinem/rust-cache@v2")
+    expect(validate.indexOf("uses: Swatinem/rust-cache@v2")).toBeLessThan(
+      validate.indexOf("run: pnpm install --frozen-lockfile")
+    )
+  })
+
+  it("runs the Rust workspace tests on every shipped host platform", async () => {
+    const [ci, toolchain] = await Promise.all([
+      readRepositoryFile(".github/workflows/ci.yml"),
+      readRepositoryFile("rust-toolchain.toml"),
+    ])
+    const validateRust = job(ci, "validate-rust")
+
+    for (const os of ["ubuntu-24.04", "windows-2025", "macos-14"]) {
+      expect(validateRust).toContain(`- os: ${os}`)
+    }
+    expect(validateRust).toContain("run: cargo test --workspace --locked")
+    // Format and lint are platform-independent; only the tests fan out.
+    expect(validateRust).toContain("if: ${{ matrix.lint }}")
+    expect(toolchain).toContain('channel = "1.95"')
+  })
+
   it("runs the React Router RSC request-isolation proof on Linux", async () => {
     const ci = await readRepositoryFile(".github/workflows/ci.yml")
     const validate = job(ci, "validate", "validate-rust")


### PR DESCRIPTION
## Summary

Eleven commits closing thirteen audit issues. Two of them are regressions the recent fix round introduced; the rest are the gaps that let those regressions through.

**Correctness**

- `fix(core-node)` — the #630 fix widened the record snapshot to every own and inherited property name, non-enumerable ones included. A class carrying any method (`toString()` is enough) then pushed a function across the boundary and failed with a raw napi conversion error, and own non-enumerable properties leaked into compiled catalogs while the same property on a plain object stayed excluded. Now: own enumerable keys plus prototype-chain getters, identically for plain objects and class instances. The same commit rejects a `Map` at the boundary — no native signature accepts one, so it converted to an empty map and rendered a silently untranslated catalog.
- `fix(next)` — moving `i18n.load` inside the per-fragment `try` isolated failures but made registration follow import resolution order, so two catalogs carrying the same message id resolved to a different winner in degrade mode than in throw mode, non-deterministically. Imports still settle in parallel; registration follows `activeLoaders` order, with the load itself still guarded.
- `fix(examples)` — `react-router-rsc-cookie` hardcoded `lang="en"` while rendering translated content, with no client fallback. It sits outside `EXAMPLE_MATRIX`, so nothing covered it. React Router bundles the root layout into the client graph too and this fixture installs i18n on the server only, so the layout reads the request scope while rendering and the attribute that render produced while hydrating.

**Coverage that would have caught them**

- `test(examples)` — `htmlLang` was set on 10 of 44 smoke checks, and the browser layer that checks the rest runs on a weekly cron. All 44 now declare it (`null` for the remix frame endpoint, which has no document element), and the matrix guard requires the key so an omission cannot pass as a check that simply did not care.
- `test` — the declaration gate linked 6 of 16 published packages by hand. It now derives the list from the workspace, refuses a published package that is neither typed nor an explicit exclusion, resolves every advertised subpath from both module modes, and asserts the advertised entry points exist — the last is what catches #637 directly, since type resolution stops at the first matching `types` condition and never sees a phantom `require` target.
- `test(runtime)` — the test barrier gates all 16 isolation proofs and had no tests, so a regression would make them pass vacuously rather than fail.

**Infrastructure**

- `ci` — CI was the only workflow without a concurrency group, permissions block, pnpm cache, or Rust cache. `cargo test` also ran on Linux only; it now fans out over the three shipped hosts. `rust-toolchain.toml` pins the MSRV so a local `cargo build` installs it instead of failing with a resolver error listing every oxc crate.
- `ci` — weekly `pnpm audit` / `cargo audit` refreshing one tracking issue in place. Scheduled, not per-PR: an advisory published upstream should open a triage item, not block unrelated work.

**Docs**

- `docs(examples)` — the waku roots hardcode `lang="en"` because Waku pre-renders the document shell. Nothing said so, and a client without JavaScript still sees the wrong lang. Recorded at each root and in the framework example notes.
- `docs` — `@palamedes/eslint-plugin` had no API reference page, and the fact that its suppression directives do not transfer to `pmds lint` in either direction was documented on one side only.

## Issue

Closes #663, closes #664, closes #665, closes #666, closes #667, closes #668, closes #669, closes #671, closes #673, closes #674, closes #675, closes #676, closes #677.

Not addressed here: #670 (coverage tooling) and #672 (replacing the hand-rolled suppression lexer) — both are larger pieces of work that deserve their own change, and #672 is explicitly not urgent.

## Validation

All nine CI checks green on `7102e6a`, including the two newly added `validate-rust` legs on `windows-2025` and `macos-14`.

Locally, full suite green:

- `pnpm build`, `pnpm format:check`, `pnpm lint`, `pnpm check-types`
- `pnpm test` — 526 JS tests across 16 packages (up from 512)
- `pnpm check:published-types`, `check:llms`, `check:release-set`, `check:remix-next-canary`, `check:workflow-contracts`, `check:example-contracts`
- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, `cargo test --workspace --locked` — on the newly pinned 1.95 toolchain

Behaviour verified against real servers rather than only in tests:

- `node scripts/verify-examples.mjs --id <example>` for `nextjs-cookie`, `nextjs-tld`, `remix-cookie`, `remix-subdomain`, `react-router-tld`, `solidstart-cookie` — at least one example from every family whose `htmlLang` values are new, all passing with the new assertions.
- The react-router-rsc fixture was driven in a real browser for both locales: `lang="de"` / `lang="en"`, the server-rendered message present, and no page errors.
- The core-node fixes were checked directly against the built package: a class with a method renders, a non-enumerable own property does not leak, a `Map` throws a branded error, `Object.fromEntries(map)` works.
- The two new guards were checked by deliberate sabotage: a phantom `require` target and a new published package without `types` both fail the declaration gate.

The Rust toolchain pin was verified end to end — with 1.94 installed, `cargo` auto-installed 1.95 on first invocation, which is the developer-experience failure #676 described.

### Correction to an earlier revision of this description

The first push claimed the react-router-rsc browser stage was "unchanged by this PR". That was wrong, and CI caught it: reading the active i18n instance in the root layout threw during hydration, because React Router ships that layout to the client graph where this fixture has no client i18n. Only the server-side `lang` assertions had been verified; the browser stage had not. `7102e6a` fixes it, and the verification above now covers the hydrated page.

## Follow-up

- #670 — no coverage measurement for JS or Rust. Every untested path in this round was found by reading code; a baseline report would surface them systematically.
- #672 — the CLI suppression scanner is ~600 lines of hand-rolled lexing, patched six times, while `analyze_source_files_cached` already parses the same files with oxc.
- `pnpm build:examples` rewrites `examples/nextjs-*/next-env.d.ts` (Next.js regenerates them, and they are committed). Reverted here; worth deciding whether they should be generated or tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UrRRk3kn1ZSXqXvuL3n3Uk